### PR TITLE
String updates

### DIFF
--- a/gui/brushselectionwindow.py
+++ b/gui/brushselectionwindow.py
@@ -531,13 +531,13 @@ class BrushGroupsMenu (Gtk.Menu):
         # Static items
         item = Gtk.SeparatorMenuItem()
         self.append(item)
-        item = Gtk.MenuItem(C_("brush groups menu", "New Group..."))
+        item = Gtk.MenuItem(C_("brush groups menu", u"New Group…"))
         item.connect("activate", self._new_brush_group_cb)
         self.append(item)
-        item = Gtk.MenuItem(C_("brush groups menu", "Import Brushes..."))
+        item = Gtk.MenuItem(C_("brush groups menu", u"Import Brushes…"))
         item.connect("activate", self.app.drawWindow.import_brush_pack_cb)
         self.append(item)
-        item = Gtk.MenuItem(C_("brush groups menu", "Get More Brushes..."))
+        item = Gtk.MenuItem(C_("brush groups menu", u"Get More Brushes…"))
         item.connect("activate", self.app.drawWindow.download_brush_pack_cb)
         self.append(item)
         # Dynamic items

--- a/gui/device.py
+++ b/gui/device.py
@@ -1,4 +1,5 @@
 # This file is part of MyPaint.
+# -*- coding: utf-8 -*-
 # Copyright (C) 2014-2018 by the MyPaint Development Team.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -478,7 +479,7 @@ class SettingsEditor (Gtk.Grid):
         # TRANSLATORS: tasks for the row's device to be configured.
         col = Gtk.TreeViewColumn(C_(
             "prefs: devices table: column header",
-            "Use for...",
+            u"Use for…",
         ))
         col.set_min_width(100)
         col.set_resizable(True)
@@ -508,7 +509,7 @@ class SettingsEditor (Gtk.Grid):
         # TRANSLATORS: interpreted normally.
         col = Gtk.TreeViewColumn(C_(
             "prefs: devices table: column header",
-            "Scroll...",
+            u"Scroll…",
         ))
         col.set_min_width(100)
         col.set_resizable(True)

--- a/gui/dialogs.py
+++ b/gui/dialogs.py
@@ -220,7 +220,7 @@ def confirm_rewrite_group(window, groupname, deleted_groupname):
         u"<b>A group named “{groupname}” already exists.</b>\n"
         u"Do you want to replace it, or should the new group be renamed?\n"
         u"If you replace it, the brushes may be moved to a group called"
-        u"“{deleted_groupname}”."
+        u" “{deleted_groupname}”."
     ).format(
         groupname=groupname,
         deleted_groupname=deleted_groupname,

--- a/gui/drawwindow.py
+++ b/gui/drawwindow.py
@@ -694,7 +694,7 @@ class DrawWindow (Gtk.Window):
 
     def import_brush_pack_cb(self, *junk):
         format_id, filename = dialogs.open_dialog(
-            _("Import brush package..."), self,
+            _(u"Import brush package…"), self,
             [(_("MyPaint brush package (*.zip)"), "*.zip")]
         )
         if not filename:

--- a/gui/externalapp.py
+++ b/gui/externalapp.py
@@ -68,7 +68,7 @@ class OpenWithDialog (Gtk.Dialog):
 
     def __init__(self, content_type, specific_file=False):
         Gtk.Dialog.__init__(self)
-        self.set_title(_("Open With..."))
+        self.set_title(_(u"Open With…"))
         self.add_button(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
         self.add_button(Gtk.STOCK_OK, Gtk.ResponseType.OK)
         self.set_default_response(Gtk.ResponseType.CANCEL)

--- a/gui/filehandling.py
+++ b/gui/filehandling.py
@@ -1054,7 +1054,7 @@ class FileHandler (object):
         dialog = Gtk.FileChooserDialog(
             C_(
                 "load dialogs: title",
-                u"Open Scratchpad...",
+                u"Open Scratchpad…",
             ),
             self.app.drawWindow,
             Gtk.FileChooserAction.OPEN,

--- a/gui/filehandling.py
+++ b/gui/filehandling.py
@@ -571,9 +571,15 @@ class FileHandler (object):
 
     def init_save_dialog(self, export):
         if export:
-            save_dialog_name = C_("Dialogs: Save As...", u"Export")
+            save_dialog_name = C_(
+                "Dialogs (window title): File→Export...",
+                u"Export"
+            )
         else:
-            save_dialog_name = C_("Dialogs: Save As...", u"Save")
+            save_dialog_name = C_(
+                "Dialogs (window title): File→Save As...",
+                u"Save As"
+            )
         dialog = Gtk.FileChooserDialog(
             save_dialog_name,
             self.app.drawWindow,
@@ -591,7 +597,7 @@ class FileHandler (object):
         box = Gtk.HBox()
         box.set_spacing(12)
         label = Gtk.Label(C_(
-            "save dialogs: formats and options: label",
+            "save dialogs: formats and options: (label)",
             u"Format to save as:",
         ))
         label.set_alignment(0.0, 0.5)
@@ -725,7 +731,7 @@ class FileHandler (object):
             file_basename = None
         warning_msg_tmpl = C_(
             "Destructive action confirm dialog: warning message",
-            u"You risk losing {abbreviated_time} of unsaved painting. "
+            u"You risk losing {abbreviated_time} of unsaved painting."
         )
         markup_tmpl = warning_msg_tmpl
         d.set_markup(markup_tmpl.format(

--- a/gui/fill.py
+++ b/gui/fill.py
@@ -114,10 +114,18 @@ class FloodFillMode (
 
     @classmethod
     def get_name(cls):
-        return _(u'Flood Fill')
+        return C_(
+            "Name of the fill mode\n"
+            "In other software, 'Flood Fill' is also known as "
+            "'Bucket Fill' or just 'Fill'",
+            u'Flood Fill'
+        )
 
     def get_usage(self):
-        return _(u"Fill areas with color")
+        return C_(
+            "Usage description of the Flood Fill mode",
+            u"Fill areas with color"
+        )
 
     def __init__(self, ignore_modifiers=False, **kwds):
         super(FloodFillMode, self).__init__(**kwds)
@@ -494,10 +502,16 @@ class FloodFillOptionsWidget (Gtk.Grid):
 
         row = 0
         label = Gtk.Label()
-        label.set_markup(_("Tolerance:"))
-        label.set_tooltip_text(
-            _("How much pixel colors are allowed to vary from the start\n"
-              "before Flood Fill will refuse to fill them"))
+        label.set_markup(C_(
+            "fill options: numeric value that determines whether tested pixels"
+            " will be included in the fill, based on color difference",
+            u"Tolerance:"))
+        label.set_tooltip_text(C_(
+            "fill options: Tolerance (tooltip) "
+            "Note: 'the start' refers to the color of "
+            "the starting point (pixel) of the fill",
+            u"How much pixel colors are allowed to vary from the start\n"
+            u"before Flood Fill will refuse to fill them"))
         label.set_alignment(1.0, 0.5)
         label.set_hexpand(False)
         self.attach(label, 0, row, 1, 1)
@@ -516,8 +530,14 @@ class FloodFillOptionsWidget (Gtk.Grid):
 
         row += 1
         label = Gtk.Label()
-        label.set_markup(_("Source:"))
-        label.set_tooltip_text(_("Which visible layers should be filled"))
+        label.set_markup(C_(
+            "fill options: option category (label) "
+            "Options under this category relate to what the fill is"
+            "based on, not where the actual fill ends up.",
+            u"Source:"))
+        label.set_tooltip_text(C_(
+            "fill options: 'Source:' category (tooltip)",
+            u"The input that the fill will be based on"))
         label.set_alignment(1.0, 0.5)
         label.set_hexpand(False)
         self.attach(label, 0, row, 1, 1)
@@ -560,8 +580,8 @@ class FloodFillOptionsWidget (Gtk.Grid):
         combo.set_cell_data_func(cell, layer_name_render)
         combo.set_tooltip_text(
             C_(
-                "fill option (not saved): Specific fill source choice",
-                "Select a specific layer you want the fill to be based on"
+                "fill options: 'Source' category: Layer dropdown (tooltip)",
+                u"Select a specific layer you want the fill to be based on"
             )
         )
         combo.set_active(0)
@@ -575,12 +595,18 @@ class FloodFillOptionsWidget (Gtk.Grid):
 
         row += 1
 
-        text = _("Sample Merged")
+        text = C_(
+            "fill options: 'Source:' category: toggle (label)\n"
+            "When this option is enabled, the fill is based\n"
+            "on the combination of all visible layers",
+            u"Sample Merged")
         checkbut = Gtk.CheckButton.new_with_label(text)
         checkbut.set_tooltip_text(
-            _("When considering which area to fill, use a\n"
-              "temporary merge of all the visible layers\n"
-              "underneath the current layer"))
+            C_("fill options: Sample Merged (tooltip)",
+               u"When considering which area to fill, use a\n"
+               u"temporary merge of all the visible layers\n"
+               u"underneath the current layer")
+        )
         self.attach(checkbut, 1, row, 1, 1)
         active = bool(prefs.get(self.SAMPLE_MERGED_PREF,
                                 self.DEFAULT_SAMPLE_MERGED))
@@ -591,11 +617,17 @@ class FloodFillOptionsWidget (Gtk.Grid):
 
         row += 1
 
-        text = _("Limit to view")
+        text = C_("fill options: toggle whether the fill will be limited "
+                  "by the viewport",
+                  u"Limit to View")
         checkbut = Gtk.CheckButton.new_with_label(text)
         checkbut.set_tooltip_text(
-            C_("fill option: fill does not reach beyond view when active",
-               "Constrain the area that may be filled to the view area"))
+            C_("fill options: Limit to View (tooltip)\n"
+               "Note: 'that can fit the view' is equivalent to: "
+               "'in which the entire visible part of the canvas can fit",
+               u"Limit the area that can be filled, based on the viewport.\n"
+               u"If the view is rotated, the fill will be limited to the\n"
+               u"smallest canvas-aligned rectangle that can fit the view."))
         self.attach(checkbut, 1, row, 1, 1)
         active = bool(prefs.get(self.LIM_TO_VIEW_PREF,
                                 self.DEFAULT_LIM_TO_VIEW))
@@ -605,17 +637,30 @@ class FloodFillOptionsWidget (Gtk.Grid):
 
         row += 1
         label = Gtk.Label()
-        label.set_markup(_("Target:"))
-        label.set_tooltip_text(_("Where the output should go"))
+        label.set_markup(C_(
+            "fill options: option category (label)\n"
+            "Options under this category relate to where the fill "
+            "will end up (default: the active layer) and how it "
+            "will be combined with that layer.",
+            u"Target:"))
+        label.set_tooltip_text(C_(
+            "fill options: 'Target:' category (tooltip)",
+            u"Where the output should go"))
         label.set_alignment(1.0, 0.5)
         label.set_hexpand(False)
         self.attach(label, 0, row, 1, 1)
 
-        text = _("New Layer (once)")
+        text = C_(
+            "fill options: Target | toggle (label)\n"
+            "When this option is enabled, the fill will be placed on a new\n"
+            "layer above the active layer. Option resets after each fill.",
+            u"New Layer (once)"
+        )
         checkbut = Gtk.CheckButton.new_with_label(text)
         checkbut.set_tooltip_text(
-            _("Create a new layer with the results of the fill.\n"
-              "This is turned off automatically after use."))
+            C_("fill options: Target | New Layer (tooltip)",
+               u"Create a new layer with the results of the fill.\n"
+               u"This is turned off automatically after use."))
         self.attach(checkbut, 1, row, 1, 1)
         active = self.DEFAULT_MAKE_NEW_LAYER
         checkbut.set_active(active)
@@ -625,8 +670,8 @@ class FloodFillOptionsWidget (Gtk.Grid):
         label = Gtk.Label()
         label.set_markup(u"<b>\u26a0</b>")  # unicode warning sign
         label.set_tooltip_text(C_(
-            "floodfill options warning text",
-            "This mode does nothing when alpha locking is enabled!")
+            "fill options: Target | Blend Mode dropdown - warning text",
+            u"This mode does nothing when alpha locking is enabled!")
         )
         label.set_alignment(1.0, 0.5)
         label.set_hexpand(False)
@@ -639,8 +684,8 @@ class FloodFillOptionsWidget (Gtk.Grid):
         modes.insert(0, lib.modes.DEFAULT_MODE)
         combo = gui.layers.new_blend_mode_combo(modes, lib.modes.MODE_STRINGS)
         combo.set_tooltip_text(C_(
-            "floodfill option tooltip text - blend modes",
-            "Blend mode used when filling"))
+            "fill options: Target | Blend Mode dropdown (tooltip)",
+            u"Blend mode used when filling"))
         # Reinstate the last _mode id_ independent of mode-list order
         mode_type = prefs.get(self.BLEND_MODE_PREF, self.DEFAULT_BLEND_MODE)
         mode_dict = {mode: index for index, mode, in enumerate(modes)}
@@ -655,9 +700,10 @@ class FloodFillOptionsWidget (Gtk.Grid):
 
         row += 1
         label = Gtk.Label()
-        label.set_markup(_("Opacity:"))
-        label.set_tooltip_text(
-            _("Opacity of the fill"))
+        label.set_markup(_(u"Opacity:"))
+        label.set_tooltip_text(C_(
+            "fill options: Opacity slider (tooltip)",
+            u"Opacity of the fill"))
         label.set_alignment(1.0, 0.5)
         label.set_hexpand(False)
         self.attach(label, 0, row, 1, 1)
@@ -679,7 +725,7 @@ class FloodFillOptionsWidget (Gtk.Grid):
         row += 1
         label = Gtk.Label()
         label.set_markup(C_(
-            "fill options: offset (grow/shrink) label",
+            "fill options: numeric option - grow/shrink fill (label)",
             u"Offset:"
         ))
         label.set_alignment(1.0, 0.5)
@@ -695,7 +741,7 @@ class FloodFillOptionsWidget (Gtk.Grid):
         self._offset_adj = adj
         spinbut = Gtk.SpinButton()
         spinbut.set_tooltip_text(C_(
-            "fill options: offset (grow/shrink) description",
+            "fill options: Offset (tooltip)",
             u"The distance in pixels to grow or shrink the fill"
         ))
         spinbut.set_hexpand(True)
@@ -706,7 +752,7 @@ class FloodFillOptionsWidget (Gtk.Grid):
         row += 1
         label = Gtk.Label()
         label.set_markup(C_(
-            "fill options: feather (blur) label",
+            "fill options: numeric option for blurring fill (label)",
             u"Feather:"
         ))
         label.set_alignment(1.0, 0.5)
@@ -721,7 +767,7 @@ class FloodFillOptionsWidget (Gtk.Grid):
         self._feather_adj = adj
         spinbut = Gtk.SpinButton()
         spinbut.set_tooltip_text(C_(
-            "fill options: feather (blur) description",
+            "fill options: Feather (tooltip)",
             u"The amount of blur to apply to the fill"
         ))
         spinbut.set_hexpand(True)
@@ -737,15 +783,15 @@ class FloodFillOptionsWidget (Gtk.Grid):
         self._gap_closing_grid = gap_closing_params
 
         text = C_(
-            "fill options: gap detection on/off label",
-            u'Use gap detection'
+            "fill options: gap detection toggle (label)",
+            u'Use Gap Detection'
         )
         checkbut = Gtk.CheckButton.new_with_label(text)
         checkbut.set_tooltip_text(C_(
-            "fill options: gap closing on/off description",
+            "fill options: Use Gap Detection (tooltip)",
             u"Try to detect gaps and not fill past them.\n"
             u"Note: This can be a lot slower than the regular fill, "
-            u"only enable when you really need it."
+            u"only enable when you need it."
         ))
         self._gap_closing_toggle = checkbut
         checkbut.connect("toggled", self._gap_closing_toggled_cb)
@@ -760,8 +806,8 @@ class FloodFillOptionsWidget (Gtk.Grid):
         gcp_row = 0
         label = Gtk.Label()
         label.set_markup(C_(
-            "fill options: maximum size of gaps label",
-            u"Max gap size:"
+            "fill options: gap-detection sub-option, numeric setting (label)",
+            u"Max Gap Size:"
         ))
         label.set_alignment(1.0, 0.5)
         label.set_hexpand(False)
@@ -775,8 +821,9 @@ class FloodFillOptionsWidget (Gtk.Grid):
         self._max_gap_adj = adj
         spinbut = Gtk.SpinButton()
         spinbut.set_tooltip_text(C_(
-            "fill options: max gap size description",
-            u"The size of the largest gaps that can be detected"
+            "fill options: Max Gap Size (tooltip)",
+            u"The size of the largest gaps that can be detected.\n"
+            u"Using large values can make the fill run a lot slower."
         ))
         spinbut.set_hexpand(True)
         spinbut.set_adjustment(adj)
@@ -785,17 +832,18 @@ class FloodFillOptionsWidget (Gtk.Grid):
 
         gcp_row += 1
         text = C_(
-            "fill options: on/off sub-option to gap closing fill; "
-            "When enabled, the fill will stay outside of detected "
-            "gaps, when disabled, they will seep into them",
+            "fill options: on/off sub-option, numeric (label)\n"
+            "When enabled, if the fill stops after going past a detected gap, "
+            "it 'pulls' the fill back out of the gap to the other side of it.",
             u"Prevent seeping"
         )
         checkbut = Gtk.CheckButton.new_with_label(text)
         active = prefs.get(self.RETRACT_SEEPS_PREF, self.DEFAULT_RETRACT_SEEPS)
         checkbut.set_active(active)
         checkbut.set_tooltip_text(C_(
-            "gui/fill.py - description of (Retract seeps) option",
-            u"Try to prevent the fill from seeping into the gaps"
+            "fill options: Prevent seeping (tooltip)",
+            u"Try to prevent the fill from seeping into the gaps.\n"
+            u"If a fill starts in a detected gap, this option will do nothing."
         ))
         checkbut.connect("toggled", self._retract_seeps_toggled_cb)
         self._retract_seeps_toggle = checkbut
@@ -806,7 +854,9 @@ class FloodFillOptionsWidget (Gtk.Grid):
         align.set_vexpand(True)
         button = Gtk.Button(label=_("Reset"))
         button.connect("clicked", self._reset_clicked_cb)
-        button.set_tooltip_text(_("Reset options to their defaults"))
+        button.set_tooltip_text(C_(
+            "fill options: Reset button (tooltip)",
+            "Reset options to their defaults"))
         align.add(button)
         self.attach(align, 0, row, 2, 1)
 
@@ -983,8 +1033,7 @@ class FlatLayerList(Gtk.ListStore):
         # Column data : name, layer_path, layer
         self.set_column_types((str, object, object))
         default_selection = C_(
-            "fill option: default layer to use for"
-            "fill unless (sample merged) is enabled",
+            "fill option: default option in the Source Layer dropdown",
             u"Selected Layer"
         )
         # Add default option and separator

--- a/gui/gtkexcepthook.py
+++ b/gui/gtkexcepthook.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # (c) 2003 Gustavo J A M Carneiro gjc at inescporto.pt
 #     2004-2005 Filip Van Raemdonck
 #
@@ -173,9 +174,9 @@ def _info(exctyp, value, tb):
     dialog.set_markup(primary)
     dialog.format_secondary_text(secondary)
 
-    dialog.add_button(_("Search Tracker..."), RESPONSE_SEARCH)
+    dialog.add_button(_(u"Search Tracker…"), RESPONSE_SEARCH)
     if "-" in lib.meta.MYPAINT_VERSION:  # only development and prereleases
-        dialog.add_button(_("Report..."), RESPONSE_REPORT)
+        dialog.add_button(_("Report…"), RESPONSE_REPORT)
         dialog.set_response_sensitive(RESPONSE_REPORT, False)
     dialog.add_button(_("Ignore Error"), Gtk.ResponseType.CLOSE)
     dialog.add_button(_("Quit MyPaint"), RESPONSE_QUIT)
@@ -188,7 +189,7 @@ def _info(exctyp, value, tb):
         else:
             dialog.set_resizable(False)
     details_expander = Gtk.Expander()
-    details_expander.set_label(_("Details..."))
+    details_expander.set_label(_(u"Details…"))
     details_expander.connect("notify::expanded", expander_cb)
 
     textview = Gtk.TextView()

--- a/gui/layerswindow.py
+++ b/gui/layerswindow.py
@@ -106,7 +106,7 @@ class LayersTool (SizedVBoxToolWidget):
     STATUSBAR_CONTEXT = 'layerstool-dnd'
 
     # TRANSLATORS: status bar messages for drag, without/with modifiers
-    STATUSBAR_DRAG_MSG = _("Move layer in stack...")
+    STATUSBAR_DRAG_MSG = _(u"Move layer in stack…")
     STATUSBAR_DRAG_INTO_MSG = _("Move layer in stack (dropping into a "
                                 "regular layer will create a new group)")
 

--- a/gui/linemode.py
+++ b/gui/linemode.py
@@ -1,4 +1,5 @@
 # This file is part of MyPaint.
+# -*- coding: utf-8 -*-
 # Copyright (C) 2012 by Richard Jones
 # Copyright (C) 2012-2018 by the MyPaint Development Team.
 #
@@ -170,7 +171,7 @@ class LineModeOptionsWidget (gui.mode.PaintingModeOptionsWidgetBase):
         curve.set_size_request(175, 125)
         self._curve = curve
         exp = Gtk.Expander()
-        exp.set_label(_("Pressure variation..."))
+        exp.set_label(_(u"Pressure variation…"))
         exp.set_use_markup(False)
         exp.add(curve)
         self.attach(exp, 0, row, 2, 1)

--- a/gui/preferenceswindow.glade
+++ b/gui/preferenceswindow.glade
@@ -1099,11 +1099,11 @@ Scrolling to pan the view needs this setting to be turned on, and for your devic
         </child>
         <child>
           <object class="GtkCheckButton" id="blink_layers_checkbutton">
-            <property name="label" translatable="yes" context="Prefs Dialog|View|Interface|Handle smooth scrolling events|checkbox label">Enabled</property>
+            <property name="label" translatable="yes" context="Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label">Enabled</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
-            <property name="tooltip_text" translatable="yes" context="Prefs Dialog|View|Interface|Handle smooth scrolling events|checkbox tooltip">When layers are created and selected, show that layer in isolation for a short time period.</property>
+            <property name="tooltip_text" translatable="yes" context="Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox tooltip">When a layer is created or selected, show only that layer for a short time period.</property>
             <property name="hexpand">True</property>
             <property name="vexpand">False</property>
             <property name="xalign">0</property>

--- a/po/af.po
+++ b/po/af.po
@@ -513,17 +513,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1184,12 +1184,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1372,7 +1372,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Open dragged file confirm dialog: continue button"
 msgid "_Open"
-msgstr "Maak oop..."
+msgstr "Maak oop…"
 
 #: ../gui/drawwindow.py:486
 msgid "Set current color"
@@ -1406,7 +1406,7 @@ msgid "_Quit"
 msgstr "Gaan uit"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1456,7 +1456,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1633,13 +1633,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Stoor"
 
@@ -1705,7 +1705,7 @@ msgstr "Lêer"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -1723,7 +1723,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Maak oop..."
+msgstr "Maak oop…"
 
 #: ../gui/filehandling.py:1427
 #, fuzzy
@@ -1735,7 +1735,7 @@ msgstr "Maak Onlangse Oop"
 #, fuzzy
 msgctxt "File→Open Most Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Maak oop..."
+msgstr "Maak oop…"
 
 #: ../gui/filehandling.py:1446
 msgctxt "File→Open Next/Prev Scrap: error message"
@@ -1756,7 +1756,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
 msgid "_Open"
-msgstr "Maak oop..."
+msgstr "Maak oop…"
 
 #: ../gui/filehandling.py:1487
 msgctxt "File→Revert: status message: canvas has no filename yet"
@@ -2130,12 +2130,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2147,7 +2147,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2333,7 +2333,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2403,7 +2403,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/af.po
+++ b/po/af.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:18+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Afrikaans <https://hosted.weblate.org/projects/mypaint/"
@@ -19,27 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -47,39 +27,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -87,214 +67,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Kleur"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Pasgemaak"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -333,142 +323,177 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Stoor"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Nuwe"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -476,58 +501,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -536,51 +561,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -590,137 +639,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -728,162 +777,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -891,373 +932,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Naam"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Herstel"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Herstel herroep"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1267,324 +1305,679 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Maak oop..."
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Volskerm"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Gaan uit"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Gaan uit"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Maak oop..."
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Stoor"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr ""
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr ""
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Lêer"
+
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Lae"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Maak oop..."
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Maak Onlangse Oop"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Maak oop..."
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Maak oop..."
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr ""
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1592,130 +1985,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1724,35 +2129,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1776,45 +2181,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1822,153 +2231,218 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Lae"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Lae"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr ""
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1980,256 +2454,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2237,188 +2736,213 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Lae"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2427,13 +2951,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2443,7 +2967,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2451,13 +2975,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2465,7 +2989,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2473,7 +2997,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2484,7 +3008,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2492,7 +3016,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2502,7 +3031,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2513,285 +3042,394 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr ""
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2801,7 +3439,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2810,52 +3468,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2877,17 +3566,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2916,112 +3603,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3034,7 +3696,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3075,6 +3737,133 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Naam"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3444,56 +4233,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3501,12 +4310,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3515,7 +4324,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3526,28 +4335,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3609,1828 +4418,2019 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Zoem uit"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Lêer"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Hulp"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
-msgstr ""
+msgstr "Lae"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-09-03 02:23+0000\n"
 "Last-Translator: Omar Aglan <omar.aglan91@yahoo.com>\n"
 "Language-Team: Arabic <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -20,29 +20,7 @@ msgstr ""
 "&& n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
 "X-Generator: Weblate 3.9-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr "<big><b>{accel_label}</b></big>"
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr "{action_label} {action_desc} {accel_label}"
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "الفعل"
 
@@ -50,41 +28,41 @@ msgstr "الفعل"
 msgid "Key combination"
 msgstr "مزيح المفاتيح"
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr "عدل المفتاح ل '%s'"
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "الفعل:"
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "المسار:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "المفتاح:"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr "إضغط مفاتيح لتحديث هذا التعيين"
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "فعل غير معروف"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
-"<b>{accel} مستخدم بالفعل في '{action}'. سيتم إستبدال التعيين الموجود "
-"بالفعل.</b>"
+"<b>{accel} مستخدم بالفعل في '{action}'. سيتم إستبدال التعيين الموجود بالفعل."
+"</b>"
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr "إفتح المجلد “{folder_basename}”…"
@@ -92,214 +70,224 @@ msgstr "إفتح المجلد “{folder_basename}”…"
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "حسنًا"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr "لا يوجد أي نسخ إحتياطية في الذاكرة المخبأة."
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr "لا تتوفر نسخ إحتياطية"
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr "إفتح مجلد الذاكرة المخبأة …"
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr "فشل إسترجاع النسخة الإحتياطية"
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr "فتح مجلد النسخ الإحتياطية …"
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr "تم إسترجاع ملف من {iso_datetime}.ora"
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "حفظ كإفتراضي"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "الخلفية"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "نمط"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "اللون"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "أضف لون إلي النمط"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "مخصص"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -338,98 +326,133 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "احفظ"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "جديد"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
@@ -440,44 +463,44 @@ msgstr[3] ""
 msgstr[4] ""
 msgstr[5] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -485,58 +508,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -545,51 +568,76 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "إختيار اللون"
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -599,137 +647,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -737,162 +785,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -900,373 +940,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "الاسم"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "تراجع"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "كرر"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1276,324 +1313,685 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "فتح"
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "ملء الشاشة"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "أنهِ"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "أنهِ"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "حفظ كإفتراضي"
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "افتح..."
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "احفظ"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr ""
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr "فتح"
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "فتح"
+
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "الطبقات"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "فتح"
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "افتح الحديث"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "فتح"
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "فتح"
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "العتمة:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1601,130 +1999,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1733,35 +2143,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1785,45 +2195,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1831,153 +2245,219 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+#, fuzzy
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr "موقع الطبقة"
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "الطبقات"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "الطبقات"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "العتمة:"
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1989,256 +2469,282 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
+msgstr "التماثل"
+
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr "معالجة الملف"
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr "مبدل القصاصات"
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr "التراجع والإعادة"
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr "أوضاع الدمج"
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr "أوضاع الخط"
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr "إظهار (أساسي)"
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr "إظهار (ثانوي/بديل)"
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr "إظهار (إعادة تعيين)"
 
@@ -2246,188 +2752,213 @@ msgstr "إظهار (إعادة تعيين)"
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "الطبقات"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2436,13 +2967,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2452,7 +2983,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2460,13 +2991,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2474,7 +3005,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2482,7 +3013,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2493,7 +3024,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2501,7 +3032,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2511,7 +3047,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2522,285 +3058,397 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+#, fuzzy
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr "ملء"
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr "فعل غير معروف"
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "موقع الطبقة"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2810,7 +3458,28 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+#, fuzzy
+msgid "Rotational"
+msgstr "تدوير"
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2819,52 +3488,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2886,17 +3586,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2925,114 +3623,89 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-#, fuzzy
-msgid "<ymin>"
-msgstr "<ymin>"
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr "<ymax>"
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr "<xmin>"
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr "<xmax>"
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
 msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+#, fuzzy
+msgid "<big><b>No Brush Dynamics</b></big>"
+msgstr "<big><b>{accel_label}</b></big>"
 
 #: ../po/tmp/inktool.glade.h:1
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
@@ -3044,7 +3717,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3085,6 +3758,135 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "الاسم"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr "الوضع"
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "العتمة:"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3454,56 +4256,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3511,12 +4333,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3525,7 +4347,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3536,28 +4358,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3619,1828 +4441,2051 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr "الفُرش"
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr "الألوان"
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr "الوضع"
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
+#, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
-msgstr ""
+msgid "Layer Properties…"
+msgstr "موقع الطبقة"
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "صغّر"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "ملف"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "مساعدة"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "تنقيح"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr "طباعة معلومات تسرب الذاكرة إلى وحدة التحكم (بطئ!)"
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr "تنقيح تسرب الذاكرة."
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr "تشغيل منظف القمامة الآن"
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr "الذاكرة الحرة المستخدمة لكائنات بايثون لم تعد قيد الاستخدام."
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr "بدء/إيقاف التنميط …"
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr "بدء أو تشغيل منمط بايثون (cProfile)"
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr "محاكاة تحطم …"
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr "تشغيل إستثناء بايثون، لكي تختبر نافذة التحطم."
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr "ردود الفعل"
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr "اختبار أجهزة الدخل"
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr "إظهار نافذة والتي تقوم بأسر الأحداث التي ترسلها أجهزة مدخلاتك."
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
-msgstr ""
+msgstr "الطبقات"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr "أظهر مستوى التقريب"
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr "أظهر آخر موضع رسم"
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr "رسم حر"
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr "تحريك"
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr "تدوير"
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr "تقريب"
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr "الخطوط"
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr "خطوط متصلة"
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr "بيضاوي"
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr "حبر"
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr "موقع الطبقة"
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr "الإطار"
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr "التماثل"
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr "إختيار اللون"
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "إختيار اللون"
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "إختيار اللون"
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "إختيار اللون"
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr "ملء"
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""
+
+#~ msgctxt "Accelerator map editor: action column markup"
+#~ msgid ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+#~ msgstr ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+
+#~ msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
+#~ msgid "{action_label} {action_desc} {accel_label}"
+#~ msgstr "{action_label} {action_desc} {accel_label}"
+
+#~ msgid "Open..."
+#~ msgstr "افتح..."
+
+#, fuzzy
+#~ msgid "<ymin>"
+#~ msgstr "<ymin>"
+
+#~ msgid "<ymax>"
+#~ msgstr "<ymax>"
+
+#~ msgid "<xmin>"
+#~ msgstr "<xmin>"
+
+#~ msgid "<xmax>"
+#~ msgstr "<xmax>"

--- a/po/ar.po
+++ b/po/ar.po
@@ -84,7 +84,7 @@ msgstr "لا تتوفر نسخ إحتياطية"
 
 #: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
-msgstr "إفتح مجلد الذاكرة المخبأة …"
+msgstr "إفتح مجلد الذاكرة المخبأة…"
 
 #: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
@@ -92,7 +92,7 @@ msgstr "فشل إسترجاع النسخة الإحتياطية"
 
 #: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
-msgstr "فتح مجلد النسخ الإحتياطية …"
+msgstr "فتح مجلد النسخ الإحتياطية…"
 
 #: ../gui/autorecover.py:182
 #, python-brace-format
@@ -520,17 +520,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1192,12 +1192,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1414,7 +1414,7 @@ msgid "_Quit"
 msgstr "أنهِ"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1464,7 +1464,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1646,13 +1646,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "احفظ"
 
@@ -1719,7 +1719,7 @@ msgstr "فتح"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -2144,12 +2144,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2161,7 +2161,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2348,7 +2348,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2418,7 +2418,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777
@@ -5704,7 +5704,7 @@ msgstr "الذاكرة الحرة المستخدمة لكائنات بايثون
 #: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
-msgstr "بدء/إيقاف التنميط …"
+msgstr "بدء/إيقاف التنميط…"
 
 #: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
@@ -5714,7 +5714,7 @@ msgstr "بدء أو تشغيل منمط بايثون (cProfile)"
 #: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
-msgstr "محاكاة تحطم …"
+msgstr "محاكاة تحطم…"
 
 #: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"

--- a/po/as.po
+++ b/po/as.po
@@ -513,17 +513,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1184,12 +1184,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1405,7 +1405,7 @@ msgid "_Quit"
 msgstr "Quit"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1455,7 +1455,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1632,13 +1632,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "সংৰক্ষণ কৰক"
 
@@ -1704,7 +1704,7 @@ msgstr "নথিপত্ৰ"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -2125,12 +2125,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2142,7 +2142,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2328,7 +2328,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2398,7 +2398,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/as.po
+++ b/po/as.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:18+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Assamese <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -19,27 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -47,39 +27,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -87,214 +67,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "বিন্যাস"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "ৰং"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Custom"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -333,142 +323,177 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "সংৰক্ষণ কৰক"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "নতুন"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -476,58 +501,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -536,51 +561,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -590,137 +639,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -728,162 +777,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -891,373 +932,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "নাম"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "পূৰ্বাবস্থা"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Redo"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1267,324 +1305,674 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr ""
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Quit"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Quit"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
+msgstr ""
+
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
+msgstr ""
+
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "সংৰক্ষণ কৰক"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
 #, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr ""
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "নথিপত্ৰ"
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "স্তৰবোৰ  "
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1412
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1427
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1432
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr ""
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1592,130 +1980,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1724,35 +2124,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1776,45 +2176,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1822,153 +2226,218 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "স্তৰবোৰ  "
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "স্তৰবোৰ  "
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr ""
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1980,256 +2449,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2237,188 +2731,213 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "স্তৰবোৰ  "
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2427,13 +2946,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2443,7 +2962,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2451,13 +2970,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2465,7 +2984,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2473,7 +2992,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2484,7 +3003,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2492,7 +3011,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2502,7 +3026,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2513,285 +3037,394 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr ""
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2801,7 +3434,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2810,52 +3463,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2877,17 +3561,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2916,112 +3598,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3034,7 +3691,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3075,6 +3732,133 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "নাম"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3444,56 +4228,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3501,12 +4305,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3515,7 +4319,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3526,28 +4330,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3609,1828 +4413,2019 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "ছোট কৰি চোৱানো"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "নথিপত্ৰ"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "ডিবাগ"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
-msgstr ""
+msgstr "স্তৰবোৰ  "
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/ast.po
+++ b/po/ast.po
@@ -513,17 +513,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1184,12 +1184,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1405,7 +1405,7 @@ msgid "_Quit"
 msgstr "Quitar"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1455,7 +1455,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1632,13 +1632,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Guardar"
 
@@ -1704,7 +1704,7 @@ msgstr "Ficheru"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -2125,12 +2125,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2142,7 +2142,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2328,7 +2328,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2398,7 +2398,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/ast.po
+++ b/po/ast.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:18+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Asturian <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -19,27 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -47,39 +27,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -87,214 +67,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Color"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Personalizáu"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -333,142 +323,177 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Guardar"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Nuevu"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -476,58 +501,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -536,51 +561,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -590,137 +639,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -728,162 +777,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -891,373 +932,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Nome"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Desfacer"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Refacer"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1267,324 +1305,674 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Pantalla completa"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Quitar"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Quitar"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
+msgstr ""
+
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
+msgstr ""
+
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Guardar"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
 #, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr ""
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Ficheru"
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Capes"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1412
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1427
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1432
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr ""
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1592,130 +1980,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1724,35 +2124,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1776,45 +2176,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1822,153 +2226,218 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Capes"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Capes"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr ""
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1980,256 +2449,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2237,188 +2731,213 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Capes"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2427,13 +2946,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2443,7 +2962,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2451,13 +2970,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2465,7 +2984,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2473,7 +2992,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2484,7 +3003,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2492,7 +3011,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2502,7 +3026,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2513,285 +3037,394 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr ""
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2801,7 +3434,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2810,52 +3463,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2877,17 +3561,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2916,112 +3598,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3034,7 +3691,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3075,6 +3732,133 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Nome"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3444,56 +4228,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3501,12 +4305,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3515,7 +4319,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3526,28 +4330,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3609,1828 +4413,2019 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Amenorgar"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Ficheru"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Aida"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Depurar"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
-msgstr ""
+msgstr "Capes"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/az.po
+++ b/po/az.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:18+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Azerbaijani <https://hosted.weblate.org/projects/mypaint/"
@@ -19,27 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -47,39 +27,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -87,214 +67,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Rəng"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Xüsusi"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -333,142 +323,177 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Qeyd Et"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Yeni"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -476,58 +501,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -536,51 +561,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -590,137 +639,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -728,162 +777,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -891,373 +932,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Ad"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Geri al"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Yenidən et"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1267,324 +1305,678 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Aç..."
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr ""
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Çıx"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Çıx"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Aç..."
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Qeyd Et"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr ""
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr ""
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Fayl"
+
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Aç..."
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Təzəlikçə Açılanlar"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Aç..."
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Aç..."
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr ""
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1592,130 +1984,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1724,35 +2128,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1776,45 +2180,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1822,153 +2230,217 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr ""
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr ""
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr ""
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1980,256 +2452,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2237,188 +2734,212 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+msgid "Import Layers"
+msgstr ""
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2427,13 +2948,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2443,7 +2964,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2451,13 +2972,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2465,7 +2986,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2473,7 +2994,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2484,7 +3005,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2492,7 +3013,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2502,7 +3028,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2513,285 +3039,394 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr ""
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2801,7 +3436,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2810,52 +3465,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2877,17 +3563,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2916,112 +3600,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3034,7 +3693,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3075,6 +3734,133 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Ad"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3444,56 +4230,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3501,12 +4307,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3515,7 +4321,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3526,28 +4332,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3609,1828 +4415,2018 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Uzaqlaşdır"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Fayl"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Yardım"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/az.po
+++ b/po/az.po
@@ -513,17 +513,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1184,12 +1184,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1372,7 +1372,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Open dragged file confirm dialog: continue button"
 msgid "_Open"
-msgstr "Aç..."
+msgstr "Aç…"
 
 #: ../gui/drawwindow.py:486
 msgid "Set current color"
@@ -1406,7 +1406,7 @@ msgid "_Quit"
 msgstr "Çıx"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1456,7 +1456,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1633,13 +1633,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Qeyd Et"
 
@@ -1705,7 +1705,7 @@ msgstr "Fayl"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -1722,7 +1722,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Aç..."
+msgstr "Aç…"
 
 #: ../gui/filehandling.py:1427
 #, fuzzy
@@ -1734,7 +1734,7 @@ msgstr "Təzəlikçə Açılanlar"
 #, fuzzy
 msgctxt "File→Open Most Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Aç..."
+msgstr "Aç…"
 
 #: ../gui/filehandling.py:1446
 msgctxt "File→Open Next/Prev Scrap: error message"
@@ -1755,7 +1755,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
 msgid "_Open"
-msgstr "Aç..."
+msgstr "Aç…"
 
 #: ../gui/filehandling.py:1487
 msgctxt "File→Revert: status message: canvas has no filename yet"
@@ -2129,12 +2129,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2146,7 +2146,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2331,7 +2331,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2401,7 +2401,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/be.po
+++ b/po/be.po
@@ -515,17 +515,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1186,12 +1186,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1374,7 +1374,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Open dragged file confirm dialog: continue button"
 msgid "_Open"
-msgstr "Адкрыць..."
+msgstr "Адкрыць…"
 
 #: ../gui/drawwindow.py:486
 msgid "Set current color"
@@ -1408,7 +1408,7 @@ msgid "_Quit"
 msgstr "Выхад"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1458,7 +1458,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1636,13 +1636,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Захаваць"
 
@@ -1708,7 +1708,7 @@ msgstr "Файл"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -1725,7 +1725,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Адкрыць..."
+msgstr "Адкрыць…"
 
 #: ../gui/filehandling.py:1427
 #, fuzzy
@@ -1737,7 +1737,7 @@ msgstr "Адкрыць ранейшы файл"
 #, fuzzy
 msgctxt "File→Open Most Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Адкрыць..."
+msgstr "Адкрыць…"
 
 #: ../gui/filehandling.py:1446
 msgctxt "File→Open Next/Prev Scrap: error message"
@@ -1758,7 +1758,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
 msgid "_Open"
-msgstr "Адкрыць..."
+msgstr "Адкрыць…"
 
 #: ../gui/filehandling.py:1487
 msgctxt "File→Revert: status message: canvas has no filename yet"
@@ -2132,12 +2132,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2149,7 +2149,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2334,7 +2334,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2404,7 +2404,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/be.po
+++ b/po/be.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:18+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Belarusian <https://hosted.weblate.org/projects/mypaint/"
@@ -16,31 +16,11 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<="
-"4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -48,39 +28,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -88,214 +68,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "Колер фона"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Адмысовы"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -334,98 +324,133 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Захаваць"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Новы"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
@@ -433,44 +458,44 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -478,58 +503,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -538,51 +563,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -592,137 +641,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -730,162 +779,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -893,373 +934,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Назва"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Вярнуць"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Паўтарыць"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1269,324 +1307,679 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Адкрыць..."
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr ""
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Выхад"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Выхад"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Адкрыць..."
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Захаваць"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr ""
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr ""
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Файл"
+
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Адкрыць..."
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Адкрыць ранейшы файл"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Адкрыць..."
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Адкрыць..."
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr ""
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1594,130 +1987,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1726,35 +2131,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1778,45 +2183,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1824,153 +2233,217 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr ""
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr ""
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr ""
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1982,256 +2455,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2239,188 +2737,212 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+msgid "Import Layers"
+msgstr ""
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2429,13 +2951,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2445,7 +2967,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2453,13 +2975,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2467,7 +2989,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2475,7 +2997,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2486,7 +3008,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2494,7 +3016,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2504,7 +3031,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2515,285 +3042,394 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr ""
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2803,7 +3439,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2812,52 +3468,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2879,17 +3566,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2918,112 +3603,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3036,7 +3696,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3077,6 +3737,133 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Назва"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3446,56 +4233,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3503,12 +4310,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3517,7 +4324,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3528,28 +4335,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3611,1828 +4418,2018 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Аддаліць"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Файл"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Дапамога"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Адладка"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -513,17 +513,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1184,12 +1184,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1372,7 +1372,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Open dragged file confirm dialog: continue button"
 msgid "_Open"
-msgstr "Отваряне..."
+msgstr "Отваряне…"
 
 #: ../gui/drawwindow.py:486
 msgid "Set current color"
@@ -1406,7 +1406,7 @@ msgid "_Quit"
 msgstr "Изход"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1456,7 +1456,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1633,13 +1633,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Запазване"
 
@@ -1705,7 +1705,7 @@ msgstr "Файл"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -1723,7 +1723,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Отваряне..."
+msgstr "Отваряне…"
 
 #: ../gui/filehandling.py:1427
 #, fuzzy
@@ -1735,7 +1735,7 @@ msgstr "Отваряне на скорошен"
 #, fuzzy
 msgctxt "File→Open Most Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Отваряне..."
+msgstr "Отваряне…"
 
 #: ../gui/filehandling.py:1446
 msgctxt "File→Open Next/Prev Scrap: error message"
@@ -1756,7 +1756,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
 msgid "_Open"
-msgstr "Отваряне..."
+msgstr "Отваряне…"
 
 #: ../gui/filehandling.py:1487
 msgctxt "File→Revert: status message: canvas has no filename yet"
@@ -2130,13 +2130,13 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
-msgstr "Отчет..."
+msgid "Report…"
+msgstr "Отчет…"
 
 #: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
@@ -2147,8 +2147,8 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
-msgstr "Детайли..."
+msgid "Details…"
+msgstr "Детайли…"
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
@@ -2333,7 +2333,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2403,7 +2403,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-06-18 19:01+0000\n"
 "Last-Translator: sahwar <ve4ernik@gmail.com>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/mypaint/"
@@ -19,27 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.7\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -47,39 +27,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -87,214 +67,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "Фон"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "Шаблон"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Цвят"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Потребителски"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -333,142 +323,177 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Запазване"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Нов"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -476,58 +501,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "Създаване на група"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -536,51 +561,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -590,137 +639,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -728,162 +777,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -891,373 +932,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Име"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Отмяна"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Повтаряне"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1267,324 +1305,679 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Отваряне..."
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "На цял екран"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Изход"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Изход"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Отваряне..."
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Запазване"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr ""
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr ""
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Файл"
+
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Слоеве"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Отваряне..."
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Отваряне на скорошен"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Отваряне..."
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Отваряне..."
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Непрозрачност:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1592,130 +1985,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1724,35 +2129,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr "Отчет..."
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr "Детайли..."
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1776,45 +2181,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1822,153 +2231,218 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Слоеве"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Слоеве"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Непрозрачност:"
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1980,256 +2454,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2237,188 +2736,214 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "Създаване на група"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Слоеве"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2427,13 +2952,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2443,7 +2968,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2451,13 +2976,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2465,7 +2990,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2473,7 +2998,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2484,7 +3009,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2492,7 +3017,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2502,7 +3032,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2513,285 +3043,395 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "Създаване на група"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2801,7 +3441,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2810,52 +3470,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2877,17 +3568,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2916,112 +3605,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3034,7 +3698,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3075,6 +3739,134 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Име"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Непрозрачност:"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3444,56 +4236,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3501,12 +4313,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3515,7 +4327,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3526,28 +4338,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3609,1828 +4421,2019 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Намаляване"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Файл"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Помощ"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Дебъгване"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
-msgstr ""
+msgstr "Слоеве"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/bn.po
+++ b/po/bn.po
@@ -513,17 +513,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1184,12 +1184,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1372,7 +1372,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Open dragged file confirm dialog: continue button"
 msgid "_Open"
-msgstr "খোলো..."
+msgstr "খোলো…"
 
 #: ../gui/drawwindow.py:486
 msgid "Set current color"
@@ -1406,7 +1406,7 @@ msgid "_Quit"
 msgstr "প্রস্থান"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1456,7 +1456,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1633,13 +1633,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "সংরক্ষণ"
 
@@ -1705,7 +1705,7 @@ msgstr "ফাইল"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -1723,7 +1723,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "খোলো..."
+msgstr "খোলো…"
 
 #: ../gui/filehandling.py:1427
 #, fuzzy
@@ -1735,7 +1735,7 @@ msgstr "সম্প্রতি ব্যবহৃত"
 #, fuzzy
 msgctxt "File→Open Most Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "খোলো..."
+msgstr "খোলো…"
 
 #: ../gui/filehandling.py:1446
 msgctxt "File→Open Next/Prev Scrap: error message"
@@ -1756,7 +1756,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
 msgid "_Open"
-msgstr "খোলো..."
+msgstr "খোলো…"
 
 #: ../gui/filehandling.py:1487
 msgctxt "File→Revert: status message: canvas has no filename yet"
@@ -2130,12 +2130,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2147,7 +2147,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2333,7 +2333,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2403,7 +2403,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:18+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Bengali <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -19,27 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -47,39 +27,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -87,214 +67,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "রং"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "স্বনির্বাচিত"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -333,142 +323,177 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "সংরক্ষণ"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "নতুন"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -476,58 +501,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -536,51 +561,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -590,137 +639,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -728,162 +777,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -891,373 +932,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "নাম"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "বাতিল করো"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "আবার করো"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1267,324 +1305,679 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "খোলো..."
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "সম্পূর্ণ পর্দা জুড়ে"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "প্রস্থান"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "প্রস্থান"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "খোলো..."
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "সংরক্ষণ"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr ""
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr ""
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "ফাইল"
+
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "লেয়ারসমূহ"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "খোলো..."
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "সম্প্রতি ব্যবহৃত"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "খোলো..."
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "খোলো..."
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr ""
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1592,130 +1985,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1724,35 +2129,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1776,45 +2181,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1822,153 +2231,218 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "লেয়ারসমূহ"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "লেয়ারসমূহ"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr ""
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1980,256 +2454,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2237,188 +2736,213 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "লেয়ারসমূহ"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2427,13 +2951,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2443,7 +2967,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2451,13 +2975,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2465,7 +2989,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2473,7 +2997,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2484,7 +3008,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2492,7 +3016,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2502,7 +3031,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2513,285 +3042,394 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr ""
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2801,7 +3439,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2810,52 +3468,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2877,17 +3566,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2916,112 +3603,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3034,7 +3696,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3075,6 +3737,133 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "নাম"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3444,56 +4233,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3501,12 +4310,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3515,7 +4324,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3526,28 +4335,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3609,1828 +4418,2019 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "ছোট আকারে প্রদর্শন"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "ফাইল"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "সহায়তা"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "ডিবাগ"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
-msgstr ""
+msgstr "লেয়ারসমূহ"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/br.po
+++ b/po/br.po
@@ -520,17 +520,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1191,12 +1191,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1412,7 +1412,7 @@ msgid "_Quit"
 msgstr "Kuitaat"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1462,7 +1462,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1642,13 +1642,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Enrollañ"
 
@@ -1714,7 +1714,7 @@ msgstr "Restr"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -2135,12 +2135,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2152,7 +2152,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2338,7 +2338,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2408,7 +2408,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/br.po
+++ b/po/br.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:18+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Breton <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -18,32 +18,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=5; plural=(n % 10 == 1 && n % 100 != 11 && n % 100 != "
 "71 && n % 100 != 91) ? 0 : ((n % 10 == 2 && n % 100 != 12 && n % 100 != 72 "
-"&& n % 100 != 92) ? 1 : ((((n % 10 == 3 || n % 10 == 4) || n % 10 == 9) && ("
-"n % 100 < 10 || n % 100 > 19) && (n % 100 < 70 || n % 100 > 79) && (n % 100 <"
-" 90 || n % 100 > 99)) ? 2 : ((n != 0 && n % 1000000 == 0) ? 3 : 4)));\n"
+"&& n % 100 != 92) ? 1 : ((((n % 10 == 3 || n % 10 == 4) || n % 10 == 9) && "
+"(n % 100 < 10 || n % 100 > 19) && (n % 100 < 70 || n % 100 > 79) && (n % 100 "
+"< 90 || n % 100 > 99)) ? 2 : ((n != 0 && n % 1000000 == 0) ? 3 : 4)));\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -51,39 +31,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -91,214 +71,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Liv"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Diouzhoc'h"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -337,98 +327,133 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Enrollañ"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Nevez"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
@@ -438,44 +463,44 @@ msgstr[2] ""
 msgstr[3] ""
 msgstr[4] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -483,58 +508,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -543,51 +568,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -597,137 +646,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -735,162 +784,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -898,373 +939,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Anv"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Nullañ"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Adober"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1274,324 +1312,677 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Skrammad a-bezh"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Kuitaat"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Kuitaat"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
+msgstr ""
+
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
+msgstr ""
+
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Enrollañ"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
 #, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr ""
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Restr"
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Treuzfollennoù"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1412
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1427
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1432
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr ""
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1599,130 +1990,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1731,35 +2134,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1783,45 +2186,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1829,153 +2236,218 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Treuzfollennoù"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Treuzfollennoù"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr ""
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1987,256 +2459,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2244,188 +2741,213 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Treuzfollennoù"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2434,13 +2956,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2450,7 +2972,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2458,13 +2980,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2472,7 +2994,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2480,7 +3002,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2491,7 +3013,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2499,7 +3021,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2509,7 +3036,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2520,285 +3047,394 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr ""
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2808,7 +3444,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2817,52 +3473,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2884,17 +3571,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2923,112 +3608,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3041,7 +3701,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3082,6 +3742,133 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Anv"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3451,56 +4238,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3508,12 +4315,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3522,7 +4329,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3533,28 +4340,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3616,1828 +4423,2019 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Zoum bihanaat"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Restr"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Dizreinañ"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
-msgstr ""
+msgstr "Treuzfollennoù"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/brx.po
+++ b/po/brx.po
@@ -534,17 +534,17 @@ msgstr "MyPaint ब्रास थफला (*.zip)"
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
-msgstr "गोदान हानजा..."
+msgid "New Group…"
+msgstr "गोदान हानजा…"
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1205,12 +1205,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1425,7 +1425,7 @@ msgid "_Quit"
 msgstr ""
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1475,7 +1475,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1653,13 +1653,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "थिना दोन"
 
@@ -1724,7 +1724,7 @@ msgstr ""
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -2145,12 +2145,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2162,7 +2162,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2347,7 +2347,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2418,7 +2418,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/brx.po
+++ b/po/brx.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2015-11-26 21:19+0000\n"
 "Last-Translator: Andrew Chadwick <a.t.chadwick@gmail.com>\n"
-"Language-Team: Bodo "
-"<https://hosted.weblate.org/projects/mypaint/mypaint/brx/>\n"
+"Language-Team: Bodo <https://hosted.weblate.org/projects/mypaint/mypaint/brx/"
+">\n"
 "Language: brx\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,29 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Weblate 2.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr "<big><b>{accel_label}</b></big>"
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr "{action_label} {action_desc} {accel_label}"
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "हाबा"
 
@@ -49,32 +27,32 @@ msgstr "हाबा"
 msgid "Key combination"
 msgstr "साबि ज'मा खालामनाय"
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr "'%s' नि थाखाय साबिखौ सुजु"
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "हाबा:"
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "लामा:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "साबि:"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr "बे मावबिफानखौ अापडेट खालामनो साबिफोरखौ थु"
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "मिथिजायै हाबा"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
@@ -83,7 +61,7 @@ msgstr ""
 "<b>{accel} अा '{action}' नि थाखाय बाहायजाखागासिनो दं | थाखानाय मावबिफानअा "
 "सोलायजागोन |</b>"
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr "फल्डारखौ बेखेव “{folder_basename}”…"
@@ -91,194 +69,203 @@ msgstr "फल्डारखौ बेखेव “{folder_basename}”…"
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "गनाय"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr "केछेआव जेबो बेकअापफोर मोनाखैै |"
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr "जेबो बेकआप गैया"
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr "केछे फल्डारखौ बेखेव…"
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr "बेकअाप बोखांफिन्नायअा फेलें जादों"
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr "बेकअापफोरनि फल्डारखौ बेखेव…"
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr "{iso_datetime}.ora निफ्राय बोखांफिनजानाय फाइल"
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "जेरै दं बिदिनो थिना दोन"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "इयुनसावगारी"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "नेरसोन"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "गाब"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "नेरसोनफोराव गाब दाजाबफादेर"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr "मोनसे एबा मोन्नै इयुनसावगारीफोरा लोड जानाय नंअा"
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr "इयुनसावगारीफोर लोड जानायअाव गोरोन्थि जाबाय"
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
-msgstr ""
-"अननानै लोड जायै फाइलफोरखौ खोमोर, एबा libgdkpixbuf इन्सट'लेसनखौ नाइबिजिर ."
+msgstr "अननानै लोड जायै फाइलफोरखौ खोमोर, एबा libgdkpixbuf इन्सट'लेसनखौ नाइबिजिर ."
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr "Gdk-Pixbuf लोड जानो हायाखि \"{filename}\", अारो \"{error}\" खौरां होबाय"
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr "{filename} अा लाथिख' मह'र (w={w}, h={h})"
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr "ब्राश सेटिंग्स सुजुगिरि"
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr "सोमोन्दै"
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "अानजाद नायग्रा"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr "सोलोंजेन्नाय"
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "दाखोन"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr "गोख्रैथि"
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr ""
+
+#: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr "थालांनाय सिन नागिरनाय"
 
-#: ../gui/brusheditor.py:359
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "हुब्लिर"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr "गाब"
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "नेमखानथि"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr "जेबो ब्रास सायक'अाखै, बेनि सोलाय अननानै “गोदान महरै दाजाबफा” खौ बाहाय |"
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr "जेबो ब्रास सायख'जायाखै!"
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "ब्रासखौ गोदान मुं हो"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "बे मुंनि ब्रासअा सिगांनिफ्रायनो दंखायो!"
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr "जेबो ब्रास सायख'जायाखै!"
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr "थारैनो “{brush_name}” ब्रासखौ डिस्क निफ्राय खोमोरसै ?"
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr "(मुं गैजायै ब्रास)"
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr "{brush_name} [थिना दोनजायै]"
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr "ब्रास अाइख'न"
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr "ब्रास अाइख'न (सुजुगासिनो)"
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr "जेबो ब्रास सायख'जायाखै"
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -287,7 +274,7 @@ msgstr ""
 "<b>%s</b>\n"
 "<small>सिगां थार ब्रासखौ सायख'ग्रो</small>"
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
@@ -296,7 +283,7 @@ msgstr ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>सोलायनायफोरा दासिमबो थिना दोनजायाखै</small>"
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
@@ -305,7 +292,7 @@ msgstr ""
 "<b>%s</b> (editing)\n"
 "<small>जायखिया ब्रासजों एबा गाबजों गाबफोन</small>"
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -346,98 +333,138 @@ msgstr "हारसिङैनो"
 msgid "Use the default icon"
 msgstr "थाखानाय अायख'नखौ बाहाय"
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "थिना दोन"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr "बे दिन्थिफुंनाय अायख'नखौ थिना दोन, अारो सुजुनायखौ फोजोब"
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr "गोमानाय & मोननाय"
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr "खोमोरजाखांबाय"
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr "अांगोफोर"
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr "खालि"
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr "क्लासिक"
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr "थुबुर#1"
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr "थुबुर#2"
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr "थुबुर#3"
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr "थुबुर#4"
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr "थुबुर#5"
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr "अानजाद नायग्रा"
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "गोदान"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr "मिथिजायै ब्रास"
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr "अांगोफोराव दाजाबफादेर"
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr "अांगोफोरनिफ्राय खोमोर"
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr "क्लोन"
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr "ब्रास सेटिंग्सखो सुजु"
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
-msgstr "खोमोर"
+#: ../gui/brushselectionwindow.py:250
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
+msgstr "हानजानि मुं लिरफिन"
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
-msgstr "थारैनो डिस्क निफ्राय ब्रासखौ खोमोरनो ?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, fuzzy, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
+msgstr "थारैनो “{brush_name}” ब्रासखौ डिस्क निफ्राय खोमोरसै ?"
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
@@ -448,44 +475,44 @@ msgstr[1] ""
 "गुबुन\n"
 "%d ब्रासफोर"
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr "हानजा “{group_name}”"
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr "हानजानि मुं लिरफिन"
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr "जिफ ब्रासथुबुर बायदि दैथायहर"
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr "हानजाखौ खोमोर"
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr "हानजानि मुं लिरफिन"
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "बेबायदि मुंनि मोनसे हानजा सिगांनिफ्रायनो दंखायो !"
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr "थारैनो “{group_name}” हानजाखौ खोमोरनो ?"
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -495,58 +522,58 @@ msgstr ""
 "“{group_name}” हानजाखौ खोमोरनो हाया\n"
 "माखासे गोनां हानजाफोरखौ खोमोरनो हानाय जाया |"
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr "ब्रासफोरखौ दैथायहर"
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr "MyPaint ब्रास थफला (*.zip)"
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "गोदान हानजा..."
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -555,51 +582,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -609,137 +660,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -747,162 +798,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -910,373 +953,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr ""
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr ""
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr ""
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1286,324 +1326,673 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr ""
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr ""
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr ""
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "जेरै दं बिदिनो थिना दोन"
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
+msgstr ""
+
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
+msgstr ""
+
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "थिना दोन"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
 #, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
+#: ../gui/filehandling.py:1015
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
 msgstr ""
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1427
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1432
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+#, fuzzy
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr "गिदिंफिन"
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr ""
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1611,130 +2000,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1743,35 +2144,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1795,45 +2196,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1841,153 +2246,218 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr ""
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr ""
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr ""
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "ब्रासखौ गोदान मुं हो"
 
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr ""
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr ""
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr ""
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr ""
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 msgid "Stroke lead-in end"
 msgstr ""
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr ""
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1999,256 +2469,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr "दिनथिफुनाय"
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2256,188 +2751,213 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "हानजानि मुं लिरफिन"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+msgid "Import Layers"
+msgstr ""
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2446,13 +2966,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2462,7 +2982,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2470,13 +2990,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2484,7 +3004,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2492,7 +3012,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2503,7 +3023,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2511,7 +3031,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2521,7 +3046,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2532,285 +3057,396 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr "मिथिजायै हाबा"
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "हानजानि मुं लिरफिन"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2820,7 +3456,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2829,52 +3485,84 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr "खोमोर"
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2896,17 +3584,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2935,113 +3621,89 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr "<ymin>"
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr "<ymax>"
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr "<xmin>"
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr "<xmax>"
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
 msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+#, fuzzy
+msgid "<big><b>No Brush Dynamics</b></big>"
+msgstr "<big><b>{accel_label}</b></big>"
 
 #: ../po/tmp/inktool.glade.h:1
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
@@ -3053,7 +3715,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3094,6 +3756,132 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr ""
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3463,56 +4251,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3520,12 +4328,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3534,7 +4342,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3545,28 +4353,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3628,1828 +4436,2047 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+#, fuzzy
+msgid "Delete Point"
+msgstr "हानजाखौ खोमोर"
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "दिनथिफुंनाय"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""
+
+#~ msgctxt "Accelerator map editor: action column markup"
+#~ msgid ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+#~ msgstr ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+
+#~ msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
+#~ msgid "{action_label} {action_desc} {accel_label}"
+#~ msgstr "{action_label} {action_desc} {accel_label}"
+
+#~ msgctxt "brush list commands"
+#~ msgid "Really delete brush from disk?"
+#~ msgstr "थारैनो डिस्क निफ्राय ब्रासखौ खोमोरनो ?"
+
+#~ msgid "<ymin>"
+#~ msgstr "<ymin>"
+
+#~ msgid "<ymax>"
+#~ msgstr "<ymax>"
+
+#~ msgid "<xmin>"
+#~ msgstr "<xmin>"
+
+#~ msgid "<xmax>"
+#~ msgstr "<xmax>"

--- a/po/bs_Latn.po
+++ b/po/bs_Latn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:18+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Bosnian (latin) <https://hosted.weblate.org/projects/mypaint/"
@@ -16,31 +16,11 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<="
-"4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -48,39 +28,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -88,214 +68,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Obojen"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Vlastito"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -334,98 +324,133 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Snimi"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Novo"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
@@ -433,44 +458,44 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -478,58 +503,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -538,51 +563,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -592,137 +641,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -730,162 +779,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -893,373 +934,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Ime"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Vrati"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Ponovi"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1269,324 +1307,679 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Otvori..."
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr ""
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Izađi"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Izađi"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Otvori..."
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Snimi"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr ""
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr ""
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Datoteka"
+
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Otvori..."
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Otvori skorašnje"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Otvori..."
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Otvori..."
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr ""
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1594,130 +1987,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1726,35 +2131,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1778,45 +2183,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1824,153 +2233,217 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr ""
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr ""
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr ""
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1982,256 +2455,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2239,188 +2737,212 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+msgid "Import Layers"
+msgstr ""
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2429,13 +2951,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2445,7 +2967,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2453,13 +2975,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2467,7 +2989,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2475,7 +2997,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2486,7 +3008,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2494,7 +3016,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2504,7 +3031,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2515,285 +3042,394 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr ""
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2803,7 +3439,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2812,52 +3468,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2879,17 +3566,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2918,112 +3603,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3036,7 +3696,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3077,6 +3737,133 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Ime"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3446,56 +4233,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3503,12 +4310,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3517,7 +4324,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3528,28 +4335,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3611,1828 +4418,2018 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Umanji"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Datoteka"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Pomoć"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/bs_Latn.po
+++ b/po/bs_Latn.po
@@ -515,17 +515,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1186,12 +1186,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1374,7 +1374,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Open dragged file confirm dialog: continue button"
 msgid "_Open"
-msgstr "Otvori..."
+msgstr "Otvori…"
 
 #: ../gui/drawwindow.py:486
 msgid "Set current color"
@@ -1408,7 +1408,7 @@ msgid "_Quit"
 msgstr "Izađi"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1458,7 +1458,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1636,13 +1636,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Snimi"
 
@@ -1708,7 +1708,7 @@ msgstr "Datoteka"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -1725,7 +1725,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Otvori..."
+msgstr "Otvori…"
 
 #: ../gui/filehandling.py:1427
 #, fuzzy
@@ -1737,7 +1737,7 @@ msgstr "Otvori skorašnje"
 #, fuzzy
 msgctxt "File→Open Most Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Otvori..."
+msgstr "Otvori…"
 
 #: ../gui/filehandling.py:1446
 msgctxt "File→Open Next/Prev Scrap: error message"
@@ -1758,7 +1758,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
 msgid "_Open"
-msgstr "Otvori..."
+msgstr "Otvori…"
 
 #: ../gui/filehandling.py:1487
 msgctxt "File→Revert: status message: canvas has no filename yet"
@@ -2132,12 +2132,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2149,7 +2149,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2334,7 +2334,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2404,7 +2404,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/ca.po
+++ b/po/ca.po
@@ -533,18 +533,18 @@ msgstr "Paquet de pinzells de MyPaint (*.zip)"
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
-msgstr "Grup nou..."
+msgid "New Group…"
+msgstr "Grup nou…"
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
-msgstr "Importa Pinzells..."
+msgid "Import Brushes…"
+msgstr "Importa Pinzells…"
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
-msgstr "Obté més pinzells..."
+msgid "Get More Brushes…"
+msgstr "Obté més pinzells…"
 
 #: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
@@ -1231,13 +1231,13 @@ msgstr "Escriu"
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
-msgstr "Ús per..."
+msgid "Use for…"
+msgstr "Ús per…"
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
-msgstr "Desplaçament..."
+msgid "Scroll…"
+msgstr "Desplaçament…"
 
 #. Name and preview column: will be indented
 #: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
@@ -1460,8 +1460,8 @@ msgid "_Quit"
 msgstr "Surt"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
-msgstr "Importa paquet de pinzell..."
+msgid "Import brush package…"
+msgstr "Importa paquet de pinzell…"
 
 #: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
@@ -1516,8 +1516,8 @@ msgstr ""
 "“{type_name}” ({content_type})?"
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
-msgstr "Obre amb..."
+msgid "Open With…"
+msgstr "Obre amb…"
 
 #: ../gui/externalapp.py:123
 msgid "Icon"
@@ -1707,13 +1707,13 @@ msgstr "JPEG qualitat 90%  (*.jpg; *.jpeg)"
 
 #: ../gui/filehandling.py:576
 #, fuzzy
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr "Exporta…"
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Anomena i desa…"
 
@@ -1784,8 +1784,8 @@ msgstr "Obre"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
-msgstr "Obre el quadre d'esborranys..."
+msgid "Open Scratchpad…"
+msgstr "Obre el quadre d'esborranys…"
 
 #: ../gui/filehandling.py:1099
 #, fuzzy
@@ -2241,13 +2241,13 @@ msgstr ""
 "encara no ho ha informat ningú."
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
-msgstr "Cerca al seguidor..."
+msgid "Search Tracker…"
+msgstr "Cerca al seguidor…"
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
-msgstr "Informa..."
+msgid "Report…"
+msgstr "Informa…"
 
 #: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
@@ -2258,8 +2258,8 @@ msgid "Quit MyPaint"
 msgstr "Surt de MyPaint"
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
-msgstr "Detalls..."
+msgid "Details…"
+msgstr "Detalls…"
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
@@ -2468,8 +2468,8 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
-msgstr "Mou la capa a la pila..."
+msgid "Move layer in stack…"
+msgstr "Mou la capa a la pila…"
 
 #: ../gui/layerswindow.py:110
 msgid ""
@@ -2541,8 +2541,8 @@ msgid "Stroke trail-off beginning"
 msgstr "Començament dels traços"
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
-msgstr "Variació de la pressió..."
+msgid "Pressure variation…"
+msgstr "Variació de la pressió…"
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
@@ -3732,7 +3732,7 @@ msgstr "Suprimeix aquest pinzell del disc"
 #, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid "_Recover & Save…"
-msgstr "_Recupera i desa..."
+msgstr "_Recupera i desa…"
 
 #: ../po/tmp/autorecover.glade.h:12
 #, fuzzy

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-03-07 14:05+0000\n"
 "Last-Translator: Joan Montané <joan@montane.cat>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -19,29 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.5.1-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr "<big><b>{accel_label}</b></big>"
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr "{action_label} {action_desc} {accel_label}"
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "Acció"
 
@@ -49,32 +27,32 @@ msgstr "Acció"
 msgid "Key combination"
 msgstr "Combinació de tecles"
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr "Edita la tecla per a «%s»"
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "Acció:"
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "Camí:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "Tecla:"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr "Premeu les tecles per a actualitzar aquesta tasca"
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "Acció desconeguda"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
@@ -83,7 +61,7 @@ msgstr ""
 "<b>{accel} ja es fa servir per '{action}'. L'assignació existent serà "
 "canviada.</b>"
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr "Obre la carpeta “{folder_basename}”…"
@@ -91,196 +69,206 @@ msgstr "Obre la carpeta “{folder_basename}”…"
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "D'acord"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr "No s'han trobat còpies de seguretat a la memòria cau."
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr "No hi ha còpies de seguretat disponibles"
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr "Obre la carpeta de la memòria cau…"
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr "La recuperació de la còpia de seguretat ha fallat"
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr "Obre la carpeta de les còpies de seguretat…"
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr "Fitxer recuperat de {iso_datetime}.ora"
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "Desa com a predeterminat"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "Fons"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "Patró"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Color"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "Afegir color per patrons"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr "No s'han pogut carregar un o més fons"
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr "Error al carregar els fons"
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
-"Elimina els fitxers que no es poden carregar, o comprova la teva instal·"
-"lació de libgdkpixbuf."
+"Elimina els fitxers que no es poden carregar, o comprova la teva "
+"instal·lació de libgdkpixbuf."
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 "Gdk-Pixbuf no ha pogut carregar \"{filename}\", i ha informat: \"{error}\""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr "{filename} té mida zero (w={w}, h={h})"
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr "Editor de paràmetres del pinzell"
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr "Quant a"
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "Experimental"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr "Bàsic"
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr "Opacitat"
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr "Pinzellades"
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "Difumina"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr "Velocitat"
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr ""
+
+#: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr "Seguiment"
 
-#: ../gui/brusheditor.py:359
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "Traç"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr "Color"
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Personalitzat"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr "Cap pinzell seleccionat, feu servir en el seu lloc \"Agrega com nou\"."
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr "No hi ha cap pinzell seleccionat!"
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "Canvi de nom del pinzell"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "Ja existeix un pinzell amb aquest nom!"
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr "No hi ha cap pinzell seleccionat!"
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr "Segur que voleu suprimir el pinzell “{brush_name}”del disc?"
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr "(Pinzell Sense Nom)"
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr "{brush_name}1 [unsaved]"
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr "Icona de Pinzell"
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr "Icona de pinzell (edició)"
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr "No hi ha cap pinzell seleccionat"
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -289,7 +277,7 @@ msgstr ""
 "<b>%s</b>\n"
 "<small>Has de seleccionar primer un pinzell</small>"
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
@@ -298,7 +286,7 @@ msgstr ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Els canvis encara no s'han desat</small>"
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
@@ -307,7 +295,7 @@ msgstr ""
 "<b>%s</b> (editing)\n"
 "<small>Pinta amb qualsevol pinzell  o color</small>"
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -348,142 +336,182 @@ msgstr "Auto"
 msgid "Use the default icon"
 msgstr "Utilitza la icona per defecte"
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Desa"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr "Desa aquesta icona de vista prèvia i finalitza l'edició"
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr "Perdut i Trobat"
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr "Suprimit"
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr "Preferits"
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr "Tinta"
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr "Clàssic"
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr "Conjunt#1"
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr "Conjunt#2"
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr "Conjunt#3"
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr "Conjunt#4"
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr "Conjunt#5"
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr "Experimental"
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Nou"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr "Pinzell desconegut"
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr "Afegeix a fovorits"
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr "Suprimeix de favorits"
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr "Clona"
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr "Edita la configuració de pinzell"
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
-msgstr "Suprimeix"
+#: ../gui/brushselectionwindow.py:250
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
+msgstr "Canvia nom al grup"
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
-msgstr "Segur que voleu esborrar el pinzell del disc?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, fuzzy, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
+msgstr "Segur que voleu suprimir el pinzell “{brush_name}”del disc?"
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] "%d pinzell"
 msgstr[1] "%d pinzells"
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr "Grup “{group_name}”"
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr "Canvia nom al grup"
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr "Exporta com a Pinzell comprimit"
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr "Suprimeix el grup"
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr "Canvi nom del grup"
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "Ja existeix un grup amb aquest nom!"
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr "Segur que voleu eliminar el grup “{group_name}”?"
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -493,58 +521,58 @@ msgstr ""
 "No es pot eliminar el grup “{group_name}”.\n"
 "Alguns grups especials no poden ser eliminats."
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr "Exporta pinzells"
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr "Paquet de pinzells de MyPaint (*.zip)"
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "Grup nou..."
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr "Importa Pinzells..."
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr "Obté més pinzells..."
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "Crea un grup"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr "Botó"
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr "Btó"
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr "Prem el botó"
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr "Afegeix una nova dreçera"
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr "Suprimeix la vinculació actual"
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr "Edita la vinculació per «%s»"
@@ -553,7 +581,7 @@ msgstr "Edita la vinculació per «%s»"
 msgid "Button press:"
 msgstr "Prem el botó:"
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
@@ -561,7 +589,7 @@ msgstr ""
 "Manté pressionades les tecles de modificació i prem un botó sobre aquest "
 "text per configurar una nova vinculació."
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
@@ -569,40 +597,68 @@ msgstr ""
 "{button} no pot ser enllaçat sense les tecles de modificació (això significa "
 "que és fix, ho sentim)"
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr "{button_combination} ja està vinculat a la acció '{action_name}'"
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr "Tria el Color"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr "Estableix el color utilitzat per pintar"
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+#, fuzzy
+msgid "Set the color Hue used for painting"
+msgstr "Estableix el color utilitzat per pintar"
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "Trieu col."
+
+#: ../gui/colorpicker.py:296
+#, fuzzy
+msgid "Set the color Chroma used for painting"
+msgstr "Estableix el color utilitzat per pintar"
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+#, fuzzy
+msgid "Set the color Luma used for painting"
+msgstr "Estableix el color utilitzat per pintar"
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr "Detalls del Color"
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr "Color de pinzell actual, i el color més recent usat per pintar"
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr "Màscara Gamut activa"
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -614,7 +670,7 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr "To HCY i crominància."
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
@@ -623,12 +679,12 @@ msgstr ""
 "Editor de màscara Gamut. Clica al mig per crear, o manipular formes o rotar "
 "la màscara utilitzant les vores del disc."
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr "Tríada atmosfèrica"
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
@@ -637,22 +693,22 @@ msgstr ""
 "Taciturn i subjectiu, definides per un primàri dominant i dos primaris que "
 "són menys intensos."
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr "Triada desplaçada"
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr "Ponderat més fortament cap al color dominant."
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr "Complementari"
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
@@ -661,12 +717,12 @@ msgstr ""
 "Contrastos oposats, equilibrats tenint els neutrals centrals entre ells "
 "sobre la roda de color."
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr "Ànim i accent"
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
@@ -675,12 +731,12 @@ msgstr ""
 "Una ampla gamma de colors, amb un accent complementari de variació i "
 "aspectes destacats."
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr "Separat complementari"
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
@@ -689,72 +745,72 @@ msgstr ""
 "Dos colors anàlegs i un complement per a ells, sense colors secundaris entre "
 "ells."
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr "Màscara Gamut nova a partir de la plantilla"
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr "Editor de la màscara Gamut"
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr "Actiu"
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr "Ajuda…"
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr "Crea la màscara a partir de la plantilla."
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr "Carrega la mascara a partir del fitxer de la paleta de Gimp."
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr "Desa la màscara com a un fitxer paleta de Gimp."
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr "Suprimeix la màscara."
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr "Obre l'ajuda en línia d'aquest diàleg en un navegador web."
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr "Desa la màscara com a paleta GIMP"
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr "Carrega la màscara a partir d'una paleta GIMP"
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr "Estableix la màscara Gamut."
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr "Roda HCY"
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -764,162 +820,154 @@ msgstr ""
 "seccions circulars són equiluminants."
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr "To HSV"
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr "Saturació HSV"
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr "Valor HSV"
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr "Saturació i valor HSV"
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr "To i valor HSV"
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr "To i saturació HSV"
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr "Gira el cub (mostra eixos diferents)"
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr "Cub HSV"
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr "Un cub HSV que es pot girar per mostrar seccions planes diferents."
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr "Quadrat HSV"
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr "Un quadrat HSV que es pot girar per mostrar tons diferents."
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr "Triangle HSV"
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr "El selector de color GTK estàndard"
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr "Roda HSV"
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr "Canvis de color de la saturació i el valor."
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr "Propietats de la paleta"
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr "Paleta"
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr "Estableix el color a partir d'una paleta editable i carregable."
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr "Paleta sense títol"
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr "Editor de paleta"
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr "Carrega des d'un fitxer paleta de GIMP"
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr "Desa com a un fitxer paleta de Gimp"
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr "Afegeix una mostra buida nova"
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr "Suprimeix la mostra actual"
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr "Suprimeix totes les mostres"
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr "Títol:"
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr "Nom o descripció per a aquesta paleta"
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr "Columnes:"
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr "Nombre de columnes"
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr "Nom del color:"
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr "Nom del color actual"
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr "Ranura de paletes buida"
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr "Carrega la paleta"
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr "Desa la paleta"
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -930,379 +978,377 @@ msgstr ""
 "Deixa anar els colors aquí,\n"
 "arrossega'ls per organitzar-ho."
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr "Ranura de paleta buida (arrossega el color aquí)"
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr "Afegeix una ranura buida"
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr "Insereix fila"
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr "Insereix columna"
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr "Omple el buit (RGB)"
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr "Omple el buit (HCY)"
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr "Omple el buit (HSV)"
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "Fitxer paleta de GIMP (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr "Tots els fitxers (*)"
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "Fitxer paleta de GIMP (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr "Tots els fitxers (*)"
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr "Escull un color de la pantalla"
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr "R"
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr "G"
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr "B"
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr "H"
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr "C"
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr "Y"
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr "Lliscadors de components"
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr "Ajusta els components individuals del color."
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr "Roig RGB"
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr "Verd RGB"
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr "Blau RGB"
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr "To HSV"
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr "Saturació HSV"
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr "Valor HSV"
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr "To HCY"
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr "Crominància HCY"
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr "Luminància HCY (Y')"
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr "Detergent liquid"
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
-msgstr "Canvieu el color usant un detergent liquid semblant als colors propers."
+msgstr ""
+"Canvieu el color usant un detergent liquid semblant als colors propers."
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr "Anells concèntrics"
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr "Canvia el color usant anells HSV concèntric."
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr "Bol creuat"
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr "Canvieu el color amb rampes HSV creuant un bol radial de color."
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr "Cursor/disc"
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr "Goma d'esborrar"
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr "Teclat"
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr "Ratolí"
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr "Ploma"
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr "Ratolí tàctil"
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr "Pantalla tàctil"
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr "Ignora"
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr "Qualsevol tasca"
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr "Tasques no pintat"
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr "Sols navegació"
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr "Escala"
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr "Panoràmica"
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr "Dispositiu"
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr "Eixos"
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr "Escriu"
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr "Ús per..."
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr "Desplaçament..."
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Nom"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr "Sobreescriu el pinzell?"
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr "Reemplaça"
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr "Canvia el nom"
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr "Reemplaça-ho tot"
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr "Canvia el nom a tot"
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr "Importa pinzell"
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr "Pinzell existent"
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 "<b>Ja existeix un pinzell anomenat «%s».</b>\n"
 "Voleu reemplaçar-lo, o voleu canviar el nom al pinzell nou?"
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr "Sobreescriviu el grup del pinzell?"
 
-#: ../gui/dialogs.py:190
-#, python-brace-format
+#: ../gui/dialogs.py:220
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 "<b>Ja existeix un grup anomenat `{groupname}'.</b>\n"
 "Voleu reemplaçar-lo, o hauríeu de canviar al grup el nom?\n"
 "Si el reemplaceu, els pinzells es mouran al grup anomenat "
 "`{deleted_groupname}'."
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr "Importeu el paquet del pinzell?"
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, fuzzy, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr "<b>Voleu de veritat importar el paquet «%s»?</b>"
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr "Carrega els paràmetres del pinzell des de la drecera de la ranura %d"
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr "Emmagatzema els paràmetres del pinzell a la derecera de la ranura %d"
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr "Restaura el pinzell %d"
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr "Desa el pinzell %d"
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr "Desfés %s"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Desfés"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr "Refés %s"
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Refés"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr "{button_combination} és {resultant_action}"
@@ -1312,90 +1358,127 @@ msgstr "{button_combination} és {resultant_action}"
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ";  "
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr "Amb {modifiers} premuts:  {button_actions}."
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
-msgstr "Nom de capa"
-
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
-#, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
-"<b>{name}</b>\n"
-"{description}"
+
+#: ../gui/document.py:909
+#, python-brace-format
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
+msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr "MyPaint - %s"
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr "MyPaint"
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Obre"
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr "Estableix el color actual"
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr "Surt del mode pantalla completa"
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr "Surt de la pantalla completa"
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr "Entra al mode pantalla completa"
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Pantalla completa"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Surt"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+#, fuzzy
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr "Realment voleu sortir?"
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Surt"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr "Importa paquet de pinzell..."
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr "Paquet de pinzell de MyPaint (*.zip)"
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr "S'ha llançat {app_name} per editar la capa “{layer_name}”"
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr "Error: fallada en llançar {app_name} per editar la capa “{layer_name}”"
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
@@ -1403,184 +1486,403 @@ msgstr ""
 "Edició cancel·lada. Podeu encara editar  “{layer_name}” des del menú de "
 "capes."
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr "S'ha actualitzat la capa “{layer_name}” amb editors externs"
 
-#: ../gui/externalapp.py:46
-#, python-brace-format
-msgid ""
-"MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
-"application should it use?"
-msgstr ""
-"MyPaint necessita editar un fitxer del tipus  “{type_name}” ({content_type})"
-". Quina aplicació hauria d'emprar?"
-
-#: ../gui/externalapp.py:50
-#, python-brace-format
-msgid ""
-"What application should MyPaint use for editing files of type "
-"“{type_name}” ({content_type})?"
-msgstr ""
-"Quina aplicació hauria d'emprar per editar fitxers del tipus  “{type_name}” "
-"({content_type})?"
-
-#: ../gui/externalapp.py:56
-msgid "Open With..."
-msgstr "Obre amb..."
-
-#: ../gui/externalapp.py:107
-msgid "Icon"
-msgstr "Icona"
-
-#: ../gui/externalapp.py:150
-msgid "no description"
-msgstr "Sense descripció"
-
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr "Tots els formats reconeguts"
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr "OpenRaster (*.ora)"
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr "PNG (*.png)"
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr "JPEG (*.jpg; *.jpeg)"
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr "Per extensió (prefereix el format predeterminat)"
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr "PNG sòlid amb fons (*.png)"
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr "PNG transparent (*.png)"
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr "PNG múltiple transparent (*.XXX.png)"
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr "JPEG qualitat 90%  (*.jpg; *.jpeg)"
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr "Desa..."
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr "Formatació per desar com:"
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr "Confirmació"
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr "Realment voleu continuar?"
-
-#: ../gui/filehandling.py:234
-#, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
-msgstr "Això descarregarà en {abbreviated_time} les imatges no desades"
-
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr "De_sa com esbós"
-
-#: ../gui/filehandling.py:282
-#, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
-msgstr "S'està carregant “{file_basename}”…"
-
-#: ../gui/filehandling.py:296
+#: ../gui/externalapp.py:48
 #, python-brace-format
 msgctxt "file handling: open failed (statusbar)"
 msgid "Could not load “{file_basename}”."
 msgstr "No es pot carregar “{file_basename}”."
 
-#: ../gui/filehandling.py:321
+#: ../gui/externalapp.py:61
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
-msgstr "S'ha carregat “{file_basename}”."
+msgid ""
+"MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
+"application should it use?"
+msgstr ""
+"MyPaint necessita editar un fitxer del tipus  "
+"“{type_name}” ({content_type}). Quina aplicació hauria d'emprar?"
 
-#: ../gui/filehandling.py:422
+#: ../gui/externalapp.py:65
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
-msgstr "S'està exportant a “{file_basename}”…"
+msgid ""
+"What application should MyPaint use for editing files of type "
+"“{type_name}” ({content_type})?"
+msgstr ""
+"Quina aplicació hauria d'emprar per editar fitxers del tipus  "
+"“{type_name}” ({content_type})?"
 
-#: ../gui/filehandling.py:427
+#: ../gui/externalapp.py:71
+msgid "Open With..."
+msgstr "Obre amb..."
+
+#: ../gui/externalapp.py:123
+msgid "Icon"
+msgstr "Icona"
+
+#: ../gui/externalapp.py:166
+msgid "no description"
+msgstr "Sense descripció"
+
+#: ../gui/filehandling.py:126
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
+msgstr "S'està carregant “{file_basename}”…"
+
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:134
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr "S'està desant “{file_basename}”…"
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:138
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
+msgstr "S'està exportant a “{file_basename}”…"
+
+#: ../gui/filehandling.py:145
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
 msgstr "Errada en exportar a “{file_basename}”."
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:149
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
 msgstr "Errada en desar “{file_basename}”."
 
-#: ../gui/filehandling.py:476
+#: ../gui/filehandling.py:153
 #, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr "No es pot carregar “{file_basename}”."
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "Desa la paleta"
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
 msgstr "S'ha exportat amb èxit a “{file_basename}”."
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:187
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
 msgstr "S'ha desat amb èxit “{file_basename}”."
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Obre..."
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:195
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr "S'ha carregat “{file_basename}”."
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
+msgstr "S'ha carregat “{file_basename}”."
+
+#: ../gui/filehandling.py:427
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
+msgstr "Tots els formats reconeguts"
+
+#: ../gui/filehandling.py:432
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:437
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:442
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
+msgstr "JPEG (*.jpg; *.jpeg)"
+
+#: ../gui/filehandling.py:490
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
+msgstr "Per extensió (prefereix el format predeterminat)"
+
+#: ../gui/filehandling.py:494
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:498
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr "PNG sòlid amb fons (*.png)"
+
+#: ../gui/filehandling.py:502
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:506
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr "PNG transparent (*.png)"
+
+#: ../gui/filehandling.py:510
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr "PNG múltiple transparent (*.XXX.png)"
+
+#: ../gui/filehandling.py:514
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr "PNG múltiple transparent (*.XXX.png)"
+
+#: ../gui/filehandling.py:518
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr "JPEG qualitat 90%  (*.jpg; *.jpeg)"
+
+#: ../gui/filehandling.py:576
+#, fuzzy
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr "Exporta…"
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Anomena i desa…"
+
+#: ../gui/filehandling.py:601
+#, fuzzy
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr "Formatació per desar com:"
+
+#: ../gui/filehandling.py:668
+#, fuzzy
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr "Realment voleu continuar?"
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+#, fuzzy
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr "De_sa com esbós"
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, fuzzy, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr "Això descarregarà en {abbreviated_time} les imatges no desades"
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr "Obre…"
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Obre"
+
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr "Obre el quadre d'esborranys..."
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Importa pinzell"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Obre"
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Obre el més recent"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Obre"
+
+#: ../gui/filehandling.py:1446
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
 msgstr "Encara no hi ha fitxers esbossos anomenats \"%s\"."
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1455
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr "Obre esbós nou"
+
+#: ../gui/filehandling.py:1463
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr "Obre esbós previ"
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Obre"
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+#, fuzzy
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr "Reverteix"
+
+#: ../gui/fill.py:121
+#, fuzzy
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr "Farciment total"
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+#, fuzzy
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr "Omple les àrees amb color"
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+#, fuzzy
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr "Tolerància:"
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+#, fuzzy
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
@@ -1588,19 +1890,36 @@ msgstr ""
 "Quants píxels de colors es poden variar des del principi\n"
 "abans que el farciment total refusi omplir-los"
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+#, fuzzy
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr "Font:"
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
-msgstr "Quines capes visibles s'han d'omplir"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
+msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+#, fuzzy
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr "Mostra fusionada"
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+#, fuzzy
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
@@ -1610,19 +1929,50 @@ msgstr ""
 "una mescla temporal de totes les\n"
 "capes visibles sota la capa actual"
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+#, fuzzy
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr "Ajusta a la visualització"
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+#, fuzzy
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr "Objectiu:"
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+#, fuzzy
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr "On ha d'anar la sortida"
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr "Capa nova (una vegada)"
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+#, fuzzy
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
@@ -1630,21 +1980,108 @@ msgstr ""
 "Creeu una nova capa amb els resultats de l'emplenament.\n"
 "Això s'apagarà automàticament després d'usar-ho."
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Opacitat:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr "Reinicia"
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+#, fuzzy
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr "Reinicia les opcions als valors predeterminats"
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "Selecciona capa"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr "<b>{brush_name}</b>"
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1654,130 +2091,142 @@ msgstr ""
 "<b>{brush_name}</b>\n"
 "{brush_desc}"
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr "Edita el marc"
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr "Ajusta el marc del document"
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr "Mida del marc"
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr "px"
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr "Alçada:"
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr "Amplada:"
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr "Resolució:"
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr "PPP"
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr "Punts per polzada (realment píxels per polzada)"
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr "Color:"
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr "Color del marc"
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr "<b>Dimensions del marc</b>"
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr "<b>Densitat de píxels</b>"
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr "Configura el marc de la capa"
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr "Estableix el marc a les extensions de la capa actual"
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr "Configura el marc del document"
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr "Configura el marc per a la combinació de totes les capes"
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr "Retalla la capa al marc"
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr "Retalla parts de la capa actual que es trobin fora del marc"
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr "Activat"
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr "{units} {width:g}×{height:g}"
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr "polzades"
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr "cm"
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr "cm"
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr "Dibuix a ma alçada"
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr "Pinta pinzellades de forma lliure"
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr "Suau:"
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr "Pressió:"
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr "Errada detectada"
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr "<big><b>S'ha detectat un error de programació.</b></big>"
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1791,35 +2240,35 @@ msgstr ""
 "Informeu als desenvolupadors sobre això usant el seguidor d'incidències si "
 "encara no ho ha informat ningú."
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr "Cerca al seguidor..."
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr "Informa..."
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr "Ignora l'error"
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr "Surt de MyPaint"
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr "Detalls..."
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr "S'ha produït una excepció mentre s'analitzava l'excepció."
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1863,45 +2312,50 @@ msgstr ""
 "            #### Rastreig d'error\n"
 "        "
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr "Entinta"
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr "Dibuixa i, a continuació, ajusta les línies suaus"
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr "Prova del dispositiu d'entrada"
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr "(sense pressió)"
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr "Pressió:"
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr "(sense inclinació)"
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr "Inclinació:"
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr "(sense dispositiu)"
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
 msgstr "Dispositiu:"
 
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+#, fuzzy
+msgid "Barrel Rotation:"
+msgstr "Reinicia la rotació"
+
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr "Mou la capa"
 
@@ -1909,161 +2363,228 @@ msgstr "Mou la capa"
 msgid "Move the current layer"
 msgstr "Mou la capa actual"
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
-msgstr "{default_name} a {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
+msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
-msgstr "Tipus"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
+msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+#, fuzzy
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr "Propietats"
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr "Visible"
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Capa"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+#, fuzzy
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr "Bloquejat"
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+#, fuzzy
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ", "
+
+#: ../gui/layers.py:990
+#, fuzzy, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr "Afegeix {layer_default_name}"
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Capes"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr "Organitza les capes i assigna el efectes"
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr "Opacitat de la capa: %d%%"
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr "Mou la capa a la pila..."
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 "Mou la capa a la pila (deixant anar en una capa regular es crearà un grup "
 "nou)"
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr "Capa"
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
-msgstr "Mode:"
+#: ../gui/layervis.py:53
+#, fuzzy, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
+msgstr "<b>{brush_name}</b>"
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
-"Mode barreja: com es combina la capa actual amb les capes que hi han a sota."
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Opacitat:"
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "Gira la visualització"
 
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-"Opacitat de la capa: quant de la capa actual s'usarà. Els valors més petits "
-"la fan més transparent."
-
-#: ../gui/linemode.py:37
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr "Pressió d'entrada"
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr "Pressió d'entrada al traç per a eines de línia"
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr "Pressió al punt mig"
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr "Pressió en la meitat del traç per a eines de línia"
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr "Pressió final"
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr "Pressió al final del traç per eines de línia"
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr "Capçal"
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 msgid "Stroke lead-in end"
 msgstr "Traç guiat fins el final"
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr "Cua"
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr "Començament dels traços"
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr "Variació de la pressió..."
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr "Línies i corbes"
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr "Mode genèric línia/corba"
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr "Dibuixa línies rectes; Maj afegeix corbes, Ctrl redueix l'angle"
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr "Línies connectades"
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 "Dibuixa una seqüencia de línies; Maj afegeix corbes, Ctrl redueix l'angle"
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr "El·lipses i cercles"
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr "Dibuixa el·lipses; Maj gira, Ctrl disminueix la ràtio/angle"
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
+#, fuzzy
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 "Copyright (C) 2005-2015\n"
 "Martin Renold i l'equip de desenvolupament de MyPaint"
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -2082,256 +2603,286 @@ msgstr ""
 "Aquest programa es distribueix amb l'esperança que sigui útil, però SENSE "
 "CAP GARANTIA. Consulteu el fitxer COPYING per obtenir més detalls."
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr "Programació"
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr "Portabilitat"
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr "Gestió del projecte"
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr "pinzells"
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr "Patrons"
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr "Icones d'eina"
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr "Icona d'escriptori"
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr "Paletes"
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr "Documentació"
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr "Suport"
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr "Divulgació"
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr "Comunitat"
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ", "
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr "Carles Ferrando Garcia <carles.ferrando@gmail.com>"
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr "Mida:"
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr "Opac:"
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr "Nítid:"
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr "Guany:"
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr "Opcions d'eina"
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr "Configuració especialitzada per a l'eina d'edició actual"
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr "<b>{mode_name}</b>"
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr "<i>Sense opcions disponibles</i>"
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr "Escala: %.01f%%"
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr "Tria la configuració del pinzell, el color del traç i la capa…"
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr "Tria el color…"
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr "Preferències"
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr "Previsualització"
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr "Mostra la previsualització a tota l'àrea de treball"
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr "Mostra el visor"
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr "Quadre d'esborranys"
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr "Mescla colors i fes els esbossos en pàgines de gargots separades"
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr "Element previ"
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr "Element següent"
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
 msgstr "(Res a mostrar)"
 
-#: ../gui/symmetry.py:76
+#: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Place axis"
 msgstr "Posa l'eix"
 
-#: ../gui/symmetry.py:80
+#: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Move axis"
 msgstr "Mou l'eix"
 
-#: ../gui/symmetry.py:84
+#: ../gui/symmetry.py:88
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr "Suprimeix l'eix"
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr "Edita la simetria de l'eix"
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr "Ajusta l'eix de simetria del dibuix."
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
+#, fuzzy
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr "Posició:"
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr "Posició:"
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr "Cap"
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr "%d px"
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr "Alfa:"
 
-#: ../gui/symmetry.py:352
+#: ../gui/symmetry.py:376
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
+msgstr "Simetria"
+
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+#, fuzzy
 msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+msgid "X axis Position"
 msgstr "Posició de l'eix"
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:477
+#, fuzzy
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr "Posició de l'eix"
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr "Habilitat"
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr "Gestió de fitxers"
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr "Commutador de gargots"
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr "Desfés i refés"
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr "Modes degradats"
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr "Modes de línia"
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr "Visualització (principal)"
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr "Visualització (alternativa/secundaria)"
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr "Visualització (restablint)"
 
@@ -2339,188 +2890,214 @@ msgstr "Visualització (restablint)"
 msgid "<b>MyPaint</b>"
 msgstr "<b>MyPaint</b>"
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr "Desplaça la visualització"
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr "Arrossega la visualització del llenç"
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr "Amplia la visualització"
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr "Amplia la visualització del llenç"
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr "Gira la visualització"
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr "Gira la visualització del llenç"
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, fuzzy, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr "%s: tanca la pestanya"
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
-msgstr "%s: edita les propietats"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
+msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr "Ordre desconeguda"
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr "No definit (ordre encara no iniciada)"
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr "{seconds:.01f}s de pintat amb {brush_name}"
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr "Farciment total"
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr "Talla la capa"
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "Canvia nom al grup"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr "Neteja la capa"
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr "Enganxa la capa"
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr "Capa nova de visible"
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr "Barreja la capes visibles"
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr "Baixa la barreja"
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr "Normalitza el mode capa"
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Importa pinzell"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr "Afegeix {layer_default_name}"
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr "Suprimeix capa"
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr "Selecciona capa"
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr "Capa duplicada"
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr "Mou la capa amunt"
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr "Mou la capa avall"
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr "Mou la capa a la pila"
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr "Canvia el nom a la capa"
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr "Fes la capa visible"
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr "Fes la capa invisible"
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr "Bloqueja la capa"
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr "Desbloqueja la capa"
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr "Estableix la opacitat de la capa: %0.1f%%"
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr "Mode desconegut"
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr "Estableix el mode capa: %s"
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr "Habilita el marc"
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr "Deshabilita el marc"
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr "Actualitza el marc"
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr "Edita la capa externament"
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr "Error en carregar “{basename}”."
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr "Els registres poden tenir més detalls sobre aquest error."
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr "Des d'ara"
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr "abans"
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2532,13 +3109,14 @@ msgstr ""
 "Esteu executant més d'una instància de MyPaint?\n"
 "Tanca l'aplicació i espera {cache_update_interval}s per intentar-ho de nou."
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
-msgstr "Copia de seguretat incompleta actualitzada fa{last_modified_time} {ago}"
+msgstr ""
+"Copia de seguretat incompleta actualitzada fa{last_modified_time} {ago}"
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2548,11 +3126,11 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 "Copia de seguretat actualitzada fa {last_modified_time} {ago}\n"
-"Mida: {autosave.width}×{autosave.height} píxels, Capes: {autosave.num_layers}"
-"\n"
+"Mida: {autosave.width}×{autosave.height} píxels, Capes: {autosave."
+"num_layers}\n"
 "Conté {unsaved_time} de dibuixos no desats."
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2562,13 +3140,13 @@ msgstr ""
 "No es pot escriure “{filename}”: {err}\n"
 "Teniu prou espai al dispositiu ?"
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr "No es pot escriure “{filename}”: {err}"
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2578,7 +3156,7 @@ msgstr ""
 "{error_loading_common}\n"
 "El fitxer no existeix."
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2588,7 +3166,7 @@ msgstr ""
 "No teniu permís per obrir aquest fitxer.\n"
 "{error_loading_common}."
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2604,7 +3182,7 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2614,7 +3192,13 @@ msgstr ""
 "{error_loading_common}\n"
 "Extensió de format de fitxer desconegut: “{ext}”"
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+#, fuzzy
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr "Importa pinzell"
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2628,7 +3212,7 @@ msgstr ""
 "Si la vostra màquina no té massa memòria, intenteu desar-ho en format PNG, "
 "La funció de desat PNG de MyPaint és més eficient."
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2644,98 +3228,207 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/helpers.py:402
-#, python-brace-format
+#: ../lib/floodfill.py:131
+#, fuzzy
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr "Omple"
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr "{days}d{hours}h"
 
-#: ../lib/helpers.py:404
-#, python-brace-format
+#: ../lib/helpers.py:537
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr "{hours}h{minutes}m"
 
-#: ../lib/helpers.py:406
-#, python-brace-format
+#: ../lib/helpers.py:539
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr "{minutes}m{seconds}s"
 
-#: ../lib/helpers.py:408
-#, python-brace-format
+#: ../lib/helpers.py:541
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr "{seconds}s"
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr "Capa"
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr "%(name)s %(number)d"
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr "^(.*?)\\s*(\\d+)$"
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
+#, fuzzy
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr "Capa vectorial"
+
+#: ../lib/layer/data.py:1158
+#, fuzzy
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr "Capa vectorial"
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
-msgstr "Capa de mapa de bits desconeguda"
+msgid "Bitmap"
+msgstr ""
 
-#: ../lib/layer/data.py:1169
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1244
 msgctxt "layer default names"
-msgid "Unknown Data Layer"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
 msgstr "Capa de dades desconeguda"
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "Capa de pintura nova"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr "Grup"
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "Grup de capes nou"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr "Marcador de posició"
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr "Arrel"
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ", "
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+#, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "Visualització"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+#, fuzzy
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr "Capa visible"
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+#, fuzzy
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr "Suprimeix capa"
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr "Bloqueja la capa"
+
+#: ../lib/layervis.py:697
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr "Desbloqueja la capa"
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr "Passa per"
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr "Els continguts del grup s'apliquen directament al fons del grup"
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr "Normal"
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr "La capa superior només, sense barrejar colors."
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr "Multiplica"
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
@@ -2743,11 +3436,11 @@ msgstr ""
 "Igual a carregar dues diapositives en un projector i projectar el resultat "
 "combinat."
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr "Pantalla"
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
@@ -2755,11 +3448,11 @@ msgstr ""
 "Igual que il·luminar dos projectors de diapositives separats en una pantalla "
 "simultàniament. Aquesta és la inversa de «Multiplicar»."
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr "Sobreposa"
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
@@ -2767,27 +3460,27 @@ msgstr ""
 "Sobreposa el fons amb la capa superior, preservant els ressaltats i les "
 "ombres dels fons. Aquesta és la inversa de «LLum dura»."
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr "Fosc"
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr "La capa superior s'utilitza quan és més fosca que el fons."
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr "Il·lumina"
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr "La capa superior s'utilitza quan és més clara que el fons."
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr "Esvaeix"
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
@@ -2797,11 +3490,11 @@ msgstr ""
 "cambra fosca fotogràfica del mateix nom que s'utilitza per millorar el "
 "contrast en ombres."
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr "Crema"
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
@@ -2811,43 +3504,43 @@ msgstr ""
 "tècnica de cambra fosca fotogràfica del mateix nom que s'utilitza per reduir "
 "els punts forts més brillants."
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr "Llum dura"
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr "Semblant a il·luminar amb un focus dur el fons."
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr "Llum tova"
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr "Semblant a il·luminar amb un focus difús el fons."
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr "Diferència"
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr "Resta el color fosc del il·luminat dels dos."
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr "Exclusió"
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr "Semblant al mode «Diferència», però baix en contrast."
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr "To"
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
@@ -2855,11 +3548,11 @@ msgstr ""
 "Combina el to de la capa superior amb la saturació i la lluminositat del "
 "fons."
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr "Saturació"
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
@@ -2867,47 +3560,47 @@ msgstr ""
 "Aplica la saturació dels colors de les capes superiors al to i lluminositat "
 "del fons."
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 "Aplica el to i la saturació de la capa superior a la lluminositat del fons."
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr "Lluminositat"
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr "Aplica la lluminositat de la capa superior al to i saturació del fons."
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr "Més"
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr "Aquesta capa i el seu fons s'afegeixen juntes."
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr "Destinació dins"
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 "Utilitza el fons només on aquesta capa ho cobreix. Tota la resta és ignorat."
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr "Destinació fora"
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
@@ -2915,11 +3608,11 @@ msgstr ""
 "Utilitza el fons només on aquesta capa no ho cobreix. Tota la resta és "
 "ignorat."
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr "Font a sobre de tot"
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
@@ -2927,11 +3620,11 @@ msgstr ""
 "La font que superposa a la destinació reemplaça la destinació. La destinació "
 "es col·loca en un altre lloc."
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr "Destinació dalt de tot"
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
@@ -2939,7 +3632,18 @@ msgstr ""
 "La destinació que superposa la font reemplaça la font. La font es col·loca "
 "en un altre lloc."
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, fuzzy, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr "%(name)s %(number)d"
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
@@ -2948,7 +3652,7 @@ msgstr ""
 "No es possible construir un objecte intern vital. El vostre sistema no "
 "tindre prou memòria per fer aquesta operació."
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2962,7 +3666,30 @@ msgstr ""
 "Motiu: {err}\n"
 "Carpeta objectiu: “{dirname}”."
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+#, fuzzy
+msgid "Vertical"
+msgstr "Emmirallat vertical"
+
+#: ../lib/tiledsurface.py:49
+#, fuzzy
+msgid "Horizontal"
+msgstr "Emmirallat horizontal"
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+#, fuzzy
+msgid "Rotational"
+msgstr "Reinicia la rotació"
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr "La lectura del PNG ha fallat: %s"
@@ -2971,57 +3698,95 @@ msgstr "La lectura del PNG ha fallat: %s"
 msgid "Recover interrupted work?"
 msgstr "Recuperem el treball interromput?"
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
-msgstr "_Recupera i desa..."
+msgid "_Look for backups at startup"
+msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr "Suprimeix"
+
+#: ../po/tmp/autorecover.glade.h:9
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr "Suprimeix aquest pinzell del disc"
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr "_Recupera i desa..."
+
+#: ../po/tmp/autorecover.glade.h:12
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr "Desa aquesta copia de seguretat al disc, i continua treballant en ell."
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
-msgstr "_Ignora per ara"
+msgid "Decide _Later"
+msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 "Comença a treballar en un llenç nou. Aquestes còpies de seguretat es "
 "conservaran."
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
+#, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 "MyPaint ha fallat amb treball no desat, però hi han copies de seguretat. "
 "Podeu recuperar un fitxer ara o deixeu-lo fins que torneu a iniciar MyPaint."
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr "Miniatura"
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr "Descripció"
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
-msgstr "Copia a un nou"
+msgid "Live update"
+msgstr "Actualització en directe"
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
-msgstr "Copia aquests paràmetres i la icona del pinzell actual a un pinzell nou"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
+msgstr ""
+"Actualitza el darrer traç del llenç amb els paràmetres en aquesta finestra, "
+"en temps real"
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
-msgstr "Canvia el nom a aquest pinzell"
+msgid "Save these settings to the brush"
+msgstr "Desa aquestos paràmetres al pinzell"
 
 #: ../po/tmp/brusheditor.glade.h:5
 msgid "Edit Icon"
@@ -3044,20 +3809,17 @@ msgid "Delete this brush from the disk"
 msgstr "Suprimeix aquest pinzell del disc"
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
-msgstr "Actualització en directe"
+msgid "Copy to New"
+msgstr "Copia a un nou"
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
-"Actualitza el darrer traç del llenç amb els paràmetres en aquesta finestra, "
-"en temps real"
+"Copia aquests paràmetres i la icona del pinzell actual a un pinzell nou"
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
-msgstr "Desa aquestos paràmetres al pinzell"
+msgid "Rename this brush"
+msgstr "Canvia el nom a aquest pinzell"
 
 #: ../po/tmp/brusheditor.glade.h:13
 msgid "Brush Setting"
@@ -3085,12 +3847,7 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr "Notes:"
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr "Nom del paràmetre:"
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
@@ -3098,19 +3855,16 @@ msgstr ""
 "variarà en conseqüència."
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
-msgstr "Valor base:"
+#: ../po/tmp/brusheditor.glade.h:22
+#, fuzzy
+msgid "Value:"
+msgstr "Valor HSV"
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr "Reinicia el valor base al valor per defecte"
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr "Reinicia aquesta entrada per no tindre efectes al paràmetre"
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
@@ -3118,11 +3872,7 @@ msgstr ""
 "Valor mínim per a l'eix de sortida.\n"
 "Això es pot establir amb el lliscador principal de {dname}."
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr "<ymin>"
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
@@ -3130,27 +3880,23 @@ msgstr ""
 "Valor màxim per a l'eix de sortida.\n"
 "Això es pot establir amb el lliscador principal de {dname}."
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr "<ymax>"
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr "Sortida"
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr "Entrada"
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr "Ajusta el valor màxim"
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr "Ajusta el valor mínim"
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
@@ -3158,11 +3904,7 @@ msgstr ""
 "Valor mínim per a l'eix d'entrada.\n"
 "Utilitzeu l'escala emergent per ajustar-ho."
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr "<xmin>"
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
@@ -3170,38 +3912,36 @@ msgstr ""
 "Valor màxim per a l'eix d'entrada.\n"
 "Utilitzeu l'escala emergent per ajustar-ho."
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr "<xmax>"
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr "Variació del valor base per al llapis d'entrada i altres criteris"
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr "Dinàmiques del pinzell"
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr "Detalls bàsics per a aquest paràmetre"
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr "Edita el paràmetre"
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr "Ajusta el mapatge d'entrada en detall"
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr "{tooltip}"
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
 msgstr "{dname}:"
+
+#: ../po/tmp/brusheditor.glade.h:42
+#, fuzzy
+msgid "Brush dynamics are not available for this setting."
+msgstr "Detalls bàsics per a aquest paràmetre"
+
+#: ../po/tmp/brusheditor.glade.h:43
+#, fuzzy
+msgid "<big><b>No Brush Dynamics</b></big>"
+msgstr "<big><b>{accel_label}</b></big>"
 
 #: ../po/tmp/inktool.glade.h:1
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
@@ -3213,7 +3953,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr "Prem:"
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3258,6 +3998,141 @@ msgstr "Suprimeix punt"
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
 msgstr "Suprimeix el punt seleccionat"
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+#, fuzzy
+msgid "Insert Point"
+msgstr "Insereix fila"
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+#, fuzzy
+msgid "Cull Points"
+msgstr "Suprimeix punt"
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Nom"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr "Mode"
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Opacitat"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr "Mode de composició de la capa actual."
+
+#: ../po/tmp/layervis.glade.h:2
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr "Gira la visualització del llenç"
+
+#: ../po/tmp/layervis.glade.h:3
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr "Gira la visualització del llenç"
+
+#: ../po/tmp/layervis.glade.h:4
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr "Quines capes visibles s'han d'omplir"
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
+msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
 msgctxt "footer: color picker button: tooltip"
@@ -3666,13 +4541,34 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr "Amaga el cursor mentre es pinta"
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+#, fuzzy
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr "Activat"
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr "Visualització"
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
@@ -3682,18 +4578,18 @@ msgstr ""
 "l'estil del disc.\n"
 "Les diferents tradicions tenen diferents harmonies de colors."
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr "Els primaris són:"
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr "Estàndard digital Roig/Verd/Blau"
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
@@ -3701,7 +4597,7 @@ msgstr ""
 "El  &apos;monitor d'ordinador&apos; roig, verd i blau primàries, disposats "
 "equitativament al voltant del cercle. El verd és oposat a la magenta."
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
@@ -3710,12 +4606,12 @@ msgstr ""
 "El  &apos;monitor d'ordinador&apos; roig, verd i blau primàries, disposats "
 "equitativament al voltant del cercle. El verd és oposat a la magenta."
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr "El tradicional dels artistes Roig/Groc/Blau"
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
@@ -3725,7 +4621,7 @@ msgstr ""
 "segle XVIII, aproximada amb colors purs i uniformement disposats al voltant "
 "del cercle. El verd oposat al roig."
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3736,12 +4632,12 @@ msgstr ""
 "segle XVIII, aproximada amb colors purs i uniformement disposats al voltant "
 "del cercle. El verd oposat al roig."
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr "Roig-Verd i Blau-Groc són parell oposats"
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3756,7 +4652,7 @@ msgstr ""
 "presenten un model similar. Aquí fem servir el pur roig, groc, etc. com els "
 "quatre primaris."
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3772,28 +4668,28 @@ msgstr ""
 "Aquí fem servir el pur roig, groc, etc. com els quatre primaris."
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr "<b>Roda de color</b>"
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr "Color"
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr "Pantalla (normal)"
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr "Desactivat (no sensible a la pressió)"
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr "Finestra (no recomanat)"
@@ -3854,253 +4750,310 @@ msgid "Reload the file your current work was loaded from."
 msgstr "Torneu a carregar el fitxer del qual s'ha carregat el treball actual."
 
 #: ../po/tmp/resources.xml.h:12
+#, fuzzy
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Import Layers…"
+msgstr "Importa pinzells…"
+
+#: ../po/tmp/resources.xml.h:13
+msgctxt "Accel Editor (descriptions)"
+msgid "Import layers from one or more files."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save"
 msgstr "Desa"
 
-#: ../po/tmp/resources.xml.h:13
+#: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file."
 msgstr "Deseu el vostre treball a un fitxer."
 
-#: ../po/tmp/resources.xml.h:14
+#: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As…"
 msgstr "Anomena i desa…"
 
-#: ../po/tmp/resources.xml.h:15
+#: ../po/tmp/resources.xml.h:17
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file, assigning it a new name."
 msgstr "Deseu el vostre treball a un fitxer, assignant-hi un nom nou."
 
-#: ../po/tmp/resources.xml.h:16
+#: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Export…"
 msgstr "Exporta…"
 
-#: ../po/tmp/resources.xml.h:17
+#: ../po/tmp/resources.xml.h:19
 msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 "Exporta el treball a un fitxer, però continua treballant al mateix fitxer."
 
-#: ../po/tmp/resources.xml.h:18
+#: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As Scrap"
 msgstr "Desa com esbós"
 
-#: ../po/tmp/resources.xml.h:19
+#: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
 msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 "Desa com un fitxer de esbós nou, o desa una nova revisió si ja és un esbós."
 
-#: ../po/tmp/resources.xml.h:20
+#: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Previous Scrap"
 msgstr "Obre esbós previ"
 
-#: ../po/tmp/resources.xml.h:21
+#: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file before the current one."
 msgstr "Carrega el fitxer esbós abans que l'actual."
 
-#: ../po/tmp/resources.xml.h:22
+#: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Next Scrap"
 msgstr "Obre esbós nou"
 
-#: ../po/tmp/resources.xml.h:23
+#: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file after the current one."
 msgstr "Carrega el fitxer esbós després de l'actual."
 
-#: ../po/tmp/resources.xml.h:24
+#: ../po/tmp/resources.xml.h:26
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Recover File from an Automated Backup…"
 msgstr "Recupera el fitxer des d'una copia de seguretat automàtica…"
 
-#: ../po/tmp/resources.xml.h:25
+#: ../po/tmp/resources.xml.h:27
 msgctxt "Accel Editor (descriptions)"
 msgid "Try to save and resume interrupted unsaved work."
 msgstr "Intenta desar i continuar el treball interromput no desat."
 
-#: ../po/tmp/resources.xml.h:26
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr "Grups de pinzells"
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr "Pinzells"
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr "Llista de grups de pinzells."
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr "Ajustadors de color"
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr "Colors"
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr "Disponibles ajustadors de color."
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr "Mode"
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr "Mode"
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr "Mode de composició de la capa actual."
 
-#: ../po/tmp/resources.xml.h:35
+#: ../po/tmp/resources.xml.h:37
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Pressure"
+msgstr "Pressió d'entrada"
+
+#: ../po/tmp/resources.xml.h:38
+msgctxt "Accel Editor (descriptions)"
+msgid "Send harder pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:39
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Pressure"
+msgstr "Pressió d'entrada"
+
+#: ../po/tmp/resources.xml.h:40
+msgctxt "Accel Editor (descriptions)"
+msgid "Send softer pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:41
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Rotation"
+msgstr "Incrementa la saturació"
+
+#: ../po/tmp/resources.xml.h:42
+msgctxt "Accel Editor (descriptions)"
+msgid "Increase barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:43
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
+msgstr "Disminueix la saturació"
+
+#: ../po/tmp/resources.xml.h:44
+msgctxt "Accel Editor (descriptions)"
+msgid "Decrease barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:45
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Size"
 msgstr "Increment la mida de pinzell"
 
-#: ../po/tmp/resources.xml.h:36
+#: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush bigger."
 msgstr "Fes més gran el pinzell de treball."
 
-#: ../po/tmp/resources.xml.h:37
+#: ../po/tmp/resources.xml.h:47
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Size"
 msgstr "Disminueix la mida del pinzell"
 
-#: ../po/tmp/resources.xml.h:38
+#: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush smaller."
 msgstr "Fes més petit el pinzell de treball."
 
-#: ../po/tmp/resources.xml.h:39
+#: ../po/tmp/resources.xml.h:49
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Opacity"
 msgstr "Incrementa la opacitat del pinzell"
 
-#: ../po/tmp/resources.xml.h:40
+#: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush more opaque."
 msgstr "Fes més opac el pinzell de treball."
 
-#: ../po/tmp/resources.xml.h:41
+#: ../po/tmp/resources.xml.h:51
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Opacity"
 msgstr "Disminueix la opacitat del pinzell"
 
-#: ../po/tmp/resources.xml.h:42
+#: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush less opaque."
 msgstr "Fes menys opac el pinzell de treball."
 
-#: ../po/tmp/resources.xml.h:43
+#: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Lighten Painting Color"
 msgstr "Il·lumina el color de la pintura"
 
-#: ../po/tmp/resources.xml.h:44
+#: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase the lightness of the current painting color."
 msgstr "Incrementa la lluminositat del color de pintura actual."
 
-#: ../po/tmp/resources.xml.h:45
+#: ../po/tmp/resources.xml.h:55
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Darken Painting Color"
 msgstr "Foscor del color de la pintura"
 
-#: ../po/tmp/resources.xml.h:46
+#: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease the lightness of the current painting color."
 msgstr "Disminueix la lluminositat del color de la pintura actual."
 
-#: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
-msgstr "Canvia el to en sentit antihorari"
-
-#: ../po/tmp/resources.xml.h:48
-msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
-msgstr ""
-"Gira el to del color de la pintura en sentit antihorari a la roda del color."
-
-#: ../po/tmp/resources.xml.h:49
+#: ../po/tmp/resources.xml.h:57
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Change Hue Clockwise"
 msgstr "Canvia el to en sentit horari"
 
-#: ../po/tmp/resources.xml.h:50
+#: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
 msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 "Gira el to del color de la pintura en sentit horari a la roda del color."
 
-#: ../po/tmp/resources.xml.h:51
+#: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr "Canvia el to en sentit antihorari"
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+"Gira el to del color de la pintura en sentit antihorari a la roda del color."
+
+#: ../po/tmp/resources.xml.h:61
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Increase Saturation"
 msgstr "Incrementa la saturació"
 
-#: ../po/tmp/resources.xml.h:52
+#: ../po/tmp/resources.xml.h:62
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color more saturated (more colorful, purer)."
 msgstr "Fes el color de la pintura més saturat (més colorit, més pur)."
 
-#: ../po/tmp/resources.xml.h:53
+#: ../po/tmp/resources.xml.h:63
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Decrease Saturation"
 msgstr "Disminueix la saturació"
 
-#: ../po/tmp/resources.xml.h:54
+#: ../po/tmp/resources.xml.h:64
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color less saturated (grayer)."
 msgstr "Fes el color de la pintura menys saturat (més gris)."
 
-#: ../po/tmp/resources.xml.h:55
+#: ../po/tmp/resources.xml.h:65
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Reload Brush Settings"
 msgstr "Torna a carregar els paràmetres del pinzell"
 
-#: ../po/tmp/resources.xml.h:56
+#: ../po/tmp/resources.xml.h:66
 msgctxt "Accel Editor (descriptions)"
 msgid "Restore all brush settings to the current brush’s saved values."
 msgstr ""
 "Restaura tots els paràmetres del pinzell als valors guardats del pinzell "
 "actual."
 
-#: ../po/tmp/resources.xml.h:57
+#: ../po/tmp/resources.xml.h:67
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Pick Stroke and Layer"
 msgstr "Tria traç i capa"
 
-#: ../po/tmp/resources.xml.h:58
+#: ../po/tmp/resources.xml.h:68
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
 msgstr ""
 "Tria una configuració del pinzell del llenç: restaura el pinzell, color i "
 "capa."
 
-#: ../po/tmp/resources.xml.h:59
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr "Dreceres de teclat del pinzell, restaura color"
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
@@ -4109,290 +5062,343 @@ msgstr ""
 "Commuta quan es restaura el pinzell des d'una drecera de teclat que també "
 "restaura el color desat."
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr "Desa el pinzell a la drecera més recent de teclat"
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr "Desa el pinzell a la drecera usada més recent de teclat."
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "Neteja la capa"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr "Neteja el contingut de la capa actual."
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Trim Layer to Frame"
-msgstr "Talla la capa al marc"
+#: ../po/tmp/resources.xml.h:75
+#, fuzzy
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr "Opcions d'eina"
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:76
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Trim Layer to Frame"
+msgstr "Retalla la capa al marc"
+
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr "Esborra parts de la capa actual que es troben fora del marc."
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr "Esborra parts de la capa actual que es troben fora del marc."
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "Grup de capes nou a sota"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "Grup de capes nou a sota"
+
+#: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr "Copia la capa al porta-retalls"
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr "Copia el contingut de la capa actual al porta-retalls."
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr "Enganxa la capa des del porta-retalls"
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr "Reemplaça la capa actual amb el contingut del porta-retalls."
 
-#: ../po/tmp/resources.xml.h:71
+#: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Edit Layer in External App…"
 msgstr "Edita la capa en un aplicació externa…"
 
-#: ../po/tmp/resources.xml.h:72
+#: ../po/tmp/resources.xml.h:90
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
+msgid "Edit the active layer in an external application."
 msgstr "Comença editant la capa actual en una aplicació externa."
 
-#: ../po/tmp/resources.xml.h:73
+#: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Update Layer with External Edits"
 msgstr "Actualitza la capa amb editors externs"
 
-#: ../po/tmp/resources.xml.h:74
+#: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
 msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 "Publica els canvis desats des d'una aplicació externa (normalment automàtic)."
 
-#: ../po/tmp/resources.xml.h:75
+#: ../po/tmp/resources.xml.h:93
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer at Cursor"
 msgstr "Vés a la capa al cursor"
 
-#: ../po/tmp/resources.xml.h:76
+#: ../po/tmp/resources.xml.h:94
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr "Selecciona una capa triant un objecte en ella."
 
-#: ../po/tmp/resources.xml.h:77
+#: ../po/tmp/resources.xml.h:95
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Above"
 msgstr "Vés a la capa superior"
 
-#: ../po/tmp/resources.xml.h:78
+#: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer up in the layer stack."
 msgstr "Vés una capa amunt en la pila de capes."
 
-#: ../po/tmp/resources.xml.h:79
+#: ../po/tmp/resources.xml.h:97
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Below"
 msgstr "Vés a la capa inferior"
 
-#: ../po/tmp/resources.xml.h:80
+#: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer down in the layer stack."
 msgstr "Vés una capa avall en la pila de capes."
 
-#: ../po/tmp/resources.xml.h:81
+#: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer"
 msgstr "Capa de pintura nova"
 
-#: ../po/tmp/resources.xml.h:82
+#: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer above the current layer."
 msgstr "Afegeix una capa de pintura nova a sobre de la capa actual."
 
-#: ../po/tmp/resources.xml.h:83
+#: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer…"
 msgstr "Capa vectorial nova…"
 
-#: ../po/tmp/resources.xml.h:84
+#: ../po/tmp/resources.xml.h:102
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer above the current layer, and begin editing it."
 msgstr ""
 "Afegeix una capa vectorial nova a sobre de la capa actual, i comença editant-"
 "la."
 
-#: ../po/tmp/resources.xml.h:85
+#: ../po/tmp/resources.xml.h:103
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group"
 msgstr "Grup de capes nou"
 
-#: ../po/tmp/resources.xml.h:86
+#: ../po/tmp/resources.xml.h:104
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group above the current layer."
 msgstr "Afegeix un grup de capes nou a sobre de la capa actual."
 
-#: ../po/tmp/resources.xml.h:87
+#: ../po/tmp/resources.xml.h:105
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer Below"
 msgstr "Capa de pintura nova a sota"
 
-#: ../po/tmp/resources.xml.h:88
+#: ../po/tmp/resources.xml.h:106
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer below the current layer."
 msgstr "Afegeix una capa de pintura nova baix la capa actual."
 
-#: ../po/tmp/resources.xml.h:89
+#: ../po/tmp/resources.xml.h:107
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer Below…"
 msgstr "Capa vectorial nova a sota…"
 
-#: ../po/tmp/resources.xml.h:90
+#: ../po/tmp/resources.xml.h:108
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer below the current layer, and begin editing it."
 msgstr ""
 "Afegeix una capa vectorial nova baix la capa actual, i comença editant-la."
 
-#: ../po/tmp/resources.xml.h:91
+#: ../po/tmp/resources.xml.h:109
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group Below"
 msgstr "Grup de capes nou a sota"
 
-#: ../po/tmp/resources.xml.h:92
+#: ../po/tmp/resources.xml.h:110
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group below the current layer."
 msgstr "Afegeix un grup de capes nou baix la capa actual."
 
-#: ../po/tmp/resources.xml.h:93
+#: ../po/tmp/resources.xml.h:111
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Layer Down"
 msgstr "Fusiona la capa inferior"
 
-#: ../po/tmp/resources.xml.h:94
+#: ../po/tmp/resources.xml.h:112
 msgctxt "Accel Editor (descriptions)"
 msgid "Merge the current layer with the layer beneath it."
 msgstr "Fusioneu la capa actual amb la capa que hi ha a sota."
 
-#: ../po/tmp/resources.xml.h:95
+#: ../po/tmp/resources.xml.h:113
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Visible Layers"
 msgstr "Fusiona capes visibles"
 
-#: ../po/tmp/resources.xml.h:96
+#: ../po/tmp/resources.xml.h:114
 msgctxt "Accel Editor (descriptions)"
 msgid "Consolidate all visible layers, and delete the originals."
 msgstr "Consolida totes les capes visibles, i suprimeix les originals."
 
-#: ../po/tmp/resources.xml.h:97
+#: ../po/tmp/resources.xml.h:115
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer from Visible"
 msgstr "Capa nova des de visible"
 
-#: ../po/tmp/resources.xml.h:98
+#: ../po/tmp/resources.xml.h:116
 msgctxt "Accel Editor (descriptions)"
 msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
 msgstr "Semblant a «Fusiona capes visibles» però sense suprimir les originals."
 
-#: ../po/tmp/resources.xml.h:99
+#: ../po/tmp/resources.xml.h:117
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Delete Layer"
 msgstr "Suprimeix capa"
 
-#: ../po/tmp/resources.xml.h:100
+#: ../po/tmp/resources.xml.h:118
 msgctxt "Accel Editor (descriptions)"
 msgid "Remove the current layer from the layer stack."
 msgstr "Suprimeix la capa actual des de la pila de capes."
 
-#: ../po/tmp/resources.xml.h:101
+#: ../po/tmp/resources.xml.h:119
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Convert to Normal Painting Layer"
 msgstr "Converteix a capa de pintura normal"
 
-#: ../po/tmp/resources.xml.h:102
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
-"Convertiu la capa o el grup actual en una capa de pintura en mode \"Normal\""
-", conservant la seva aparença."
+"Convertiu la capa o el grup actual en una capa de pintura en mode \"Normal"
+"\", conservant la seva aparença."
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr "Incrementa la opacitat de la capa"
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr "Fes la capa menys transparent."
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr "Redueix la opacitat de la capa"
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr "Fes la capa més transparent."
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr "Apuja la capa"
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr "Apuja la capa actual un escaló en la pila de capes."
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr "Abaixa la capa"
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr "Abaixa la capa actual un escaló en la pila de capes."
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr "Duplica la capa"
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr "Fes una copia exacta de la capa actual."
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
+#, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
-msgstr "Canvia el nom a la capa…"
+msgid "Layer Properties…"
+msgstr "Propietats"
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
-msgstr "Entreu un nom nou per la capa actual."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr "Capa bloquejada"
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
@@ -4400,248 +5406,342 @@ msgstr ""
 "Commuta l'estat bloquejat de la capa actual. Les capes bloquejades no es "
 "poden modificar."
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr "Capa visible"
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr "Commuta l'estat de visibilitat de la capa actual, fent-la oculta."
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr "Mostra el fons"
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr "Commuta la visibilitat de la capa de fons."
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr "Suprimeix la capa actual des de la pila de capes."
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr "Reinicia i centra la visualització"
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 "Reinicia l'ampliació/reducció, gir i emmirallat, i torna a centrar el "
 "document."
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr "Ajusta a la visualització"
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 "Canvia entre una visualització encaixada i la vostra ubicació de treball i "
 "ampliació/reducció."
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr "Reinicia"
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr "Reinicia l'ampliació/reducció"
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr "Restaura l'ampliació/reducció al valor per defecte."
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr "Reinicia la rotació"
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr "Restaura la rotació a 0°"
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr "Reinicia l'emmirallat"
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
-msgstr "Desconnecta l'emmirallat de la la visualització."
+msgid "Reset the view's mirroring."
+msgstr "Reinicia l'emmirallat"
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr "Amplia"
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr "Augmenta l'ampliació."
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Disminueix"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr "Disminueix l'ampliació."
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
+#, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
-msgstr "Gira en sentit antihorari"
+msgid "Pan Left"
+msgstr "Visualització panoràmica"
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
-msgstr "Gira la visualització en sentit antihorari."
+msgid "Move your view of the canvas to the left."
+msgstr "Gira la visualització: inclineu la vostra visualització del llenç."
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr "Llum dura"
+
+#: ../po/tmp/resources.xml.h:159
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+"Visualització panoràmica: moveu horitzontalment o verticalment la vostra "
+"visualització del llenç."
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr "Gira la visualització: inclineu la vostra visualització del llenç."
+
+#: ../po/tmp/resources.xml.h:162
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr "Visualització panoràmica"
+
+#: ../po/tmp/resources.xml.h:163
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr "Gira la visualització: inclineu la vostra visualització del llenç."
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr "Gira en sentit horari"
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr "Gira la visualització en sentit horari."
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr "Gira en sentit antihorari"
+
+#: ../po/tmp/resources.xml.h:167
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr "Gira la visualització en sentit antihorari."
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr "Emmirallat horizontal"
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr "Inverteix la visualització d'esquerra a dreta."
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr "Emmirallat vertical"
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr "Inverteix la visualització de dalt a baix."
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr "Capa sola"
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr "Commuta quan sols es mostra la capa actual."
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr "Activa el pintat simètric"
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr "Pinzellades emmirallades al llarg de l'eix de simetria"
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr "Marc habilitat"
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr "Commuta la visibilitat del marc del document."
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr "Imprimeix els valors de l'entrada del pinzell a la consola"
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 "Mostra les entrades generades internament pel motor del pinzell a la consola."
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr "Visualitza la composició"
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr "Mostra les actualitzacions de la composició a la pantalla per depurar."
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr "Sense memòria intermèdia doble"
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 "Desconnectada la memòria intermèdia doble que normalment està habilitada."
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+#, fuzzy
+msgid "Delete Point"
+msgstr "Suprimeix punt"
+
+#: ../po/tmp/resources.xml.h:187
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr "Suprimeix el punt seleccionat"
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr "Mode de pintura"
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr "Mode de pintura: Normal"
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr "Aplica el color normalment quan pintis."
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr "Mode de pintura: Goma d'esborrar"
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr "Esborra usant el pinzell actual."
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr "Mode de pintura: Alfa bloquejat"
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr "Aplicant el pinzell no es pot canviar la opacitat de la capa."
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr "Mode de pintura: Acoloreix"
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
@@ -4649,247 +5749,243 @@ msgstr ""
 "Aplica el color a la capa actual sense afectar la seva brillantor o la seva "
 "opacitat."
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Fitxer"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "Surt"
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr "Tanca la finestra principal i surt de l'aplicació."
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "Edició"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr "Eina actual"
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "Color"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr "Ajusta el color"
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr "Diàleg emergent de l'historial de colors"
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr "Mostra una línia de temps dels colors recents sota el cursor."
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr "Diàleg de detalls del color"
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr "Mostra el diàleg dels detalls del color amb una entrada de text."
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr "Color de la paleta següent"
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr "Estableix el color de pintat al color següent de la paleta."
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr "Color de la paleta prèvia"
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr "Estableix el color de pintat al color prèvi de la paleta."
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr "Afegeix color a la paleta"
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr "Afegeix el color actual a la paleta."
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "Capa"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr "Opacitat"
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr "Vés a la capa"
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr "Capa nova a sota"
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr "Propietats"
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr "Quadre d'esborranys"
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr "Quadre d'esborranys nou"
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 "Carrega el quadre d'esborranys per defecte com llenç del quadre d'esborranys "
 "nou."
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr "Obre el quadre d'esborranys…"
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr "Carrega un fitxer d'imatge al disc dins del quadre d'esborranys."
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr "Desa el quadre d'esborranys"
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr "Desa el quadre d'esborranys al fitxer que el conté al disc."
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr "Exporta el quadre d'esborranys com…"
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 "Exporta el quadre d'esborranys al disc sota un nom de fitxer de la vostra "
 "elecció."
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr "Reverteix el quadre d'esborranys"
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr "Reverteix el quadre d'esborranys al seu estat desat últim."
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr "Desa el quadre d'esborranys per defecte"
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr "Desa el quadre d'esborranys per defecte al «Quadre d'esborranys nou»."
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr "Neteja el quadre d'esborranys per defecte"
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr "Neteja el quadre d'esborranys per defecte al llenç en blanc."
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr "Copia el fons principal al quadre d'esborranys"
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
-msgstr "Copia la imatge de fons del document de treball al quadre d'esborranys."
+msgstr ""
+"Copia la imatge de fons del document de treball al quadre d'esborranys."
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "Finestra"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "Pinzell"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr "Dreceres de teclat"
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr "Ajuda de dreceres de teclat del pinzell"
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr "Mostra una explicació de com funcionen les dreceres de teclat."
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "Canvia el pinzell…"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr "Mostra un canviador de pinzell sota el cursor."
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "Canvia el color…"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
@@ -4897,12 +5993,12 @@ msgstr ""
 "Mostra un canviador de pinzell sota el cursor amb tot els selectors de "
 "colors llistats."
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "Canvia el color (subconjunt ràpid)…"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
@@ -4910,209 +6006,213 @@ msgid ""
 msgstr ""
 "Mostra un canviador de pinzell sota el cursor amb sols un selector llistat."
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr "Obté més pinzells…"
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr "Descarrega paquets de pinzells del wiki de MyPaint."
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr "Importa pinzells…"
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr "Carrega un paquet de pinzells del disc."
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Ajuda"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr "Ajuda en línia"
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr "Vés a la documentació del wiki de MyPaint."
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "Quant a MyPaint"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr "Mostra la llicència de MyPaint, nombre de versió i crèdits."
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Depura"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr "Imprimeix la pèrdua de memòria a la consola (lent!!)"
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr "Depura les pèrdues de memòria."
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr "Inicia el recopilador de dades innecessàries ara"
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr "Memòria lliure usada pels objectes de Python que no estan en ús."
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr "Inicia/atura l'anàlisi del rendiment…"
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr "Inicia o atura l'anàlisi de rendiment de Python (cProfile)"
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr "Simula una fallada…"
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr "Augmenta l'excepció de Python per provar el diàleg de fallades."
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "Visualització"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr "Retroacció"
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr "Ajusta la visualització"
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
+#, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr "Menú emergent"
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr "Mostra el menú principal com emergent."
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "Pantalla completa"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr "Commuta entre pantalla completa i mode finestra."
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "Edita les preferències"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr "Edita els paràmetres globals de MyPaint."
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr "Prova els dispositius d'entrada"
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 "Mostra un diàleg que capturi tots els esdeveniments que els vostres "
 "dispositius d'entrada enviïn."
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr "Selector de fons"
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr "Canvieu la textura del paper de fons."
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr "Editor de paràmetres del pinzell"
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr "Edita els paràmetres del pinzell actiu."
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr "Editor d'icones del pinzell"
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr "Edita les icones del pinzell."
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr "Panell de capes"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
-msgstr "Commuta el quadre acoblale de capes (organitza capes o assigna modes)."
+msgid "Dockable panel for managing layers."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr "Mostra el panell de capes"
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr "Mostra el quadre acoblable de capes (organitza capes o assigna modes)."
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr "Roda HCY"
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
@@ -5121,42 +6221,32 @@ msgstr ""
 "Selector de color to/cromaticitat/luminància cilíndric acoblable. Les "
 "llesques circulars són equiluminants."
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "Paleta de colors"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr "Selector de color de paleta acoblable."
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr "Roda HSV"
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr "Canviador de valor de color i saturació acoblable."
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr "Triangle HSV"
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr "Selector de color acoblable: el triangle de color GTK antic."
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr "Cub HSV"
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
@@ -5165,224 +6255,217 @@ msgstr ""
 "Selector de color acoblable: cub HSV que pot ser girat per mostrar llesques "
 "planes diferents."
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr "Quadrat HSV"
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
-msgstr ""
-"Selector de color acoblable: quadrat HSV que pot ser girat per mostrar tons "
-"diferents."
+msgid "Dockable color selector: HSV square with Hue ring."
+msgstr "Selector de color acoblable amb anells concèntrics HSV."
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr "Lliscadors de components"
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr "Selector de color acoblable mostrant components individuals de color."
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr "Detergent liquid"
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr "Selector de color acoblable mostrant un rentat de colors propers."
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr "Anells concèntrics"
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr "Selector de color acoblable amb anells concèntrics HSV."
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr "Bol creuat"
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 "Selector de color acoblable amb rampes HSV creuant un bol radial de color."
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr "Panell del quadre d'esborranys"
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
-"Commuta el quadre acoblable del quadre d'esborranys (mescla color i fes "
-"esbossos)."
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr "Mostra el panell del quadre d'esborranys"
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 "Mostra el quadre acoblable del quadre d'esborranys (mescla color i fes "
 "esbossos)."
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr "Panell de previsualització"
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
-"Commuta el quadre acoblable de previsualització (visió de conjunt de l'àrea "
-"de dibuix sencera)."
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "Previsualització"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 "Mostra el quadre acoblable de previsualització (visió de conjunt de l'àrea "
 "de dibuix sencera)."
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr "Panell d'opcions d'eines"
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
-"Commuta el quadre acoblable d'opcions d'eina (opcions per l'eina actual)."
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr "Mostra el panell d'opció d'eines"
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 "Mostra el quadre acoblable d'opcions d'eina (opcions per l'eina actual)."
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr "Pinzell i panell d'historial del color"
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
-"Commuta el quadre d'historial (pinzells i colors usats de forma recent)."
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr "Pinzells i colors recents"
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
-msgstr "Mostra el quadre d'historial (pinzells i colors usats de forma recent)."
+msgstr ""
+"Mostra el quadre d'historial (pinzells i colors usats de forma recent)."
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr "Amaga els controls a la pantalla completa"
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 "Commuta l'amagat automàtic a la interfície de l'usuari en pantalla completa."
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr "Mostra el nivell d'ampliació/reducció"
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr "Commuta la retroacció del nivell de l'ampliació/reducció."
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr "Mostra la posició de l'últim pintat"
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr "Commuta la retroacció mostrant on ha acabat el darrer traç."
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr "Mostra el filtre"
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr "Mostra el colors normalment"
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr "Filtra els colors: mostra els colors sense modificacions."
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr "Mostra els colors com escala de grisos"
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr "Filtra els colors: mostra sols la brillantor (luminància YCbCr/HCY)"
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr "Mostra els colors invertits"
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
-msgstr "Filtre de colors: vídeo invers. El negre és blanc i el vermell és cian."
+msgstr ""
+"Filtre de colors: vídeo invers. El negre és blanc i el vermell és cian."
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr "Mostra colors amb un simulat insensible al roig"
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
@@ -5390,269 +6473,269 @@ msgstr ""
 "Filtra colors per simular la deuteranòpia, una forma comú de ceguesa del "
 "color."
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr "Mostra colors amb un simulat insensible al verd"
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 "Filtra colors per simular protanòpia, una forma comú de ceguesa del color."
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr "Mostra colors amb un simulat insensible al blau"
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 "Filtra colors per simular tritanòpia, una forma rara de ceguesa de color."
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr "A mà alçada"
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr "A ma alçada"
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 "A ma alçada: dibuixa i pinta de forma lliure sense restriccions geomètriques."
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr "A mà alçada"
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr "Dibuixa i pinta lliurement sense restriccions geomètriques."
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr "Visualització panoràmica"
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr "Panoràmica"
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 "Visualització panoràmica: moveu horitzontalment o verticalment la vostra "
 "visualització del llenç."
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr "Visualització panoràmica"
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 "Moveu de forma interactiva la vostra visualització del llenç horitzontalment "
 "o verticalment."
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr "Gira la visualització"
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr "Gira"
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr "Gira la visualització: inclineu la vostra visualització del llenç."
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr "Gira la visualització"
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr "Gireu de forma interactiva la vostra visualització del llenç."
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr "Amplia/redueix la visualització"
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr "Amplia/redueix"
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr "Amplia/redueix la visualització: amplia o redueix el llenç."
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr "Amplia/redueix la visualització"
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr "Amplia o redueix de forma interactiva el llenç."
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr "Línies i corbes"
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr "Línies"
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr "Línies i corbes: dibuixa línies rectes o corbes."
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr "Línies i corbes"
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr "Dibuixa línies rectes o corbes."
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr "Línies connectades"
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr "Connecta línies"
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr "Línies connectades: dibuixa seqüencies de línies rectes o corbes."
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr "Línies connectades"
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr "Dibuixa seqüencies de línies rectes o corbes."
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr "El·lipses i corbes"
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr "El·lipse"
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr "El·lipses i corbes: dibuixa formes arredonides."
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr "El·lipses i Cercles"
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr "Dibuixa cercles i el·lipses."
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr "Entinta"
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr "Tinta"
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr "Entinta: dibuixa línies controlades suaus."
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr "Entinta"
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr "Dibuixa línies controlades suaus."
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr "Reposicionament de capa"
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr "Posició de la capa."
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr "Reposicionament de capa: mou la capa actual del llenç."
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr "Reposició de la capa"
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr "Moveu de forma interactiva la capa actual del llenç."
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr "Edita el marc"
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr "Marc"
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
@@ -5660,12 +6743,12 @@ msgstr ""
 "Edita el marc: defineix un marc al voltant del document per donar-li una "
 "mida finita."
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr "Edita el marc"
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
@@ -5673,80 +6756,292 @@ msgstr ""
 "Defineix de forma interactiva un marc al voltant del document per donar-li "
 "una mida finita."
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Edita la simetria del dibuix"
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr "Simetria"
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 "Edita la simetria del dibuix: ajusta l'eix usat per la simetria del dibuix."
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Edita la simetria del dibuix"
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr "Ajusta de forma interactiva l'eix usat per la simetria del dibuix."
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr "Escolliu el color"
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr "Trieu col."
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 "Escolliu el color: configura el color de pintat des dels píxels de la "
 "pantalla."
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "Tria el Color"
+
+#: ../po/tmp/resources.xml.h:401
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr "Configura el color de pintat des dels píxels de la pantalla."
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "Tria el Color"
+
+#: ../po/tmp/resources.xml.h:403
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr "Configura el color de pintat des dels píxels de la pantalla."
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "Tria el Color"
+
+#: ../po/tmp/resources.xml.h:405
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr "Configura el color de pintat des dels píxels de la pantalla."
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr "Escolliu un color"
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr "Configura el color de pintat des dels píxels de la pantalla."
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr "Farciment total"
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr "Omple"
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr "Farciment total: Omple un àrea amb color."
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr "Farciment total"
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr "Omple un àrea amb color."
+
+#~ msgctxt "Accelerator map editor: action column markup"
+#~ msgid ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+#~ msgstr ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+
+#~ msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
+#~ msgid "{action_label} {action_desc} {accel_label}"
+#~ msgstr "{action_label} {action_desc} {accel_label}"
+
+#~ msgctxt "brush list context menu"
+#~ msgid "Delete"
+#~ msgstr "Suprimeix"
+
+#~ msgctxt "brush list commands"
+#~ msgid "Really delete brush from disk?"
+#~ msgstr "Segur que voleu esborrar el pinzell del disc?"
+
+#~ msgid "HSV Triangle"
+#~ msgstr "Triangle HSV"
+
+#~ msgid "The standard GTK color selector"
+#~ msgstr "El selector de color GTK estàndard"
+
+#~ msgid "Pick a color from the screen"
+#~ msgstr "Escull un color de la pantalla"
+
+#~ msgid "Layer Name"
+#~ msgstr "Nom de capa"
+
+#~ msgid ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+#~ msgstr ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+
+#~ msgid "Save..."
+#~ msgstr "Desa..."
+
+#~ msgid "Confirm"
+#~ msgstr "Confirmació"
+
+#~ msgid "Open..."
+#~ msgstr "Obre..."
+
+#~ msgid "{default_name} at {path}"
+#~ msgstr "{default_name} a {path}"
+
+#~ msgid "Type"
+#~ msgstr "Tipus"
+
+#~ msgid "Mode:"
+#~ msgstr "Mode:"
+
+#~ msgid ""
+#~ "Blending mode: how the current layer combines with the layers underneath "
+#~ "it."
+#~ msgstr ""
+#~ "Mode barreja: com es combina la capa actual amb les capes que hi han a "
+#~ "sota."
+
+#~ msgid ""
+#~ "Layer opacity: how much of the current layer to use. Smaller values make "
+#~ "it more transparent."
+#~ msgstr ""
+#~ "Opacitat de la capa: quant de la capa actual s'usarà. Els valors més "
+#~ "petits la fan més transparent."
+
+#~ msgid "%s: edit properties"
+#~ msgstr "%s: edita les propietats"
+
+#~ msgctxt "layer unique names: match regex (leave untranslated if unsure)"
+#~ msgid "^(.*?)\\s*(\\d+)$"
+#~ msgstr "^(.*?)\\s*(\\d+)$"
+
+#~ msgctxt "layer default names"
+#~ msgid "Unknown Bitmap Layer"
+#~ msgstr "Capa de mapa de bits desconeguda"
+
+#~ msgctxt "Autosave Recovery dialog|"
+#~ msgid "_Ignore for Now"
+#~ msgstr "_Ignora per ara"
+
+#~ msgid "Setting name:"
+#~ msgstr "Nom del paràmetre:"
+
+#~ msgid "Base value:"
+#~ msgstr "Valor base:"
+
+#~ msgid "Reset the base value to its default"
+#~ msgstr "Reinicia el valor base al valor per defecte"
+
+#~ msgid "<ymin>"
+#~ msgstr "<ymin>"
+
+#~ msgid "<ymax>"
+#~ msgstr "<ymax>"
+
+#~ msgid "<xmin>"
+#~ msgstr "<xmin>"
+
+#~ msgid "<xmax>"
+#~ msgstr "<xmax>"
+
+#~ msgid "Edit Setting"
+#~ msgstr "Edita el paràmetre"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Trim Layer to Frame"
+#~ msgstr "Talla la capa al marc"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Rename Layer…"
+#~ msgstr "Canvia el nom a la capa…"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Enter a new name for the current layer."
+#~ msgstr "Entreu un nom nou per la capa actual."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Turn off mirroring of the view."
+#~ msgstr "Desconnecta l'emmirallat de la la visualització."
+
+#~ msgctxt "Menu→Edit (labels)"
+#~ msgid "Current Tool"
+#~ msgstr "Eina actual"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+#~ msgstr ""
+#~ "Commuta el quadre acoblale de capes (organitza capes o assigna modes)."
+
+#~ msgctxt "Menu→Color (labels), Accel Editor (labels)"
+#~ msgid "HSV Triangle"
+#~ msgstr "Triangle HSV"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Dockable color selector: the old GTK color triangle."
+#~ msgstr "Selector de color acoblable: el triangle de color GTK antic."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid ""
+#~ "Dockable color selector: HSV square which can be rotated to show "
+#~ "different hues."
+#~ msgstr ""
+#~ "Selector de color acoblable: quadrat HSV que pot ser girat per mostrar "
+#~ "tons diferents."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+#~ msgstr ""
+#~ "Commuta el quadre acoblable del quadre d'esborranys (mescla color i fes "
+#~ "esbossos)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+#~ msgstr ""
+#~ "Commuta el quadre acoblable de previsualització (visió de conjunt de "
+#~ "l'àrea de dibuix sencera)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+#~ msgstr ""
+#~ "Commuta el quadre acoblable d'opcions d'eina (opcions per l'eina actual)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the History panel (recently used brushes and colors)."
+#~ msgstr ""
+#~ "Commuta el quadre d'historial (pinzells i colors usats de forma recent)."

--- a/po/ckb.po
+++ b/po/ckb.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2018-07-02 22:05+0000\n"
 "Last-Translator: Haval Abdulkarim <haval.abdulkarim@gmail.com>\n"
 "Language-Team: Sorani <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -19,29 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.1-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr "<big><b>{accel_label}</b></big>"
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr "{action_label} {action_desc} {accel_label}"
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -49,39 +27,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr "دەستکاریکردنی کلیل بۆ '%s'"
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "کردار:"
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "ڕێڕەو:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "کلیل:"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr "پەنجە بنێ بە کلیلەکان بۆ نوێکردنەوەی ئەم ئەرکە"
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "کرداری نەناسراو"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr "کردنەوەی بوخچەی \"{folder_basename}\"…"
@@ -89,194 +67,204 @@ msgstr "کردنەوەی بوخچەی \"{folder_basename}\"…"
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "باشە"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr "کردنەوەی بوخچەی حەشارگە…"
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "پاشەکەوتکردن وەک بنەڕەت"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "پاشبەند"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "چنراو"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "ڕەنگ"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "زیادکردنی ڕەنگ بۆ چنراوەکان"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr "هەڵە ڕوویدا لە بارکردنی پاشبەندەکان"
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr "{filename} قەبارەکەی سفرە (پانی={w}، بەرزی={h})"
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr "فڵچەی دەستکاریکەری ڕێکخستن"
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr "دەربارە"
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "تاقیکاری"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr "سەرەتایی"
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr "ناڕوون"
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "لەکە"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr "خێرایی"
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr ""
+
+#: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr ""
 
-#: ../gui/brusheditor.py:359
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "جەڵتە"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr "ڕەنگ"
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr ""
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 "هیچ فڵچەیەک دیاری نەکراوە، تکایە \"زیادکردن وەک نوێ\" بەکاربهێنە جگە لەمە."
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr "هیچ فڵچەیەک دیاری نەکراوە!"
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "ناولێنانەوەی فڵچە"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "فڵچەیەک بەم ناوە بوونی هەیە!"
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr "هیچ فڵچەیەک دیاری نەکراوە!"
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr "بەڕاست دەتەوێت فڵچەی \"{brush_name}\" بسڕیتەوە لەسەر پەپکە؟"
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr "(فڵچەی بێناو)"
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr "{brush_name} [پاشەکەوت نەکراو]"
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr "وێنۆچکەی فڵچە"
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr "وێنۆچکەی فڵچە (دەستکاری کراو)"
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr "هیچ فڵچەیەک دیاری نەکراوە"
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -285,7 +273,7 @@ msgstr ""
 "<b>%s</b>\n"
 "<small>سەرەتا فڵچەیەکی دروست هەڵبژێرە</small>"
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
@@ -294,7 +282,7 @@ msgstr ""
 "<b>%s</b> <i>(گۆڕدراو)</i>\n"
 "<small>گۆڕانکارییەکان هێشتا پاشەکەوت نەکراوە</small>"
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
@@ -303,7 +291,7 @@ msgstr ""
 "<b>%s</b> (دەستکاری کراو)\n"
 "<small>نیگارکردن لەڕێگەی هەر فڵچەیەک یان ڕەنگێک</small>"
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -345,142 +333,182 @@ msgstr "خۆکار"
 msgid "Use the default icon"
 msgstr "بەکارهێنانی وێنۆچکەی بنەڕەت"
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "پاشەکەوتکردن"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr "سڕایەوە"
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr "دڵخوازەکان"
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr "جەهەر(مەرەکەب)"
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr "کلاسیک"
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr "کۆمەڵە#1"
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr "کۆمەڵە#2"
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr "کۆمەڵە#3"
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr "کۆمەڵە#4"
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr "کۆمەڵە#5"
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr "تاقیکاری"
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "نوێ"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr "فڵچەی نەناسراو"
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr "زیادکردن بۆ دڵخوازەکان"
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr "لابردن لە دڵخوازەکان"
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr "لێکچوو"
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr "دەستکاریکردنی ڕێکخستنەکانی فڵچە"
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
-msgstr "سڕینەوە"
+#: ../gui/brushselectionwindow.py:250
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
+msgstr "ناولێنانەوەی دەستە"
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
 msgstr ""
 
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, fuzzy, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
+msgstr "بەڕاست دەتەوێت فڵچەی \"{brush_name}\" بسڕیتەوە لەسەر پەپکە؟"
+
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] "%d فڵچە"
 msgstr[1] "%d فڵچەکان"
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr "دەستەی \"{group_name}\""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr "ناولێنانەوەی دەستە"
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr "سڕینەوەی دەستە"
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr "ناولێنانەوەی دەستە"
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "دەستەیەک بەم ناوە بوونی هەیە!"
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr "بەڕاست دەتەوێت دەستەی \"{group_name}\" بسڕیتەوە؟"
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -490,58 +518,58 @@ msgstr ""
 "نەتوانرا دەستەی \"{group_name}\" بسڕێتەوە.\n"
 "هەندێک دەستەی تایبەت هەیە ناتوانرێت بسڕێتەوە."
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr "هەناردەکردنی فڵچەکان"
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr "گورزەی فڵچەی مای پەینت )*.zip("
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "دەستەی نوێ…"
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr "هاوردەکردنی فڵچەکان…"
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr "فڵچەی زیاتر بەدەست بهێنە…"
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "دروستکردنی دەستە"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr "دوگمە"
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr "دوگمە"
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr "دوگمە دابگرە"
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -550,52 +578,77 @@ msgstr ""
 msgid "Button press:"
 msgstr "دوگمە دابگرە:"
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr "هەڵبژاردنی ڕەنگ"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "هەڵبژاردنی ڕەنگ"
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr "وردەکارییەکانی ڕەنگ"
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -605,137 +658,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr "تەواوکەر"
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr "کارا"
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr "یارمەتی…"
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr "سڕینەوەی دەمامکەکە."
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr "یارمەتی سەرهێڵ بکەوە بۆ ئەم گفتوگۆیە لەسەر وێبگەڕێک."
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -743,162 +796,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr "نرخی HSV"
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr "HSV شەشپاڵو"
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr "HSV چوارگۆشە"
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr "HSV سێگۆشە"
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr "دیاریکەری ڕەنگی پێوانەیی GTK"
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr "HSV چەرخ"
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr "تایبەتمەندییەکانی تەختەی ڕەنگ"
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr "تەختەی ڕەنگ"
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr "تەختەی ڕەنگی بێناونیشان"
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr "دەستکاریکەری تەختەی ڕەنگ"
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr "ناونیشان:"
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr "ناو یان پێناسە بۆ ئەم تەختە ڕەنگە"
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr "ستوونەکان:"
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr "ژمارەی ستوونەکان"
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr "ناوی ڕەنگ:"
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr "ناوی هەنووکەیی ڕەنگەکان"
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr "پاشەکەوتکردنی تەختەی ڕەنگ"
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -906,373 +951,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr "تێخستنی ڕیز"
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr "تێخستنی ستوون"
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr "هەموو پەڕگەکان (*)"
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr "هەموو پەڕگەکان (*)"
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr "ڕەنگێک هەڵبژێرە لەسەر بینگەرەوە"
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr "R"
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr "G"
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr "B"
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr ""
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr "ئایا گورزەی فڵچە هاوردە دەکەی؟"
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr "پەشیمان بوونەوە %s"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "پەشیمان بوونەوە"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr ""
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1282,324 +1324,683 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "کردنەوە"
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr ""
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr ""
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "دەرچوون"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "پاشەکەوتکردنی تەختەی ڕەنگ"
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
+msgstr ""
+
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
+msgstr ""
+
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "پاشەکەوتکردن وەک…"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
 #, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
-msgstr ""
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr "کردنەوە…"
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr ""
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "کردنەوە"
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "بڕۆ بۆ چین"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "کردنەوە"
+
+#: ../gui/filehandling.py:1427
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "کردنەوە"
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "کردنەوە"
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+#, fuzzy
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr "لەبار بۆ بینین"
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr "چینێکی نوێ )جارێک("
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr ""
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "سڕینەوەی چین"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1607,130 +2008,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1739,35 +2152,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1791,45 +2204,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1837,153 +2254,220 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+#, fuzzy
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr "خاسیەتەکان"
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "چین"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr ""
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr ""
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "ناولێنانەوەی فڵچە"
 
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr ""
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr ""
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr ""
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr ""
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 msgid "Stroke lead-in end"
 msgstr ""
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr ""
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1995,256 +2479,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2252,188 +2761,214 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "ناولێنانەوەی دەستە"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "بڕۆ بۆ چین"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2442,13 +2977,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2458,7 +2993,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2466,13 +3001,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2480,7 +3015,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2488,7 +3023,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2499,7 +3034,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2507,7 +3042,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2517,7 +3057,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2528,285 +3068,402 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+#, fuzzy
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr "پڕکردنەوە"
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
-msgctxt "layer default names"
-msgid "Vector Layer"
-msgstr ""
-
 #: ../lib/layer/data.py:1153
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Vectors"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
+#: ../lib/layer/data.py:1158
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Vector Layer"
+msgstr "خاوێنکردنەوەی چین"
+
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Data Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr "کرداری نەناسراو"
+
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "چینێکی نوێی نیگارکردن"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "دەستەیەکی چینی نوێ"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+#, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "بینین"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+#, fuzzy
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr "چینی نوێ بۆ ژێرەوە"
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+#, fuzzy
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr "چینی نوێ بۆ ژێرەوە"
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2816,7 +3473,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2825,52 +3502,84 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr "سڕینەوە"
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
-msgstr "لەبەرگرتنەوە بۆ نوێ"
+msgid "Live update"
+msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2892,17 +3601,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
-msgstr ""
+msgid "Copy to New"
+msgstr "لەبەرگرتنەوە بۆ نوێ"
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2931,113 +3638,90 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
-msgstr ""
+#: ../po/tmp/brusheditor.glade.h:22
+#, fuzzy
+msgid "Value:"
+msgstr "نرخی HSV"
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
 msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+#, fuzzy
+msgid "<big><b>No Brush Dynamics</b></big>"
+msgstr "<big><b>{accel_label}</b></big>"
 
 #: ../po/tmp/inktool.glade.h:1
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
@@ -3049,7 +3733,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3090,6 +3774,136 @@ msgstr "سڕینەوەی خاڵ"
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+#, fuzzy
+msgid "Insert Point"
+msgstr "تێخستنی ڕیز"
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+#, fuzzy
+msgid "Cull Points"
+msgstr "سڕینەوەی خاڵ"
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr ""
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr "شێواز"
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "ناڕوون"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3459,56 +4273,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3516,12 +4350,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3530,7 +4364,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3541,28 +4375,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3624,1828 +4458,2051 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
-msgstr "پاشەکەوتکردن"
+msgid "Import Layers…"
+msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
-msgstr "پاشەکەوتکردن وەک…"
+msgid "Save"
+msgstr "پاشەکەوتکردن"
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
-msgstr ""
+msgid "Save As…"
+msgstr "پاشەکەوتکردن وەک…"
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr "فڵچەکان"
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr "ڕەنگەکان"
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr "شێواز"
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "خاوێنکردنەوەی چین"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "دەستەیەکی چینی نوێ"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "دەستەیەکی چینی نوێ"
+
+#: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:71
+#: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Edit Layer in External App…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
-msgstr "چینێکی نوێی نیگارکردن"
-
-#: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:85
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
-msgstr "دەستەیەکی چینی نوێ"
-
-#: ../po/tmp/resources.xml.h:86
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:87
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:88
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:89
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
-msgstr "سڕینەوەی چین"
+msgid "New Painting Layer"
+msgstr "چینێکی نوێی نیگارکردن"
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr "دەستەیەکی چینی نوێ"
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr "سڕینەوەی چین"
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
+#, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
-msgstr ""
+msgid "Layer Properties…"
+msgstr "خاسیەتەکان"
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr "لەبار بۆ بینین"
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+#, fuzzy
+msgid "Delete Point"
+msgstr "سڕینەوەی خاڵ"
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "پەڕگە"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "دەرچوون"
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "دەستکاری"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "ڕەنگ"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "چین"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr "بڕۆ بۆ چین"
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr "چینی نوێ بۆ ژێرەوە"
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr "خاسیەتەکان"
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "پەنجەرە"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "فڵچە"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "گۆڕینی فڵچە…"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "گۆرینی ڕەنگ…"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr "بەدەستهێنانی فڵچەی زیاتر…"
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "یارمەتی"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr "یارمەتی سەرهێڵ"
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "درەبارەی مای پەینت"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "بینین"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "پڕ پەردە"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "دەستکاری کردنی هەڵبژاردەکان"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr "فڵچەی دەستکاریکەری ڕێکخستنەکان"
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr "پەنالی چینەکان"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr "پیشاندانی پەنالی چینەکان"
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "ڕەنگی تەختە"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr "پێشبینینی پەڕە"
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "پێشبینین"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr "پەڕەی بژاردەکانی ئامراز"
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr "پیشاندانی پەڕەی بژاردەکانی ئامراز"
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr "پەڕەی مێژووی ڕەنگ و فڵچە"
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr "هێڵەکان"
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr "هێڵەکان و چەماوەکان"
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr "تەنە هێلکەییەکان و بازنەکان"
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr "چوارچێوە"
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr "دەستکاریکردنی چوارچێوە"
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "دەستکاریکردنی نیگاری چوونیەک"
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr "هەڵبژاردنی ڕەنگ"
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "هەڵبژاردنی ڕەنگ"
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "هەڵبژاردنی ڕەنگ"
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "هەڵبژاردنی ڕەنگ"
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr "هەڵبژاردنی ڕەنگ"
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr "پڕکردنەوە"
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""
+
+#~ msgctxt "Accelerator map editor: action column markup"
+#~ msgid ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+#~ msgstr ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+
+#~ msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
+#~ msgid "{action_label} {action_desc} {accel_label}"
+#~ msgstr "{action_label} {action_desc} {accel_label}"
+
+#~ msgctxt "brush list context menu"
+#~ msgid "Delete"
+#~ msgstr "سڕینەوە"
+
+#~ msgid "HSV Triangle"
+#~ msgstr "HSV سێگۆشە"
+
+#~ msgid "The standard GTK color selector"
+#~ msgstr "دیاریکەری ڕەنگی پێوانەیی GTK"
+
+#~ msgid "Pick a color from the screen"
+#~ msgstr "ڕەنگێک هەڵبژێرە لەسەر بینگەرەوە"

--- a/po/ckb.po
+++ b/po/ckb.po
@@ -530,17 +530,17 @@ msgstr "گورزەی فڵچەی مای پەینت )*.zip("
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr "دەستەی نوێ…"
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr "هاوردەکردنی فڵچەکان…"
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr "فڵچەی زیاتر بەدەست بهێنە…"
 
 #: ../gui/brushselectionwindow.py:554
@@ -1203,12 +1203,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1425,7 +1425,7 @@ msgid "_Quit"
 msgstr "دەرچوون"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1475,7 +1475,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1653,13 +1653,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "پاشەکەوتکردن وەک…"
 
@@ -1726,7 +1726,7 @@ msgstr "کردنەوە"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -2153,12 +2153,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2170,7 +2170,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2357,7 +2357,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2428,7 +2428,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/cs.po
+++ b/po/cs.po
@@ -536,18 +536,18 @@ msgstr "MyPaint sada štětců (*.zip)"
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
-msgstr "Nová skupina..."
+msgid "New Group…"
+msgstr "Nová skupina…"
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
-msgstr "Zavést štětce..."
+msgid "Import Brushes…"
+msgstr "Zavést štětce…"
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
-msgstr "Dostat další štětce..."
+msgid "Get More Brushes…"
+msgstr "Dostat další štětce…"
 
 #: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
@@ -1230,13 +1230,13 @@ msgstr "Typ"
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
-msgstr "Použít pro..."
+msgid "Use for…"
+msgstr "Použít pro…"
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
-msgstr "Posunovat..."
+msgid "Scroll…"
+msgstr "Posunovat…"
 
 #. Name and preview column: will be indented
 #: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
@@ -1459,8 +1459,8 @@ msgid "_Quit"
 msgstr "Ukončit"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
-msgstr "Zavést sadu štětců..."
+msgid "Import brush package…"
+msgstr "Zavést sadu štětců…"
 
 #: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
@@ -1514,8 +1514,8 @@ msgstr ""
 "“{type_name}” ({content_type})?"
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
-msgstr "Otevřít s..."
+msgid "Open With…"
+msgstr "Otevřít s…"
 
 #: ../gui/externalapp.py:123
 msgid "Icon"
@@ -1583,13 +1583,13 @@ msgstr "Uložit paletu"
 #, fuzzy
 msgctxt "Document I/O: fail dialog title"
 msgid "Export failed"
-msgstr "Exportovat paletu..."
+msgstr "Exportovat paletu…"
 
 #: ../gui/filehandling.py:172
 #, fuzzy
 msgctxt "Document I/O: fail dialog title"
 msgid "Import Layers failed"
-msgstr "Exportovat paletu..."
+msgstr "Exportovat paletu…"
 
 #: ../gui/filehandling.py:176
 #, fuzzy
@@ -1709,13 +1709,13 @@ msgstr "JPEG 90% kvalita (*.jpg; *.jpeg)"
 
 #: ../gui/filehandling.py:576
 #, fuzzy
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr "Vyvést…"
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Uložit jako…"
 
@@ -1786,8 +1786,8 @@ msgstr "Naposledy otevřené"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
-msgstr "Otevřít náčrtník..."
+msgid "Open Scratchpad…"
+msgstr "Otevřít náčrtník…"
 
 #: ../gui/filehandling.py:1099
 #, fuzzy
@@ -2243,13 +2243,13 @@ msgstr ""
 "nikdo nenahlásil."
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
-msgstr "Hledat sledování..."
+msgid "Search Tracker…"
+msgstr "Hledat sledování…"
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
-msgstr "Hlášení..."
+msgid "Report…"
+msgstr "Hlášení…"
 
 #: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
@@ -2260,8 +2260,8 @@ msgid "Quit MyPaint"
 msgstr "O programu MyPaint"
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
-msgstr "Podrobnosti..."
+msgid "Details…"
+msgstr "Podrobnosti…"
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
@@ -2472,8 +2472,8 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
-msgstr "Přesunout vrstvu v zásobníku..."
+msgid "Move layer in stack…"
+msgstr "Přesunout vrstvu v zásobníku…"
 
 #: ../gui/layerswindow.py:110
 msgid ""
@@ -2544,8 +2544,8 @@ msgid "Stroke trail-off beginning"
 msgstr "Začátek konce tahu"
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
-msgstr "Změna tlaku..."
+msgid "Pressure variation…"
+msgstr "Změna tlaku…"
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
@@ -3725,7 +3725,7 @@ msgstr "Smazat tento štětec z disku"
 #, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid "_Recover & Save…"
-msgstr "_Obnovit a uložit..."
+msgstr "_Obnovit a uložit…"
 
 #: ../po/tmp/autorecover.glade.h:12
 #, fuzzy

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.7.1-git\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2018-01-24 12:06+0000\n"
 "Last-Translator: Pavel Fric <pavelfric@yahoo.com>\n"
-"Language-Team: Czech "
-"<https://hosted.weblate.org/projects/mypaint/mypaint/cs/>\n"
+"Language-Team: Czech <https://hosted.weblate.org/projects/mypaint/mypaint/cs/"
+">\n"
 "Language: cs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -21,29 +21,7 @@ msgstr ""
 "X-Poedit-Language: Czech\n"
 "X-Poedit-Country: CZECH REPUBLIC\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr "<big><b>{accel_label}</b></big>"
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr "{action_label} {action_desc} {accel_label}"
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "Činnost"
 
@@ -51,41 +29,41 @@ msgstr "Činnost"
 msgid "Key combination"
 msgstr "Kombinace kláves"
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr "Upravit klávesovou zkratku pro '%s'"
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "Činnost:"
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "Cesta:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "Klávesa:"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr "Stiskněte klávesu pro aktualizaci tohoto přiřazení"
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "Neznámá činnost"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
-"<b>{accel} se již používá pro '{action}'. Stávající přiřazení bude "
-"nahrazeno.</b>"
+"<b>{accel} se již používá pro '{action}'. Stávající přiřazení bude nahrazeno."
+"</b>"
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr "Otevřít složku “{folder_basename}”…"
@@ -93,196 +71,206 @@ msgstr "Otevřít složku “{folder_basename}”…"
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "OK"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr "Nebyly nalezeny žádné zálohy v cache."
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr "Nejsou dostupné žádné zálohy"
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr "Otevřít složku cache…"
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr "Obnovení zálohy selhalo"
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr "Otevřít složku se zálohou…"
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr "Obnoven soubor z {iso_datetime}.ora"
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "Uložit jako výchozí"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "Pozadí"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "Vzor"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Barva"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "Přidat barvu do vzorů"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr "Jedno nebo více pozadí se nepodařilo nahrát"
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr "Chyba při nahrávání pozadí"
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 "Odstraňte, prosím, nenahratelné soubory, nebo prověřte svou instalaci "
 "libgdkpixbuf."
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr "Gdk-Pixbuf se nepodařilo nahrát \"{filename}\", a nahlásil \"{error}\""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr "{filename} má nulový rozměr (w={w}, h={h})"
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr "Editor nastavení štětců"
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr "O programu"
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "Pokusný"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr "Základní"
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr "Neprůhlednost"
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr "Body"
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "Šmouha"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr "Rychlost"
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr ""
+
+#: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr "Sledování"
 
-#: ../gui/brusheditor.py:359
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "Tah"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr "Barva"
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Vlastní"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 "Není vybrán žádný štětec, prosím, použijte místo toho \"Přidat jako nový\"."
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr "Není vybrán žádný štětec!"
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "Přejmenovat štětec"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "Štětec s tímto názvem již existuje!"
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr "Není vybrán žádný štětec!"
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr "Opravdu smazat štětec “{brush_name}” z disku?"
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr "(nepojmenovaný štětec)"
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr "{brush_name} [neuložen]"
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr "Ikona štětce"
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr "Ikona štětce (upravení)"
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr "Není vybrán žádný štětec"
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -291,7 +279,7 @@ msgstr ""
 "<b>%s</b>\n"
 "<small>Nejprve vyberte platný štětec</small>"
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
@@ -300,7 +288,7 @@ msgstr ""
 "<b>%s</b> <i>(změněno)</i>\n"
 "<small>Změny ještě nejsou uloženy</small>"
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
@@ -309,7 +297,7 @@ msgstr ""
 "<b>%s</b> (upravování)\n"
 "<small>Malujte jakýmkoli štětcem nebo barvou</small>"
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -350,98 +338,138 @@ msgstr "Automaticky"
 msgid "Use the default icon"
 msgstr "Použít výchozí ikonu"
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Uložit"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr "Uložit tuto ikonu náhledu a ukončit úpravy"
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr "Ztraceno a nalezeno"
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr "Smazáno"
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr "Oblíbené"
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr "Inkoust"
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr "Klasický"
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr "Sada#1"
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr "Sada#2"
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr "Sada#3"
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr "Sada#4"
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr "Sada#5"
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr "Pokusný"
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Nový"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr "Neznámý štětec"
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr "Přidat do oblíbených"
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr "Odstranit z oblíbených"
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr "Klonovat"
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr "Upravit přednastavení štětce"
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
-msgstr "Smazat"
+#: ../gui/brushselectionwindow.py:250
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
+msgstr "Přejmenovat skupinu"
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
-msgstr "Opravdu smazat štětec z disku?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, fuzzy, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
+msgstr "Opravdu smazat štětec “{brush_name}” z disku?"
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
@@ -449,44 +477,44 @@ msgstr[0] "%d štětec"
 msgstr[1] "%d štětce"
 msgstr[2] "%d štětců"
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr "Skupina “{group_name}”"
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr "Přejmenovat skupinu"
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr "Vyvést jako zazipovanou sadu štětců"
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr "Smazat skupinu"
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr "Přejmenovat skupinu"
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "Skupina s tímto názvem již existuje!"
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr "Opravdu smazat skupinu “{group_name}”?"
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -496,58 +524,58 @@ msgstr ""
 "Nelze smazat skupinu “{group_name}”.\n"
 "Některé speciální skupiny nelze smazat."
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr "Vyvést štětce"
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr "MyPaint sada štětců (*.zip)"
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "Nová skupina..."
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr "Zavést štětce..."
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr "Dostat další štětce..."
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "Vytvořit skupinu"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr "Tlačítko"
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr "Tlačítko"
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr "Stisknutí tlačítka"
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr "Přidat novou klávesovou zkratku"
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr "Odstranit nynější klávesovou zkratku"
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr "Upravit klávesovou zkratku pro '%s'"
@@ -556,7 +584,7 @@ msgstr "Upravit klávesovou zkratku pro '%s'"
 msgid "Button press:"
 msgstr "Stisknutí tlačítka:"
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
@@ -564,7 +592,7 @@ msgstr ""
 "Podržet modifikátory, a stisknout tlačítko nad tímto textem pro nastavení "
 "nové klávesové zkratky."
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
@@ -572,40 +600,68 @@ msgstr ""
 "{button} nelze přiřadit bez klávesových modifikátorů (jeho význam je dán "
 "pevně)"
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr "{button_combination} je již přiřazen k činnosti '{action_name}'"
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr "Vybrat barvu"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr "Nastavit barvu používanou pro malování"
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+#, fuzzy
+msgid "Set the color Hue used for painting"
+msgstr "Nastavit barvu používanou pro malování"
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "Vybrat barvu"
+
+#: ../gui/colorpicker.py:296
+#, fuzzy
+msgid "Set the color Chroma used for painting"
+msgstr "Nastavit barvu používanou pro malování"
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+#, fuzzy
+msgid "Set the color Luma used for painting"
+msgstr "Nastavit barvu používanou pro malování"
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr "Podrobnosti barvy"
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr "Nově vybraná barva a barva nedávno použitá pro malování"
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr "Maska tónového rozsahu činná"
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr "Omezit paletu pro určité nálady pomocí masky tónového rozsahu."
@@ -615,7 +671,7 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr "Sytost barvy a odstín HCY."
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
@@ -624,12 +680,12 @@ msgstr ""
 "Editor masky tónového rozsahu. Klepněte doprostřed pro vytvoření nebo "
 "pracujte s tvary, nebo otáčejte maskou pomocí okrajů disku."
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr "Atmosférická trojice barev"
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
@@ -638,22 +694,22 @@ msgstr ""
 "Náladová a subjektivní, určená jednou převládající základní barvou a dvěma "
 "základními barvami, jež jsou méně silné."
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr "Posunutá trojice barev"
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr "Nakloněno silněji směrem k převládající základní barvě."
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr "Doplňkové barvy"
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
@@ -662,12 +718,12 @@ msgstr ""
 "Kontrastní opaky, vyvážené na barevném kole středovými neutrálními barvami "
 "mezi nimi."
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr "Nálada a důraz"
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
@@ -676,12 +732,12 @@ msgstr ""
 "Jeden hlavní rozsah barev s doplňkovým důrazem na obměny a nejdůležitější "
 "barvy."
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr "Rozdělit doplňkové barvy"
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
@@ -689,72 +745,72 @@ msgid ""
 msgstr ""
 "Dvě obdobné barvy a doplněk k nim, s žádnými druhotnými barvami mezi nimi."
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr "Nová maska tónového rozsahu z předlohy"
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr "Editor masky tónového rozsahu"
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr "Činné"
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr "Nápověda…"
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr "Vytvořit masku z předlohy."
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr "Nahrát masku ze souboru palety GIMP."
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr "Uložit masku do souboru s paletou GIMP."
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr "Vymazat masku."
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr "Otevřít nápovědu na internetu pro tento dialog v prohlížeči."
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr "Uložit masku jako paletu GIMP"
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr "Nahrát masku ze souboru palety GIMP"
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr "Nastavit masku tónového rozsahu."
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr "Kolo HCY"
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -764,162 +820,154 @@ msgstr ""
 "Kolečka mají stejnou světelnost."
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr "Odstín HSV"
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr "Sytost HSV"
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr "Hodnota HSV"
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr "Sytost a hodnota HSV"
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr "Odstín a hodnota HSV"
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr "Odstín a sytost HSV"
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr "Otáčet krychlí (ukázat různé osy)"
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr "Krychle HSV"
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr "Krychle HSV, kterou lze otáčet pro ukázání různých řezů."
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr "Barevný čtverec HSV"
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr "Čtverec barev HSV, kterým lze otáčet pro ukázání různých odstínů."
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr "Trojúhelník barev HSV"
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr "Volič barev GTK"
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr "Kolo HSV"
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr "Změnit hodnotu a sytost."
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr "Vlastnosti palety"
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr "Paleta"
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr "Nastavit barvu z nahratelné, upravitelné palety."
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr "Nepojmenovaná paleta"
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr "Editor palety"
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr "Nahrát ze souboru palety GIMP"
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr "Uložit do souboru s paletou GIMP"
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr "Přidat nový prázdný vzorek"
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr "Odstranit nynější  vzorek"
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr "Odstranit všechny  vzorky"
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr "Název:"
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr "Název nebo popis pro tuto paletu"
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr "Sloupce:"
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr "Počet sloupců"
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr "Název barvy:"
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr "Název nynější barvy"
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr "Prázdné místo na paletě"
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr "Nahrát paletu"
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr "Uložit paletu"
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -930,379 +978,376 @@ msgstr ""
 "Zde upusťte barvy\n"
 "a přetahujte je pro jejich uspořádání."
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr "Prázdné místo na paletě (sem přetáhněte barvu)"
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr "Přidat prázdné místo"
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr "Vložit řádek"
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr "Vložit sloupec"
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr "Vyplnit mezeru (RGB)"
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr "Vyplnit mezeru (HCY)"
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr "Vyplnit mezeru (HSV)"
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "Soubor s paletou GIMP (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr "Všechny soubory (*)"
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "Soubor s paletou GIMP (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr "Všechny soubory (*)"
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr "Vybrat barvu z obrazovky"
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr "R"
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr "G"
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr "B"
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr "H"
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr "C"
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr "Y"
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr "Posuvníky složek"
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr "Přizpůsobit jednotlivé složky barvy."
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr "Červená RGB"
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr "Zelená RGB"
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr "Modrá RGB"
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr "Odstín HSV"
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr "Sytost HSV"
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr "Hodnota HSV"
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr "Odstín HCY"
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr "Sytost barvy HCY"
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr "Jasnost HCY (Y')"
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr "Plynulé stínování"
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr "Změnit barvu pomocí plynulého stínování sousedních barev."
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr "Soustředné kruhy"
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr "Změnit barvu pomocí soustředných kruhů."
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr "Barevný talíř"
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr "Změnit barvu pomocí ramp HSV křížících barevný talíř."
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr "Ukazatel myši"
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr "Guma"
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr "Klávesnice"
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr "Myš"
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr "Pero"
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr "Dotyková plocha"
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr "Dotyková obrazovka"
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr "Přehlížet"
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr "Oblíbené úkoly"
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr "Úkoly bez vztahu k malování"
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr "Jen pohyb"
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr "Zvětšení"
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr "Posunutí"
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr "Zařízení"
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr "Osy"
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr "Typ"
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr "Použít pro..."
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr "Posunovat..."
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Název"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr "Přepsat štětec?"
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr "Nahradit"
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr "Přejmenovat"
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr "Nahradit vše"
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr "Přejmenovat štětec"
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr "Zavedený štětec"
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr "Stávající štětec"
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 "<b>Štětec s názvem `%s' již existuje.</b>\n"
 "Chcete jej nahradit, nebo se má nový štětec přejmenovat?"
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr "Přepsat skupinu štětce?"
 
-#: ../gui/dialogs.py:190
-#, python-brace-format
+#: ../gui/dialogs.py:220
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 "<b>Skupina s názvem `{groupname}' již existuje.</b>\n"
 "Chcete ji nahradit, nebo se má nová skupina přejmenovat?\n"
 "Pokud ji nahradíte, štětce se mohou přesunout do skupiny nazvané "
 "`{deleted_groupname}'."
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr "Zavést sadu štětců?"
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, fuzzy, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr "<b>Opravdu chcete zavést balíček `%s'?</b>"
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr "Nahrát nastavení štětce z místa se zkratkou %d"
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr "Uložit nastavení štětce do místa se zkratkou %d"
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr "Obnovit štětec %d"
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr "Uložit mezi štětce %d"
 
-#: ../gui/document.py:538
-#, python-format, python-format
+#: ../gui/document.py:555
+#, python-format
 msgid "Undo %s"
 msgstr "Zpět %s"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Zpět"
 
-#: ../gui/document.py:550
-#, python-format, python-format
+#: ../gui/document.py:567
+#, python-format
 msgid "Redo %s"
 msgstr "Znovu %s"
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Znovu"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr "{button_combination} je {resultant_action}"
@@ -1312,102 +1357,145 @@ msgstr "{button_combination} je {resultant_action}"
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ";  "
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr "Podržením {modifiers}:  {button_actions}."
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
-msgstr "Název vrstvy"
-
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
-#, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
-"<b>{name}</b>\n"
-"{description}"
+
+#: ../gui/document.py:909
+#, python-brace-format
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
+msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
-#, python-format, python-format
+#: ../gui/drawwindow.py:269
+#, python-format
 msgid "%s - MyPaint"
 msgstr "%s - MyPaint"
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr "O programu MyPaint"
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Otevřít"
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr "Nastavit nynější barvu"
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr "Odejít z režimu na celou obrazovku"
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr "Opustit celou obrazovku"
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr "Vejít do režimu na celou obrazovku"
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Celá obrazovka"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Ukončit"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+#, fuzzy
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr "Opravdu ukončit?"
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Ukončit"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr "Zavést sadu štětců..."
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr "MyPaint sada štětců (*.zip)"
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr "Spuštěn {app_name} pro upravení vrstvy “{layer_name}”"
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 "Chyba: Nepodařilo se spustit {app_name} pro upravení vrstvy “{layer_name}”"
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr "Upravování zrušeno. “{layer_name}” lze upravit přes nabídku Vrstvy."
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr "Pomocí vnějších úprav aktualizována vrstva “{layer_name}”"
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr "Nepodařilo se nahrát “{file_basename}”."
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
@@ -1416,170 +1504,387 @@ msgstr ""
 "MyPaint potřebuje upravit soubor typu “{type_name}” ({content_type}). Který "
 "program na to má použít?"
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
-"Který program má MyPaint použít na upravení souborů typu “{type_name}” "
-"({content_type})?"
+"Který program má MyPaint použít na upravení souborů typu "
+"“{type_name}” ({content_type})?"
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr "Otevřít s..."
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr "Ikona"
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr "žádný popis"
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
+#: ../gui/filehandling.py:126
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
+msgstr "Nahrává se “{file_basename}”…"
+
+#: ../gui/filehandling.py:130
+#, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:134
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
+msgstr "Ukládá se “{file_basename}”…"
+
+#: ../gui/filehandling.py:138
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
+msgstr "Vyvádí se do “{file_basename}”…"
+
+#: ../gui/filehandling.py:145
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr "Nepodařilo se vyvést do “{file_basename}”."
+
+#: ../gui/filehandling.py:149
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr "Nepodařilo se uložit “{file_basename}”."
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr "Nepodařilo se nahrát “{file_basename}”."
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "Uložit paletu"
+
+#: ../gui/filehandling.py:168
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr "Exportovat paletu..."
+
+#: ../gui/filehandling.py:172
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr "Exportovat paletu..."
+
+#: ../gui/filehandling.py:176
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr "Naposledy otevřené"
+
+#: ../gui/filehandling.py:183
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr "Úspěšně vyvedeno do “{file_basename}”."
+
+#: ../gui/filehandling.py:187
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr "“{file_basename}” uložen úspěšně."
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr "Nahráno “{file_basename}”."
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: ../gui/filehandling.py:221
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
+msgstr "Nahráno “{file_basename}”."
+
+#: ../gui/filehandling.py:427
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "All Recognized Formats"
 msgstr "Všechny známé formáty"
 
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
+#: ../gui/filehandling.py:432
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "OpenRaster (*.ora)"
 msgstr "OpenRaster (*.ora)"
 
-#: ../gui/filehandling.py:95
+#: ../gui/filehandling.py:437
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "PNG (*.png)"
 msgstr "PNG (*.png)"
 
-#: ../gui/filehandling.py:96
+#: ../gui/filehandling.py:442
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "JPEG (*.jpg; *.jpeg)"
 msgstr "JPEG (*.jpg; *.jpeg)"
 
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
+#: ../gui/filehandling.py:490
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "By extension (prefer default format)"
 msgstr "Podle přípony (dávat přednost výchozímu formátu)"
 
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
+#: ../gui/filehandling.py:494
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:498
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
 msgstr "PNG plný s pozadím (*.png)"
 
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
+#: ../gui/filehandling.py:502
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:506
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
 msgstr "PNG průhledný (*.png)"
 
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
+#: ../gui/filehandling.py:510
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
 msgstr "Složený PNG průhledný (*.XXX.png)"
 
-#: ../gui/filehandling.py:113
+#: ../gui/filehandling.py:514
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr "Složený PNG průhledný (*.XXX.png)"
+
+#: ../gui/filehandling.py:518
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr "JPEG 90% kvalita (*.jpg; *.jpeg)"
 
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr "Uložit..."
+#: ../gui/filehandling.py:576
+#, fuzzy
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr "Vyvést…"
 
-#: ../gui/filehandling.py:177
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Uložit jako…"
+
+#: ../gui/filehandling.py:601
+#, fuzzy
+msgctxt "save dialogs: formats and options: (label)"
 msgid "Format to save as:"
 msgstr "Ukládací formát:"
 
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr "Potvrdit"
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
+#: ../gui/filehandling.py:668
+#, fuzzy
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
 msgstr "Opravdu pokračovat?"
 
-#: ../gui/filehandling.py:234
-#, python-brace-format, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
-msgstr "Toto zruší {abbreviated_time} neuložených kreseb"
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
+#: ../gui/filehandling.py:705
+#, fuzzy
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
 msgstr "_Uložit jako náčrt"
 
-#: ../gui/filehandling.py:282
-#, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
-msgstr "Nahrává se “{file_basename}”…"
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
 
-#: ../gui/filehandling.py:296
-#, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
-msgstr "Nepodařilo se nahrát “{file_basename}”."
+#: ../gui/filehandling.py:734
+#, fuzzy, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr "Toto zruší {abbreviated_time} neuložených kreseb"
 
-#: ../gui/filehandling.py:321
-#, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
-msgstr "Nahráno “{file_basename}”."
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
 
-#: ../gui/filehandling.py:422
-#, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
-msgstr "Vyvádí se do “{file_basename}”…"
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
 
-#: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
-msgstr "Ukládá se “{file_basename}”…"
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
-msgstr "Nepodařilo se vyvést do “{file_basename}”."
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr "Otevřít…"
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
-msgstr "Nepodařilo se uložit “{file_basename}”."
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Naposledy otevřené"
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
-msgstr "Úspěšně vyvedeno do “{file_basename}”."
-
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
-msgstr "“{file_basename}” uložen úspěšně."
-
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Otevřít..."
-
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr "Otevřít náčrtník..."
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Zavedený štětec"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Otevřít"
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Otevřít naposledy otevřený obraz"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Otevřít"
+
+#: ../gui/filehandling.py:1446
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
 msgstr "Nejsou ještě žádné náčrty nazvané \"%s\"."
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1455
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr "Otevřít další náčrt"
+
+#: ../gui/filehandling.py:1463
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr "Otevřít předchozí náčrt"
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Otevřít"
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+#, fuzzy
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr "Vrátit"
+
+#: ../gui/fill.py:121
+#, fuzzy
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr "Vyplnit"
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+#, fuzzy
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr "Vyplnit oblasti barvou"
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+#, fuzzy
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr "Tolerance:"
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+#, fuzzy
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
@@ -1587,19 +1892,36 @@ msgstr ""
 "Kolik barev obrazových bodů se může lišit od začátečního,\n"
 "předtím než je nástroj na vyplnění odmítne vyplnit"
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+#, fuzzy
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr "Zdroj:"
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
-msgstr "Které viditelné vrstvy se mají vyplnit"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
+msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+#, fuzzy
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr "Vrstvy sloučeny"
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+#, fuzzy
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
@@ -1609,19 +1931,50 @@ msgstr ""
 "dočasné sloučení všech viditelných vrstev\n"
 "pod nynější vrstvou"
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+#, fuzzy
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr "Přizpůsobit pohled"
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+#, fuzzy
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr "Cíl:"
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+#, fuzzy
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr "Kam má jít výstup"
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr "Nová vrstva (jednorázově)"
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+#, fuzzy
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
@@ -1629,21 +1982,108 @@ msgstr ""
 "Vytvořit novou vrstvu s výsledkem vyplnění.\n"
 "Toto je po použití automaticky vypnuto."
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Neprůhlednost:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr "Nastavit znovu"
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+#, fuzzy
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr "Nastavit volby znovu na výchozí hodnoty"
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "Vybrat vrstvu"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr "<b>{brush_name}</b>"
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1653,130 +2093,142 @@ msgstr ""
 "<b>{brush_name}</b>\n"
 "{brush_desc}"
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr "Upravit rámeček"
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr "Upravit rámeček dokumentu"
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr "Velikost rámečku"
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr "px"
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr "Výška:"
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr "Šířka:"
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr "Rozlišení:"
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr "DPI"
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr "Teček na palec (ve skutečnosti pixelů na palec)"
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr "Barva:"
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr "Barva snímku"
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr "<b>Rozměry rámečku</b>"
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr "<b>Hustota pixelů</b>"
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr "Přiřadit rámeček vrstvě"
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr "Přizpůsobit rámeček velikosti nynější vrstvy"
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr "Přizpůsobit rámeček dokumentu"
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr "Přizpůsobit rámeček kombinaci všech vrstev"
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr "Zastřihnout vrstvy na rámeček"
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr "Zastřihnout všechny části nynějších vrstev ležící mimo rámeček"
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr "Povoleno"
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr "{width:g}×{height:g} {units}"
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr "palec"
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr "cm"
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr "mm"
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr "Kresba od ruky"
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr "Malovat nepravidelně tvořenými tahy štětce"
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr "Plynulé:"
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr "Tlak:"
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr "Zjištěna chyba"
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr "<big><b>Byla zjištěna programová chyba.</b></big>"
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1790,35 +2242,35 @@ msgstr ""
 "Řekněte, prosím, o tomto vývojářům pomocí sledování potíží, pokud to ještě "
 "nikdo nenahlásil."
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr "Hledat sledování..."
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr "Hlášení..."
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr "Přehlížet chybu"
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr "O programu MyPaint"
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr "Podrobnosti..."
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr "Výjimka během rozboru výjimky."
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1849,8 +2301,8 @@ msgstr ""
 "            pokud můžete.\n"
 "            Potom tento text, prosím, nahraďte\n"
 "            delším popisem chyby.\n"
-"            Snímky obrazovky a její obrazové záznamy jsou samozřejmě skvělé!"
-"\n"
+"            Snímky obrazovky a její obrazové záznamy jsou samozřejmě "
+"skvělé!\n"
 "\n"
 "            #### Kroky k napodobení chybného chování\n"
 "\n"
@@ -1864,45 +2316,50 @@ msgstr ""
 "            #### Zpětné sledování\n"
 "        "
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr "Nanášení barvy"
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr "Kreslete, a potom upravte plynulé čáry"
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr "Zkouška vstupního zařízení"
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr "(žádný přítlak)"
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr "Tlak:"
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr "(žádné sklonění)"
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr "Sklonění:"
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr "(žádné zařízení)"
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
 msgstr "Zařízení:"
 
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+#, fuzzy
+msgid "Barrel Rotation:"
+msgstr "Nastavit znovu otočení"
+
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr "Přesunout vrstvu"
 
@@ -1910,158 +2367,226 @@ msgstr "Přesunout vrstvu"
 msgid "Move the current layer"
 msgstr "Přesunout nynější vrstvu"
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
-msgstr "{default_name} pod {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
+msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
-msgstr "Typ"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
+msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+#, fuzzy
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr "Vlastnosti"
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr "Viditelná"
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Vrstva"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+#, fuzzy
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr "Uzamčená"
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+#, fuzzy
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ", "
+
+#: ../gui/layers.py:990
+#, fuzzy, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr "Přidat {layer_default_name}"
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Vrstvy"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr "Uspořádat vrstvy a přiřadit efekty"
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr "Neprůhlednost vrstvy: %d%%"
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr "Přesunout vrstvu v zásobníku..."
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 "Přesunout vrstvu v zásobníku (upuštění na jinou vrstvu vytvoří novou skupinu)"
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr "Vrstva"
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
-msgstr "Režim:"
+#: ../gui/layervis.py:53
+#, fuzzy, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
+msgstr "<b>{brush_name}</b>"
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
-msgstr "Režim míchání: Jak se nynější vrstva spojuje s vrstvami hned pod ní."
-
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Neprůhlednost:"
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
-"Neprůhlednost vrstev: Kolik z nynější vrstvy použít. Menší hodnoty dělají "
-"vrstvu průhlednější."
 
-#: ../gui/linemode.py:37
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "Otočit pohled"
+
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr "Nástupní přítlak"
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr "Přítlak pro nástroje čar na začátku tahu"
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr "Přítlak ve středu"
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr "Přítlak pro nástroje čar uprostřed tahu"
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr "Výstupní přítlak"
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr "Přítlak pro nástroje čar na konci tahu"
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr "Přední část"
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 msgid "Stroke lead-in end"
 msgstr "Konec začátku tahu"
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr "Zadní část"
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr "Začátek konce tahu"
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr "Změna tlaku..."
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr "Čáry a křivky"
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr "Režim standardní čáry/křivky"
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr "Kreslete přímé čáry, klávesa Shift přidá křivky, Ctrl omezí úhel"
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr "Spojené čáry"
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr "Kreslete řadu čar, klávesa Shift přidá křivky, Ctrl omezí úhel"
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr "Elipsy a kruhy"
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr "Kreslete elipsy, klávesa Shift otočí, Ctrl omezí poměr/ úhel"
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
+#, fuzzy
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 "Copyright (C) 2005-2015\n"
 "Martin Renold a vývojářský tým Mypaint"
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -2080,256 +2605,286 @@ msgstr ""
 "Tento program je šířen v naději, že bude užitečný, ale BEZ ZÁRUKY. "
 "Prohlédněte si soubor COPYING pro více podrobností."
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr "Programování"
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr "Přenositelnost"
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr "Správa projektu"
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr "Štětce"
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr "Vzory"
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr "Ikony nástrojů"
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr "Ikona na ploše"
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr "Paleta"
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr "Dokumentace"
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr "Podpora"
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr "Rozšíření"
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr "Společenství"
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ", "
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr "Pavel Fric"
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr "Velikost:"
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr "Neprůhlednost:"
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr "Ostrost:"
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr "Zesílení:"
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr "Volby pro nástroje"
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr "Zvláštní nastavení pro nynější nástroj úprav"
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr "<b>{mode_name}</b>"
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr "<i>Nejsou dostupné žádné volby</i>"
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr "Zvětšení: %.01f%%"
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr "Vybrat nastavení štětce, barvu tahu a vrstvu…"
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr "Vybrat barvu…"
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr "Nastavení"
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr "Náhled"
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr "Ukázat náhled celé oblasti pro kreslení"
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr "Ukázat hledáček"
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr "Náčrtník"
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr "Smíchat barvy a udělat náčrtky na samostatných listech s částmi"
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr "Předchozí položka"
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr "Další položka"
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
 msgstr "(Nic k ukázání)"
 
-#: ../gui/symmetry.py:76
+#: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Place axis"
 msgstr "Umístit osu"
 
-#: ../gui/symmetry.py:80
+#: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Move axis"
 msgstr "Posunout osu"
 
-#: ../gui/symmetry.py:84
+#: ../gui/symmetry.py:88
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr "Odstranit osu"
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr "Upravit osu souměrnosti"
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr "Upravit osu souměrnosti malby."
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
+#, fuzzy
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr "Poloha:"
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr "Poloha:"
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr "Žádný"
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr "%d px"
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr "Alfa:"
 
-#: ../gui/symmetry.py:352
+#: ../gui/symmetry.py:376
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
+msgstr "Souměrnost"
+
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+#, fuzzy
 msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+msgid "X axis Position"
 msgstr "Poloha osy"
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:477
+#, fuzzy
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr "Poloha osy"
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr "Povoleno"
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr "Zacházení se souborem"
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr "Volič náčrtů"
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr "Zpět a Znovu"
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr "Režimy míchání"
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr "Čárový režim"
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr "Pohled (hlavní)"
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr "Pohled (pomocný)"
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr "Pohled (znovunastavení)"
 
@@ -2337,188 +2892,214 @@ msgstr "Pohled (znovunastavení)"
 msgid "<b>MyPaint</b>"
 msgstr "<b>MyPaint</b>"
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr "Posunovat pohled"
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr "Posunout pohled na plátno"
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr "Přiblížit/Oddálit pohled"
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr "Přiblížit/Oddálit pohled na plátno"
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr "Otočit pohled"
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr "Otočit pohled na plátno"
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, fuzzy, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr "%s: Zavřít kartu"
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
-msgstr "%s: Upravit vlastnosti"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
+msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr "Neznámý příkaz"
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr "Nestanovený (příkaz ještě nespuštěn)"
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr "{seconds:.01f}s kreslení s {brush_name}"
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr "Vyplnit"
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr "Zastřihnout vrstvu"
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "Přejmenovat skupinu"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr "Vyprázdnit vrstvu"
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr "Vložit vrstvu"
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr "Nová vrstva z viditelného"
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr "Sloučit viditelné vrstvy"
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr "Sloučit dolů"
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr "Normalizovat režim vrstvy"
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Zavedený štětec"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr "Přidat {layer_default_name}"
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr "Odstranit vrstvu"
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr "Vybrat vrstvu"
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr "Zdvojit vrstvu"
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr "Přesunout vrstvu nahoru"
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr "Přesunout vrstvu dolů"
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr "Přesunout vrstvu v zásobníku"
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr "Přejmenovat vrstvu"
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr "Zviditelnit vrstvu"
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr "Zneviditelnit vrstvu"
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr "Uzamknout vrstvu"
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr "Odemknout vrstvu"
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr "Nastavit neprůhlednost vrstvy: %0.1f%%"
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr "Neznámý režim"
 
-#: ../lib/command.py:1332
-#, python-format, python-format
+#: ../lib/command.py:1491
+#, python-format
 msgid "Set Layer Mode: %s"
 msgstr "Nastavit režim vrstvy: %s"
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr "Povolit rámeček"
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr "Zakázat rámeček"
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr "Aktualizovat rámeček"
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr "Upravit vrstvu vně"
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr "Chyba při nahrávání “{basename}”."
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr "V zápisech může být k této chybě více podrobností."
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr "od teď"
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr "před"
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2530,13 +3111,13 @@ msgstr ""
 "Provozujete více než jednu instanci programu MyPaint?\n"
 "Zavřete program a počkejte {cache_update_interval}s a zkuste to ještě jednou."
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr "Neúplná záloha aktualizována {last_modified_time} {ago}"
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2546,12 +3127,12 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 "Záloha aktualizována {last_modified_time} {ago}\n"
-"Velikost: {autosave.width}×{autosave.height} pixelů, Vrstvy: "
-"{autosave.num_layers}\n"
+"Velikost: {autosave.width}×{autosave.height} pixelů, Vrstvy: {autosave."
+"num_layers}\n"
 "Obsahuje {unsaved_time} neuloženého malování."
 
-#: ../lib/document.py:1209
-#, python-brace-format, python-brace-format
+#: ../lib/document.py:1426
+#, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
 "Unable to write “{filename}”: {err}\n"
@@ -2560,13 +3141,13 @@ msgstr ""
 "Nelze zapsat “{filename}”: {err}\n"
 "Máme dostatek volného místa na zařízení?"
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr "Nelze zapsat “{filename}”: {err}"
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2576,8 +3157,8 @@ msgstr ""
 "{error_loading_common}\n"
 "Soubor neexistuje."
 
-#: ../lib/document.py:1264
-#, python-brace-format, python-brace-format
+#: ../lib/document.py:1485
+#, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
 "{error_loading_common}\n"
@@ -2586,7 +3167,7 @@ msgstr ""
 "{error_loading_common}\n"
 "Nemáte nezbytná oprávnění pro otevření tohoto souboru."
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2602,8 +3183,8 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/document.py:1313
-#, python-brace-format, python-brace-format
+#: ../lib/document.py:1534
+#, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
 "{error_loading_common}\n"
@@ -2612,7 +3193,13 @@ msgstr ""
 "{error_loading_common}\n"
 "Neznámá přípona souboru:  „{ext}“"
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+#, fuzzy
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr "Zavedený štětec"
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2626,7 +3213,7 @@ msgstr ""
 "Pokuste se uložit ve formátu PNG, pokud váš stroj nemá dostatek paměti. "
 "Ukládací funkce MyPaint pro formát PNG je výkonnější."
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2642,98 +3229,207 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/helpers.py:402
-#, python-brace-format
+#: ../lib/floodfill.py:131
+#, fuzzy
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr "Vyplnit"
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr "{days}d{hours}h"
 
-#: ../lib/helpers.py:404
-#, python-brace-format
+#: ../lib/helpers.py:537
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr "{hours}h{minutes}m"
 
-#: ../lib/helpers.py:406
-#, python-brace-format
+#: ../lib/helpers.py:539
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr "{minutes}m{seconds}s"
 
-#: ../lib/helpers.py:408
-#, python-brace-format
+#: ../lib/helpers.py:541
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr "{seconds}s"
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr "Vrstva"
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr "%(name)s %(number)d"
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr "^(.*?)\\s*(\\d+)$"
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
+#, fuzzy
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr "Vektorová vrstva"
+
+#: ../lib/layer/data.py:1158
+#, fuzzy
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr "Vektorová vrstva"
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
-msgstr "Neznámý štětec"
+msgid "Bitmap"
+msgstr ""
 
-#: ../lib/layer/data.py:1169
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1244
 msgctxt "layer default names"
-msgid "Unknown Data Layer"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
 msgstr "Neznámá datová vrstva"
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "Nová kreslicí vrstva"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr "Skupina"
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "Nová skupina vrstev"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr "Zástupný znak"
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr "Kořen"
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ", "
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+#, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "Pohled"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+#, fuzzy
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr "Vrstvy"
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+#, fuzzy
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr "Odstranit vrstvu"
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr "Uzamknout vrstvu"
+
+#: ../lib/layervis.py:697
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr "Odemknout vrstvu"
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr "Protlačit"
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr "Obsah skupiny se použije přímo na pozadí skupiny"
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr "Normální"
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr "Jen nejvrchnější vrstva, bez míchání barev."
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr "Znásobení"
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
@@ -2741,11 +3437,11 @@ msgstr ""
 "Podobné jako nahrání dvou snímků do promítačky a promítnutí sloučeného "
 "výsledku."
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr "Obrazovka"
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
@@ -2753,11 +3449,11 @@ msgstr ""
 "Jako současné svícení dvou samostatných promítaček na obrazovku. Toto je "
 "opak k Více než jeden."
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr "Překrytí"
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
@@ -2765,27 +3461,27 @@ msgstr ""
 "Překryje pozadí vrchní vrstvou. Zachová světlá místa pozadí a stíny. Toto je "
 "obrácený účinek k Tvrdému světlu."
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr "Ztmavení"
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr "Vrchní vrstva se použije tam, kde je tmavší než pozadí."
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr "Zesvětlení"
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr "Vrchní vrstva se použije tam, kde je jasnější než pozadí."
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr "Změna světlosti"
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
@@ -2795,11 +3491,11 @@ msgstr ""
 "fotografické temné komory, která se jmenuje stejně, která se používá na "
 "vylepšení kontrastu ve stínech."
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr "Nasvícení"
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
@@ -2809,87 +3505,87 @@ msgstr ""
 "fotografické temné komory, která se jmenuje stejně, která se používá na "
 "zmenšení přezářených světlých míst."
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr "Tvrdé světlo"
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr "Podobné svícení ostrého kužele světla na pozadí."
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr "Měkké světlo"
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr "Jako svícení rozptýleného kužele světla na pozadí."
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr "Rozdíl"
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr "Odečte tmavší barvu od světlejší z těchto dvou barev."
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr "Vyloučení"
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr "Podobné režimu Rozdíl, ale s nižším kontrastem."
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr "Odstín"
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr "Spojuje odstín vrchní vrstvy se sytostí a svítivostí pozadí."
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr "Sytost"
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr "Použije sytost barev vrchní vrstvy na odstín a svítivost pozadí."
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr "Použije odstín a sytost vrchní vrstvy na svítivost pozadí."
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr "Svítivost"
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr "Použije svítivost vrchní vrstvy na odstín a sytost pozadí."
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr "Sčítání"
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr "Tato vrstva a její pozadí jsou jednoduše přidány k sobě."
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr "Vstup cíle"
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
@@ -2897,11 +3593,11 @@ msgstr ""
 "Používá pozadí jen tam, kde ji pokrývá tato vrstva. Cokoli jiného se "
 "přehlíží."
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr "Výstup cíle"
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
@@ -2909,27 +3605,38 @@ msgstr ""
 "Používá pozadí jen tam, kde ji tato vrstva nepokrývá. Cokoli jiného se "
 "přehlíží."
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr "Zdroj nahoře"
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr "Zdroj, který překryje cíl, cíl nahradí. Cíl je umístěn jinde."
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr "Cíl nahoře"
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr "Cíl, který překryje zdroj, zdroj nahradí. Zdroj je umístěn jinde."
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, fuzzy, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr "%(name)s %(number)d"
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
@@ -2938,7 +3645,7 @@ msgstr ""
 "Nelze vytvořit zcela zásadní vnitřní předmět. Váš systém nemusí mít dost "
 "paměti na provedení této operace."
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2952,7 +3659,30 @@ msgstr ""
 "Důvod: {err}\n"
 "Cílová složka: “{dirname}”."
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+#, fuzzy
+msgid "Vertical"
+msgstr "Zrcadlit svisle"
+
+#: ../lib/tiledsurface.py:49
+#, fuzzy
+msgid "Horizontal"
+msgstr "Zrcadlit vodorovně"
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+#, fuzzy
+msgid "Rotational"
+msgstr "Nastavit znovu otočení"
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr "Čtečka PNG selhala: %s"
@@ -2961,55 +3691,92 @@ msgstr "Čtečka PNG selhala: %s"
 msgid "Recover interrupted work?"
 msgstr "Obnovit přerušenou práci?"
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
-msgstr "_Obnovit a uložit..."
+msgid "_Look for backups at startup"
+msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr "Smazat"
+
+#: ../po/tmp/autorecover.glade.h:9
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr "Smazat tento štětec z disku"
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr "_Obnovit a uložit..."
+
+#: ../po/tmp/autorecover.glade.h:12
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr "Uložit tuto zálohu na disk, potom pokračovat v práci na ní."
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
-msgstr "Nyní _přehlížet"
+msgid "Decide _Later"
+msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr "Začít pracovat na novém plátně. Tyto zálohy budou ponechány."
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
+#, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 "MyPaint spadl s neuloženou prací. Byla však udělána záloha. Nyní soubor "
 "můžete obnovit, nebo je nechat tak, až dokud MyPaint nespustíte znovu."
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr "Náhled"
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr "Popis"
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
-msgstr "Kopírovat jako nový"
+msgid "Live update"
+msgstr "Náhled ve skutečném čase"
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
-msgstr "Kopírovat tato nastavení a ikonu nynějšího štětce do nového štětce"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
+msgstr ""
+"Obnovovat poslední tah na plátně s nastaveními v tomto okně ve skutečném čase"
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
-msgstr "Přejmenovat tento štětec"
+msgid "Save these settings to the brush"
+msgstr "Uložit tato nastavení do štětce"
 
 #: ../po/tmp/brusheditor.glade.h:5
 msgid "Edit Icon"
@@ -3032,19 +3799,16 @@ msgid "Delete this brush from the disk"
 msgstr "Smazat tento štětec z disku"
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
-msgstr "Náhled ve skutečném čase"
+msgid "Copy to New"
+msgstr "Kopírovat jako nový"
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
-msgstr ""
-"Obnovovat poslední tah na plátně s nastaveními v tomto okně ve skutečném čase"
+msgid "Copy these settings and the current brush's icon to a new brush"
+msgstr "Kopírovat tato nastavení a ikonu nynějšího štětce do nového štětce"
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
-msgstr "Uložit tato nastavení do štětce"
+msgid "Rename this brush"
+msgstr "Přejmenovat tento štětec"
 
 #: ../po/tmp/brusheditor.glade.h:13
 msgid "Brush Setting"
@@ -3072,12 +3836,7 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr "Poznámky:"
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr "Název nastavení:"
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
@@ -3085,19 +3844,17 @@ msgstr ""
 "řídit podle ní."
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
-msgstr "Základní hodnota:"
+#: ../po/tmp/brusheditor.glade.h:22
+#, fuzzy
+msgid "Value:"
+msgstr "Hodnota HSV"
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr "Obnovit výchozí nastavení základní hodnoty"
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
-msgstr "Nastavit tento vstup znovu tak, aby to nemělo žádný účinek na nastavení"
+msgstr ""
+"Nastavit tento vstup znovu tak, aby to nemělo žádný účinek na nastavení"
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
@@ -3105,11 +3862,7 @@ msgstr ""
 "Nejmenší hodnota pro výstupní osu.\n"
 "Toto se nastavuje i pomocí hlavního posuvníku pro {dname}."
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr "<ymin>"
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
@@ -3117,27 +3870,23 @@ msgstr ""
 "Největší hodnota pro výstupní osu.\n"
 "Toto se nastavuje i pomocí hlavního posuvníku pro {dname}."
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr "<ymax>"
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr "Výstup"
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr "Vstup"
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr "Přizpůsobí největší hodnotu"
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr "Přizpůsobí nejmenší hodnotu"
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
@@ -3145,11 +3894,7 @@ msgstr ""
 "Nejmenší hodnota pro osu vstupu.\n"
 "Na upravení této hodnoty použijte vyskakovací stupnici."
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr "<xmin>"
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
@@ -3157,38 +3902,36 @@ msgstr ""
 "Největší hodnota pro osu vstupu.\n"
 "Na upravení této hodnoty použijte vyskakovací stupnici."
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr "<xmax>"
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr "Odchylka od základní hodnoty podle vstupu hrotu a dalších hledisek"
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr "Dynamika štětce"
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr "Zpět do nastavení"
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr "Upravit nastavení"
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr "Přizpůsobit přiřazení tohoto vstupu podrobně"
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr "{tooltip}"
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
 msgstr "{název pole}:"
+
+#: ../po/tmp/brusheditor.glade.h:42
+#, fuzzy
+msgid "Brush dynamics are not available for this setting."
+msgstr "Zpět do nastavení"
+
+#: ../po/tmp/brusheditor.glade.h:43
+#, fuzzy
+msgid "<big><b>No Brush Dynamics</b></big>"
+msgstr "<big><b>{accel_label}</b></big>"
 
 #: ../po/tmp/inktool.glade.h:1
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
@@ -3200,7 +3943,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr "Tlak:"
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3245,6 +3988,141 @@ msgstr "Smazat bod"
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
 msgstr "Smazat nyní vybraný bod"
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+#, fuzzy
+msgid "Insert Point"
+msgstr "Vložit řádek"
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+#, fuzzy
+msgid "Cull Points"
+msgstr "Smazat bod"
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Název"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr "Režim"
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Neprůhlednost"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr "Režim skládání nynější vrstvy."
+
+#: ../po/tmp/layervis.glade.h:2
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr "Otočit pohled na plátno"
+
+#: ../po/tmp/layervis.glade.h:3
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr "Otočit pohled na plátno"
+
+#: ../po/tmp/layervis.glade.h:4
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr "Které viditelné vrstvy se mají vyplnit"
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
+msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
 msgctxt "footer: color picker button: tooltip"
@@ -3293,7 +4171,7 @@ msgid "PNG solid with background (*.png)"
 msgstr "PNG plný s pozadím (*.png)"
 
 #: ../po/tmp/preferenceswindow.glade.h:4
-#, no-c-format, no-c-format
+#, no-c-format
 msgctxt "Prefs Dialog|Saving|Save Formats and Locations|Default|"
 msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr "JPEG 90 % kvalita (*.jpg; *.jpeg)"
@@ -3581,7 +4459,8 @@ msgstr ""
 
 #: ../po/tmp/preferenceswindow.glade.h:67
 msgid "Some of these settings require MyPaint to be restarted."
-msgstr "Některá z těchto nastavení vyžadují opětovné spuštění programu MyPaint."
+msgstr ""
+"Některá z těchto nastavení vyžadují opětovné spuštění programu MyPaint."
 
 #: ../po/tmp/preferenceswindow.glade.h:68
 msgctxt "Prefs Dialog|View|Interface|Icon size|"
@@ -3652,13 +4531,34 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr "Při malování skrýt ukazovátko"
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+#, fuzzy
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr "Povoleno"
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr "Pohled"
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
@@ -3667,18 +4567,18 @@ msgstr ""
 "Sada barev k ukázání jako základní na barevných kolech na způsob disku.\n"
 "Prostředí s odlišnými zvyklostmi mají různý názor na souladnost barev."
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr "Základní jsou:"
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr "Obvyklá digitální červená/zelená/modrá"
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
@@ -3686,7 +4586,7 @@ msgstr ""
 "Základní barvy &apos;počítačové obrazovky&apos; červená, zelená a modrá, "
 "rovnoměrně rozloženy kolem kruhu. Zelená je naproti červenorudé (magenta)."
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
@@ -3695,12 +4595,12 @@ msgstr ""
 "Základní barvy &apos;počítačové obrazovky&apos; červená, zelená a modrá, "
 "rovnoměrně rozloženy kolem kruhu. Zelená je naproti červenorudé (magenta)."
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr "Tradiční umělecky podaná červená/žlutá/modrá"
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
@@ -3710,7 +4610,7 @@ msgstr ""
 "18. století, napodobeno pomocí čistých barev zobrazení rovnoměrně "
 "uspořádaných okolo kruhu. Zelená je naproti červené."
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3721,12 +4621,12 @@ msgstr ""
 "18. století, napodobeno pomocí čistých barev zobrazení rovnoměrně "
 "uspořádaných okolo kruhu. Zelená je naproti červené."
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr "Červená-zelená a modrá-žlutá proti sobě jsoucí dvojice"
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3741,7 +4641,7 @@ msgstr ""
 "CIECAM02 a NCS představují podobný model. Zde používáme čistou červenou, "
 "žlutou atd. zobrazení jako čtyři základní barvy."
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3758,28 +4658,28 @@ msgstr ""
 "žlutou atd. zobrazení jako čtyři základní barvy."
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr "<b>Barevné kolo</b>"
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr "Barva"
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr "Obrazovka (normální)"
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr "Vypnuto (žádná citlivost přítlaku)"
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr "Okno (nedoporučeno)"
@@ -3840,249 +4740,306 @@ msgid "Reload the file your current work was loaded from."
 msgstr "Znovu načíst současnou práci z původního souboru."
 
 #: ../po/tmp/resources.xml.h:12
+#, fuzzy
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Import Layers…"
+msgstr "Zavést štětce…"
+
+#: ../po/tmp/resources.xml.h:13
+msgctxt "Accel Editor (descriptions)"
+msgid "Import layers from one or more files."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save"
 msgstr "Uložit"
 
-#: ../po/tmp/resources.xml.h:13
+#: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file."
 msgstr "Uložit práci do souboru."
 
-#: ../po/tmp/resources.xml.h:14
+#: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As…"
 msgstr "Uložit jako…"
 
-#: ../po/tmp/resources.xml.h:15
+#: ../po/tmp/resources.xml.h:17
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file, assigning it a new name."
 msgstr "Uložit práci do souboru s novým názvem."
 
-#: ../po/tmp/resources.xml.h:16
+#: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Export…"
 msgstr "Vyvést…"
 
-#: ../po/tmp/resources.xml.h:17
+#: ../po/tmp/resources.xml.h:19
 msgid "Export your work to a file, but keep working on the same file."
 msgstr "Vyvést práci do souboru, ale pracovat dál na dosavadním souboru."
 
-#: ../po/tmp/resources.xml.h:18
+#: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As Scrap"
 msgstr "Uložit jako náčrt"
 
-#: ../po/tmp/resources.xml.h:19
+#: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
 msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 "Uložit do nového souboru náčrtu, nebo uložit novou změnu, pokud již je náčrt."
 
-#: ../po/tmp/resources.xml.h:20
+#: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Previous Scrap"
 msgstr "Otevřít předchozí náčrt"
 
-#: ../po/tmp/resources.xml.h:21
+#: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file before the current one."
 msgstr "Nahrát předchozí soubor s náčrtem."
 
-#: ../po/tmp/resources.xml.h:22
+#: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Next Scrap"
 msgstr "Otevřít další náčrt"
 
-#: ../po/tmp/resources.xml.h:23
+#: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file after the current one."
 msgstr "Nahrát následující soubor s náčrtem."
 
-#: ../po/tmp/resources.xml.h:24
+#: ../po/tmp/resources.xml.h:26
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Recover File from an Automated Backup…"
 msgstr "Obnovit soubor z automatické zálohy…"
 
-#: ../po/tmp/resources.xml.h:25
+#: ../po/tmp/resources.xml.h:27
 msgctxt "Accel Editor (descriptions)"
 msgid "Try to save and resume interrupted unsaved work."
 msgstr "Zkuste uložit a pokračovat v přerušené neuložené práci."
 
-#: ../po/tmp/resources.xml.h:26
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr "Skupiny štětců"
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr "Štětce"
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr "Seznam skupin štětců."
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr "Voliče barev"
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr "Barvy"
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr "Dostupné seřizovač barev."
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr "Režim"
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr "Režim"
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr "Režim skládání nynější vrstvy."
 
-#: ../po/tmp/resources.xml.h:35
+#: ../po/tmp/resources.xml.h:37
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Pressure"
+msgstr "Nástupní přítlak"
+
+#: ../po/tmp/resources.xml.h:38
+msgctxt "Accel Editor (descriptions)"
+msgid "Send harder pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:39
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Pressure"
+msgstr "Nástupní přítlak"
+
+#: ../po/tmp/resources.xml.h:40
+msgctxt "Accel Editor (descriptions)"
+msgid "Send softer pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:41
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Rotation"
+msgstr "Zvýšit sytost barvy"
+
+#: ../po/tmp/resources.xml.h:42
+msgctxt "Accel Editor (descriptions)"
+msgid "Increase barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:43
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
+msgstr "Snížit sytost barvy"
+
+#: ../po/tmp/resources.xml.h:44
+msgctxt "Accel Editor (descriptions)"
+msgid "Decrease barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:45
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Size"
 msgstr "Zvětšit velikost štětce"
 
-#: ../po/tmp/resources.xml.h:36
+#: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush bigger."
 msgstr "Udělat pracovní štětec větším."
 
-#: ../po/tmp/resources.xml.h:37
+#: ../po/tmp/resources.xml.h:47
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Size"
 msgstr "Zmenšit velikost štětce"
 
-#: ../po/tmp/resources.xml.h:38
+#: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush smaller."
 msgstr "Udělat pracovní štětec menším."
 
-#: ../po/tmp/resources.xml.h:39
+#: ../po/tmp/resources.xml.h:49
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Opacity"
 msgstr "Zvětšit krycí schopnost štětce"
 
-#: ../po/tmp/resources.xml.h:40
+#: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush more opaque."
 msgstr "Udělat pracovní štětec více neprůhledným."
 
-#: ../po/tmp/resources.xml.h:41
+#: ../po/tmp/resources.xml.h:51
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Opacity"
 msgstr "Zmenšit krycí schopnost štětce"
 
-#: ../po/tmp/resources.xml.h:42
+#: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush less opaque."
 msgstr "Udělat pracovní štětec méně neprůhledným."
 
-#: ../po/tmp/resources.xml.h:43
+#: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Lighten Painting Color"
 msgstr "Zesvětlit kreslicí barvu"
 
-#: ../po/tmp/resources.xml.h:44
+#: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase the lightness of the current painting color."
 msgstr "Zvětšit světlost nynější kreslicí barvy."
 
-#: ../po/tmp/resources.xml.h:45
+#: ../po/tmp/resources.xml.h:55
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Darken Painting Color"
 msgstr "Ztmavit kreslicí barvu"
 
-#: ../po/tmp/resources.xml.h:46
+#: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease the lightness of the current painting color."
 msgstr "Zmenšit světlost nynější kreslicí barvy."
 
-#: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
-msgstr "Změnit odstín barvy proti směru hodinových ručiček"
-
-#: ../po/tmp/resources.xml.h:48
-msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
-msgstr ""
-"Otočit odstín kreslicí barvy na barevném kole proti směru hodinových ručiček."
-
-#: ../po/tmp/resources.xml.h:49
+#: ../po/tmp/resources.xml.h:57
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Change Hue Clockwise"
 msgstr "Změnit odstín barvy po směru hodinových ručiček"
 
-#: ../po/tmp/resources.xml.h:50
+#: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
 msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 "Otočit odstín kreslicí barvy na barevném kole po směru hodinových ručiček."
 
-#: ../po/tmp/resources.xml.h:51
+#: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr "Změnit odstín barvy proti směru hodinových ručiček"
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+"Otočit odstín kreslicí barvy na barevném kole proti směru hodinových ručiček."
+
+#: ../po/tmp/resources.xml.h:61
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Increase Saturation"
 msgstr "Zvýšit sytost barvy"
 
-#: ../po/tmp/resources.xml.h:52
+#: ../po/tmp/resources.xml.h:62
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color more saturated (more colorful, purer)."
 msgstr "Udělat malovací barvu sytější (barevnější, čistější)."
 
-#: ../po/tmp/resources.xml.h:53
+#: ../po/tmp/resources.xml.h:63
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Decrease Saturation"
 msgstr "Snížit sytost barvy"
 
-#: ../po/tmp/resources.xml.h:54
+#: ../po/tmp/resources.xml.h:64
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color less saturated (grayer)."
 msgstr "Udělat malovací barvu méně sytou (šedivější)."
 
-#: ../po/tmp/resources.xml.h:55
+#: ../po/tmp/resources.xml.h:65
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Reload Brush Settings"
 msgstr "Nahrát znovu nastavení štětců"
 
-#: ../po/tmp/resources.xml.h:56
+#: ../po/tmp/resources.xml.h:66
 msgctxt "Accel Editor (descriptions)"
 msgid "Restore all brush settings to the current brush’s saved values."
 msgstr ""
 "Obnovit všechna nastavení štětců znovu na uložené hodnoty nynějšího štětce."
 
-#: ../po/tmp/resources.xml.h:57
+#: ../po/tmp/resources.xml.h:67
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Pick Stroke and Layer"
 msgstr "Vybrat štětec a vrstvu"
 
-#: ../po/tmp/resources.xml.h:58
+#: ../po/tmp/resources.xml.h:68
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
 msgstr "Sebrat tah štětcem z plátna: obnoví štětec, barvu a vrstvu."
 
-#: ../po/tmp/resources.xml.h:59
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr "Barva při obnovení štětce klávesovou zkratkou"
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
@@ -4091,212 +5048,265 @@ msgstr ""
 "Přepnout, zda se po obnovení štětce z klávesové zkratky obnoví i uložená "
 "barva."
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr "Uložit štětec s naposledy použitou klávesovou zkratkou"
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr "Uložit nastavení štětce s naposledy použitou klávesovou zkratkou."
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "Vyprázdnit vrstvu"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr "Vyprázdnit obsah nynější vrstvy."
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Trim Layer to Frame"
-msgstr "Zastřihnout vrstvu do rámečku"
+#: ../po/tmp/resources.xml.h:75
+#, fuzzy
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr "Volby pro nástroje"
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:76
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Trim Layer to Frame"
+msgstr "Zastřihnout vrstvy na rámeček"
+
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr "Vymazat části nynější vrstvy ležící mimo rámeček."
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr "Vymazat části nynější vrstvy ležící mimo rámeček."
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "Nová skupina vrstev pod"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "Nová skupina vrstev pod"
+
+#: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr "Kopírovat vrstvu do schránky"
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr "Kopírovat obsah nynější vrstvy do schránky."
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr "Vložit vrstvu ze schránky"
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr "Nahradí nynější vrstvu obsahem schránky."
 
-#: ../po/tmp/resources.xml.h:71
+#: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Edit Layer in External App…"
 msgstr "Upravit vrstvu ve vnějším programu…"
 
-#: ../po/tmp/resources.xml.h:72
+#: ../po/tmp/resources.xml.h:90
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
+msgid "Edit the active layer in an external application."
 msgstr "Začít upravování nynější vrstvy ve vnějším programu."
 
-#: ../po/tmp/resources.xml.h:73
+#: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Update Layer with External Edits"
 msgstr "Aktualizovat vrstvu pomocí vnějších úprav"
 
-#: ../po/tmp/resources.xml.h:74
+#: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
 msgid "Commit changes saved from the external app (normally automatic)."
 msgstr "Zapsat změny uložené z vnějšího programu (obyčejně automaticky)."
 
-#: ../po/tmp/resources.xml.h:75
+#: ../po/tmp/resources.xml.h:93
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer at Cursor"
 msgstr "Vybrat vrstvu na ukazovátku myši"
 
-#: ../po/tmp/resources.xml.h:76
+#: ../po/tmp/resources.xml.h:94
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr "Vybrat vrstvu zvolením prvku na ní."
 
-#: ../po/tmp/resources.xml.h:77
+#: ../po/tmp/resources.xml.h:95
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Above"
 msgstr "Jít na vrstvu výše"
 
-#: ../po/tmp/resources.xml.h:78
+#: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer up in the layer stack."
 msgstr "Jít v zásobníku vrstev o jednu vrstvu nahoru."
 
-#: ../po/tmp/resources.xml.h:79
+#: ../po/tmp/resources.xml.h:97
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Below"
 msgstr "Jít na vrstvu níže"
 
-#: ../po/tmp/resources.xml.h:80
+#: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer down in the layer stack."
 msgstr "Jít v zásobníku vrstev o jednu vrstvu dolů."
 
-#: ../po/tmp/resources.xml.h:81
+#: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer"
 msgstr "Nová kreslicí vrstva"
 
-#: ../po/tmp/resources.xml.h:82
+#: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer above the current layer."
 msgstr "Přidat novou kreslicí vrstvu nad nynější vrstvu."
 
-#: ../po/tmp/resources.xml.h:83
+#: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer…"
 msgstr "Nová vektorová vrstva…"
 
-#: ../po/tmp/resources.xml.h:84
+#: ../po/tmp/resources.xml.h:102
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer above the current layer, and begin editing it."
-msgstr "Přidat novou vektorovou vrstvu nad nynější vrstvu a začít ji upravovat."
+msgstr ""
+"Přidat novou vektorovou vrstvu nad nynější vrstvu a začít ji upravovat."
 
-#: ../po/tmp/resources.xml.h:85
+#: ../po/tmp/resources.xml.h:103
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group"
 msgstr "Nová skupina vrstev"
 
-#: ../po/tmp/resources.xml.h:86
+#: ../po/tmp/resources.xml.h:104
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group above the current layer."
 msgstr "Přidat novou skupinu vrstev nad nynější vrstvu."
 
-#: ../po/tmp/resources.xml.h:87
+#: ../po/tmp/resources.xml.h:105
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer Below"
 msgstr "Nová kreslicí vrstva pod"
 
-#: ../po/tmp/resources.xml.h:88
+#: ../po/tmp/resources.xml.h:106
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer below the current layer."
 msgstr "Přidat novou kreslicí vrstvu pod nynější vrstvu."
 
-#: ../po/tmp/resources.xml.h:89
+#: ../po/tmp/resources.xml.h:107
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer Below…"
 msgstr "Nová vektorová vrstva pod…"
 
-#: ../po/tmp/resources.xml.h:90
+#: ../po/tmp/resources.xml.h:108
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer below the current layer, and begin editing it."
-msgstr "Přidat novou vektorovou vrstvu pod nynější vrstvu a začít ji upravovat."
+msgstr ""
+"Přidat novou vektorovou vrstvu pod nynější vrstvu a začít ji upravovat."
 
-#: ../po/tmp/resources.xml.h:91
+#: ../po/tmp/resources.xml.h:109
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group Below"
 msgstr "Nová skupina vrstev pod"
 
-#: ../po/tmp/resources.xml.h:92
+#: ../po/tmp/resources.xml.h:110
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group below the current layer."
 msgstr "Přidat novou skupinu vrstev pod nynější vrstvu."
 
-#: ../po/tmp/resources.xml.h:93
+#: ../po/tmp/resources.xml.h:111
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Layer Down"
 msgstr "Sloučit vrstvy dolů"
 
-#: ../po/tmp/resources.xml.h:94
+#: ../po/tmp/resources.xml.h:112
 msgctxt "Accel Editor (descriptions)"
 msgid "Merge the current layer with the layer beneath it."
 msgstr "Sloučit nynější vrstvu s vrstvou ležící pod ní."
 
-#: ../po/tmp/resources.xml.h:95
+#: ../po/tmp/resources.xml.h:113
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Visible Layers"
 msgstr "Sloučit viditelné vrstvy"
 
-#: ../po/tmp/resources.xml.h:96
+#: ../po/tmp/resources.xml.h:114
 msgctxt "Accel Editor (descriptions)"
 msgid "Consolidate all visible layers, and delete the originals."
 msgstr "Sjednotit všechny viditelné vrstvy a smazat původní vrstvy."
 
-#: ../po/tmp/resources.xml.h:97
+#: ../po/tmp/resources.xml.h:115
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer from Visible"
 msgstr "Nová vrstva z viditelných vrstev"
 
-#: ../po/tmp/resources.xml.h:98
+#: ../po/tmp/resources.xml.h:116
 msgctxt "Accel Editor (descriptions)"
 msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
 msgstr "Jako \"sloučit viditelné vrstvy\", ale nesmaže to původní (originály)."
 
-#: ../po/tmp/resources.xml.h:99
+#: ../po/tmp/resources.xml.h:117
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Delete Layer"
 msgstr "Vybrat vrstvu"
 
-#: ../po/tmp/resources.xml.h:100
+#: ../po/tmp/resources.xml.h:118
 msgctxt "Accel Editor (descriptions)"
 msgid "Remove the current layer from the layer stack."
 msgstr "Odstranit nynější vrstvu ze zásobníku vrstev."
 
-#: ../po/tmp/resources.xml.h:101
+#: ../po/tmp/resources.xml.h:119
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Convert to Normal Painting Layer"
 msgstr "Převést na běžnou kreslicí vrstvu"
 
-#: ../po/tmp/resources.xml.h:102
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
@@ -4305,568 +5315,658 @@ msgstr ""
 "Převést nynější vrstvu nebo skupinu na kreslicí vrstvu v Normálním režimu, "
 "při zachování jejího vzhledu."
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr "Zvětšit neprůhlednost vrstvy"
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr "Udělat vrstvu méně průhlednou."
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr "Zmenšit neprůhlednost vrstvy"
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr "Udělat vrstvu více průhlednou."
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr "Dát vrstvu nahoru"
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr "Posunout nynější vrstvu o jeden krok v zásobníku vrstev nahoru."
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr "Dát vrstvu dolů"
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr "Posunout nynější vrstvu o jeden krok v zásobníku vrstev dolů."
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr "Zdvojit vrstvu"
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr "Udělat přesnou kopii nynější vrstvy."
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
+#, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
-msgstr "Přejmenovat vrstvu…"
+msgid "Layer Properties…"
+msgstr "Vlastnosti"
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
-msgstr "Zadat nový název pro nynější vrstvu."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr "Uzamknutá vrstva"
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 "Přepnout stav uzamknutí nynější vrstvy. Uzamknuté vrstvy se nedají měnit."
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr "Viditelná vrstva"
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr "Přepnout stav viditelnosti nynější vrstvy, její skrytí."
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr "Ukázat pozadí"
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr "Přepnout viditelnost vrstvy pozadí."
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr "Odstranit nynější vrstvu ze zásobníku vrstev."
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr "Nastavit znovu a vystředit pohled"
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 "Nastavit znovu zvětšení, otočení a zrcadlení a dokument znovu vystředit."
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr "Přizpůsobit pohled"
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr "Přepnout mezi přizpůsobeným pohledem a místem vaší práce a zvětšením."
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr "Nastavit znovu"
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr "Nastavit znovu přiblížení"
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr "Nastavit zvětšení pohledu na výchozí hodnotu."
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr "Nastavit znovu otočení"
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr "Nastavit otočení pohledu na 0°"
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr "Nastavit znovu zrcadlení"
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
-msgstr "Vypnout zrcadlení pohledu."
+msgid "Reset the view's mirroring."
+msgstr "Nastavit znovu zrcadlení"
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr "Přiblížit"
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr "Zvýšit zvětšení."
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Oddálit"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr "Snížit zvětšení."
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
+#, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
-msgstr "Otočit proti směru hodinových ručiček"
+msgid "Pan Left"
+msgstr "Posunout pohled"
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
-msgstr "Otočit pohled proti směru hodinových ručiček."
+msgid "Move your view of the canvas to the left."
+msgstr "Otočit pohled: Naklonit váš pohled na plátno."
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr "Tvrdé světlo"
+
+#: ../po/tmp/resources.xml.h:159
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr "Přejet v pohledu: Posunout váš pohled na plátno vodorovně nebo svisle."
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr "Otočit pohled: Naklonit váš pohled na plátno."
+
+#: ../po/tmp/resources.xml.h:162
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr "Posunout pohled"
+
+#: ../po/tmp/resources.xml.h:163
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr "Otočit pohled: Naklonit váš pohled na plátno."
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr "Otočit po směru hodinových ručiček"
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr "Otočit pohled po směru hodinových ručiček."
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr "Otočit proti směru hodinových ručiček"
+
+#: ../po/tmp/resources.xml.h:167
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr "Otočit pohled proti směru hodinových ručiček."
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr "Zrcadlit vodorovně"
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr "Převrátit pohled zleva doprava."
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr "Zrcadlit svisle"
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr "Převrátit pohled shora dolů."
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr "Jednotlivá vrstva"
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr "Stanovit, zda je viditelná jen nynější vrstva."
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr "Souměrné malování zapnuto"
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr "Zrcadlit tahy štětcem podél osy souměrnosti"
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr "Rámeček zapnut"
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr "Přepnout viditelnost rámečku dokumentu."
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr "Tisknout vstupní hodnoty štětců do konzole"
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr "Ukázat vnitřně vytvořené vstupy stroje štětce na konzoli."
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr "Zviditelnit průběh zpracování"
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr "Ukazovat aktualizace zpracování na obrazovce, kvůli ladění."
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr "Vypnout dvojité uložení do vyrovnávací paměti"
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr "Vypnout dvojité ukládání do vyrovnávací paměti GTK, obyčejně povoleno."
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+#, fuzzy
+msgid "Delete Point"
+msgstr "Smazat bod"
+
+#: ../po/tmp/resources.xml.h:187
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr "Smazat nyní vybraný bod"
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr "Kreslicí režim"
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr "Kreslicí režim: Malovat normálně"
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr "Použít barvu, normálně při malování."
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr "Kreslicí režim: Guma"
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr "Mazat tahy pomocí nynějšího štětce."
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr "Kreslicí režim: Uzamknout alfa kanál"
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr "Použití štětce neovlivní průhlednost vrstvy."
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr "Kreslicí režim: Barvit"
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr "Použít barvu na současnou vrstvu bez změny jasu či průhlednosti."
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Soubor"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "Ukončit"
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr "Zavřít hlavní okno a ukončit program."
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "Upravit"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr "Nynější nástroj"
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "Barva"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr "Přizpůsobit barvu"
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr "Vyskakovací historie barev"
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr "Vyvolat časovou osu nedávných barev pod ukazovátkem."
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr "Podrobnosti barev"
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr "Ukázat dialog s podrobnostmi barvy s textovým vstupem."
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr "Další barva v paletě"
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr "Nastavit kreslicí barvu na další barvu v paletě barev."
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr "Předchozí barva v paletě"
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr "Nastavit kreslicí barvu na předchozí barvu v paletě barev."
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr "Přidat barvu do palety"
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr "Přidat nynější barvu, s níž se maluje, do palety."
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "Vrstva"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr "Neprůhlednost"
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr "Jít na vrstvu"
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr "Nová vrstva pod"
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr "Vlastnosti"
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr "Náčrtník"
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr "Nový náčrtník"
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr "Nahrát výchozí náčrtník jako nové plátno s náčrtníkem."
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr "Otevřít náčrtník…"
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr "Nahrát obrázkový soubor na disku do náčrtníku."
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr "Uložit náčrtník"
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr "Uložit náčrtník do jeho stávajícího souboru na disku."
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr "Vyvést náčrtník jako…"
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr "Vyvést náčrtník na disk, pod názvem souboru dle vaší volby."
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr "Vrátit náčrtník"
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr "Vrátit náčrtník do jeho naposledy uloženého stavu."
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr "Uložit náčrtník jako výchozí"
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr "Uložit náčrtník jako výchozí pro Nový náčrtník."
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr "Vyprázdnit výchozí náčrtník"
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr "Vyprázdnit výchozí náčrtník do prázdného plátna."
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr "Kopírovat hlavní pozadí do náčrtníku"
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr "Kopírovat obrázek pozadí z pracovního dokumentu do náčrtníku."
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "Okno"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "Štětec"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr "Klávesové zkratky"
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr "Nápověda ke klávesovým zkratkám pro štětce"
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr "Ukázat vysvětlení, jak klávesová zkratka pracuje."
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "Změnit štětec…"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr "Vyvolat měnič štětce pod ukazovátkem."
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "Změnit barvu…"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
-msgstr "Vyvolat měnič barev pod ukazovátkem. Jsou uvedeny všechny voliče barev."
+msgstr ""
+"Vyvolat měnič barev pod ukazovátkem. Jsou uvedeny všechny voliče barev."
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "Změnit barvu (rychlý výběr)…"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
@@ -4875,209 +5975,213 @@ msgstr ""
 "Vyvolat měnič barev pod ukazovátkem. Jsou uvedeny pouze voliče barev "
 "pracující na jedno klepnutí."
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr "Dostat další štětce…"
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr "Stáhnout balíčky se štětci ze stránky programu MyPaint."
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr "Zavést štětce…"
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr "Nahrát sadu štětců z disku."
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Nápověda"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr "Nápověda na internetu"
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr "Jít na stránku s dokumentací k MyPaint."
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "O programu MyPaint"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr "Ukázat povolení pro MyPaint, číslo verze a zásluhy."
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Ladění"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr "Vytisknout informace o přetečení paměti do konzole (pomalé!)"
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr "Ladit úniky paměti."
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr "Spustit popeláře, aby uklidil paměť, nyní"
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr "Volná paměť pro objekty Pythonu, které se už nepoužívají."
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr "Spustit/Zastavit profilování Pythonu…"
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr "Spustit/Zastavit profilování Pythonu (cProfile)"
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr "Napodobit pád…"
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr "Vytáhnout výjimku pro Python, na vyzkoušení dialogu pro případ pádu."
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "Pohled"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr "Zpětná vazba"
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr "Přizpůsobit pohled"
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
+#, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr "Ukázat související nabídku"
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr "Ukázat hlavní nabídku jako vyskakovací okno."
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "Celá obrazovka"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr "Přepnout mezi režimem celé obrazovky a okenním režimem."
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "Nastavení"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr "Upravit obecná nastavení programu MyPaint."
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr "Vyzkoušet vstupní zařízení"
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 "Ukázat dialog, který zachytí všechny události poslané vašimi vstupními "
 "zařízeními."
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr "Volič pozadí"
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr "Změnit povrch papíru pozadí."
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr "Editor nastavení štětců"
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr "Upravit nastavení činných štětců."
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr "Editor symbolů štětců"
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr "Upravit symboly štětců."
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr "Pruh vrstev"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
-msgstr "Přepnout panel vrstev (uspořádat vrstvy nebo přiřadit režimy)."
+msgid "Dockable panel for managing layers."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr "Ukázat panel vrstev"
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr "Odkrýt panel vrstev (uspořádat vrstvy nebo přiřadit režimy)."
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr "Kolo HCY"
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
@@ -5086,42 +6190,32 @@ msgstr ""
 "Ukotvitelný válcový volič barevného odstín/sytosti barvy/jasnosti. Kulaté "
 "kotouče mají stejnou světelnost."
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "Paleta barev"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr "Ukotvitelný volič barev v paletě."
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr "Kolo HSV"
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr "Ukotvitelná nabídka pro volbu hodnoty barvy a její sytosti."
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr "Trojúhelník barev HSV"
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr "Ukotvitelný volič barev: dobře známý barevný trojúhelník GTK."
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr "Krychle HSV"
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
@@ -5130,571 +6224,773 @@ msgstr ""
 "Ukotvitelný volič barev: Krychle HSV, kterou lze otáčet pro ukázání různých "
 "řezů."
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr "Čtverec HSV"
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
-msgstr ""
-"Ukotvitelný volič barev: Krychle HSV, kterou lze otáčet pro ukázání různých "
-"odstínů."
+msgid "Dockable color selector: HSV square with Hue ring."
+msgstr "Ukotvitelný volič barev se soustřednými kruhy HSV."
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr "Posuvníky složek"
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr "Ukotvitelný volič barev ukazující jednotlivé složky barvy."
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr "Plynulé stínování"
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr "Ukotvitelný volič barev ukazující plynulý stříkanec blízkých barev."
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr "Soustředné kruhy"
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr "Ukotvitelný volič barev se soustřednými kruhy HSV."
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr "Barevný talíř"
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 "Ukotvitelný volič barev s nakloněnými plošinami HSV křížícími paprsčitě se "
 "rozbíhající misku s barvami."
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr "Panel náčrtníku"
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
-msgstr "Přepnout panel náčrtníku (míchat barvy a dělat náčrtky)."
+msgid "Dockable Panel for mixing colors and testing brushes."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr "Ukázat panel náčrtníku"
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr "Odkrýt panel náčrtníku (míchat barvy a dělat náčrtky)."
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr "Panel s náhledy"
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
-msgstr "Přepnout panel náhledu (přehled o celé oblasti kresby)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "Náhled"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr "Odkrýt panel náhledu (přehled o celé oblasti kresby)."
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr "Panel s volbami pro nástroje"
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
-msgstr "Přepnout panel nástrojových voleb (volby pro nynější nástroj)."
+msgid "Dockable panel for adjusting the options with the activated tool."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr "Ukázat panel s volbami pro nástroje"
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr "Odkrýt panel nástrojových voleb (volby pro nynější nástroj)."
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr "Panel s historií štětců a barev"
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
-msgstr "Přepnout panel historie (nedávno použité štětce a barvy)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr "Nedávné štětce a barvy"
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr "Odkrýt panel historie (nedávno použité štětce a barvy)."
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr "Skrýt ovládání v režimu celé obrazovky"
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 "Přepnout automatické skrývání uživatelského rozhraní v režimu celé obrazovky."
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr "Ukázat úroveň přiblížení"
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr "Přepnout zpětnou vazbu úrovně zvětšení."
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr "Ukázat poslední polohu malování"
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr "Přepnout zpětnou vazbu ukazující, kde skončil poslední tah."
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr "Filtrovat pohled"
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr "Zobrazit barvy normálně"
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr "Filtrovat barvy: Ukázat barvy nezměněné."
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr "Zobrazit barvy v odstínech šedi"
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr "Filtrovat barvy: Ukázat pouze jas (HCY/YCbCr Luma)"
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr "Zobrazit barvy obrácené"
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
-msgstr "Filtrovat barvy: Obrátit obraz. Černá je bílá a červená je modrozelená."
+msgstr ""
+"Filtrovat barvy: Obrátit obraz. Černá je bílá a červená je modrozelená."
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr "Zobrazit barvy s umělou necitlivostí k červené"
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 "Filtrovat barvy. Napodobit barvoslepost na zelenou, běžný druh barvosleposti."
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr "Zobrazit barvy s umělou necitlivostí k zelené"
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 "Filtrovat barvy. Napodobit neschopnost rozeznat červenou, běžný druh "
 "barvosleposti."
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr "Zobrazit barvy s umělou necitlivostí k modré"
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 "Filtrovat barvy. Napodobit částečnou barvoslepost, při níž člověk není "
 "schopný vnímat modrou, vzácný druh barvosleposti."
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr "Kreslení od ruky"
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr "Kreslení od ruky"
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr "Kreslení od ruky: Kreslit a malovat volně, bez omezení."
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr "Kreslení od ruky"
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr "Kreslení od ruky: Kreslit a malovat volně, bez omezení."
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr "Posunout pohled"
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr "Posunout"
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr "Přejet v pohledu: Posunout váš pohled na plátno vodorovně nebo svisle."
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr "Posunout pohled"
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr "Interaktivně posunout váš pohled na plátno vodorovně nebo svisle."
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr "Otočit pohled"
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr "Otočit"
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr "Otočit pohled: Naklonit váš pohled na plátno."
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr "Otočit pohled"
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr "Interaktivně otočit váš pohled na plátno."
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr "Zvětšení pohledu"
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr "Zvětšení"
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr "Zvětšení pohledu: Přibližovat a oddalovat plátno."
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr "Zvětšení pohledu"
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr "Přibližovat a oddalovat plátno."
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr "Čáry a křivky"
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr "Čáry"
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr "Čáry a křivky: Kreslit přímé a zakřivené čáry."
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr "Čáry a křivky"
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr "Kreslit přímé a zakřivené čáry."
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr "Spojené čáry"
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr "Spojené čáry"
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr "Spojené čáry: Kreslit sledy přímých nebo zakřivených čar."
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr "Spojené čáry"
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr "Kreslit sledy přímých nebo zakřivených čar."
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr "Elipsy a kruhy"
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr "Elipsa"
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr "Elipsy a kruhy: Kreslit zakulacené tvary."
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr "Elipsy a kruhy"
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr "Kreslit elipsy a kruhy."
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr "Tuš"
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr "Inkoust"
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr "Tuš: Kreslit jemné kontrolované čáry."
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr "Tuš"
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr "Kreslit jemné kontrolované čáry."
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr "Přemístit vrstvu"
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr "Umístění vrstvy"
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr "Přesunout vrstvu: Přemístit nynější vrstvu na plátně."
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr "Přemístit vrstvu"
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr "Přemístit nynější vrstvu na plátně."
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr "Upravit rámeček"
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr "Rámeček"
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 "Upravit rámeček: Určit konečnou velikost dokumentu pomocí rámečku okolo něj."
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr "Upravit rámeček"
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr "Určit konečnou velikost dokumentu pomocí rámečku okolo něj."
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Upravit osu souměrnosti"
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr "Souměrnost"
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr "Upravit osu souměrnosti: Upravit osu používanou pro souměrné kreslení."
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Upravit osu souměrnosti"
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr "Upravit osu používanou pro souměrné kreslení."
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr "Vybrat barvu"
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr "Vybrat barvu"
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr "Vybrat barvu: Nastavit kreslicí barvu z pixelů obrazovky."
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "Vybrat barvu"
+
+#: ../po/tmp/resources.xml.h:401
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr "Nastavit kreslicí barvu z pixelů obrazovky."
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "Vybrat barvu"
+
+#: ../po/tmp/resources.xml.h:403
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr "Nastavit kreslicí barvu z pixelů obrazovky."
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "Vybrat barvu"
+
+#: ../po/tmp/resources.xml.h:405
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr "Nastavit kreslicí barvu z pixelů obrazovky."
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr "Vybrat barvu"
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr "Nastavit kreslicí barvu z pixelů obrazovky."
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr "Vyplnit"
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr "Vyplnit"
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr "Vyplnit: Vyplnit oblast barvou."
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr "Vyplnit"
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr "Vyplnit oblast barvou."
+
+#~ msgctxt "Accelerator map editor: action column markup"
+#~ msgid ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+#~ msgstr ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+
+#~ msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
+#~ msgid "{action_label} {action_desc} {accel_label}"
+#~ msgstr "{action_label} {action_desc} {accel_label}"
+
+#~ msgctxt "brush list context menu"
+#~ msgid "Delete"
+#~ msgstr "Smazat"
+
+#~ msgctxt "brush list commands"
+#~ msgid "Really delete brush from disk?"
+#~ msgstr "Opravdu smazat štětec z disku?"
+
+#~ msgid "HSV Triangle"
+#~ msgstr "Trojúhelník barev HSV"
+
+#~ msgid "The standard GTK color selector"
+#~ msgstr "Volič barev GTK"
+
+#~ msgid "Pick a color from the screen"
+#~ msgstr "Vybrat barvu z obrazovky"
+
+#~ msgid "Layer Name"
+#~ msgstr "Název vrstvy"
+
+#~ msgid ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+#~ msgstr ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+
+#~ msgid "Save..."
+#~ msgstr "Uložit..."
+
+#~ msgid "Confirm"
+#~ msgstr "Potvrdit"
+
+#~ msgid "Open..."
+#~ msgstr "Otevřít..."
+
+#~ msgid "{default_name} at {path}"
+#~ msgstr "{default_name} pod {path}"
+
+#~ msgid "Type"
+#~ msgstr "Typ"
+
+#~ msgid "Mode:"
+#~ msgstr "Režim:"
+
+#~ msgid ""
+#~ "Blending mode: how the current layer combines with the layers underneath "
+#~ "it."
+#~ msgstr ""
+#~ "Režim míchání: Jak se nynější vrstva spojuje s vrstvami hned pod ní."
+
+#~ msgid ""
+#~ "Layer opacity: how much of the current layer to use. Smaller values make "
+#~ "it more transparent."
+#~ msgstr ""
+#~ "Neprůhlednost vrstev: Kolik z nynější vrstvy použít. Menší hodnoty dělají "
+#~ "vrstvu průhlednější."
+
+#~ msgid "%s: edit properties"
+#~ msgstr "%s: Upravit vlastnosti"
+
+#~ msgctxt "layer unique names: match regex (leave untranslated if unsure)"
+#~ msgid "^(.*?)\\s*(\\d+)$"
+#~ msgstr "^(.*?)\\s*(\\d+)$"
+
+#~ msgctxt "layer default names"
+#~ msgid "Unknown Bitmap Layer"
+#~ msgstr "Neznámý štětec"
+
+#~ msgctxt "Autosave Recovery dialog|"
+#~ msgid "_Ignore for Now"
+#~ msgstr "Nyní _přehlížet"
+
+#~ msgid "Setting name:"
+#~ msgstr "Název nastavení:"
+
+#~ msgid "Base value:"
+#~ msgstr "Základní hodnota:"
+
+#~ msgid "Reset the base value to its default"
+#~ msgstr "Obnovit výchozí nastavení základní hodnoty"
+
+#~ msgid "<ymin>"
+#~ msgstr "<ymin>"
+
+#~ msgid "<ymax>"
+#~ msgstr "<ymax>"
+
+#~ msgid "<xmin>"
+#~ msgstr "<xmin>"
+
+#~ msgid "<xmax>"
+#~ msgstr "<xmax>"
+
+#~ msgid "Edit Setting"
+#~ msgstr "Upravit nastavení"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Trim Layer to Frame"
+#~ msgstr "Zastřihnout vrstvu do rámečku"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Rename Layer…"
+#~ msgstr "Přejmenovat vrstvu…"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Enter a new name for the current layer."
+#~ msgstr "Zadat nový název pro nynější vrstvu."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Turn off mirroring of the view."
+#~ msgstr "Vypnout zrcadlení pohledu."
+
+#~ msgctxt "Menu→Edit (labels)"
+#~ msgid "Current Tool"
+#~ msgstr "Nynější nástroj"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+#~ msgstr "Přepnout panel vrstev (uspořádat vrstvy nebo přiřadit režimy)."
+
+#~ msgctxt "Menu→Color (labels), Accel Editor (labels)"
+#~ msgid "HSV Triangle"
+#~ msgstr "Trojúhelník barev HSV"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Dockable color selector: the old GTK color triangle."
+#~ msgstr "Ukotvitelný volič barev: dobře známý barevný trojúhelník GTK."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid ""
+#~ "Dockable color selector: HSV square which can be rotated to show "
+#~ "different hues."
+#~ msgstr ""
+#~ "Ukotvitelný volič barev: Krychle HSV, kterou lze otáčet pro ukázání "
+#~ "různých odstínů."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+#~ msgstr "Přepnout panel náčrtníku (míchat barvy a dělat náčrtky)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+#~ msgstr "Přepnout panel náhledu (přehled o celé oblasti kresby)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+#~ msgstr "Přepnout panel nástrojových voleb (volby pro nynější nástroj)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the History panel (recently used brushes and colors)."
+#~ msgstr "Přepnout panel historie (nedávno použité štětce a barvy)."
 
 #, fuzzy
 #~ msgid "Rename..."
@@ -5793,9 +7089,6 @@ msgstr "Vyplnit oblast barvou."
 #~ "rychlost atd.) jsou přístupné jako tooltipy. Přesuňte myš na náhled a "
 #~ "uvidíte je.\n"
 
-#~ msgid "Open Recent files"
-#~ msgstr "Naposledy otevřené"
-
 #, fuzzy
 #~ msgid "This will discard %d second of unsaved painting."
 #~ msgid_plural "This will discard %d seconds of unsaved painting."
@@ -5845,10 +7138,6 @@ msgstr "Vyplnit oblast barvou."
 #~ msgstr "uložit nastavení"
 
 #, fuzzy
-#~ msgid "Add Layer"
-#~ msgstr "Vrstvy"
-
-#, fuzzy
 #~ msgid "Change Layer Visibility"
 #~ msgstr "Viditelnost vrstvy"
 
@@ -5871,10 +7160,6 @@ msgstr "Vyplnit oblast barvou."
 #~ msgctxt "Menu|File|"
 #~ msgid "Save"
 #~ msgstr "Uložit"
-
-#, fuzzy
-#~ msgid "Export to a file"
-#~ msgstr "Exportovat paletu..."
 
 #, fuzzy
 #~ msgctxt "Menu|Brush|"

--- a/po/csb.po
+++ b/po/csb.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:19+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Kashubian <https://hosted.weblate.org/projects/mypaint/"
@@ -20,27 +20,7 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -48,39 +28,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -88,214 +68,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Swòje"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -334,98 +324,133 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Zapiszë"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Nowi"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
@@ -433,44 +458,44 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -478,58 +503,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -538,51 +563,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -592,137 +641,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -730,162 +779,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -893,373 +934,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Miono"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Copni"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Daj nazôd"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1269,324 +1307,679 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Òtemkni..."
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr ""
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Zakùńczë"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Zakùńczë"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Òtemkni..."
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Zapiszë"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr ""
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr ""
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Lopk"
+
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Òtemkni..."
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Òtemkni wczasniészi"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Òtemkni..."
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Òtemkni..."
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr ""
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1594,130 +1987,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1726,35 +2131,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1778,45 +2183,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1824,153 +2233,217 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr ""
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr ""
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr ""
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1982,256 +2455,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2239,188 +2737,212 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+msgid "Import Layers"
+msgstr ""
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2429,13 +2951,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2445,7 +2967,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2453,13 +2975,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2467,7 +2989,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2475,7 +2997,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2486,7 +3008,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2494,7 +3016,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2504,7 +3031,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2515,285 +3042,394 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr ""
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2803,7 +3439,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2812,52 +3468,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2879,17 +3566,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2918,112 +3603,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3036,7 +3696,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3077,6 +3737,133 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Miono"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3446,56 +4233,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3503,12 +4310,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3517,7 +4324,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3528,28 +4335,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3611,1828 +4418,2018 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Zmiészi"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Lopk"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Pòmòc"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/csb.po
+++ b/po/csb.po
@@ -515,17 +515,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1186,12 +1186,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1374,7 +1374,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Open dragged file confirm dialog: continue button"
 msgid "_Open"
-msgstr "Òtemkni..."
+msgstr "Òtemkni…"
 
 #: ../gui/drawwindow.py:486
 msgid "Set current color"
@@ -1408,7 +1408,7 @@ msgid "_Quit"
 msgstr "Zakùńczë"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1458,7 +1458,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1636,13 +1636,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Zapiszë"
 
@@ -1708,7 +1708,7 @@ msgstr "Lopk"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -1725,7 +1725,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Òtemkni..."
+msgstr "Òtemkni…"
 
 #: ../gui/filehandling.py:1427
 #, fuzzy
@@ -1737,7 +1737,7 @@ msgstr "Òtemkni wczasniészi"
 #, fuzzy
 msgctxt "File→Open Most Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Òtemkni..."
+msgstr "Òtemkni…"
 
 #: ../gui/filehandling.py:1446
 msgctxt "File→Open Next/Prev Scrap: error message"
@@ -1758,7 +1758,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
 msgid "_Open"
-msgstr "Òtemkni..."
+msgstr "Òtemkni…"
 
 #: ../gui/filehandling.py:1487
 msgctxt "File→Revert: status message: canvas has no filename yet"
@@ -2132,12 +2132,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2149,7 +2149,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2334,7 +2334,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2404,7 +2404,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/da.po
+++ b/po/da.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-03-07 14:05+0000\n"
 "Last-Translator: Allan Nordhøy <epost@anotheragency.no>\n"
 "Language-Team: Danish <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -19,29 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.5.1-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr "<big><b>{accel_label}</b></big>"
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr "{action_label} {action_desc} {accel_label}"
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "Handling"
 
@@ -49,32 +27,32 @@ msgstr "Handling"
 msgid "Key combination"
 msgstr "Taste kombination"
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr "Rediger tastaturgenvej for '%s'"
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "Handling:"
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "Sti:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "Taster:"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr "Tryk på tasterne for at opdatere denne tildeling"
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "Ukendt handling"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
@@ -83,7 +61,7 @@ msgstr ""
 "<b>{accel} er allerede i brug af '{action}'. Den eksisterende tildeling vil "
 "blive erstattet.</b>"
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr "Åbn mappen \"{folder_basename}\" …"
@@ -91,196 +69,206 @@ msgstr "Åbn mappen \"{folder_basename}\" …"
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "Ok"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr "Ingen sikkerhedskopier blev fundet i cachen."
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr "Ingen tilgængelige sikkerhedskopier"
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr "Åben cache mappen …"
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr "Sikkerhedskopiens gendannelse mislykkedes"
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr "Åbne til sikkerhedskopi mappen …"
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr "Gendannet fil fra {iso_datetime}.ora"
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "Gem som standard"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "Baggrund"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "Mønster"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Farve"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "Tilføj farve til mønstre"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr "En eller flere baggrunde kunne ikke hentes"
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr "Fejl ved hentning af baggrunde"
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 "Fjern venligst filerne som ikke kan hentes eller tjek libgdkpixbuf "
 "installationen."
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 "Gdk-Pixbuf kunne ikke indlæse \"{filename}\" og rapporterede \"{error}\""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr "{filename} har nul størrelse (w = {w}, h = {h})"
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr "Pensel indstillinger redigering"
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr "Om"
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "Eksperimentel"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr "Grundlæggende"
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr "Opacitet"
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr "Klatter"
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "Udtværing"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr "Hastighed"
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr ""
+
+#: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr "Sporing"
 
-#: ../gui/brusheditor.py:359
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "Strøg"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr "Farve"
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Bruger"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr "Ingen pensel er valgt, brug \"Tilføj som ny\" i stedet."
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr "Der er ikke valgt nogen pensel!"
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "Omdøb pensel"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "En pensel med dette navn eksisterer allerede!"
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr "Der er ikke valgt nogen pensel!"
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr "Er du sikker på at slette penslen “{brush_name}” fra harddisken?"
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr "(Pensel uden navn)"
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr "{brush_name} [ikke gemt]"
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr "Pensel ikon"
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr "Pensel ikon (redigering)"
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr "Der er ikke valgt nogen pensel"
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -289,7 +277,7 @@ msgstr ""
 "<b>%s</b>\n"
 "<small>Vælg en valid pensel først</small>"
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
@@ -298,7 +286,7 @@ msgstr ""
 "<b>%s</b> <i>(ændret)</i>\n"
 "<small>Ændringerne er ikke gemt endnu</small>"
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
@@ -307,7 +295,7 @@ msgstr ""
 "<b>%s</b> (redigering)\n"
 "<small>Maling med pensel eller farve</small>"
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -348,142 +336,182 @@ msgstr "Auto"
 msgid "Use the default icon"
 msgstr "Brug standard ikon"
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Gem"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr "Gem forhåndsvisning ikon og forlad redigering"
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr "Hittegods"
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr "Slettet"
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr "Favoritter"
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr "Blæk"
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr "Klassisk"
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr "Sæt 1"
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr "Sæt 2"
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr "Sæt 3"
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr "Sæt 4"
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr "Sæt 5"
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr "Eksperimentel"
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Ny"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr "Ukendt pensel"
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr "Føj til favoritter"
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr "Slet fra favoritter"
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr "Klon"
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr "Rediger pensel indstillinger"
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
-msgstr "Slet"
+#: ../gui/brushselectionwindow.py:250
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
+msgstr "Omdøb gruppe"
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
-msgstr "Virkelig slette pensel fra disken?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, fuzzy, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
+msgstr "Er du sikker på at slette penslen “{brush_name}” fra harddisken?"
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] "%d pensel"
 msgstr[1] "%d pensler"
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr "Gruppe “{group_name}”"
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr "Omdøb gruppe"
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr "Eksporter som komprimeret penselssæt"
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr "Slet gruppe"
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr "Omdøb gruppe"
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "En gruppe med dette navn eksisterer allerede!"
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr "Virkelig slette gruppen \"{group_name}\"?"
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -493,58 +521,58 @@ msgstr ""
 "Kunne ikke slette gruppen \"{group_name}\".\n"
 "Nogle særlige grupper kan ikke slettes."
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr "Eksporter pensler"
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr "MyPaint pensel pakke (* .zip)"
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "Ny gruppe ..."
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr "Importer pensler ..."
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr "Hent flere pensler ..."
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "Opret gruppe"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr "Knap"
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr "Knap"
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr "Tryk på knappen"
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr "Tilføj ny binding"
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr "Fjern nuværende binding"
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr "Rediger binding for '%s'"
@@ -553,7 +581,7 @@ msgstr "Rediger binding for '%s'"
 msgid "Button press:"
 msgstr "Tryk på knappen:"
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
@@ -561,47 +589,75 @@ msgstr ""
 "Hold nede kombinationstaster og tryk på en knap over denne tekst for at "
 "angive en ny binding."
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 "{button} kan ikke bindes uden kombinationstaster (dens betydning er fastlagt)"
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr "{button_combination} er allerede bundet til handlingen '{action_name}'"
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr "Vælg farve"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr "Sæt farven som bruges til maling"
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+#, fuzzy
+msgid "Set the color Hue used for painting"
+msgstr "Sæt farven som bruges til maling"
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "Vælg farve"
+
+#: ../gui/colorpicker.py:296
+#, fuzzy
+msgid "Set the color Chroma used for painting"
+msgstr "Sæt farven som bruges til maling"
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+#, fuzzy
+msgid "Set the color Luma used for painting"
+msgstr "Sæt farven som bruges til maling"
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr "Farve detaljer"
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr "Aktuelle penselsfarve og farven senest brugt til maleri"
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr "Farveskala maske aktiv"
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -613,7 +669,7 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr "HCY farvetone og chroma."
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
@@ -622,12 +678,12 @@ msgstr ""
 "Farevskala maske redigering. Klik i midten for at oprette eller manipulere "
 "figurer eller roter masken ved hjælp af kanten på disken."
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr "Atmosfæriske Triade"
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
@@ -636,22 +692,22 @@ msgstr ""
 "Mut og underspillet, der er defineret af en dominerende farve og to "
 "primærvalg som er mindre intense."
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr "Skiftet triade"
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr "Vægtet mere kraftigt mod den dominerende farve."
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr "Supplerende"
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
@@ -660,12 +716,12 @@ msgstr ""
 "Kontrasterende modsætninger, afbalanceret ved at have centrale neutrale "
 "mellem dem på farvehjulet."
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr "Humør og betoning"
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
@@ -673,12 +729,12 @@ msgid ""
 msgstr ""
 "En hoved udvalg af farver, med en supplerende accent for variation og højlys."
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr "Split komplementære"
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
@@ -687,72 +743,72 @@ msgstr ""
 "To sammenlignelige farver og et supplement til dem, med ingen sekundære "
 "farver mellem dem."
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr "Ny farveskala maske fra skabelon"
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr "Farveskala maske redigering"
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr "Aktiv"
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr "Hjælp …"
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr "Opret maske fra skabelon."
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr "Indlæs maske fra en GIMP palette fil."
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr "Gem maske til en GIMP palette fil."
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr "Slet masken."
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr "Åbn onlinehjælpen til denne dialog i en webbrowser."
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr "Gem maske som GIMP palette"
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr "Hent maske fra GIMP palette"
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr "Sæt farveskala maske."
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr "HCY farvehjul"
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -762,162 +818,154 @@ msgstr ""
 "skiver er ens i lysstyrke."
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr "HSV farvetone"
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr "HSV mætning"
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr "HSV værdi"
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr "HSV mætning og værdi"
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr "HSV farvetone og værdi"
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr "HSV farvetone og mætning"
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr "Roter terningen (Vis forskellige akser)"
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr "HSV terning"
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr "En HSV terning, der kan roteres for at vise forskellige plane skiver."
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr "HSV firkant"
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr "En HSV firkant, som kan drejes for at vise forskellige nuancer."
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr "HSV trekant"
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr "Standard farvevælger for GTK"
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr "HSV farvehjul"
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr "Mætning og værdi farve vælger."
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr "Palette egenskaber"
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr "Paletten"
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr "Indstil farven fra en indlæsbar og redigerbar palette."
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr "Palette uden navn"
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr "Palette redigering"
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr "Indlæs fra en GIMP palette fil"
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr "Gem til en GIMP palette fil"
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr "Tilføj en ny tom farveprøve"
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr "Fjern den aktuelle farveprøve"
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr "Fjern alle farveprøver"
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr "Titel:"
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr "Navn eller beskrivelse for denne palette"
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr "Kolonner:"
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr "Antallet af kolonner"
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr "Farve navn:"
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr "Nuværende farves navn"
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr "Tom palette plads"
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr "Indlæs palette"
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr "Gem palette"
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -928,381 +976,378 @@ msgstr ""
 "Drop farver her, \n"
 "Træk dem for at organisere dem."
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr "Tom palette plads (træk en farve her)"
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr "Tilføje tom plads"
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr "Indsæt række"
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr "Indsæt kolonne"
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr "Udfyld hul (RGB)"
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr "Udfyld hul (HCY)"
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr "Udfyld hul (HSV)"
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "GIMP palette fil (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr "Alle filer (*)"
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "GIMP palette fil (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr "Alle filer (*)"
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr "Opsaml en farve fra skærmen"
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr "R"
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr "G"
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr "B"
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr "H"
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr "C"
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr "Y"
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr "Komponent skydere"
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr "Juster individuelle komponenter af farve."
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr "RGB-rød"
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr "RGB-grøn"
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr "RGB-blå"
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr "HSV farvetone"
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr "HSV mætning"
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr "HSV værdi"
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr "HCY farvetone"
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr "HCY Chroma"
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr "HCY Luma (Y')"
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr "Flydende vask"
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr "Ændr farve ved hjælp af en væske-lignende vask af nærliggende farver."
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr "Koncentriske cirkler"
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr "Ændre farve ved hjælp af koncentriske cirkler HSV."
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr "Krydsende skål"
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 "Ændre farve med HSV ramper der krydser en radial (strålende ud fra et "
 "centrum) skål af farve."
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr "Markør/puck"
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr "Viskelæder"
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr "Tastatur"
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr "Mus"
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr "Pen"
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr "Tegneplade"
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr "Touchscreen"
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr "Ignorer"
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr "Enhver opgave"
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr "Ikke-maleri opgaver"
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr "Kun navigation"
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr "Zoom"
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr "Panorering"
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr "Enhed"
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr "Akser"
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr "Type"
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr "Brug for ..."
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr "Rul ..."
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Navn"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr "Overskriv pensel?"
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr "Erstat"
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr "Omdøb"
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr "Erstat alle"
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr "Omdøb alle"
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr "Importeret pensel"
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr "Eksisterende pensel"
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 "<b>En pensel ved navn '%s' findes allerede.</b>\n"
 "Vil du erstatte den, eller skal den nye pensel omdøbes?"
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr "Overskriv pensel gruppe?"
 
-#: ../gui/dialogs.py:190
-#, python-brace-format
+#: ../gui/dialogs.py:220
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 "<b>En gruppe med navnet '{groupname}' findes allerede.</b>\n"
 "Vil du erstatte den, eller skal den nye gruppe omdøbes?\n"
 "Hvis du erstatter kan penslerne blive flyttet til en gruppe kaldet "
 "'{deleted_groupname}'."
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr "Importer pensel pakke?"
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, fuzzy, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr "<b>Vil du virkelig importere pakken '%s'?</b>"
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr "Indlæs pensel indstillinger fra genvej plads %d"
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr "Gem pensel indstillinger i genvej plads %d"
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr "Gendan pensel %d"
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr "Gem til pensel %d"
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr "Fortryd %s"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Fortryd"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr "Omgør %s"
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Omgør"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr "{button_combination} er {resultant_action}"
@@ -1312,91 +1357,128 @@ msgstr "{button_combination} er {resultant_action}"
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ",  "
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr "Med {modifiers} holdt nede:  {button_actions}."
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
-msgstr "Lag navn"
-
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
-#, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
-"<b>{name}</b>\n"
-"{description}"
+
+#: ../gui/document.py:909
+#, python-brace-format
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
+msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr "%s - MyPaint"
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr "MyPaint"
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Åben"
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr "Sæt nuværende farve"
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr "Forlad fuldskærmsvisning"
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr "Forlad fuldskærmsvisning"
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr "Vælg fuldskærmsvisning"
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Fuldskærmsvisning"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Afslut"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+#, fuzzy
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr "Virkelig afslutte?"
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Afslut"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr "Import pensel pakke ..."
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr "MyPaint pensel pakke (* .zip)"
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr "Startede {app_name} for at redigere laget \"{layer_name}\""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 "Fejl: kunne ikke starte {app_name} for at redigere laget \"{layer_name}\""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
@@ -1404,184 +1486,403 @@ msgstr ""
 "Redigering annulleret. Du kan stadig redigere \"{layer_name}\" fra menuen "
 "lag."
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr "Opdaterede lag \"{layer_name}\" med eksterne redigeringer"
 
-#: ../gui/externalapp.py:46
-#, python-brace-format
-msgid ""
-"MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
-"application should it use?"
-msgstr ""
-"MyPaint har brug at redigere en fil af typen \"{type_name}\" ({content_type})"
-". Hvilket program skal der bruges?"
-
-#: ../gui/externalapp.py:50
-#, python-brace-format
-msgid ""
-"What application should MyPaint use for editing files of type "
-"“{type_name}” ({content_type})?"
-msgstr ""
-"Hvilket program skal MyPaint bruge til redigering af filer af typen \""
-"{type_name}\" ({content_type})?"
-
-#: ../gui/externalapp.py:56
-msgid "Open With..."
-msgstr "Åbn med ..."
-
-#: ../gui/externalapp.py:107
-msgid "Icon"
-msgstr "Ikon"
-
-#: ../gui/externalapp.py:150
-msgid "no description"
-msgstr "ingen beskrivelse"
-
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr "Alle kendte formater"
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr "OpenRaster (* .ora)"
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr "PNG (*.png)"
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr "JPEG (*.jpg; *.jpeg)"
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr "Efter filendelse (foretrækker standardformat)"
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr "PNG fast med baggrund (*.png)"
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr "PNG gennemsigtig (*.png)"
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr "Flere PNG gennemsigtig (*. XXX.png)"
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr "JPEG 90% kvalitet (*.jpg; *.jpeg)"
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr "Gem ..."
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr "Format der gemmes som:"
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr "Bekræft"
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr "Virkelig fortsætte?"
-
-#: ../gui/filehandling.py:234
-#, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
-msgstr "Dette vil slette {abbreviated_time} af ikke gemt maleri"
-
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr "_Gem som skrot"
-
-#: ../gui/filehandling.py:282
-#, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
-msgstr "Indlæser \"{file_basename}\" …"
-
-#: ../gui/filehandling.py:296
+#: ../gui/externalapp.py:48
 #, python-brace-format
 msgctxt "file handling: open failed (statusbar)"
 msgid "Could not load “{file_basename}”."
 msgstr "\"{file_basename}\" kunne ikke indlæses."
 
-#: ../gui/filehandling.py:321
+#: ../gui/externalapp.py:61
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
-msgstr "Indlæst \"{file_basename}\"."
+msgid ""
+"MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
+"application should it use?"
+msgstr ""
+"MyPaint har brug at redigere en fil af typen "
+"\"{type_name}\" ({content_type}). Hvilket program skal der bruges?"
 
-#: ../gui/filehandling.py:422
+#: ../gui/externalapp.py:65
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
-msgstr "Eksporterer til \"{file_basename}\" …"
+msgid ""
+"What application should MyPaint use for editing files of type "
+"“{type_name}” ({content_type})?"
+msgstr ""
+"Hvilket program skal MyPaint bruge til redigering af filer af typen "
+"\"{type_name}\" ({content_type})?"
 
-#: ../gui/filehandling.py:427
+#: ../gui/externalapp.py:71
+msgid "Open With..."
+msgstr "Åbn med ..."
+
+#: ../gui/externalapp.py:123
+msgid "Icon"
+msgstr "Ikon"
+
+#: ../gui/externalapp.py:166
+msgid "no description"
+msgstr "ingen beskrivelse"
+
+#: ../gui/filehandling.py:126
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
+msgstr "Indlæser \"{file_basename}\" …"
+
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:134
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr "Gemmer \"{file_basename}\" …"
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:138
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
+msgstr "Eksporterer til \"{file_basename}\" …"
+
+#: ../gui/filehandling.py:145
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
 msgstr "Kunne ikke eksporteres til \"{file_basename}\"."
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:149
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
 msgstr "Kunne ikke gemme \"{file_basename}\"."
 
-#: ../gui/filehandling.py:476
+#: ../gui/filehandling.py:153
 #, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr "\"{file_basename}\" kunne ikke indlæses."
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "Gem palette"
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
 msgstr "Eksporteret til \"{file_basename}\" korrekt."
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:187
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
 msgstr "Gemt \"{file_basename}\"."
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Åben ..."
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:195
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr "Indlæst \"{file_basename}\"."
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
+msgstr "Indlæst \"{file_basename}\"."
+
+#: ../gui/filehandling.py:427
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
+msgstr "Alle kendte formater"
+
+#: ../gui/filehandling.py:432
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (* .ora)"
+
+#: ../gui/filehandling.py:437
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:442
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
+msgstr "JPEG (*.jpg; *.jpeg)"
+
+#: ../gui/filehandling.py:490
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
+msgstr "Efter filendelse (foretrækker standardformat)"
+
+#: ../gui/filehandling.py:494
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (* .ora)"
+
+#: ../gui/filehandling.py:498
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr "PNG fast med baggrund (*.png)"
+
+#: ../gui/filehandling.py:502
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:506
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr "PNG gennemsigtig (*.png)"
+
+#: ../gui/filehandling.py:510
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr "Flere PNG gennemsigtig (*. XXX.png)"
+
+#: ../gui/filehandling.py:514
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr "Flere PNG gennemsigtig (*. XXX.png)"
+
+#: ../gui/filehandling.py:518
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr "JPEG 90% kvalitet (*.jpg; *.jpeg)"
+
+#: ../gui/filehandling.py:576
+#, fuzzy
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr "Eksporter …"
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Gem som …"
+
+#: ../gui/filehandling.py:601
+#, fuzzy
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr "Format der gemmes som:"
+
+#: ../gui/filehandling.py:668
+#, fuzzy
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr "Virkelig fortsætte?"
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+#, fuzzy
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr "_Gem som skrot"
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, fuzzy, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr "Dette vil slette {abbreviated_time} af ikke gemt maleri"
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr "Åben …"
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Åben"
+
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr "Åbn Skitseblok ..."
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Importeret pensel"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Åben"
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Åbn seneste"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Åben"
+
+#: ../gui/filehandling.py:1446
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
 msgstr "Der findes ingen skrot filer med navnet \"%s\" endnu."
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1455
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr "Åbn næste skrot"
+
+#: ../gui/filehandling.py:1463
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr "Åbn tidligere skrot"
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Åben"
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+#, fuzzy
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr "Forkast"
+
+#: ../gui/fill.py:121
+#, fuzzy
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr "Spandudfyldning"
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+#, fuzzy
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr "Udfyld områder med farve"
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+#, fuzzy
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr "Tolerance:"
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+#, fuzzy
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
@@ -1589,19 +1890,36 @@ msgstr ""
 "Hvor meget pixel farver får lov til at variere fra starten før "
 "spandudfyldning vil nægte at udfylde dem"
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+#, fuzzy
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr "Kilde:"
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
-msgstr "Hvilke synlige lag skal udfyldes"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
+msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+#, fuzzy
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr "Opsamlet prøve"
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+#, fuzzy
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
@@ -1611,19 +1929,50 @@ msgstr ""
 "brug en midlertidig samling af alle synlige lag \n"
 "under det aktuelle lag"
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+#, fuzzy
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr "Tilpas til visning"
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+#, fuzzy
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr "Mål:"
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+#, fuzzy
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr "Hvor resultatet skal gå"
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr "Nyt lag (en gang)"
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+#, fuzzy
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
@@ -1631,21 +1980,108 @@ msgstr ""
 "Opret et nyt lag med resultaterne af fyld.\n"
 "Dette slukkes automatisk efter brug."
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Opacitet:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr "Nulstil"
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+#, fuzzy
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr "Nulstil indstillinger til deres standardindstillinger"
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "Vælg lag"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr "<b>{brush_name}</b>"
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1655,130 +2091,142 @@ msgstr ""
 "<b>{brush_name}</b>\n"
 "{brush_desc}"
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr "Rediger ramme"
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr "Juster dokument ramme"
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr "Ramme størrelse"
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr "px"
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr "Højde:"
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr "Bredde:"
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr "Opløsning:"
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr "DPI"
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr "Dots Per Inch (rettere Pixels Per Inch)"
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr "Farve:"
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr "Ramme farve"
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr "<b>Ramme dimensioner</b>"
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr "<b>Pixel tæthed</b>"
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr "Sæt ramme til lag"
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr "Sæt ramme til det aktuelle lags mål"
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr "Sæt ramme til dokument"
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr "Sæt ramme til kombinationen af alle lag"
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr "Trim laget til ramme"
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr "Trim dele af det aktuelle lag, der ligger uden for rammen"
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr "Aktiveret"
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr "{width:g}×{height:g} {units}"
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr "tommer"
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr "cm"
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr "mm"
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr "Frihånds tegning"
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr "Male friforms penselstrøg"
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr "Udglat:"
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr "Tryk:"
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr "Fejl registreret"
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr "<big><b>En programmerings fejl er blevet opdaget.</b></big>"
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1792,35 +2240,35 @@ msgstr ""
 "Fortæl venligst udviklerne om dette ved hjælp af problemsporing, hvis ingen "
 "andre har rapporteret den endnu."
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr "Søg sporing ..."
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr "Rapporter ..."
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr "Ignorer fejl"
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr "Afslut MyPaint"
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr "Detaljer ..."
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr "Undtagelse under analyse af undtagelsen."
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1867,45 +2315,50 @@ msgstr ""
 "            #### Traceback\n"
 "        "
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr "Farvelægning"
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr "Tegne, og derefter justere bløde linjer"
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr "Input-enhed test"
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr "(ingen tryk)"
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr "Tryk:"
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr "(ingen tilt)"
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr "Tilt:"
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr "(ingen enhed)"
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
 msgstr "Enhed:"
 
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+#, fuzzy
+msgid "Barrel Rotation:"
+msgstr "Nulstil rotation"
+
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr "Flyt lag"
 
@@ -1913,161 +2366,228 @@ msgstr "Flyt lag"
 msgid "Move the current layer"
 msgstr "Flyt det aktuelle lag"
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
-msgstr "{default_name} på {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
+msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
-msgstr "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
+msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+#, fuzzy
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr "Egenskaber"
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr "Synlige"
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Lag"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+#, fuzzy
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr "Låst"
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+#, fuzzy
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ", "
+
+#: ../gui/layers.py:990
+#, fuzzy, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr "Tilføj {layer_default_name}"
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Lag"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr "Arranger lag og tildel effekter"
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr "Lag opacitet: %d%%"
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr "Flyt lag i stakken ..."
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 "Flyt lag i stakken (flytter sig ned til et almindeligt lag, vil oprette en "
 "ny gruppe)"
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr "Lag"
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
-msgstr "Tilstand:"
+#: ../gui/layervis.py:53
+#, fuzzy, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
+msgstr "<b>{brush_name}</b>"
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
-"Blandingstilstand: hvordan det aktuelle lag kombinerer med lag nedenunder."
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Opacitet:"
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "Roter visningen"
 
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-"Lag opacitet: hvor meget af det aktuelle lag som bruges. Mindre værdier gør "
-"det mere gennemsigtig."
-
-#: ../gui/linemode.py:37
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr "Indgangs tryk"
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr "Strøgets indgangs tryk for linje værktøjer"
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr "Midtpunkts tryk"
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr "Strøgets midtpunkts tryk for linje værktøjer"
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr "Udgangs tryk"
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr "Strøgets udgangs tryk for linje værktøjer"
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr "Hoved"
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 msgid "Stroke lead-in end"
 msgstr "Strøgets opstart slutning"
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr "Hale"
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr "Strøgets udtoning begyndelse"
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr "Tryk variation ..."
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr "Linjer og kurver"
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr "Generisk linje/kurve tilstand"
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr "Tegn lige streger; Skift tasten tilføjer kurver, Ctrl begrænser vinkel"
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr "Forbundne linjer"
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 "Tegn en række af linjer; Skift tasten tilføjer kurver, Ctrl begrænser vinklen"
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr "Ellipser og cirkler"
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr "Tegne ellipser; Skift tasten roterer, Ctrl begrænser forholdet/vinkel"
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
+#, fuzzy
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 "Copyright (C) 2005-2015\n"
 "Martin Renold og MyPaint udviklingsteam"
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -2080,78 +2600,78 @@ msgid ""
 msgstr ""
 "Dette program er gratis software. Du kan redistribuere det og/eller "
 "modificere det under betingelserne i GNU General Public License, som er "
-"publiceret af Free Software Foundation, enten version 2 af licensen, eller ("
-"efter dit valg) en senere version.\n"
+"publiceret af Free Software Foundation, enten version 2 af licensen, eller "
+"(efter dit valg) en senere version.\n"
 "\n"
 "Dette program er distribueret i håb om, at det vil være nyttigt, men uden "
 "nogen garanti. Se filen COPYING for flere detaljer."
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr "programmering"
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr "bærbarhed"
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr "projektledelse"
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr "pensler"
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr "mønstre"
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr "værktøjs ikoner"
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr "skrivebords ikon"
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr "paletter"
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr "dokumentation"
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr "support"
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr "opsøgende"
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr "fællesskab"
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ", "
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
@@ -2166,186 +2686,216 @@ msgstr ""
 "Har du kommentarer til oversættelsen, kan du sende \n"
 "en mail til: illustratorkaki@gmail.com"
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr "Størrelse:"
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr "Uigennemsigtig:"
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr "Skarphed:"
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr "Forstærkning:"
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr "Værktøj valgmuligheder"
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr "Specielle indstillinger for den aktuelle redigeringsværktøj"
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr "<b>{mode_name}</b>"
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr "<i>Ingen tilgængelige indstillinger</i>"
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr "Zoom: %.01f%%"
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr "Vælg indstillinger for penselstrøg, stregfarve og lag …"
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr "Vælg farve …"
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr "Præferencer"
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr "Forhåndsvisning"
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr "Vis forhåndsvisning af hele tegning område"
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr "Vis søgeren"
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr "Skitseblok"
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr "Bland farver og lav skitser på separate skitsebloks sider"
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr "Forrige element"
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr "Næste element"
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
 msgstr "(Intet at vise)"
 
-#: ../gui/symmetry.py:76
+#: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Place axis"
 msgstr "Placer akser"
 
-#: ../gui/symmetry.py:80
+#: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Move axis"
 msgstr "Flyt akse"
 
-#: ../gui/symmetry.py:84
+#: ../gui/symmetry.py:88
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr "Fjern akse"
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr "Rediger symmetri akse"
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr "Juster maleriets symmetri akse."
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
+#, fuzzy
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr "Placering:"
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr "Placering:"
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr "Ingen"
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr "%d px"
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr "Alfa:"
 
-#: ../gui/symmetry.py:352
+#: ../gui/symmetry.py:376
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
+msgstr "Symmetri"
+
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+#, fuzzy
 msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+msgid "X axis Position"
 msgstr "Placering af akse"
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:477
+#, fuzzy
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr "Placering af akse"
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr "Aktiveret"
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr "Fil håndtering"
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr "Skrot tilstandsskifter"
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr "Fortryd og Omgør"
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr "Blandings tilstande"
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr "Linje tilstande"
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr "Vis (Hoved)"
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr "Vis (Alternativ/Sekundær)"
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr "Vis (Nulstilling)"
 
@@ -2353,188 +2903,214 @@ msgstr "Vis (Nulstilling)"
 msgid "<b>MyPaint</b>"
 msgstr "<b>MyPaint</b>"
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr "Rulning visning"
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr "Træk lærred visningen"
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr "Zoom visning"
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr "Zoom lærred visningen"
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr "Roter visningen"
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr "Roter lærred visningen"
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, fuzzy, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr "%s: luk faneblad"
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
-msgstr "%s: rediger egenskaber"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
+msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr "Ukendt kommando"
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr "Udefineret (kommandoen endnu ikke er startet)"
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr "{seconds:.01f}er af maling med  {brush_name}"
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr "Spandudfyldning"
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr "Trim lag"
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "Omdøb gruppe"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr "Ryd lag"
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr "Indsæt lag"
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr "Nyt lag fra synlige"
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr "Foren synlige lag"
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr "Foren nedad"
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr "Normaliser lagets blandingstilstand"
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Importeret pensel"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr "Tilføj {layer_default_name}"
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr "Slet lag"
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr "Vælg lag"
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr "Dupliker lag"
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr "Flyt lag op"
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr "Flyt lag ned"
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr "Flyt lag i stakken"
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr "Omdøb lag"
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr "Synliggør lag"
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr "Gør laget usynligt"
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr "Lås lag"
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr "Lås lag op"
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr "Indstil lagets opacitet: %0.1f%%"
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr "Ukendt tilstand"
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr "Sæt lagets blandingstilstand: %s"
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr "Aktiver ramme"
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr "Deaktiver ramme"
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr "Opdater ramme"
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr "Rediger laget eksternt"
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr "Fejl ved indlæsning \"{basename}\"."
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr "Logfilerne kan have flere detaljer om denne fejl."
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr "fra nu"
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr "siden"
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2546,13 +3122,13 @@ msgstr ""
 "Kører du mere end én gang forekomst af MyPaint?\n"
 "Luk appen og vent {cache_update_interval}er med at prøve igen."
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr "Ufuldstændig backup opdateret {last_modified_time} {ago}"
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2562,11 +3138,11 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 "Sikkerhedskopi opdateret {last_modified_time} {ago} \n"
-"Størrelse: {autosave.width}×{autosave.height} pixel. Lag: "
-"{autosave.num_layers}\n"
+"Størrelse: {autosave.width}×{autosave.height} pixel. Lag: {autosave."
+"num_layers}\n"
 "Indeholder {unsaved_time} af ikke-gemt maleri."
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2576,13 +3152,13 @@ msgstr ""
 "Der kan ikke skrives til \"{filename}\": {err}\n"
 "Har du har nok plads tilbage på enheden?"
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr "Der kan ikke skrives til \"{filename}\": {err}"
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2592,7 +3168,7 @@ msgstr ""
 "{error_loading_common}\n"
 "Filen findes ikke."
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2602,7 +3178,7 @@ msgstr ""
 "{error_loading_common}\n"
 "Du har ikke de tilladelser, der kræves for at åbne denne fil."
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2618,7 +3194,7 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2628,7 +3204,13 @@ msgstr ""
 "{error_loading_common}\n"
 "Ukendt fil format: \"{ext}\""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+#, fuzzy
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr "Importeret pensel"
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2642,7 +3224,7 @@ msgstr ""
 "Prøv at gemme i PNG-format i stedet for, hvis din maskine ikke har en masse "
 "hukommelse. Mypaints PNG gemme funktion er mere effektiv."
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2658,98 +3240,207 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/helpers.py:402
-#, python-brace-format
+#: ../lib/floodfill.py:131
+#, fuzzy
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr "Fyld"
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr "{days}d{hours}t"
 
-#: ../lib/helpers.py:404
-#, python-brace-format
+#: ../lib/helpers.py:537
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr "{hours}t{minutes}m"
 
-#: ../lib/helpers.py:406
-#, python-brace-format
+#: ../lib/helpers.py:539
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr "{minutes}m{seconds}s"
 
-#: ../lib/helpers.py:408
-#, python-brace-format
+#: ../lib/helpers.py:541
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr "{seconds}s"
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr "Lag"
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr "%(name)s %(number)d"
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr "^(.*?)\\s*(\\d+)$"
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
+#, fuzzy
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr "Vektor lag"
+
+#: ../lib/layer/data.py:1158
+#, fuzzy
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr "Vektor lag"
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
-msgstr "Ukendt Bitmap lag"
+msgid "Bitmap"
+msgstr ""
 
-#: ../lib/layer/data.py:1169
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1244
 msgctxt "layer default names"
-msgid "Unknown Data Layer"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
 msgstr "Ukendt data lag"
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "Nyt maleri lag"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr "Gruppe"
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "Ny lag gruppe"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr "Pladsholder"
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr "Roden"
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ", "
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+#, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "Vis"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+#, fuzzy
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr "Lag synlige"
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+#, fuzzy
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr "Slet lag"
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr "Lås lag"
+
+#: ../lib/layervis.py:697
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr "Lås lag op"
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr "Gennemgang"
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr "Gruppens indhold anvendes direkte på gruppens baggrund"
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr "Normal"
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr "Øverste lag kun, uden at blande farver."
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr "Multiplicer"
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
@@ -2757,11 +3448,11 @@ msgstr ""
 "Som ved indlæsning af to dias i en projektor og projicere det kombinerede "
 "resultat."
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr "Skærm"
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
@@ -2769,11 +3460,11 @@ msgstr ""
 "Som at pege to separate lysbilledapparater op på en skærm samtidigt. Det "
 "omvendte af 'Multiplicer'."
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr "Læg over"
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
@@ -2781,27 +3472,27 @@ msgstr ""
 "Lægger det øverste lag over baggrunden, bevarer baggrundens højlys og "
 "skygger. Det modsatte af 'Hårdt lys'."
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr "Gør kun mørkere"
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr "Det øverste lag bruges hvor det er mørkere end baggrunden."
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr "Gør kun lysere"
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr "Det øverste lag bruges, hvor det er mere lys end baggrunden."
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr "Lysne"
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
@@ -2811,11 +3502,11 @@ msgstr ""
 "fotografiske mørkekammer teknik af samme navn, der bruges til at forbedre "
 "kontrasten i skygger."
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr "Brænd"
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
@@ -2825,43 +3516,43 @@ msgstr ""
 "fotografiske mørkekammer teknik af samme navn, der bruges til at reducere "
 "overdrevet højlys."
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr "Hårdt lys"
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr "Svarer til at rette et stærkt spotlight på baggrunden."
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr "Blødt lys"
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr "Ligesom  at skinne et diffust spotlight på baggrunden."
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr "Forskel"
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr "Trækker den mørkere farve fra lysere af de to."
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr "Træk fra"
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr "Magen til 'Forskel' tilstanden, men svagere i kontrast."
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr "Farvetone"
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
@@ -2869,11 +3560,11 @@ msgstr ""
 "Kombinerer farvetonen/nuancen af det øverste lag med mætning og lysstyrke "
 "fra baggrunden."
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr "Mætning"
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
@@ -2881,7 +3572,7 @@ msgstr ""
 "Gælder for mætning af det øverste lags farver i relation til farvetone og "
 "lysstyrke fra baggrunden."
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
@@ -2889,11 +3580,11 @@ msgstr ""
 "Relaterer farvetone og mætning fra det øverste lag til lysstyrken af "
 "baggrunden."
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr "Lysstyrke"
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
@@ -2901,30 +3592,30 @@ msgstr ""
 "Relaterer lysstyrken af det øverste lag til farvetone og mætning fra "
 "baggrunden."
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr "Læg til"
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr "Dette lag og dens baggrund er simpelthen adderet sammen."
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr "Destination ind"
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 "Bruger baggrunden, kun hvor dette lag dækker den. Alt andet er ignoreret."
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr "Destination ud"
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
@@ -2932,11 +3623,11 @@ msgstr ""
 "Bruger baggrunden, kun hvor dette lag ikke dækker den. Alt andet er "
 "ignoreret."
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr "Kilde på toppen"
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
@@ -2944,11 +3635,11 @@ msgstr ""
 "Kilde, som overlapper destinationen, erstatter destinationen. Destination er "
 "placeres et andet sted."
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr "Destination på toppen"
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
@@ -2956,7 +3647,18 @@ msgstr ""
 "Destination, som overlapper kilden, erstatter kilden. Kilde placeres et "
 "andet sted."
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, fuzzy, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr "%(name)s %(number)d"
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
@@ -2965,7 +3667,7 @@ msgstr ""
 "Ude af stand til at konstruere en afgørende indre objekt. Dit system har "
 "måske ikke tilstrækkelig hukommelse til at udføre denne handling."
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2979,7 +3681,30 @@ msgstr ""
 "Årsag: {err} \n"
 "Destinationsmappe: \"{dirname}\"."
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+#, fuzzy
+msgid "Vertical"
+msgstr "Spejl lodret"
+
+#: ../lib/tiledsurface.py:49
+#, fuzzy
+msgid "Horizontal"
+msgstr "Spejl vandret"
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+#, fuzzy
+msgid "Rotational"
+msgstr "Nulstil rotation"
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr "PNG indlæsning mislykkedes: %s"
@@ -2988,57 +3713,94 @@ msgstr "PNG indlæsning mislykkedes: %s"
 msgid "Recover interrupted work?"
 msgstr "Gendanne det afbrudte arbejde?"
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
-msgstr "_Gendan og gem ..."
+msgid "_Look for backups at startup"
+msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr "Slet"
+
+#: ../po/tmp/autorecover.glade.h:9
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr "Slet denne pensel fra disken"
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr "_Gendan og gem ..."
+
+#: ../po/tmp/autorecover.glade.h:12
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 "Gem denne sikkerhedskopi til disk og derefter fortsæt med at arbejde på det."
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
-msgstr "_Ignorer for nu"
+msgid "Decide _Later"
+msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr "Begynd at arbejde på et nyt lærred. Disse sikkerhedskopier bevares."
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
+#, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 "MyPaint gik ned med ikke-gemt arbejde, men det lavede sikkerhedskopier. Du "
 "kan gendanne en fil nu eller lade det være indtil du begynder MyPaint igen."
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr "Miniature"
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr "Beskrivelse"
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
-msgstr "Kopier til ny"
+msgid "Live update"
+msgstr "Realtids opdatering"
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
-"Kopier disse indstillinger og den aktuelle pensels ikon til en ny pensel"
+"Opdater det sidste strøg på lærredet med indstillingerne i vinduet - i "
+"realtid"
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
-msgstr "Omdøb pensel"
+msgid "Save these settings to the brush"
+msgstr "Gem disse indstillinger til penslen"
 
 #: ../po/tmp/brusheditor.glade.h:5
 msgid "Edit Icon"
@@ -3061,20 +3823,17 @@ msgid "Delete this brush from the disk"
 msgstr "Slet denne pensel fra disken"
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
-msgstr "Realtids opdatering"
+msgid "Copy to New"
+msgstr "Kopier til ny"
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
-"Opdater det sidste strøg på lærredet med indstillingerne i vinduet - i "
-"realtid"
+"Kopier disse indstillinger og den aktuelle pensels ikon til en ny pensel"
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
-msgstr "Gem disse indstillinger til penslen"
+msgid "Rename this brush"
+msgstr "Omdøb pensel"
 
 #: ../po/tmp/brusheditor.glade.h:13
 msgid "Brush Setting"
@@ -3102,12 +3861,7 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr "Bemærkninger:"
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr "Indstilling navn:"
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
@@ -3115,19 +3869,16 @@ msgstr ""
 "påvirker dette."
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
-msgstr "Basisværdien:"
+#: ../po/tmp/brusheditor.glade.h:22
+#, fuzzy
+msgid "Value:"
+msgstr "HSV værdi"
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr "Nulstil den grundlæggende værdi til dens standard"
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr "Nulstille dette input til ikke have nogen indflydelse på indstillingen"
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
@@ -3135,11 +3886,7 @@ msgstr ""
 "Minimumsværdien for output akse.\n"
 "Dette kan indstilles ved hjælp af hoved skyderen for {dname}."
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr "<ymin>"
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
@@ -3147,27 +3894,23 @@ msgstr ""
 "Maksimal værdi for output akse.\n"
 "Dette kan indstilles ved hjælp af hoved skyderen for {dname}."
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr "<ymax>"
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr "Resultat"
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr "Input"
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr "Justerer den maksimale værdi"
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr "Justerer den mindste værdi"
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
@@ -3175,11 +3918,7 @@ msgstr ""
 "Minimumsværdien for input aksen.\n"
 "Brug popup skala for at justere den."
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr "<xmin>"
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
@@ -3187,38 +3926,36 @@ msgstr ""
 "Maksimumsværdien for input aksen.\n"
 "Brug popup skala for at justere den."
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr "<xmax>"
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr "Variation af basisværdien af stylus input og andre kriterier"
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr "Penseldynamik"
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr "Grundlæggende oplysninger om denne indstilling"
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr "Rediger indstillingen"
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr "Juster dette inputs kortlægning i detaljer"
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr "{tooltip}"
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
 msgstr "{dname}:"
+
+#: ../po/tmp/brusheditor.glade.h:42
+#, fuzzy
+msgid "Brush dynamics are not available for this setting."
+msgstr "Grundlæggende oplysninger om denne indstilling"
+
+#: ../po/tmp/brusheditor.glade.h:43
+#, fuzzy
+msgid "<big><b>No Brush Dynamics</b></big>"
+msgstr "<big><b>{accel_label}</b></big>"
 
 #: ../po/tmp/inktool.glade.h:1
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
@@ -3230,7 +3967,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr "Tryk:"
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3275,6 +4012,141 @@ msgstr "Slet punkt"
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
 msgstr "Slet den aktuelt markerede punkt"
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+#, fuzzy
+msgid "Insert Point"
+msgstr "Indsæt række"
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+#, fuzzy
+msgid "Cull Points"
+msgstr "Slet punkt"
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Navn"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr "Tilstand"
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Opacitet"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr "Det aktuelle lags kompositionsteknik tilstand."
+
+#: ../po/tmp/layervis.glade.h:2
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr "Roter lærred visningen"
+
+#: ../po/tmp/layervis.glade.h:3
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr "Roter lærred visningen"
+
+#: ../po/tmp/layervis.glade.h:4
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr "Hvilke synlige lag skal udfyldes"
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
+msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
 msgctxt "footer: color picker button: tooltip"
@@ -3503,8 +4375,8 @@ msgstr ""
 "\n"
 "Dette forudsætter, at skærmen er kalibreret til noget tæt på sRGB, standard "
 "farverummet til nettet og en pessimistisk tilnærmelse til de fleste PC-"
-"skærme. Hvis du ved at din skærm er radikalt anderledes end det, brug \""
-"ingen automatisk konverteringer eller kodning\" indstillingen i stedet."
+"skærme. Hvis du ved at din skærm er radikalt anderledes end det, brug "
+"\"ingen automatisk konverteringer eller kodning\" indstillingen i stedet."
 
 #: ../po/tmp/preferenceswindow.glade.h:47
 msgctxt "Prefs Dialog|Load & Save|Color Management|"
@@ -3680,13 +4552,34 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr "Skjul markøren mens der males"
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+#, fuzzy
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr "Aktiveret"
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr "Vis"
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
@@ -3695,18 +4588,18 @@ msgstr ""
 "Sæt af farver der vises som primære på disk-stil farvehjul.\n"
 "Forskellige traditioner har forskellige farveharmonier."
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr "Primærfarver er:"
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr "Standard digital Rød/Grøn/Blå"
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
@@ -3714,7 +4607,7 @@ msgstr ""
 "Rød, grøn og blå &apos;computerskærm&apos; primærvalg, jævnt arrangeret "
 "omkring cirklen. Grøn er modsatte magenta."
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
@@ -3723,12 +4616,12 @@ msgstr ""
 "Rød, grøn og blå 'computerskærm' primærvalg, jævnt arrangeret omkring "
 "cirklen. Grøn er modsatte magenta."
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr "Traditionel kunstner rød/gul/blå"
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
@@ -3738,7 +4631,7 @@ msgstr ""
 "lige siden 1800-tallet, tilnærmet med ren visnings farver arrangeret jævnt "
 "omkring cirklen. Grøn er modsat rød."
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3749,12 +4642,12 @@ msgstr ""
 "lige siden 1800-tallet, tilnærmet med ren visnings farver arrangeret jævnt "
 "omkring cirklen. Grøn er modsat rød."
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr "Rød-grøn og blå-gul modstående par"
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3768,7 +4661,7 @@ msgstr ""
 "er modsat blå. CIECAM02 og NCS præsenterer en lignende model. Her bruger vi "
 "ren visning af rød, gul osv som de fire primærfarver."
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3784,28 +4677,28 @@ msgstr ""
 "visning af rød, gul osv som de fire primærfarver."
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr "<b>Farvehjul</b>"
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr "Farve"
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr "Skærm (normal)"
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr "Deaktiveret (ingen trykfølsomhed)"
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr "Vindue (anbefales ikke)"
@@ -3866,249 +4759,306 @@ msgid "Reload the file your current work was loaded from."
 msgstr "Genindlæs filen dit nuværende arbejde blev indlæst fra."
 
 #: ../po/tmp/resources.xml.h:12
+#, fuzzy
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Import Layers…"
+msgstr "Importer pensler …"
+
+#: ../po/tmp/resources.xml.h:13
+msgctxt "Accel Editor (descriptions)"
+msgid "Import layers from one or more files."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save"
 msgstr "Gem"
 
-#: ../po/tmp/resources.xml.h:13
+#: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file."
 msgstr "Gem dit arbejde til en fil."
 
-#: ../po/tmp/resources.xml.h:14
+#: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As…"
 msgstr "Gem som …"
 
-#: ../po/tmp/resources.xml.h:15
+#: ../po/tmp/resources.xml.h:17
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file, assigning it a new name."
 msgstr "Gem dit arbejde til en fil, tildele det et nyt navn."
 
-#: ../po/tmp/resources.xml.h:16
+#: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Export…"
 msgstr "Eksporter …"
 
-#: ../po/tmp/resources.xml.h:17
+#: ../po/tmp/resources.xml.h:19
 msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 "Eksporter dit arbejde til en fil, men fortsætte med at arbejde på den samme "
 "fil."
 
-#: ../po/tmp/resources.xml.h:18
+#: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As Scrap"
 msgstr "Gem som skrot"
 
-#: ../po/tmp/resources.xml.h:19
+#: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
 msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 "Gem til en ny skrot fil eller gem en ny revision hvis det allerede er skrot."
 
-#: ../po/tmp/resources.xml.h:20
+#: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Previous Scrap"
 msgstr "Åbn tidligere skrot"
 
-#: ../po/tmp/resources.xml.h:21
+#: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file before the current one."
 msgstr "Indlæs skrot filen før den aktuelle indlæsning."
 
-#: ../po/tmp/resources.xml.h:22
+#: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Next Scrap"
 msgstr "Åbn næste skrot"
 
-#: ../po/tmp/resources.xml.h:23
+#: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file after the current one."
 msgstr "Indlæs skrot filen efter den nuværende."
 
-#: ../po/tmp/resources.xml.h:24
+#: ../po/tmp/resources.xml.h:26
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Recover File from an Automated Backup…"
 msgstr "Gendan fil fra en automatisk sikkerhedskopi …"
 
-#: ../po/tmp/resources.xml.h:25
+#: ../po/tmp/resources.xml.h:27
 msgctxt "Accel Editor (descriptions)"
 msgid "Try to save and resume interrupted unsaved work."
 msgstr "Prøv at gemme og genoptage afbrudt ikke-gemt arbejde."
 
-#: ../po/tmp/resources.xml.h:26
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr "Pensel grupper"
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr "Pensler"
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr "Liste over pensel grupper."
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr "Farve justeringer"
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr "Farver"
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr "Tilgængelig farve justeringer."
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr "Tilstand"
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr "Tilstand"
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr "Det aktuelle lags kompositionsteknik tilstand."
 
-#: ../po/tmp/resources.xml.h:35
+#: ../po/tmp/resources.xml.h:37
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Pressure"
+msgstr "Indgangs tryk"
+
+#: ../po/tmp/resources.xml.h:38
+msgctxt "Accel Editor (descriptions)"
+msgid "Send harder pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:39
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Pressure"
+msgstr "Indgangs tryk"
+
+#: ../po/tmp/resources.xml.h:40
+msgctxt "Accel Editor (descriptions)"
+msgid "Send softer pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:41
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Rotation"
+msgstr "Øg mætning"
+
+#: ../po/tmp/resources.xml.h:42
+msgctxt "Accel Editor (descriptions)"
+msgid "Increase barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:43
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
+msgstr "Formindsk mætning"
+
+#: ../po/tmp/resources.xml.h:44
+msgctxt "Accel Editor (descriptions)"
+msgid "Decrease barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:45
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Size"
 msgstr "Øg pensel størrelse"
 
-#: ../po/tmp/resources.xml.h:36
+#: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush bigger."
 msgstr "Gør aktuelle pensel større."
 
-#: ../po/tmp/resources.xml.h:37
+#: ../po/tmp/resources.xml.h:47
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Size"
 msgstr "Formindsk pensel størrelse"
 
-#: ../po/tmp/resources.xml.h:38
+#: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush smaller."
 msgstr "Gør den aktuelle pensel mindre."
 
-#: ../po/tmp/resources.xml.h:39
+#: ../po/tmp/resources.xml.h:49
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Opacity"
 msgstr "Øg pensel opacitet"
 
-#: ../po/tmp/resources.xml.h:40
+#: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush more opaque."
 msgstr "Gør den aktuelle pensel mere uigennemsigtig."
 
-#: ../po/tmp/resources.xml.h:41
+#: ../po/tmp/resources.xml.h:51
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Opacity"
 msgstr "Formindsk pensel opacitet"
 
-#: ../po/tmp/resources.xml.h:42
+#: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush less opaque."
 msgstr "Gør aktuelle pensel mindre uigennemsigtig."
 
-#: ../po/tmp/resources.xml.h:43
+#: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Lighten Painting Color"
 msgstr "Lysne maleri farve"
 
-#: ../po/tmp/resources.xml.h:44
+#: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase the lightness of the current painting color."
 msgstr "Lysere maleri farve."
 
-#: ../po/tmp/resources.xml.h:45
+#: ../po/tmp/resources.xml.h:55
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Darken Painting Color"
 msgstr "Mørkere maleri farve"
 
-#: ../po/tmp/resources.xml.h:46
+#: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease the lightness of the current painting color."
 msgstr "Gør aktuelle maleri farve mørkere."
 
-#: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
-msgstr "Redigere farvetone mod uret"
-
-#: ../po/tmp/resources.xml.h:48
-msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
-msgstr "Roter maleri farve farvetone mod uret på farvehjulet."
-
-#: ../po/tmp/resources.xml.h:49
+#: ../po/tmp/resources.xml.h:57
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Change Hue Clockwise"
 msgstr "Ændre farvetone med uret"
 
-#: ../po/tmp/resources.xml.h:50
+#: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
 msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr "Roter maleri farvens farvetone med uret på farvehjulet."
 
-#: ../po/tmp/resources.xml.h:51
+#: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr "Redigere farvetone mod uret"
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr "Roter maleri farve farvetone mod uret på farvehjulet."
+
+#: ../po/tmp/resources.xml.h:61
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Increase Saturation"
 msgstr "Øg mætning"
 
-#: ../po/tmp/resources.xml.h:52
+#: ../po/tmp/resources.xml.h:62
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color more saturated (more colorful, purer)."
 msgstr "Gør maleri farven mere mættet (mere farverig, renere)."
 
-#: ../po/tmp/resources.xml.h:53
+#: ../po/tmp/resources.xml.h:63
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Decrease Saturation"
 msgstr "Formindsk mætning"
 
-#: ../po/tmp/resources.xml.h:54
+#: ../po/tmp/resources.xml.h:64
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color less saturated (grayer)."
 msgstr "Gør maleri farve mindre mættet (mere grålig)."
 
-#: ../po/tmp/resources.xml.h:55
+#: ../po/tmp/resources.xml.h:65
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Reload Brush Settings"
 msgstr "Genindlæs pensel indstillinger"
 
-#: ../po/tmp/resources.xml.h:56
+#: ../po/tmp/resources.xml.h:66
 msgctxt "Accel Editor (descriptions)"
 msgid "Restore all brush settings to the current brush’s saved values."
 msgstr ""
 "Gendan alle pensel indstillinger til den aktuelle pensels gemte værdier."
 
-#: ../po/tmp/resources.xml.h:57
+#: ../po/tmp/resources.xml.h:67
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Pick Stroke and Layer"
 msgstr "Vælg strøg og lag"
 
-#: ../po/tmp/resources.xml.h:58
+#: ../po/tmp/resources.xml.h:68
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
 msgstr "Vælger en penselstrøg fra lærredet: gendanner pensel, farve og lag."
 
-#: ../po/tmp/resources.xml.h:59
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr "Pensel genvejs taster - gendan farve"
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
@@ -4117,214 +5067,265 @@ msgstr ""
 "Vælg om gendannelse af penslen fra en tastatur genvej også genskaber den "
 "gemte farve."
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr "Gem penslen til den seneste tastatur genvej"
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr "Gem pensel indstillinger til den senest anvendte tastatur genvej."
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "Ryd lag"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr "Fjern den aktuelle lags indhold."
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+#, fuzzy
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr "Værktøj valgmuligheder"
+
+#: ../po/tmp/resources.xml.h:76
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr "Trim laget til ramme"
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr "Slet dele af det aktuelle lag, der ligger uden for rammen."
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr "Slet dele af det aktuelle lag, der ligger uden for rammen."
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "Ny lag gruppe nedenunder"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "Ny lag gruppe nedenunder"
+
+#: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr "Kopier lag til udklipsholder"
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr "Kopier det aktuelle lags indhold til udklipsholderen."
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr "Indsæt lag fra udklipsholder"
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr "Erstat det aktuelle lag med indholdet i udklipsholder."
 
-#: ../po/tmp/resources.xml.h:71
+#: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Edit Layer in External App…"
 msgstr "Rediger laget i ekstern app …"
 
-#: ../po/tmp/resources.xml.h:72
+#: ../po/tmp/resources.xml.h:90
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
+msgid "Edit the active layer in an external application."
 msgstr "Begynde at redigere det aktuelle lag i et eksternt program."
 
-#: ../po/tmp/resources.xml.h:73
+#: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Update Layer with External Edits"
 msgstr "Opdater lag med eksterne redigeringer"
 
-#: ../po/tmp/resources.xml.h:74
+#: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
 msgid "Commit changes saved from the external app (normally automatic)."
 msgstr "Fastlæg ændringer gemt fra eksterne program (normalt automatisk)."
 
-#: ../po/tmp/resources.xml.h:75
+#: ../po/tmp/resources.xml.h:93
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer at Cursor"
 msgstr "Gå til laget ved markøren"
 
-#: ../po/tmp/resources.xml.h:76
+#: ../po/tmp/resources.xml.h:94
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr "Vælg et lag ved at vælge et objekt på det."
 
-#: ../po/tmp/resources.xml.h:77
+#: ../po/tmp/resources.xml.h:95
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Above"
 msgstr "Gå til laget ovenover"
 
-#: ../po/tmp/resources.xml.h:78
+#: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer up in the layer stack."
 msgstr "Gå et lag op i lagstakken."
 
-#: ../po/tmp/resources.xml.h:79
+#: ../po/tmp/resources.xml.h:97
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Below"
 msgstr "Gå til laget nedenunder"
 
-#: ../po/tmp/resources.xml.h:80
+#: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer down in the layer stack."
 msgstr "Gå et lag ned i stakken."
 
-#: ../po/tmp/resources.xml.h:81
+#: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer"
 msgstr "Nyt maleri lag"
 
-#: ../po/tmp/resources.xml.h:82
+#: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer above the current layer."
 msgstr "Tilføje et nyt maleri lag over det aktuelle lag."
 
-#: ../po/tmp/resources.xml.h:83
+#: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer…"
 msgstr "Nye vektor lag …"
 
-#: ../po/tmp/resources.xml.h:84
+#: ../po/tmp/resources.xml.h:102
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer above the current layer, and begin editing it."
 msgstr ""
 "Tilføj et nyt vektor lag over det aktuelle lag og begynde at redigere det."
 
-#: ../po/tmp/resources.xml.h:85
+#: ../po/tmp/resources.xml.h:103
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group"
 msgstr "Ny lag gruppe"
 
-#: ../po/tmp/resources.xml.h:86
+#: ../po/tmp/resources.xml.h:104
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group above the current layer."
 msgstr "Tilføj en ny lag gruppe over det aktuelle lag."
 
-#: ../po/tmp/resources.xml.h:87
+#: ../po/tmp/resources.xml.h:105
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer Below"
 msgstr "Nyt maleri lag nedenunder"
 
-#: ../po/tmp/resources.xml.h:88
+#: ../po/tmp/resources.xml.h:106
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer below the current layer."
 msgstr "Tilføj et nyt maleri lag under det aktuelle lag."
 
-#: ../po/tmp/resources.xml.h:89
+#: ../po/tmp/resources.xml.h:107
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer Below…"
 msgstr "Nye vektor lag nedenunder …"
 
-#: ../po/tmp/resources.xml.h:90
+#: ../po/tmp/resources.xml.h:108
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer below the current layer, and begin editing it."
 msgstr ""
 "Tilføje et nyt vektor lag under det aktuelle lag og begynde at redigere det."
 
-#: ../po/tmp/resources.xml.h:91
+#: ../po/tmp/resources.xml.h:109
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group Below"
 msgstr "Ny lag gruppe nedenunder"
 
-#: ../po/tmp/resources.xml.h:92
+#: ../po/tmp/resources.xml.h:110
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group below the current layer."
 msgstr "Tilføj en ny lag gruppe under det aktuelle lag."
 
-#: ../po/tmp/resources.xml.h:93
+#: ../po/tmp/resources.xml.h:111
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Layer Down"
 msgstr "Foren lag nedad"
 
-#: ../po/tmp/resources.xml.h:94
+#: ../po/tmp/resources.xml.h:112
 msgctxt "Accel Editor (descriptions)"
 msgid "Merge the current layer with the layer beneath it."
 msgstr "Forener det aktuelle lag med laget nedenunder."
 
-#: ../po/tmp/resources.xml.h:95
+#: ../po/tmp/resources.xml.h:113
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Visible Layers"
 msgstr "Foren synlige lag"
 
-#: ../po/tmp/resources.xml.h:96
+#: ../po/tmp/resources.xml.h:114
 msgctxt "Accel Editor (descriptions)"
 msgid "Consolidate all visible layers, and delete the originals."
 msgstr "Konsolidere alle synlige lag og slette originalerne."
 
-#: ../po/tmp/resources.xml.h:97
+#: ../po/tmp/resources.xml.h:115
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer from Visible"
 msgstr "Nyt lag fra synlige"
 
-#: ../po/tmp/resources.xml.h:98
+#: ../po/tmp/resources.xml.h:116
 msgctxt "Accel Editor (descriptions)"
 msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
 msgstr "Ligesom 'Foren synlige lag' men sletter ikke originalerne."
 
-#: ../po/tmp/resources.xml.h:99
+#: ../po/tmp/resources.xml.h:117
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Delete Layer"
 msgstr "Slet lag"
 
-#: ../po/tmp/resources.xml.h:100
+#: ../po/tmp/resources.xml.h:118
 msgctxt "Accel Editor (descriptions)"
 msgid "Remove the current layer from the layer stack."
 msgstr "Fjern det aktuelle lag fra lagstakken."
 
-#: ../po/tmp/resources.xml.h:101
+#: ../po/tmp/resources.xml.h:119
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Convert to Normal Painting Layer"
 msgstr "Konverter til normal maleri lag"
 
-#: ../po/tmp/resources.xml.h:102
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
@@ -4333,313 +5334,408 @@ msgstr ""
 "Konverter det aktuelle lag eller gruppe til et maleri lag i 'Normal' "
 "tilstand. Bevarer dets udseende."
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr "Øge lagets opacitet"
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr "Gør laget mindre gennemsigtig."
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr "Formindsk lagets opacitet"
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr "Gør laget mere gennemsigtig."
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr "Hæv lag"
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr "Hæv det aktuelle lag ét trin i lagstakken."
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr "Nederste lag"
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr "Sænk det aktuelle lag ét trin i lagstakken."
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr "Dubler lag"
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr "Laver en nøjagtig dublet af det aktuelle lag."
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
+#, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
-msgstr "Omdøb lag …"
+msgid "Layer Properties…"
+msgstr "Egenskaber"
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
-msgstr "Indtast et nyt navn for det aktuelle lag."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr "Laget er låst"
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr "Skift det aktuelle lags låste tilstand. Låste lag kan ikke ændres."
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr "Lag synlige"
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr "Skift det aktuelle lags synlighed, hvilket gør det skjult."
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr "Vis baggrund"
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr "Skift baggrund lagets synlighed."
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr "Fjern det aktuelle lag fra lagstakken."
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr "Nulstil og centrer visningen"
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr "Nulstil zoom, rotation, spejling og centrer dokumentet."
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr "Tilpas til visning"
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr "Skift mellem en tilpasset visning og dit arbejdsplacering og zoom."
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr "Nulstil"
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr "Nulstil zoom"
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr "Gendan visningens zoom til standard."
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr "Nulstil rotation"
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr "Gendan visningens rotation til 0°"
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr "Nulstil spejling"
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
-msgstr "Sluk for spejling af visningen."
+msgid "Reset the view's mirroring."
+msgstr "Nulstil spejling"
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr "Zoom ind"
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr "Øg forstørrelsen."
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Zoom ud"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr "Mindsk forstørrelsen."
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
+#, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
-msgstr "Roter mod uret"
+msgid "Pan Left"
+msgstr "Panorering visning"
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
-msgstr "Roter visningen mod uret."
+msgid "Move your view of the canvas to the left."
+msgstr "Roter visning: drej din visning af lærredet."
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr "Hårdt lys"
+
+#: ../po/tmp/resources.xml.h:159
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+"Panorerings visning: flyt din visning af lærredet vandret eller lodret."
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr "Roter visning: drej din visning af lærredet."
+
+#: ../po/tmp/resources.xml.h:162
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr "Panorering visning"
+
+#: ../po/tmp/resources.xml.h:163
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr "Roter visning: drej din visning af lærredet."
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr "Roter med uret"
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr "Rotere visningen med uret."
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr "Roter mod uret"
+
+#: ../po/tmp/resources.xml.h:167
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr "Roter visningen mod uret."
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr "Spejl vandret"
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr "Flip visningen fra venstre mod højre."
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr "Spejl lodret"
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr "Flip visningen op-ned."
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr "Lag solo"
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr "Skift om kun er det aktuelle lag som bliver vist."
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr "Symmetrisk maleri aktiv"
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr "Spejl penselstrøg langs symmetri aksen"
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr "Ramme aktiveret"
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr "Skift synligheden af dokuments ramme."
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr "Udskriv penslens input værdier til konsol"
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr "Vis penslen motorens internt genereret indgange i konsollen."
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr "Visualiser rendering"
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr "Vis rendering opdateringer på skærmen, til fejlfinding."
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr "Ingen dobbelt buffering"
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr "Sluk GTKs dobbelt buffering, er normalt aktiveret."
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+#, fuzzy
+msgid "Delete Point"
+msgstr "Slet punkt"
+
+#: ../po/tmp/resources.xml.h:187
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr "Slet den aktuelt markerede punkt"
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr "Male tilstand"
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr "Male tilstand: Normal"
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr "Anvend farve normalt, når du maler."
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr "Male tilstand: viskelæder"
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr "Slet, ved hjælp af den aktuelle pensel."
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr "Male tilstand: Lås Alfa"
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr "Anvendelse af penslen ændrer ikke lagets opacitet."
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr "Male tilstand: farvelæg"
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
@@ -4647,463 +5743,463 @@ msgstr ""
 "Anvend farve på det aktuelle lag uden at påvirke dets lysstyrke eller "
 "opacitet."
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Fil"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "Afslut"
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr "Luk hovedvinduet og afslut programmet."
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "Rediger"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr "Aktuelle værktøj"
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "Farve"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr "Juster farve"
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr "Farve historik popup"
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr "Viser popup med en tidslinje over de seneste farver under markøren."
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr "Farve detaljer dialog"
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr "Vis en farve detaljer dialog med indtastning af tekst."
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr "Næste palette farve"
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr "Angiv maleri farve til den næste farve i paletten."
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr "Forrige palette farve"
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr "Angiv maleri farve til den forrige farve i paletten."
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr "Tilføj farve til paletten"
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr "Føj den aktuelle maleri farve til paletten."
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "Lag"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr "Opacitet"
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr "Gå til lag"
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr "Nyt lag nedenunder"
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr "Egenskaber"
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr "Skitseblok"
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr "Ny Skitseblok"
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr "Indlæs standard Skitseblok som ny Skitseblok lærred."
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr "Åbn Skitseblok …"
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr "Indlæs en billedfil på disken til skitseblokken."
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr "Gem skitseblok"
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr "Gem skitseblokken til dens eksisterende fil på disken."
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr "Eksporter skitseblok som …"
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr "Eksporter skitseblokken til disk, under et navn efter eget valg."
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr "Forkast ændringer i skitseblok"
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr "Gendanner skitseblokken til sin sidst gemte tilstand."
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr "Gem skitseblok som standard"
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr "Gem skitseblok som standard for 'Ny skitseblok'."
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr "Ryd standard skitseblok"
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr "Ryd standard skitseblok til et tomt lærred."
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr "Kopier hoved baggrund til skitseblok"
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr "Kopier baggrundsbilledet fra arbejdsdokumentet til skitseblok."
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "Vindue"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "Pensel"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr "Genvejstaster"
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr "Pensel genvejstaster hjælp"
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr "Vis en forklaring på, hvordan genvejstaster virker."
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "Ændr pensel …"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr "Popup penselvælger under markøren."
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "Ændr farve…"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr "Popup farvevælger under markøren, med alle farvevælgere opført."
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "Ændr farve (hurtig delmængde)…"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
-msgstr "Popup farvevælger under markøren, med kun ét kliks farvevælgere opført."
+msgstr ""
+"Popup farvevælger under markøren, med kun ét kliks farvevælgere opført."
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr "Hent flere pensler …"
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr "Hent pensel pakker fra MyPaint wiki."
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr "Importer pensler …"
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr "Indlæs en pensel pakke fra disk."
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Hjælp"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr "Online hjælp"
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr "Gå til Mypaints dokumentation wiki."
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "Om MyPaint"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr "Vis Mypaints licens, versionsnummer og kreditering."
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Fejlfinding"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr "Udskriv information om hukommelsesfejl konsollen (langsom!)"
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr "Fejlfinding af hukommelsesfejl."
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr "Kør Garbage Collector nu"
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 "Frigiv hukommelse som bruges af Python objekter, der ikke længere er i brug."
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr "Start/Stop profilering …"
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr "Start eller stop Python profilering (cProfile)"
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr "Simuler at programmet går ned …"
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr "Indgiv en Python undtagelse, for at teste fejl dialog."
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "Vis"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr "Tilbagemelding"
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr "Juster visningen"
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
+#, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr "Popup menuen"
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr "Vis hovedmenuen som popup."
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "Fuldskærmsvisning"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr "Skift mellem fuldskærmsvisning og visning i vindue."
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "Rediger indstillinger"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr "Rediger Mypaints globale indstillinger."
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr "Test inputenheder"
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 "Vis en dialogboks, som indfanger alle begivenheder dine input enheder sender."
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr "Baggrund vælger"
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr "Ændr baggrundens papir tekstur."
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr "Pensel indstillinger redigering"
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr "Rediger den aktive pensels indstillinger."
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr "Pensel ikon redigering"
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr "Rediger pensel ikoner."
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr "Lagpanelet"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
-msgstr "Vælg laget dokbar panel (arrangere lag eller vælge tilstand)."
+msgid "Dockable panel for managing layers."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr "Vis lagpanelet"
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr "Viser laget dokbar panel (arrangere lag eller vælge modes)."
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr "HCY farvehjul"
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
@@ -5112,42 +6208,32 @@ msgstr ""
 "Dokbar cylindrisk chroma-hue-luma farvevælger. De cirkulære skiver er ens i "
 "lysstyrke."
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "Farvepaletten"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr "Dokbar palette farvevælger."
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr "HSV farvehjul"
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr "Dokbar mætning og værdi farvevælger."
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr "HSV trekant"
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr "Dokbar farvevælger: den gamle GTK farvetrekant."
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr "HSV terning"
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
@@ -5156,220 +6242,214 @@ msgstr ""
 "Dokbar farvevælger: HSV terning, der kan roteres for at vise forskellige "
 "plane skiver."
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr "HSV firkant"
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
-msgstr ""
-"Dokbar farvevælger: HSV firkant, der kan drejes for at vise forskellige "
-"farvetoner."
+msgid "Dockable color selector: HSV square with Hue ring."
+msgstr "Dokbar farvevælger med koncentriske HSV cirkler."
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr "Komponent skydere"
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr "Dokbar farvevælger som viser de individuelle komponenter af farven."
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr "Flydende vask"
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 "Dokbar farvevælger der viser en væske-lignende vask af nærliggende farver."
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr "Koncentriske cirkler"
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr "Dokbar farvevælger med koncentriske HSV cirkler."
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr "Krydsende skål"
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 "Dokbar farvevælger med HSV ramper der strækker sig over en radial (strålende "
 "ud fra et centrum) skål af farve."
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr "Skitseblok panel"
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
-msgstr "Vælger skitseblokkens dokbare panel (miks farver og lav skitser)."
+msgid "Dockable Panel for mixing colors and testing brushes."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr "Vis skitseblokkens panel"
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr "Viser skitseblokkens dokbare panel (miks farver og lav skitser)."
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr "Forhåndsvisnings panel"
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
-"Vælg Forhåndsvisnings dokbare panel (oversigt over hele tegning område)."
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "Forhåndsvisning"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 "Viser forhåndsvisnings dokbare panel (oversigt over hele tegning område)."
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr "Værktøjsindstilling panel"
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
-"Vælger Værktøjsindstillings dokbare panel (indstillinger for det aktuelle "
-"værktøj)."
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr "Vis værktøjsindstillings panel"
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 "Vælger værktøjsindstillingernes dokbare panel (indstillinger for det "
 "aktuelle værktøj)."
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr "Pensel og farve historik panel"
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
-msgstr "Vælger historik panelet (senest anvendte pensler og farver)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr "Seneste pensler og farver"
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr "Vælger historik panelet (senest anvendte pensler og farver)."
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr "Skjul kontrolelementer i fuldskærmsvisning"
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr "Vælger automatisk skjulning af brugergrænsefladen i fuldskærmsvisning."
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr "Vis zoom niveau"
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr "Vælger zoom niveau feedback."
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr "Vis sidste maleri position"
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr "Vælger feedback, der viser hvor det sidste strøg sluttede."
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr "Visnings filter"
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr "Vis farver normalt"
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr "Filtrer farver: vis farver uændret."
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr "Vis farver som gråtoner"
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr "Filtrer farver: Vis kun lysstyrke (HCY/YCbCr Luma)"
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr "Vis farver inverteret"
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr "Filtrer farver: inverse video. Sort er hvid og rød er cyan."
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr "Vis farver med simuleret ufølsomhed overfor rødt"
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
@@ -5377,265 +6457,266 @@ msgstr ""
 "Filtrer farver for at simulere deuteranopia, en almindelig form for "
 "farveblindhed."
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr "Vis farver med simuleret ufølsomhed overfor grøn"
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 "Filtrer farver for at simulere protanopia, en almindelig form for "
 "farveblindhed."
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr "Vis farver med simuleret ufølsomhed overfor blå"
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 "Filtrer farver for at simulere tritanopia, en sjælden form for farveblindhed."
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr "Frihånd"
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr "Frihånd"
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr "Frihånd: tegn og mal frit uden geometriske begrænsninger."
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr "Frihånd"
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr "Tegn og mal frit uden geometriske begrænsninger."
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr "Panorering visning"
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr "Panorering"
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
-msgstr "Panorerings visning: flyt din visning af lærredet vandret eller lodret."
+msgstr ""
+"Panorerings visning: flyt din visning af lærredet vandret eller lodret."
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr "Panorering visning"
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr "Flyt visningen af lærredet interaktivt vandret eller lodret."
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr "Roter visningen"
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr "Roter"
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr "Roter visning: drej din visning af lærredet."
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr "Roter visningen"
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr "Roter interaktivt visningen af lærredet."
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr "Zoom visning"
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr "Zoom"
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr "Zoom visning: zoom ind eller ud på lærredet."
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr "Zoom visning"
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr "Zoom interaktivt ind eller ud af lærredet."
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr "Linjer og kurver"
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr "Linjer"
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr "Linjer og kurver: tegne lige eller buede linjer."
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr "Linjer og kurver"
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr "Tegn lige eller buede linjer."
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr "Forbundne linjer"
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr "Forb. linjer"
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr "Forbundne linjer: tegne sekvenser af lige eller buede linjer."
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr "Forbundne linjer"
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr "Tegne sekvenser af lige eller buede linjer."
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr "Ellipser og cirkler"
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr "Ellipse"
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr "Ellipser og cirkler: tegne afrundede former."
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr "Ellipser og cirkler"
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr "Tegn cirkler og ellipser."
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr "Farvelægning"
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr "Blæk"
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr "Rentegning: tegn jævne kontrollerede linjer."
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr "Rentegning"
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr "Tegn jævne kontrollerede linjer."
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr "Omplacer lag"
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr "Lag pos."
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr "Omplacer lag: flytte det aktuelle lags placering på lærredet."
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr "Omplacer lag"
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr "Omplacer interaktivt det aktuelle lags placering på lærredet."
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr "Rediger ramme"
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr "Ramme"
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
@@ -5643,12 +6724,12 @@ msgstr ""
 "Rediger ramme: definer en ramme omkring dokumentet for at give det en "
 "fastlagt størrelse."
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr "Rediger ramme"
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
@@ -5656,78 +6737,285 @@ msgstr ""
 "Definere interaktivt en ramme omkring dokumentet for at give det en fastlagt "
 "størrelse."
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Rediger maleri symmetri"
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr "Symmetri"
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 "Rediger maleri symmetri: justere aksen der bruges til symmetrisk maleri."
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Rediger maleri symmetri"
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr "Juster interaktivt aksen der bruges til symmetrisk maleri."
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr "Vælg farve"
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr "Vælg farve"
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr "Vælg farve: sæt maleri farve ud fra skærmen pixels."
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "Vælg farve"
+
+#: ../po/tmp/resources.xml.h:401
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr "Sæt maleri farve ud fra skærmen pixels."
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "Vælg farve"
+
+#: ../po/tmp/resources.xml.h:403
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr "Sæt maleri farve ud fra skærmen pixels."
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "Vælg farve"
+
+#: ../po/tmp/resources.xml.h:405
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr "Sæt maleri farve ud fra skærmen pixels."
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr "Vælg farve"
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr "Sæt maleri farve ud fra skærmen pixels."
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr "Spandudfyldning"
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr "Fyld"
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr "Spandudfyldning: fyld et område med farve."
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr "Spandudfyldning"
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr "Udfyld et område med farve."
+
+#~ msgctxt "Accelerator map editor: action column markup"
+#~ msgid ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+#~ msgstr ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+
+#~ msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
+#~ msgid "{action_label} {action_desc} {accel_label}"
+#~ msgstr "{action_label} {action_desc} {accel_label}"
+
+#~ msgctxt "brush list context menu"
+#~ msgid "Delete"
+#~ msgstr "Slet"
+
+#~ msgctxt "brush list commands"
+#~ msgid "Really delete brush from disk?"
+#~ msgstr "Virkelig slette pensel fra disken?"
+
+#~ msgid "HSV Triangle"
+#~ msgstr "HSV trekant"
+
+#~ msgid "The standard GTK color selector"
+#~ msgstr "Standard farvevælger for GTK"
+
+#~ msgid "Pick a color from the screen"
+#~ msgstr "Opsaml en farve fra skærmen"
+
+#~ msgid "Layer Name"
+#~ msgstr "Lag navn"
+
+#~ msgid ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+#~ msgstr ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+
+#~ msgid "Save..."
+#~ msgstr "Gem ..."
+
+#~ msgid "Confirm"
+#~ msgstr "Bekræft"
+
+#~ msgid "Open..."
+#~ msgstr "Åben ..."
+
+#~ msgid "{default_name} at {path}"
+#~ msgstr "{default_name} på {path}"
+
+#~ msgid "Type"
+#~ msgstr "Type"
+
+#~ msgid "Mode:"
+#~ msgstr "Tilstand:"
+
+#~ msgid ""
+#~ "Blending mode: how the current layer combines with the layers underneath "
+#~ "it."
+#~ msgstr ""
+#~ "Blandingstilstand: hvordan det aktuelle lag kombinerer med lag nedenunder."
+
+#~ msgid ""
+#~ "Layer opacity: how much of the current layer to use. Smaller values make "
+#~ "it more transparent."
+#~ msgstr ""
+#~ "Lag opacitet: hvor meget af det aktuelle lag som bruges. Mindre værdier "
+#~ "gør det mere gennemsigtig."
+
+#~ msgid "%s: edit properties"
+#~ msgstr "%s: rediger egenskaber"
+
+#~ msgctxt "layer unique names: match regex (leave untranslated if unsure)"
+#~ msgid "^(.*?)\\s*(\\d+)$"
+#~ msgstr "^(.*?)\\s*(\\d+)$"
+
+#~ msgctxt "layer default names"
+#~ msgid "Unknown Bitmap Layer"
+#~ msgstr "Ukendt Bitmap lag"
+
+#~ msgctxt "Autosave Recovery dialog|"
+#~ msgid "_Ignore for Now"
+#~ msgstr "_Ignorer for nu"
+
+#~ msgid "Setting name:"
+#~ msgstr "Indstilling navn:"
+
+#~ msgid "Base value:"
+#~ msgstr "Basisværdien:"
+
+#~ msgid "Reset the base value to its default"
+#~ msgstr "Nulstil den grundlæggende værdi til dens standard"
+
+#~ msgid "<ymin>"
+#~ msgstr "<ymin>"
+
+#~ msgid "<ymax>"
+#~ msgstr "<ymax>"
+
+#~ msgid "<xmin>"
+#~ msgstr "<xmin>"
+
+#~ msgid "<xmax>"
+#~ msgstr "<xmax>"
+
+#~ msgid "Edit Setting"
+#~ msgstr "Rediger indstillingen"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Trim Layer to Frame"
+#~ msgstr "Trim laget til ramme"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Rename Layer…"
+#~ msgstr "Omdøb lag …"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Enter a new name for the current layer."
+#~ msgstr "Indtast et nyt navn for det aktuelle lag."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Turn off mirroring of the view."
+#~ msgstr "Sluk for spejling af visningen."
+
+#~ msgctxt "Menu→Edit (labels)"
+#~ msgid "Current Tool"
+#~ msgstr "Aktuelle værktøj"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+#~ msgstr "Vælg laget dokbar panel (arrangere lag eller vælge tilstand)."
+
+#~ msgctxt "Menu→Color (labels), Accel Editor (labels)"
+#~ msgid "HSV Triangle"
+#~ msgstr "HSV trekant"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Dockable color selector: the old GTK color triangle."
+#~ msgstr "Dokbar farvevælger: den gamle GTK farvetrekant."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid ""
+#~ "Dockable color selector: HSV square which can be rotated to show "
+#~ "different hues."
+#~ msgstr ""
+#~ "Dokbar farvevælger: HSV firkant, der kan drejes for at vise forskellige "
+#~ "farvetoner."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+#~ msgstr "Vælger skitseblokkens dokbare panel (miks farver og lav skitser)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+#~ msgstr ""
+#~ "Vælg Forhåndsvisnings dokbare panel (oversigt over hele tegning område)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+#~ msgstr ""
+#~ "Vælger Værktøjsindstillings dokbare panel (indstillinger for det aktuelle "
+#~ "værktøj)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the History panel (recently used brushes and colors)."
+#~ msgstr "Vælger historik panelet (senest anvendte pensler og farver)."

--- a/po/da.po
+++ b/po/da.po
@@ -533,18 +533,18 @@ msgstr "MyPaint pensel pakke (* .zip)"
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
-msgstr "Ny gruppe ..."
+msgid "New Group…"
+msgstr "Ny gruppe …"
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
-msgstr "Importer pensler ..."
+msgid "Import Brushes…"
+msgstr "Importer pensler …"
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
-msgstr "Hent flere pensler ..."
+msgid "Get More Brushes…"
+msgstr "Hent flere pensler …"
 
 #: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
@@ -1230,13 +1230,13 @@ msgstr "Type"
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
-msgstr "Brug for ..."
+msgid "Use for…"
+msgstr "Brug for …"
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
-msgstr "Rul ..."
+msgid "Scroll…"
+msgstr "Rul …"
 
 #. Name and preview column: will be indented
 #: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
@@ -1459,8 +1459,8 @@ msgid "_Quit"
 msgstr "Afslut"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
-msgstr "Import pensel pakke ..."
+msgid "Import brush package…"
+msgstr "Import pensel pakke …"
 
 #: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
@@ -1516,8 +1516,8 @@ msgstr ""
 "\"{type_name}\" ({content_type})?"
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
-msgstr "Åbn med ..."
+msgid "Open With…"
+msgstr "Åbn med …"
 
 #: ../gui/externalapp.py:123
 msgid "Icon"
@@ -1707,13 +1707,13 @@ msgstr "JPEG 90% kvalitet (*.jpg; *.jpeg)"
 
 #: ../gui/filehandling.py:576
 #, fuzzy
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr "Eksporter …"
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Gem som …"
 
@@ -1784,8 +1784,8 @@ msgstr "Åben"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
-msgstr "Åbn Skitseblok ..."
+msgid "Open Scratchpad…"
+msgstr "Åbn Skitseblok …"
 
 #: ../gui/filehandling.py:1099
 #, fuzzy
@@ -2241,13 +2241,13 @@ msgstr ""
 "andre har rapporteret den endnu."
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
-msgstr "Søg sporing ..."
+msgid "Search Tracker…"
+msgstr "Søg sporing …"
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
-msgstr "Rapporter ..."
+msgid "Report…"
+msgstr "Rapporter …"
 
 #: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
@@ -2258,8 +2258,8 @@ msgid "Quit MyPaint"
 msgstr "Afslut MyPaint"
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
-msgstr "Detaljer ..."
+msgid "Details…"
+msgstr "Detaljer …"
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
@@ -2471,8 +2471,8 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
-msgstr "Flyt lag i stakken ..."
+msgid "Move layer in stack…"
+msgstr "Flyt lag i stakken …"
 
 #: ../gui/layerswindow.py:110
 msgid ""
@@ -2544,8 +2544,8 @@ msgid "Stroke trail-off beginning"
 msgstr "Strøgets udtoning begyndelse"
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
-msgstr "Tryk variation ..."
+msgid "Pressure variation…"
+msgstr "Tryk variation …"
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
@@ -3747,7 +3747,7 @@ msgstr "Slet denne pensel fra disken"
 #, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid "_Recover & Save…"
-msgstr "_Gendan og gem ..."
+msgstr "_Gendan og gem …"
 
 #: ../po/tmp/autorecover.glade.h:12
 #, fuzzy

--- a/po/de.po
+++ b/po/de.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MyPaint GIT\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-05-14 16:49+0000\n"
 "Last-Translator: ssantos <ssantos@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -17,29 +17,7 @@ msgstr ""
 "X-Poedit-Country: GERMANY\n"
 "X-Poedit-SourceCharset: utf-8\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr "<big><b>{accel_label}</b></big>"
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr "{action_label} {action_desc} {accel_label}"
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "Aktion"
 
@@ -47,32 +25,32 @@ msgstr "Aktion"
 msgid "Key combination"
 msgstr "Tastenkombination"
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr "Tastenkürzel für „%s“ bearbeiten"
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "Aktion:"
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "Pfad:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "Taste:"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr "Tasten drücken, um diese Zuweisung zu aktualisieren"
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "Unbekannte Aktion"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
@@ -81,7 +59,7 @@ msgstr ""
 "<b>{accel} wird bereits für „{action}“ verwendet. Die bestehende Zuweisung "
 "wird ersetzt.</b>"
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr "Ordner „{folder_basename}“ öffnen …"
@@ -89,196 +67,206 @@ msgstr "Ordner „{folder_basename}“ öffnen …"
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "OK"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr "Keine Sicherungen im Cache gefunden."
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr "Keine verfügbaren Sicherungen"
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr "Zwischenspeicherordner öffnen …"
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr "Wiederherstellung der Sicherung fehlgeschlagen"
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr "Ordner der Sicherung öffnen …"
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr "Datei aus {iso_datetime}.ora wiederhergestellt"
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "Als Standard setzen"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "Hintergrund"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "Muster"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Farbe"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "Farbe zu Mustern hinzufügen"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr "Einer oder mehrere Hintergründe konnten nicht geladen werden"
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr "Fehler beim Laden der Hintergrundbilder"
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 "Bitte die nicht-ladbaren Dateien entfernen (oder die libgdkpixbuf-"
 "Installation überprüfen)."
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr "Gdk-Pixbuf konnte „{filename}“ nicht laden und berichtet: „{error}“"
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr "{filename} hat die Größe Null (w={w}, h={h})"
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr "Editor für Pinseleinstellungen"
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr "Über"
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "Experimentell"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr "Grundlegend"
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr "Deckkraft"
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr "Abdrücke"
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "Schmieren"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr "Geschwindigkeit"
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr ""
+
+#: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr "Verfolgung"
 
-#: ../gui/brusheditor.py:359
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "Strich"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr "Farbe"
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Benutzerdefiniert"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 "Kein Pinsel ausgewählt, bitte stattdessen „Als neu hinzufügen“ verwenden."
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr "Kein Pinsel ausgewählt!"
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "Pinsel umbenennen"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "Ein Pinsel mit diesem Namen existiert bereits!"
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr "Kein Pinsel ausgewählt!"
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr "Pinsel mit dem Namen „{brush_name}“ wirklich löschen?"
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr "(unbenannter Pinsel)"
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr "{brush_name} [ungespeichert]"
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr "Pinselsymbol"
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr "Pinselsymbol (bearbeiten)"
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr "Kein Pinsel ausgewählt"
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -287,7 +275,7 @@ msgstr ""
 "<b>%s</b>\n"
 "<small>Zuerst einen gültigen Pinsel wählen</small>"
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
@@ -296,7 +284,7 @@ msgstr ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Änderungen sind noch nicht gespeichert</small>"
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
@@ -305,7 +293,7 @@ msgstr ""
 "<b>%s</b> (editing)\n"
 "<small>Mit beliebigem Pinsel oder Farbe zeichnen</small>"
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -346,142 +334,182 @@ msgstr "Auto"
 msgid "Use the default icon"
 msgstr "Standardsymbol verwenden"
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Speichern"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr "Dieses Vorschausymbol speichern und die Bearbeitung abschließen"
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr "Verloren und Gefunden"
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr "Gelöscht"
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr "Favoriten"
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr "Tusche"
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr "Klassisch"
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr "Satz#1"
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr "Satz#2"
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr "Satz#3"
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr "Satz#4"
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr "Satz#5"
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr "Experimentell"
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Neu"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr "Unbekannter Pinsel"
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr "Zu Favoriten hinzufügen"
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr "Aus Favoriten entfernen"
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr "Klonen"
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr "Pinseleinstellungen bearbeiten"
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
-msgstr "Löschen"
+#: ../gui/brushselectionwindow.py:250
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
+msgstr "Gruppe umbenennen"
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
-msgstr "Pinsel wirklich löschen?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, fuzzy, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
+msgstr "Pinsel mit dem Namen „{brush_name}“ wirklich löschen?"
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] "%d Pinsel"
 msgstr[1] "%d Pinsel"
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr "Gruppe „{group_name}“"
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr "Gruppe umbenennen"
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr "Als gezippten Pinselsatz exportieren"
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr "Gruppe löschen"
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr "Gruppe umbenennen"
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "Eine Gruppe mit diesem Namen existiert bereits!"
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr "Gruppe „{group_name}“ wirklich löschen?"
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -491,58 +519,58 @@ msgstr ""
 "Gruppe „{group_name}“ konnte nicht gelöscht werden.\n"
 "Einige spezielle Gruppen können nicht gelöscht werden."
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr "Pinsel exportieren"
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr "MyPaint Pinselpaket (*.zip)"
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "Neue Gruppe …"
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr "Pinselsatz importieren …"
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr "Weitere Pinsel herunterladen …"
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "Gruppe erstellen"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr "Maustaste"
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr "Taste"
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr "Maustasten"
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr "Neue Verknüpfung anlegen"
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr "Aktuelle Datei erneut laden"
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr "Verknüpfung für „%s“ ändern"
@@ -551,7 +579,7 @@ msgstr "Verknüpfung für „%s“ ändern"
 msgid "Button press:"
 msgstr "Maustasten:"
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
@@ -559,7 +587,7 @@ msgstr ""
 "Sondertasten gedrückt halten und dann eine Maustaste über diesem Text "
 "drücken, um eine neue Verknüpfung festzulegen."
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
@@ -567,41 +595,69 @@ msgstr ""
 "{button} kann nicht ohne Sondertaste belegt werden (sie hat schon eine feste "
 "Zuordnung)"
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 "{button_combination} ist bereits mit der Aktion „{action_name}“ verbunden"
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr "Farbpipette"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr "Zum Malen verwendete Farbe einstellen"
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+#, fuzzy
+msgid "Set the color Hue used for painting"
+msgstr "Zum Malen verwendete Farbe einstellen"
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "Farb. wählen"
+
+#: ../gui/colorpicker.py:296
+#, fuzzy
+msgid "Set the color Chroma used for painting"
+msgstr "Zum Malen verwendete Farbe einstellen"
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+#, fuzzy
+msgid "Set the color Luma used for painting"
+msgstr "Zum Malen verwendete Farbe einstellen"
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr "Farbinfos"
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr "Aktuelle Pinselfarbe und die zuletzt verwendete Farbe"
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr "Aktive Gamutmaske"
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -612,7 +668,7 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr "HCY-Farbwert und Chrominanz."
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
@@ -621,12 +677,12 @@ msgstr ""
 "Gamutmasken-Editor. In die Mitte klicken, um Umrisse zu erstellen oder zu "
 "verändern, oder die Maske mit Hilfe der Kreisränder drehen."
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr "Atmosphärische Triade"
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
@@ -635,22 +691,22 @@ msgstr ""
 "Düster und subjektiv, definiert durch eine dominante Primärfarbe und zwei "
 "weniger intensive Primärfarben."
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr "Verzerrte Triade"
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr "Stärkere Gewichtung in Richtung der dominanten Farbe."
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr "Komplementär"
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
@@ -659,12 +715,12 @@ msgstr ""
 "Gegenüberliegende Farben, ausbalanciert durch im Farbkreis zentral liegende "
 "Neutraltöne zwischen ihnen."
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr "Stimmung und Akzent"
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
@@ -673,12 +729,12 @@ msgstr ""
 "Ein Hauptbereich an Farben, mit einem komplementären Akzent für Abwechslung "
 "und Highlights."
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr "In Komplementärfarben aufspalten"
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
@@ -687,72 +743,72 @@ msgstr ""
 "Zwei analoge Farben und eine derer Komplementärfarben ohne Sekundärfarben "
 "zwischen ihnen."
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr "Neue Gamutmaske aus Vorlage erstellen"
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr "Gamutmasken-Editor"
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr "Aktiv"
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr "Hilfe …"
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr "Maske aus Vorlage erzeugen."
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr "Maske aus einer GIMP-Palettendatei laden."
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr "Maske als GIMP-Palettendatei speichern."
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr "Maske löschen."
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr "Online-Hilfe für diesen Dialog in einem Webbrowser öffnen."
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr "Maske als GIMP-Palette speichern"
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr "Maske aus einer GIMP-Palette laden"
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr "Gamutmaske festlegen."
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr "HCY-Farbkreis"
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -763,166 +819,158 @@ msgstr ""
 "Die kreisförmigen Scheiben haben gleiche Luminanz."
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr "HSV-Farbton"
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr "HSV-Sättigung"
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr "Grundwert"
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr "HSV-Sättigung und Wert ändern"
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr "HSV-Farbton und -Wert"
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr "HSV-Farbton und -Sättigung"
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr "Würfel drehen (andere Achsen anzeigen)"
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr "HSV-Würfel"
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 "Ein HSV-Würfel, der gedreht werden kann, um verschiedene planare Schnitte "
 "anzuzeigen."
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr "HSV-Quadrat"
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 "Ein HSV-Quadrat, das gedreht werden kann, um verschiedene Farbtöne "
 "anzuzeigen."
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr "HSV-Farbdreieck"
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr "GTK-Farbwähler"
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr "HSV-Farbkreis"
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr "Sättigung und Wert ändern."
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr "Paletteneigenschaften"
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr "Palette"
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr "Farbe aus einer ladbaren, bearbeitbaren Palette einstellen."
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr "Unbenannte Ebene"
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr "Paletteneditor"
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr "Aus einer GIMP-Palettendatei laden"
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr "Als GIMP-Palettendatei speichern"
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr "Neues leeres Farbmuster hinzufügen"
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr "Markiertes Farbmuster entfernen"
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr "Alle Farbmuster entfernen"
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr "Titel:"
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr "Bezeichnung oder Beschreibung für diese Palette"
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr "Spalten:"
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr "Anzahl der Spalten"
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr "Farbname:"
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr "Name der aktuellen Farbe"
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr "Leeres Palettenfeld"
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr "Palette laden"
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr "Palette speichern"
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -933,379 +981,376 @@ msgstr ""
 "Farben hier ablegen,\n"
 "zum Umsortieren ziehen."
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr "Leeres Palettenfeld (Farbe hierher ziehen)"
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr "Leeren Slot hinzufügen"
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr "Zeile einfügen"
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr "Spalte einfügen"
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr "Lücke füllen (RGB)"
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr "Lücke füllen (HCY)"
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr "Lücke füllen (HSV)"
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "GIMP-Palettendatei (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr "Alle Dateien (*)"
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "GIMP-Palettendatei (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr "Alle Dateien (*)"
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr "Farbe vom Bildschirm wählen"
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr "R"
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr "G"
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr "B"
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr "H"
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr "C"
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr "Y"
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr "Komponentenregler"
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr "Individuelle Komponenten der Farbe anpassen."
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr "RGB Rot"
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr "RGB Grün"
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr "RGB Blau"
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr "HSV-Farbton"
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr "HSV-Sättigung"
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr "HSV-Wert"
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr "HCY-Farbton"
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr "HCY-Sättigung"
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr "HCY-Luminanz (Y')"
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr "Weichzeichnen"
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr "Farbe durch Weichzeichnen der benachbarten Farben verändern."
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr "Konzentrische Ringe"
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr "Farbe durch konzentrische HSV-Ringe verändern."
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr "Farbschüssel"
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr "Farbe mit einer Farbschüssel und kreuzenden HSV-Rampen verändern."
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr "Mauszeiger"
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr "Radierer"
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr "Tastatur"
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr "Maus"
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr "Stift"
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr "Touchpad"
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr "Touchbildschirm"
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr "Ignorieren"
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr "Beliebige Aufgabe"
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr "Aufgaben ohne Malbezug"
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr "Nur navigieren"
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr "Zoom"
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr "Verschieben"
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr "Gerät"
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr "Achsen"
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr "Typ"
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr "Verwenden für …"
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr "Scrollen …"
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Name"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr "Pinsel überschreiben?"
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr "Ersetzen"
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr "Umbenennen"
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr "Alle ersetzen"
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr "Alle umbenennen"
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr "Importierter Pinsel"
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr "Existierender Pinsel"
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 "<b>Ein Pinsel mit dem Namen „%s“ existiert bereits.</b>\n"
 "Soll er ersetzt werden oder soll der neue Pinsel umbenannt werden?"
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr "Pinselgruppe überschreiben?"
 
-#: ../gui/dialogs.py:190
-#, python-brace-format
+#: ../gui/dialogs.py:220
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 "<b>Eine Gruppe mit dem Namen „{groupname}“ existiert bereits.</b>\n"
 "Soll diese ersetzt werden oder soll die neue Gruppe umbenannt werden?\n"
 "Wenn sie ersetzt wird, könnten die Pinsel in eine Gruppe "
 "„{deleted_groupname}“ verschoben werden."
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr "Pinselsatz importieren?"
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, fuzzy, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr "<b>Wollen Sie wirklich das Paket „%s“ importieren?</b>"
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr "Pinseleinstellungen aus dem Schnellzugriff Slot %d laden"
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr "Pinseleinstellungen im Schnellzugriff Slot %d sichern"
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr "Pinsel %d wiederherstellen"
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr "Als Pinsel %d speichern"
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr "Rückgängig  %s"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Rückgängig"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr "Wiederholen %s"
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Wiederherstellen"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr "{button_combination} ist {resultant_action}"
@@ -1315,92 +1360,129 @@ msgstr "{button_combination} ist {resultant_action}"
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ";  "
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr "Mit {modifiers} gedrückt:  {button_actions}."
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
-msgstr "Ebenenname"
-
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
-#, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
-"<b>{name}</b>\n"
-"{description}"
+
+#: ../gui/document.py:909
+#, python-brace-format
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
+msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr "%s - MyPaint"
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr "MyPaint"
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Öffnen"
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr "Aktuelle Farbe setzen"
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr "Vollbildmodus verlassen"
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr "Vollbildmodus verlassen"
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr "Vollbildmodus starten"
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Vollbild"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Beenden"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+#, fuzzy
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr "Wirklich beenden?"
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Beenden"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr "Pinselsatz importieren …"
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr "MyPaint Pinselpaket (*.zip)"
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr "{app_name} gestartet, um Ebene “{layer_name}” zu bearbeiten"
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 "Fehler: Start von {app_name}, um Ebene “{layer_name}” zu bearbeiten, "
 "fehlgeschlagen"
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
@@ -1408,12 +1490,18 @@ msgstr ""
 "Bearbeitung abgebrochen. Sie können „{layer_name}“ immer noch im Ebenenmenü "
 "bearbeiten."
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr "Ebene „{layer_name}“ mit externen Änderungen aktualisiert"
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr "„{file_basename}“ konnte nicht geladen werden."
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
@@ -1422,170 +1510,386 @@ msgstr ""
 "MyPaint muss eine Datei vom Typ „{type_name}“ ({content_type}) bearbeiten. "
 "Welche Anwendung soll verwendet werden?"
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
-"Welche Anwendung soll MyPaint verwenden, um Dateien vom Typ „{type_name}“ "
-"({content_type}) zu bearbeiten?"
+"Welche Anwendung soll MyPaint verwenden, um Dateien vom Typ "
+"„{type_name}“ ({content_type}) zu bearbeiten?"
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr "Öffnen mit …"
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr "Symbol"
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr "keine Beschreibung"
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
+#: ../gui/filehandling.py:126
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
+msgstr "„{file_basename}“ wird geladen …"
+
+#: ../gui/filehandling.py:130
+#, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:134
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
+msgstr "„{file_basename}“ wird gespeichert …"
+
+#: ../gui/filehandling.py:138
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
+msgstr "Export nach „{file_basename}“ läuft …"
+
+#: ../gui/filehandling.py:145
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr "Export nach „{file_basename}“ fehlgeschlagen."
+
+#: ../gui/filehandling.py:149
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr "Speichern von „{file_basename}“ fehlgeschlagen."
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr "„{file_basename}“ konnte nicht geladen werden."
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "Palette speichern"
+
+#: ../gui/filehandling.py:168
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr "Als Datei exportieren"
+
+#: ../gui/filehandling.py:172
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr "Als Datei exportieren"
+
+#: ../gui/filehandling.py:176
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr "Zuletzt verwendete Dateien öffnen"
+
+#: ../gui/filehandling.py:183
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr "Erfolgreich nach „{file_basename}“ exportiert."
+
+#: ../gui/filehandling.py:187
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr "„{file_basename}“ erfolgreich gespeichert."
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr "\"{file_basename}\" geladen."
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
+msgstr "\"{file_basename}\" geladen."
+
+#: ../gui/filehandling.py:427
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "All Recognized Formats"
 msgstr "Alle unterstützte Formate"
 
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
+#: ../gui/filehandling.py:432
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "OpenRaster (*.ora)"
 msgstr "OpenRaster (*.ora)"
 
-#: ../gui/filehandling.py:95
+#: ../gui/filehandling.py:437
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "PNG (*.png)"
 msgstr "PNG (*.png)"
 
-#: ../gui/filehandling.py:96
+#: ../gui/filehandling.py:442
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "JPEG (*.jpg; *.jpeg)"
 msgstr "JPEG (*.jpg; *.jpeg)"
 
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
+#: ../gui/filehandling.py:490
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "By extension (prefer default format)"
 msgstr "Nach Erweiterung (Standardformat bevorzugen)"
 
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
+#: ../gui/filehandling.py:494
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:498
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
 msgstr "PNG deckend mit Hintergrund (*.png)"
 
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
+#: ../gui/filehandling.py:502
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:506
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
 msgstr "PNG transparent (*.png)"
 
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
+#: ../gui/filehandling.py:510
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
 msgstr "Mehrere PNG transparent (*.XXX.png)"
 
-#: ../gui/filehandling.py:113
+#: ../gui/filehandling.py:514
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr "Mehrere PNG transparent (*.XXX.png)"
+
+#: ../gui/filehandling.py:518
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr "JPEG 90 % Qualität (*.jpg; *.jpeg)"
 
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr "Speichern …"
+#: ../gui/filehandling.py:576
+#, fuzzy
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr "Exportieren …"
 
-#: ../gui/filehandling.py:177
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Speichern unter …"
+
+#: ../gui/filehandling.py:601
+#, fuzzy
+msgctxt "save dialogs: formats and options: (label)"
 msgid "Format to save as:"
 msgstr "Speicherformat:"
 
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr "Bestätigen"
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
+#: ../gui/filehandling.py:668
+#, fuzzy
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
 msgstr "Wirklich fortfahren?"
 
-#: ../gui/filehandling.py:234
-#, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
-msgstr "Dies wird {abbreviated_time} nicht gespeicherter Arbeit verwerfen"
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
+#: ../gui/filehandling.py:705
+#, fuzzy
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
 msgstr "Als Entwurf speichern"
 
-#: ../gui/filehandling.py:282
-#, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
-msgstr "„{file_basename}“ wird geladen …"
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
 
-#: ../gui/filehandling.py:296
-#, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
-msgstr "„{file_basename}“ konnte nicht geladen werden."
+#: ../gui/filehandling.py:734
+#, fuzzy, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr "Dies wird {abbreviated_time} nicht gespeicherter Arbeit verwerfen"
 
-#: ../gui/filehandling.py:321
-#, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
-msgstr "\"{file_basename}\" geladen."
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
 
-#: ../gui/filehandling.py:422
-#, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
-msgstr "Export nach „{file_basename}“ läuft …"
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
 
-#: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
-msgstr "„{file_basename}“ wird gespeichert …"
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
-msgstr "Export nach „{file_basename}“ fehlgeschlagen."
-
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
-msgstr "Speichern von „{file_basename}“ fehlgeschlagen."
-
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
-msgstr "Erfolgreich nach „{file_basename}“ exportiert."
-
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
-msgstr "„{file_basename}“ erfolgreich gespeichert."
-
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
 msgstr "Öffnen …"
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Zuletzt verwendete Dateien öffnen"
+
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr "Notizblock öffnen …"
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Importierter Pinsel"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Öffnen"
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Zuletzt gespeichertes Bild laden"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Öffnen"
+
+#: ../gui/filehandling.py:1446
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
 msgstr "Es gibt noch keine Notizen mit dem Namem „%s“."
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1455
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr "Nächsten Entwurf öffnen"
+
+#: ../gui/filehandling.py:1463
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr "Letzten Entwurf öffnen"
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Öffnen"
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+#, fuzzy
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr "Zurücksetzen"
+
+#: ../gui/fill.py:121
+#, fuzzy
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr "Füllen"
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+#, fuzzy
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr "Bereiche mit Farbe füllen"
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+#, fuzzy
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr "Toleranz:"
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+#, fuzzy
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
@@ -1593,19 +1897,36 @@ msgstr ""
 "Erlaubte Farbabweichung bevor Füllen\n"
 "diese nicht mehr füllt"
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+#, fuzzy
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr "Quelle:"
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
-msgstr "Welche sichtbaren Ebenen sollen gefüllt werden"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
+msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+#, fuzzy
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr "Ebenen vereinen"
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+#, fuzzy
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
@@ -1615,19 +1936,50 @@ msgstr ""
 "aktiven Ebene verwenden, um die zu füllende\n"
 "Fläche zu bestimmen"
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+#, fuzzy
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr "Zeichnung in Ansicht einpassen"
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+#, fuzzy
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr "Ziel:"
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+#, fuzzy
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr "Wohin die Ausgabe gehen soll"
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr "Neue Ebene (einmalig)"
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+#, fuzzy
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
@@ -1635,21 +1987,108 @@ msgstr ""
 "Eine neue Ebene mit dem Füllergebnis erzeugen.\n"
 "Wird nach Benutzung wieder automatisch deaktiviert."
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Deckkraft:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr "Zurücksetzen"
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+#, fuzzy
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr "Optionen auf ihre Standardwerte zurücksetzen"
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "Ebene auswählen"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr "<b>{brush_name}</b>"
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1659,131 +2098,143 @@ msgstr ""
 "<b>{brush_name}</b>\n"
 "{brush_desc}"
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr "Rahmen bearbeiten"
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr "Dokumentrahmen anpassen"
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr "Rahmengröße"
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr "px"
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr "Höhe:"
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr "Breite:"
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr "Auflösung:"
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr "DPI"
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr "Dots pro Inch (in Wirklichkeit Pixel pro Inch)"
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr "Farbe:"
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr "Rahmenfarbe"
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr "<b>Rahmenmaße</b>"
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr "<b>Pixeldichte</b>"
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr "Rahmen einer Ebene zuweisen"
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr "Rahmen der Größe der aktuellen Ebene anpassen"
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr "Rahmen an Dokument anpassen"
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr "Den Rahmen auf die Kombination aller Ebenen anpassen"
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr "Ebene auf den Rahmen zuschneiden"
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 "Alle Teile der aktuellen Ebene zuschneiden, die außerhalb des Rahmens liegen"
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr "Aktiviert"
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr "{width:g}×{height:g} {units}"
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr "Zoll"
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr "cm"
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr "mm"
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr "Freihandzeichnen"
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr "Pinselstriche freihand zeichnen"
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr "Weich:"
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr "Druck:"
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr "Fehler festgestellt"
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr "<big><b>Ein Programmierfehler wurde festgestellt.</b></big>"
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1797,35 +2248,35 @@ msgstr ""
 "Bitte teilen Sie den Entwicklern diesen Fehler über den Bugtracker mit, "
 "falls ihn noch niemand gemeldet hat."
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr "Tracker suchen …"
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr "Melden …"
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr "Fehler ignorieren"
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr "MyPaint beenden"
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr "Einzelheiten …"
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr "Fehler beim Analysieren des Ausnahmefehlers."
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1870,45 +2321,50 @@ msgstr ""
 "            #### Traceback\n"
 "        "
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr "Einfärben"
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr "Zeichnen und dann weiche Linien anpassen"
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr "Eingabegeräte-Test"
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr "(kein Druck)"
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr "Druck:"
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr "(keine Neigung)"
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr "Neigung:"
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr "(kein Gerät)"
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
 msgstr "Gerät:"
 
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+#, fuzzy
+msgid "Barrel Rotation:"
+msgstr "Drehung zurücksetzen"
+
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr "Ebene bewegen"
 
@@ -1916,164 +2372,233 @@ msgstr "Ebene bewegen"
 msgid "Move the current layer"
 msgstr "Aktuelle Ebene bewegen"
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
-msgstr "{default_name} unter {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
+msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
-msgstr "Typ"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
+msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+#, fuzzy
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr "Eigenschaften"
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr "Sichtbar"
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Ebene"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+#, fuzzy
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr "Gesperrt"
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+#, fuzzy
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ", "
+
+#: ../gui/layers.py:990
+#, fuzzy, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr "{layer_default_name} hinzufügen"
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Ebenen"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr "Ebenen anordnen und Effekte zuweisen"
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr "Ebenendeckkraft: %d %%"
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr "Ebene im Stapel bewegen …"
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 "Ebene im Stapel bewegen (Fallenlassen in eine reguläre Ebene erstellt eine "
 "neue Gruppe)"
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr "Ebene"
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
-msgstr "Modus:"
+#: ../gui/layervis.py:53
+#, fuzzy, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
+msgstr "<b>{brush_name}</b>"
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
-"Blendmodus: wie die aktuelle Ebene mit den Ebenen darunter kombiniert wird."
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Deckkraft:"
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "Ansicht drehen"
 
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-"Ebenendeckkraft: kleinere Werte machen die aktuelle Ebene transparenter."
-
-#: ../gui/linemode.py:37
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr "Eingangsdruck"
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr "Eingangsdruck für Linienwerkzeuge"
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr "Mittlerer Druck"
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr "Druck für Linienwerkzeuge in der Mitte des Striches"
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr "Ausgangsdruck"
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr "Ausgangsdruck für Linienwerkzeuge"
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr "Kopf"
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 #, fuzzy
 msgid "Stroke lead-in end"
 msgstr "Strich Lead-In Ende"
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr "Schwanz"
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 #, fuzzy
 msgid "Stroke trail-off beginning"
 msgstr "Strich Trail-Off Anfang"
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr "Druckveränderung …"
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr "Linien und Kurven"
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr "Generischer Linien-/Kurvenmodus"
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 "Gerade Linien zeichnen; Umschalttaste fügt Kurven hinzu, Strg erzwingt Winkel"
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr "Verbundene Linien"
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 "Mehrere Linien zeichnen; Umschalttaste fügt Kurven hinzu, Strg erzwingt "
 "Winkel"
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr "Ellipsen und Kreise"
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
-msgstr "Ellipsen zeichnen; Umschalttaste dreht, Strg bestimmt Verhältnis/Winkel"
+msgstr ""
+"Ellipsen zeichnen; Umschalttaste dreht, Strg bestimmt Verhältnis/Winkel"
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
+#, fuzzy
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 "Copyright (C) 2005–2015\n"
 "Martin Renold und das MyPaint-Entwicklungsteam"
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -2086,8 +2611,8 @@ msgid ""
 msgstr ""
 "MyPaint ist freie Software. Sie können es unter den Bedingungen der GNU "
 "General Public License, wie von der Free Software Foundation herausgegeben, "
-"weitergeben und/oder modifizieren, entweder unter Version 2 der Lizenz oder ("
-"wenn Sie es wünschen) jeder späteren Version.\n"
+"weitergeben und/oder modifizieren, entweder unter Version 2 der Lizenz oder "
+"(wenn Sie es wünschen) jeder späteren Version.\n"
 "\n"
 "Die Veröffentlichung von MyPaint erfolgt in der Hoffnung, dass es Ihnen von "
 "Nutzen sein wird, aber OHNE JEDE GEWÄHRLEISTUNG – sogar ohne die implizite "
@@ -2098,72 +2623,72 @@ msgstr ""
 "erhalten haben. Falls nicht, schreiben Sie an die Free Software Foundation, "
 "Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA."
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr "Programmierung"
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr "Portierbarkeit"
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr "Projektmanagement"
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr "Pinsel"
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr "Muster"
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr "Werkzeugsymbole"
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr "Desktopsymbol"
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr "Paletten"
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr "Dokumentation"
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr "Unterstützung"
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr "Verbreitung"
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr "Gemeinschaft"
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ", "
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
@@ -2174,186 +2699,216 @@ msgstr ""
 "Vinzenz Vietzke\n"
 "Manuel Stumpf"
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr "Größe:"
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr "Deckkraft:"
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr "Schärfe:"
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr "Verstärkung:"
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr "Werkzeugoptionen"
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr "Spezielle Einstellungen für das aktuelle Arbeitswerkzeug"
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr "<b>{mode_name}</b>"
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr "<i>Keine Optionen verfügbar</i>"
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr "Zoom: %.01f %%"
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr "Pinselstrich Einstellungen, Strichfarbe und Ebene wählen …"
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr "Farbe wählen …"
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr "Einstellungen"
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr "Vorschau"
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr "Vorschau des gesamten Zeichenbereichs zeigen"
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr "Ansichtssucher anzeigen"
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr "Notizblock"
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr "Farben mischen und Skizzen auf separaten Schmierblättern anfertigen"
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr "Vorheriges Element"
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr "Nächstes Element"
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
 msgstr "(Nichts zum Anzeigen)"
 
-#: ../gui/symmetry.py:76
+#: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Place axis"
 msgstr "Achse platzieren"
 
-#: ../gui/symmetry.py:80
+#: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Move axis"
 msgstr "Achse bewegen"
 
-#: ../gui/symmetry.py:84
+#: ../gui/symmetry.py:88
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr "Achse entfernen"
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr "Symmetrieachse bearbeiten"
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr "Symmetrieachse der Zeichnung anpassen."
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
+#, fuzzy
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr "Position:"
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr "Position:"
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr "Keine"
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr "%d px"
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr "Alpha:"
 
-#: ../gui/symmetry.py:352
+#: ../gui/symmetry.py:376
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
+msgstr "Symmetrie"
+
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+#, fuzzy
 msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+msgid "X axis Position"
 msgstr "Achsenposition"
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:477
+#, fuzzy
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr "Achsenposition"
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr "Aktiviert"
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr "Dateibehandlung"
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr "Notizenwähler"
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr "Rückgängig und Wiederholen"
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr "Überblendungsmodi"
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr "Linienmodus"
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr "Ansicht (Primär)"
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr "Ansicht (Alternative)"
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr "Ansicht (Zurücksetzen)"
 
@@ -2361,188 +2916,214 @@ msgstr "Ansicht (Zurücksetzen)"
 msgid "<b>MyPaint</b>"
 msgstr "<b>MyPaint</b>"
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr "Ansicht scrollen"
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr "Leinwandansicht verschieben"
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr "Ansicht zoomen"
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr "Leinwandansicht zoomen"
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr "Ansicht drehen"
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr "Leinwandansicht drehen"
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, fuzzy, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr "%s: Reiter schließen"
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
-msgstr "%s: Eigenschaften bearbeiten"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
+msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr "Unbekannter Befehl"
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr "Nicht definiert (Befehl noch nicht gestartet)"
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr "{seconds:.01f}s zeichnen mit {brush_name}"
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr "Füllen"
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr "Ebene zuschneiden"
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "Gruppe umbenennen"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr "Ebene leeren"
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr "Ebene einfügen"
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr "Neue Ebene aus Sichtbarem"
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr "Sichtbare Ebenen zusammenfügen"
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr "Nach unten vereinen"
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr "Ebenenmodus normalisieren"
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Importierter Pinsel"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr "{layer_default_name} hinzufügen"
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr "Ebene löschen"
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr "Ebene auswählen"
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr "Ebene duplizieren"
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr "Ebene nach oben bewegen"
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr "Ebene nach unten bewegen"
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr "Ebene im Stapel bewegen"
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr "Ebene umbenennen"
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr "Ebene sichtbar machen"
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr "Ebene unsichtbar machen"
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr "Ebene sperren"
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr "Ebene entsperren"
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr "Ebenendeckkraft festlegen: %0.1f %%"
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr "Unbekannter Modus"
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr "Ebenenmodus festlegen: %s"
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr "Rahmen aktivieren"
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr "Rahmen deaktivieren"
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr "Rahmen aktualisieren"
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr "Ebene extern bearbeiten"
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr "Fehler beim Laden von „{basename}“."
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr "Die Logs haben eventuell mehr Details zu diesem Fehler."
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr "ab jetzt"
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr "vor"
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2555,13 +3136,13 @@ msgstr ""
 "Anwendung schließen und vor erneutem Versuch {cache_update_interval} Sek. "
 "warten."
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr "Unvollständiges Backup aktualisiert {ago} {last_modified_time}"
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2571,11 +3152,11 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 "Backup aktualisiert {ago} {last_modified_time}\n"
-"Größe: {autosave.width}×{autosave.height} Pixel, Ebenen: "
-"{autosave.num_layers}\n"
+"Größe: {autosave.width}×{autosave.height} Pixel, Ebenen: {autosave."
+"num_layers}\n"
 "Enthält {unsaved_time} ungespeicherter Arbeit."
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2585,14 +3166,14 @@ msgstr ""
 "Speichern der Datei „{filename}“ mit folgendem Fehler fehlgeschlagen: {err}\n"
 "Ist genügend freier Speicherplatz vorhanden?"
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 "Speichern der Datei „{filename}“ mit folgendem Fehler fehlgeschlagen: {err}"
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2602,7 +3183,7 @@ msgstr ""
 "{error_loading_common}\n"
 "Die Datei ist nicht vorhanden."
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2612,7 +3193,7 @@ msgstr ""
 "{error_loading_common}\n"
 "Sie haben nicht die nötigen Rechte, um diese Datei zu öffnen."
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2628,7 +3209,7 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2638,7 +3219,13 @@ msgstr ""
 "{error_loading_common}\n"
 "Unbekannte Dateiendung: „{ext}“"
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+#, fuzzy
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr "Importierter Pinsel"
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2653,7 +3240,7 @@ msgstr ""
 "Format abzuspeichern.\n"
 "In MyPaint ist das Speichern von PNG effizienter."
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2669,98 +3256,207 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/helpers.py:402
-#, python-brace-format
+#: ../lib/floodfill.py:131
+#, fuzzy
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr "Füllen"
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr "{days}d{hours}h"
 
-#: ../lib/helpers.py:404
-#, python-brace-format
+#: ../lib/helpers.py:537
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr "{hours}h{minutes}m"
 
-#: ../lib/helpers.py:406
-#, python-brace-format
+#: ../lib/helpers.py:539
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr "{minutes}m{seconds}s"
 
-#: ../lib/helpers.py:408
-#, python-brace-format
+#: ../lib/helpers.py:541
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr "{seconds}s"
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr "Ebene"
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr "%(name)s %(number)d"
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr "^(.*?)\\s*(\\d+)$"
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
+#, fuzzy
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr "Vektorebene"
+
+#: ../lib/layer/data.py:1158
+#, fuzzy
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr "Vektorebene"
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
-msgstr "Unbekannte Bitmapebene"
+msgid "Bitmap"
+msgstr ""
 
-#: ../lib/layer/data.py:1169
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1244
 msgctxt "layer default names"
-msgid "Unknown Data Layer"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
 msgstr "Unbekannte Datenebene"
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "Neue Zeichenebene"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr "Gruppe"
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "Neue Ebenengruppe"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr "Platzhalter"
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr "Wurzel"
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ", "
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+#, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "Ansicht"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+#, fuzzy
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr "Ebene hinzufügen"
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+#, fuzzy
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr "Ebene löschen"
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr "Ebene sperren"
+
+#: ../lib/layervis.py:697
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr "Ebene entsperren"
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr "Durchdrücken"
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr "Gruppeninhalte gelten direkt für den Hintergrund der Gruppe"
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr "Normal"
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr "Nur die oberste Ebene, ohne Überblenden."
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr "Multiplizieren"
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
@@ -2768,11 +3464,11 @@ msgstr ""
 "Als ob zwei Dias hintereinander im Diaprojektor eingelegt sind und das "
 "vereinte Ergebnis projiziert wird."
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr "Bildschirm"
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
@@ -2780,11 +3476,11 @@ msgstr ""
 "Als ob zwei Diaprojektoren zeitgleich auf eine Leinwand gerichtet sind. Dies "
 "ist das Gegenteil zu „Multiplizieren“."
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr "Überlagern"
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
@@ -2792,30 +3488,30 @@ msgstr ""
 "Überlagert den Hintergrund mit der obersten Ebene, behält Highlights und "
 "Schatten des Hintergrunds bei. Dies ist das Gegenteil von „Hartem Licht“."
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr "Dunkler"
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 "Die oberste Ebene wird dort verwendet, wo sie dunkler als der Hintergrund "
 "ist."
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr "Heller"
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 "Die oberste Ebene wird dort verwendet, wo sie heller als der Hintergrund ist."
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr "Abwedeln"
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
@@ -2825,11 +3521,11 @@ msgstr ""
 "ähnlich der fotografischen Dunkelkammertechnik desselben Namens, die "
 "verwendet wird, um den Kontrast im Schatten zu verbessern."
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr "Nachbelichten"
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
@@ -2839,43 +3535,43 @@ msgstr ""
 "ist ähnlich der fotografischen Dunkelkammertechnik desselben Namens, die zur "
 "Reduktion überbelichteter Bereiche verwendet wird."
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr "Hartes Licht"
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr "Ähnlich eines grellen auf den Hintergrund scheinenden Strahlers."
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr "Weiches Licht"
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr "Wie ein diffuser Strahler, der auf den Hintergrund scheint."
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr "Differenz"
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr "Subtrahiert die dunklere Farbe von der helleren der beiden."
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr "Ausschluss"
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr "Ähnlich dem Modus „Differenz“, aber mit niedrigerem Kontrast."
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr "Farbton"
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
@@ -2883,11 +3579,11 @@ msgstr ""
 "Kombiniert den Farbton der obersten Ebene mit der Sättigung und Luminanz des "
 "Hintergrunds."
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr "Sättigung"
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
@@ -2895,7 +3591,7 @@ msgstr ""
 "Wendet die Sättigung der obersten Ebene auf Farbton und Luminanz des "
 "Hintergrunds an."
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
@@ -2903,11 +3599,11 @@ msgstr ""
 "Wendet Farbton und Sättigung der obersten Ebene auf die Luminanz des "
 "Hintergrunds an."
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr "Luminanz"
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
@@ -2915,19 +3611,19 @@ msgstr ""
 "Wendet die Luminanz der obersten Ebene auf Farbton und Sättigung des "
 "Hintergrunds an."
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr "Addition"
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr "Diese Ebene und ihr Hintergrund werden einfach addiert."
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr "Zieleingang"
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
@@ -2935,11 +3631,11 @@ msgstr ""
 "Verwendet den Hintergrund nur, wo diese Ebene ihn überdeckt. Alles andere "
 "wird ignoriert."
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr "Zielausgang"
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
@@ -2947,11 +3643,11 @@ msgstr ""
 "Verwendet den Hintergrund nur, wo diese Ebene ihn nicht überdeckt. Alles "
 "andere wird ignoriert."
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr "Quelle obenauf"
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
@@ -2959,11 +3655,11 @@ msgstr ""
 "Quelle, die das Ziel überlappt, ersetzt das Ziel. Das Ziel wird anderswo "
 "platziert."
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr "Ziel obenauf"
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
@@ -2971,7 +3667,18 @@ msgstr ""
 "Ziel, das die Quelle überlappt, ersetzt die Quelle. Die Quelle wird anderswo "
 "platziert."
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, fuzzy, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr "%(name)s %(number)d"
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
@@ -2981,7 +3688,7 @@ msgstr ""
 "besitzt möglicherweise nicht genügend Speicher, um diese Operation "
 "auszuführen."
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2995,7 +3702,30 @@ msgstr ""
 "Grund: {err}\n"
 "Zielordner: „{dirname}“."
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+#, fuzzy
+msgid "Vertical"
+msgstr "Vertikal spiegeln"
+
+#: ../lib/tiledsurface.py:49
+#, fuzzy
+msgid "Horizontal"
+msgstr "Horizontal spiegeln"
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+#, fuzzy
+msgid "Rotational"
+msgstr "Drehung zurücksetzen"
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr "Laden von PNG fehlgeschlagen: %s"
@@ -3004,58 +3734,92 @@ msgstr "Laden von PNG fehlgeschlagen: %s"
 msgid "Recover interrupted work?"
 msgstr "Unterbrochene Arbeit wiederherstellen?"
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
-msgstr "_Wiederherstellen und Speichern …"
+msgid "_Look for backups at startup"
+msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr "Löschen"
+
+#: ../po/tmp/autorecover.glade.h:9
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr "Diesen Pinsel von der Festplatte löschen"
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr "_Wiederherstellen und Speichern …"
+
+#: ../po/tmp/autorecover.glade.h:12
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr "Dieses Backup auf Festplatte speichern, dann daran weiterarbeiten."
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
-msgstr "_Im Moment ignorieren"
+msgid "Decide _Later"
+msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr "Auf einer neuen Leinwand beginnen. Diese Backups werden aufbewahrt."
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
+#, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 "MyPaint ist mit nicht gespeicherter Arbeit abgestürzt, aber es hat Backups "
 "erzeugt. Sie können nun eine Datei wiederherstellen, oder damit warten, bis "
 "Sie MyPaint erneut starten."
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr "Miniaturbild"
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr "Beschreibung"
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
-msgstr "Kopie als Neu"
+msgid "Live update"
+msgstr "Echtzeitvorschau"
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
-msgstr ""
-"Diese Einstellungen und das aktuelle Pinselsymbol in einen neuen Pinsel "
-"kopieren"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
+msgstr "Letzten Pinselstrich in Echtzeit aktualisieren"
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
-msgstr "Diesen Pinsel umbenennen"
+msgid "Save these settings to the brush"
+msgstr "Diese Einstellungen für den Pinsel speichern"
 
 #: ../po/tmp/brusheditor.glade.h:5
 msgid "Edit Icon"
@@ -3078,18 +3842,18 @@ msgid "Delete this brush from the disk"
 msgstr "Diesen Pinsel von der Festplatte löschen"
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
-msgstr "Echtzeitvorschau"
+msgid "Copy to New"
+msgstr "Kopie als Neu"
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
-msgstr "Letzten Pinselstrich in Echtzeit aktualisieren"
+msgid "Copy these settings and the current brush's icon to a new brush"
+msgstr ""
+"Diese Einstellungen und das aktuelle Pinselsymbol in einen neuen Pinsel "
+"kopieren"
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
-msgstr "Diese Einstellungen für den Pinsel speichern"
+msgid "Rename this brush"
+msgstr "Diesen Pinsel umbenennen"
 
 #: ../po/tmp/brusheditor.glade.h:13
 msgid "Brush Setting"
@@ -3117,12 +3881,7 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr "Notizen:"
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr "Name der Einstellung:"
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
@@ -3130,21 +3889,18 @@ msgstr ""
 "diesen."
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
-msgstr "Ausgangswert:"
+#: ../po/tmp/brusheditor.glade.h:22
+#, fuzzy
+msgid "Value:"
+msgstr "Grundwert"
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr "Den Ausgangswert auf seinen Standardwert zurücksetzen"
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 "Diese Eingabe zurücksetzen, so dass sie keine Auswirkung auf die "
 "Einstellungen hat"
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
@@ -3152,11 +3908,7 @@ msgstr ""
 "Kleinster Wert für die Ausgabeachse.\n"
 "Wird durch den Hauptschieberegler für {dname} kontrolliert."
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr "<ymin>"
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
@@ -3164,27 +3916,23 @@ msgstr ""
 "Größter Wert für die Ausgabeachse.\n"
 "Wird durch den Hauptschieberegler für {dname} kontrolliert."
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr "<ymax>"
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr "Ausgabe"
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr "Eingabe"
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr "Passt den Maximalwert an"
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr "Passt den Minimalwert an"
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
@@ -3192,11 +3940,7 @@ msgstr ""
 "Kleinster Wert für die Eingabeachse.\n"
 "Zum Anpassen die Popup-Skala verwenden."
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr "<xmin>"
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
@@ -3204,38 +3948,36 @@ msgstr ""
 "Größter Wert für die Eingabeachse.\n"
 "Zum Anpassen die Popup-Skala verwenden."
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr "<xmax>"
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr "Veränderung des Ausgangswerts durch Stifteingabe und andere Kriterien"
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr "Pinseldynamik"
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr "Grundangaben für diese Einstellung"
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr "Einstellungen bearbeiten"
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr "Die Zuordnung dieses Eingabeparameters detailliert bearbeiten"
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr "{tooltip}"
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
 msgstr "{dname}:"
+
+#: ../po/tmp/brusheditor.glade.h:42
+#, fuzzy
+msgid "Brush dynamics are not available for this setting."
+msgstr "Grundangaben für diese Einstellung"
+
+#: ../po/tmp/brusheditor.glade.h:43
+#, fuzzy
+msgid "<big><b>No Brush Dynamics</b></big>"
+msgstr "<big><b>{accel_label}</b></big>"
 
 #: ../po/tmp/inktool.glade.h:1
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
@@ -3247,7 +3989,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr "Druck:"
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3292,6 +4034,141 @@ msgstr "Punkt löschen"
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
 msgstr "Den aktuell gewählten Punkt löschen"
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+#, fuzzy
+msgid "Insert Point"
+msgstr "Zeile einfügen"
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+#, fuzzy
+msgid "Cull Points"
+msgstr "Punkt löschen"
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Name"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr "Modus"
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Deckkraft"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr "Den Rahmen auf die aktive Ebene zuschneiden"
+
+#: ../po/tmp/layervis.glade.h:2
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr "Leinwandansicht drehen"
+
+#: ../po/tmp/layervis.glade.h:3
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr "Leinwandansicht drehen"
+
+#: ../po/tmp/layervis.glade.h:4
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr "Welche sichtbaren Ebenen sollen gefüllt werden"
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
+msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
 msgctxt "footer: color picker button: tooltip"
@@ -3699,13 +4576,34 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr "Cursor beim Zeichnen verbergen"
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+#, fuzzy
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr "Aktiviert"
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr "Ansicht"
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
@@ -3714,18 +4612,18 @@ msgstr ""
 "Der Satz Farben, der in Farbkreisen als Primärfarben angezeigt wird.\n"
 "Unterschiedliche Traditionen haben unterschiedliche Farbharmonien."
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr "Primäre Farben:"
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr "Standard digitales Rot/Grün/Blau"
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
@@ -3733,7 +4631,7 @@ msgstr ""
 "Die rote, grüne und blaue „Computerbildschirm“-Primärfarben,\n"
 "gleichmäßig um einen Kreis angeordnet. Grün ist gegenüber von Magenta."
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
@@ -3742,12 +4640,12 @@ msgstr ""
 "Die rote, grüne und blaue „Computerbildschirm“-Primärfarben,\n"
 "gleichmäßig um einen Kreis angeordnet. Grün ist gegenüber von Magenta."
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr "Traditionelles künstlerisches Rot/Gelb/Blau"
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
@@ -3758,7 +4656,7 @@ msgstr ""
 "angenähert durch pure im Kreis angeordnete Display-Farben. Grün ist "
 "gegenüber von Rot."
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3770,12 +4668,12 @@ msgstr ""
 "angenähert durch pure im Kreis angeordnete Display-Farben. Grün ist "
 "gegenüber von Rot."
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr "Gegenüberliegendes Rot-Grün und Blau-Gelb paaren"
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3791,7 +4689,7 @@ msgstr ""
 "repräsentieren ähnliche Modelle.\n"
 "Hier verwenden wir pures Rot, Gelb usw. als die vier Primärfarben."
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3809,28 +4707,28 @@ msgstr ""
 "Hier verwenden wir pures Rot, Gelb usw. als die vier Primärfarben."
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr "<b>Farbkreis</b>"
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr "Farbe"
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr "Bildschirm (normal)"
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr "Deaktiviert (keine Drucksensitivität)"
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr "Fenster (nicht empfohlen)"
@@ -3891,251 +4789,308 @@ msgid "Reload the file your current work was loaded from."
 msgstr "Die aktuelle Datei nochmals neu laden."
 
 #: ../po/tmp/resources.xml.h:12
+#, fuzzy
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Import Layers…"
+msgstr "Pinsel importieren …"
+
+#: ../po/tmp/resources.xml.h:13
+msgctxt "Accel Editor (descriptions)"
+msgid "Import layers from one or more files."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save"
 msgstr "Speichern"
 
-#: ../po/tmp/resources.xml.h:13
+#: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file."
 msgstr "Bild als Datei speichern."
 
-#: ../po/tmp/resources.xml.h:14
+#: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As…"
 msgstr "Speichern unter …"
 
-#: ../po/tmp/resources.xml.h:15
+#: ../po/tmp/resources.xml.h:17
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file, assigning it a new name."
 msgstr "Bild als neue Datei speichern."
 
-#: ../po/tmp/resources.xml.h:16
+#: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Export…"
 msgstr "Exportieren …"
 
-#: ../po/tmp/resources.xml.h:17
+#: ../po/tmp/resources.xml.h:19
 msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 "Bild in eine Datei exportieren, aber mit bisheriger Datei weiterarbeiten."
 
-#: ../po/tmp/resources.xml.h:18
+#: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As Scrap"
 msgstr "Als Entwurf speichern"
 
-#: ../po/tmp/resources.xml.h:19
+#: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
 msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 "Als neuen Entwurf speichern, oder eine neue Revision speichern falls dieser "
 "bereits existiert."
 
-#: ../po/tmp/resources.xml.h:20
+#: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Previous Scrap"
 msgstr "Letzten Entwurf öffnen"
 
-#: ../po/tmp/resources.xml.h:21
+#: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file before the current one."
 msgstr "Den vorhergehenden Entwurf laden."
 
-#: ../po/tmp/resources.xml.h:22
+#: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Next Scrap"
 msgstr "Nächsten Entwurf öffnen"
 
-#: ../po/tmp/resources.xml.h:23
+#: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file after the current one."
 msgstr "Den nachfolgenden Entwurf laden."
 
-#: ../po/tmp/resources.xml.h:24
+#: ../po/tmp/resources.xml.h:26
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Recover File from an Automated Backup…"
 msgstr "Datei aus automatischem Backup wiederherstellen …"
 
-#: ../po/tmp/resources.xml.h:25
+#: ../po/tmp/resources.xml.h:27
 msgctxt "Accel Editor (descriptions)"
 msgid "Try to save and resume interrupted unsaved work."
 msgstr ""
 "Versuchen, unterbrochene nicht gespeicherte Arbeit zu speichern und dann "
 "zurückzukehren."
 
-#: ../po/tmp/resources.xml.h:26
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr "Pinselgruppen"
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr "Pinsel"
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr "Liste mit Pinselgruppen."
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr "Farbwähler"
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr "Farben"
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr "Verfügbare Farbwähler."
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr "Modus"
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr "Modus"
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr "Kompositionsmodus der aktuellen Ebene."
 
-#: ../po/tmp/resources.xml.h:35
+#: ../po/tmp/resources.xml.h:37
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Pressure"
+msgstr "Eingangsdruck"
+
+#: ../po/tmp/resources.xml.h:38
+msgctxt "Accel Editor (descriptions)"
+msgid "Send harder pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:39
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Pressure"
+msgstr "Eingangsdruck"
+
+#: ../po/tmp/resources.xml.h:40
+msgctxt "Accel Editor (descriptions)"
+msgid "Send softer pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:41
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Rotation"
+msgstr "Farbsättigung erhöhen"
+
+#: ../po/tmp/resources.xml.h:42
+msgctxt "Accel Editor (descriptions)"
+msgid "Increase barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:43
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
+msgstr "Farbsättigung verringern"
+
+#: ../po/tmp/resources.xml.h:44
+msgctxt "Accel Editor (descriptions)"
+msgid "Decrease barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:45
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Size"
 msgstr "Pinselradius erhöhen"
 
-#: ../po/tmp/resources.xml.h:36
+#: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush bigger."
 msgstr "Den Pinselradius vergrößern."
 
-#: ../po/tmp/resources.xml.h:37
+#: ../po/tmp/resources.xml.h:47
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Size"
 msgstr "Pinselradius verringern"
 
-#: ../po/tmp/resources.xml.h:38
+#: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush smaller."
 msgstr "Den Pinselradius verkleinern."
 
-#: ../po/tmp/resources.xml.h:39
+#: ../po/tmp/resources.xml.h:49
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Opacity"
 msgstr "Pinseldeckkraft erhöhen"
 
-#: ../po/tmp/resources.xml.h:40
+#: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush more opaque."
 msgstr "Den Arbeitspinsel deckender einstellen."
 
-#: ../po/tmp/resources.xml.h:41
+#: ../po/tmp/resources.xml.h:51
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Opacity"
 msgstr "Pinseldeckkraft verringern"
 
-#: ../po/tmp/resources.xml.h:42
+#: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush less opaque."
 msgstr "Den Arbeitspinsel weniger deckend einstellen."
 
-#: ../po/tmp/resources.xml.h:43
+#: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Lighten Painting Color"
 msgstr "Zeichenfarbe aufhellen"
 
-#: ../po/tmp/resources.xml.h:44
+#: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase the lightness of the current painting color."
 msgstr "Die Helligkeit der aktuellen Zeichenfarbe erhöhen."
 
-#: ../po/tmp/resources.xml.h:45
+#: ../po/tmp/resources.xml.h:55
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Darken Painting Color"
 msgstr "Zeichenfarbe abdunkeln"
 
-#: ../po/tmp/resources.xml.h:46
+#: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease the lightness of the current painting color."
 msgstr "Die Helligkeit der aktuellen Zeichenfarbe verringern."
 
-#: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
-msgstr "Farbton gegen den Uhrzeigersinn ändern"
-
-#: ../po/tmp/resources.xml.h:48
-msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
-msgstr "Farbton der Malfarbe gegen Uhrzeigersinn auf dem Farbkreis drehen."
-
-#: ../po/tmp/resources.xml.h:49
+#: ../po/tmp/resources.xml.h:57
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Change Hue Clockwise"
 msgstr "Farbton im Uhrzeigersinn ändern"
 
-#: ../po/tmp/resources.xml.h:50
+#: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
 msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr "Farbton der Malfarbe im Uhrzeigersinn auf dem Farbkreis drehen."
 
-#: ../po/tmp/resources.xml.h:51
+#: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr "Farbton gegen den Uhrzeigersinn ändern"
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr "Farbton der Malfarbe gegen Uhrzeigersinn auf dem Farbkreis drehen."
+
+#: ../po/tmp/resources.xml.h:61
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Increase Saturation"
 msgstr "Farbsättigung erhöhen"
 
-#: ../po/tmp/resources.xml.h:52
+#: ../po/tmp/resources.xml.h:62
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color more saturated (more colorful, purer)."
 msgstr "Malfarbe mehr sättigen (farbiger, kräftiger)."
 
-#: ../po/tmp/resources.xml.h:53
+#: ../po/tmp/resources.xml.h:63
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Decrease Saturation"
 msgstr "Farbsättigung verringern"
 
-#: ../po/tmp/resources.xml.h:54
+#: ../po/tmp/resources.xml.h:64
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color less saturated (grayer)."
 msgstr "Malfarbe weniger sättigen (grauer)."
 
-#: ../po/tmp/resources.xml.h:55
+#: ../po/tmp/resources.xml.h:65
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Reload Brush Settings"
 msgstr "Pinseleinstellungen neu laden"
 
-#: ../po/tmp/resources.xml.h:56
+#: ../po/tmp/resources.xml.h:66
 msgctxt "Accel Editor (descriptions)"
 msgid "Restore all brush settings to the current brush’s saved values."
 msgstr ""
 "Alle Pinseleinstellungen auf die aktuell gespeicherten Werte zurücksetzen."
 
-#: ../po/tmp/resources.xml.h:57
+#: ../po/tmp/resources.xml.h:67
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Pick Stroke and Layer"
 msgstr "Pinsel und Ebene wählen"
 
-#: ../po/tmp/resources.xml.h:58
+#: ../po/tmp/resources.xml.h:68
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
 msgstr "Pinselstrich von der Leinwand wählen: setzt Pinsel, Farbe und Ebene."
 
-#: ../po/tmp/resources.xml.h:59
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr "Pinsel-Tastenkürzel setzen Farbe zurück"
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
@@ -4144,218 +5099,271 @@ msgstr ""
 "Umschalten, ob das Laden eines Pinsels über Tastenkürzel auch die Farbe "
 "ändert oder nicht."
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr "Pinsel mit letztgenutztem Tastenkürzel speichern"
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr "Pinseleinstellungen mit letztgenutztem Tastenkürzel speichern."
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "Ebene leeren"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr "Inhalt der aktuellen Ebene leeren."
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Trim Layer to Frame"
-msgstr "Ebene am Rahmen abschneiden"
+#: ../po/tmp/resources.xml.h:75
+#, fuzzy
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr "Werkzeugoptionen"
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:76
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Trim Layer to Frame"
+msgstr "Ebene auf den Rahmen zuschneiden"
+
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
-msgstr "Bereiche der aktuellen Ebene löschen, die außerhalb des Rahmens liegen."
+msgstr ""
+"Bereiche der aktuellen Ebene löschen, die außerhalb des Rahmens liegen."
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr ""
+"Bereiche der aktuellen Ebene löschen, die außerhalb des Rahmens liegen."
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "Neue Ebenengruppe darunter"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "Neue Ebenengruppe darunter"
+
+#: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr "Ebene in Zwischenablage kopieren"
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr "Den Inhalt der aktuellen Ebene in die Zwischenablage kopieren."
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr "Ebene aus Zwischenablage einfügen"
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr "Ersetzt die aktuelle Ebene mit dem Inhalt der Zwischenablage."
 
-#: ../po/tmp/resources.xml.h:71
+#: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Edit Layer in External App…"
 msgstr "Ebene extern bearbeiten …"
 
-#: ../po/tmp/resources.xml.h:72
+#: ../po/tmp/resources.xml.h:90
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
+msgid "Edit the active layer in an external application."
 msgstr "Die aktuelle Ebene in einer externen Anwendung bearbeiten."
 
-#: ../po/tmp/resources.xml.h:73
+#: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Update Layer with External Edits"
 msgstr "Ebene mit externen Änderungen aktualisieren"
 
-#: ../po/tmp/resources.xml.h:74
+#: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
 msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 "Von externen Anwendungen gespeicherte Änderungen übertragen (normalerweise "
 "automatisch der Fall)."
 
-#: ../po/tmp/resources.xml.h:75
+#: ../po/tmp/resources.xml.h:93
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer at Cursor"
 msgstr "Ebene am Mauszeiger auswählen"
 
-#: ../po/tmp/resources.xml.h:76
+#: ../po/tmp/resources.xml.h:94
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr "Ebene anwählen, wenn ein Element aus dieser gewählt wird."
 
-#: ../po/tmp/resources.xml.h:77
+#: ../po/tmp/resources.xml.h:95
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Above"
 msgstr "Ebene höher gehen"
 
-#: ../po/tmp/resources.xml.h:78
+#: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer up in the layer stack."
 msgstr "Im Ebenenstapel eine Ebene höher gehen."
 
-#: ../po/tmp/resources.xml.h:79
+#: ../po/tmp/resources.xml.h:97
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Below"
 msgstr "Ebene tiefer gehen"
 
-#: ../po/tmp/resources.xml.h:80
+#: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer down in the layer stack."
 msgstr "Im Ebenenstapel eine Ebene tiefer gehen."
 
-#: ../po/tmp/resources.xml.h:81
+#: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer"
 msgstr "Neue Zeichenebene"
 
-#: ../po/tmp/resources.xml.h:82
+#: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer above the current layer."
 msgstr "Eine neue Zeichenebene über der aktuellen Ebene hinzufügen."
 
-#: ../po/tmp/resources.xml.h:83
+#: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer…"
 msgstr "Neue Vektorebene …"
 
-#: ../po/tmp/resources.xml.h:84
+#: ../po/tmp/resources.xml.h:102
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer above the current layer, and begin editing it."
 msgstr ""
 "Eine neue Vektorebene über der aktuellen Ebene hinzufügen und bearbeiten."
 
-#: ../po/tmp/resources.xml.h:85
+#: ../po/tmp/resources.xml.h:103
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group"
 msgstr "Neue Ebenengruppe"
 
-#: ../po/tmp/resources.xml.h:86
+#: ../po/tmp/resources.xml.h:104
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group above the current layer."
 msgstr "Eine neue Ebenengruppe über der aktuellen Ebene hinzufügen."
 
-#: ../po/tmp/resources.xml.h:87
+#: ../po/tmp/resources.xml.h:105
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer Below"
 msgstr "Neue Zeichenebene darunter"
 
-#: ../po/tmp/resources.xml.h:88
+#: ../po/tmp/resources.xml.h:106
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer below the current layer."
 msgstr "Eine neue Zeichenebene unter der aktuellen Ebene hinzufügen."
 
-#: ../po/tmp/resources.xml.h:89
+#: ../po/tmp/resources.xml.h:107
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer Below…"
 msgstr "Neue Vektorebene darunter …"
 
-#: ../po/tmp/resources.xml.h:90
+#: ../po/tmp/resources.xml.h:108
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer below the current layer, and begin editing it."
 msgstr ""
 "Eine neue Vektorebene unter der aktuellen Ebene hinzufügen und bearbeiten."
 
-#: ../po/tmp/resources.xml.h:91
+#: ../po/tmp/resources.xml.h:109
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group Below"
 msgstr "Neue Ebenengruppe darunter"
 
-#: ../po/tmp/resources.xml.h:92
+#: ../po/tmp/resources.xml.h:110
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group below the current layer."
 msgstr "Eine neue Ebenengruppe unter der aktuellen Ebene hinzufügen."
 
-#: ../po/tmp/resources.xml.h:93
+#: ../po/tmp/resources.xml.h:111
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Layer Down"
 msgstr "Ebene nach unten vereinen"
 
-#: ../po/tmp/resources.xml.h:94
+#: ../po/tmp/resources.xml.h:112
 msgctxt "Accel Editor (descriptions)"
 msgid "Merge the current layer with the layer beneath it."
 msgstr "Ebene mit darunterliegender Ebene vereinen."
 
-#: ../po/tmp/resources.xml.h:95
+#: ../po/tmp/resources.xml.h:113
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Visible Layers"
 msgstr "Sichtbare Ebenen vereinen"
 
-#: ../po/tmp/resources.xml.h:96
+#: ../po/tmp/resources.xml.h:114
 msgctxt "Accel Editor (descriptions)"
 msgid "Consolidate all visible layers, and delete the originals."
 msgstr "Alle sichtbaren Ebenen vereinen und ursprüngliche Ebenen löschen."
 
-#: ../po/tmp/resources.xml.h:97
+#: ../po/tmp/resources.xml.h:115
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer from Visible"
 msgstr "Neue Ebene aus sichtbaren Ebenen"
 
-#: ../po/tmp/resources.xml.h:98
+#: ../po/tmp/resources.xml.h:116
 msgctxt "Accel Editor (descriptions)"
 msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
 msgstr ""
 "Wie „Sichtbare Ebenen vereinen“, löscht jedoch die ursprünglichen Ebenen "
 "nicht."
 
-#: ../po/tmp/resources.xml.h:99
+#: ../po/tmp/resources.xml.h:117
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Delete Layer"
 msgstr "Ebene löschen"
 
-#: ../po/tmp/resources.xml.h:100
+#: ../po/tmp/resources.xml.h:118
 msgctxt "Accel Editor (descriptions)"
 msgid "Remove the current layer from the layer stack."
 msgstr "Die aktuelle Ebene aus dem Ebenenstapel löschen."
 
-#: ../po/tmp/resources.xml.h:101
+#: ../po/tmp/resources.xml.h:119
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Convert to Normal Painting Layer"
 msgstr "In Zeichenebene umwandeln"
 
-#: ../po/tmp/resources.xml.h:102
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
@@ -4364,72 +5372,74 @@ msgstr ""
 "Wandelt die aktuelle Ebene oder Gruppe in eine Zeichenebene im „Normal“-"
 "Modus um, Erscheinungsbild wird beibehalten."
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr "Deckkraft der Ebene erhöhen"
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr "Die Transparenz der Ebene wird verringert."
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr "Deckkraft der Ebene verringern"
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr "Die Transparenz der Ebene wird erhöht."
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr "Ebene anheben"
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr "Die aktuelle Ebene im Ebenenstapel eine Stufe nach oben schieben."
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr "Ebene absenken"
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr "Die aktuelle Ebene im Ebenenstapel eine Stufe nach unten schieben."
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr "Ebene duplizieren"
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr "Erzeugt ein exaktes Duplikat der aktuellen Ebene."
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
+#, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
-msgstr "Ebene umbenennen …"
+msgid "Layer Properties…"
+msgstr "Eigenschaften"
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
-msgstr "Einen neuen Namen für die aktuelle Ebene eingeben."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr "Ebene gesperrt"
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
@@ -4437,244 +5447,338 @@ msgstr ""
 "Den Sperrstatus der aktuellen Ebene umschalten. Gesperrte Ebenen können "
 "nicht verändert werden."
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr "Ebene sichtbar"
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr "Die Sichtbarkeit der aktuellen Ebene umschalten."
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr "Hintergrund anzeigen"
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr "Die Sichtbarkeit der aktuellen Ebene umschalten."
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr "Die aktuelle Ebene aus dem Ebenenstapel löschen."
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr "Zurücksetzen und zentrieren"
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 "Vergrößerung, Drehung und Spiegelung zurücksetzen und Dokument zentrieren."
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr "Zeichnung in Ansicht einpassen"
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr "Zwischen eingepasster Ansicht und der Arbeitsansicht wechseln."
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr "Zurücksetzen"
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr "Vergrößerung zurücksetzen"
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr "Die Vergrößerung auf ihren Standardwert zurücksetzen."
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr "Drehung zurücksetzen"
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr "Die Drehung der Ansicht auf 0° setzen"
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr "Spiegelung zurücksetzen"
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
-msgstr "Spiegelung der Ansicht abschalten."
+msgid "Reset the view's mirroring."
+msgstr "Spiegelung zurücksetzen"
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr "Vergrößern"
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr "Vergrößerung erhöhen."
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Verkleinern"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr "Vergrößerung verringern."
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
+#, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
-msgstr "Gegen Uhrzeigersinn drehen"
+msgid "Pan Left"
+msgstr "Ansicht verschieben"
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
-msgstr "Die Ansicht gegen den Uhrzeigersinn drehen."
+msgid "Move your view of the canvas to the left."
+msgstr "Ansicht drehen: die Ansicht der Leinwand drehen."
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr "Hartes Licht"
+
+#: ../po/tmp/resources.xml.h:159
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+"Ansicht verschieben: die Ansicht der Leinwand horizontal oder vertikal "
+"bewegen."
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr "Ansicht drehen: die Ansicht der Leinwand drehen."
+
+#: ../po/tmp/resources.xml.h:162
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr "Ansicht verschieben"
+
+#: ../po/tmp/resources.xml.h:163
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr "Ansicht drehen: die Ansicht der Leinwand drehen."
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr "Im Uhrzeigersinn drehen"
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr "Die Ansicht im Uhrzeigersinn drehen."
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr "Gegen Uhrzeigersinn drehen"
+
+#: ../po/tmp/resources.xml.h:167
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr "Die Ansicht gegen den Uhrzeigersinn drehen."
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr "Horizontal spiegeln"
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr "Ansicht von links nach rechts spiegeln."
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr "Vertikal spiegeln"
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr "Ansicht von oben nach unten spiegeln."
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr "Einzelne Ebene"
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr "Festlegen, ob nur die aktuelle Ebene sichtbar ist."
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr "Symmetrisches Zeichnen aktiv"
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr "Pinselstriche an der Symmetrieachse spiegeln"
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr "Rahmen aktiv"
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr "Sichtbarkeit des Dokumentrahmens umschalten."
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr "Pinseleingabewerte in Konsole ausgeben"
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 "Die intern generierten Eingaben der Brush-Engine in der Konsole anzeigen."
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr "Rendering visualisieren"
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr "Renderupdates zum Debuggen auf dem Bildschirm anzeigen."
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr "GTK-Doppelpufferung abschalten"
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr "Doppelpufferung von GTK abschalten (normalerweise eingeschaltet)."
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+#, fuzzy
+msgid "Delete Point"
+msgstr "Punkt löschen"
+
+#: ../po/tmp/resources.xml.h:187
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr "Den aktuell gewählten Punkt löschen"
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr "Zeichenmodus"
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr "Zeichenmodus: Normal"
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr "Beim Zeichnen Farbe normal auftragen."
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr "Zeichenmodus: Radierer"
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr "Mit dem aktuellen Pinsel radieren."
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr "Zeichenmodus: Alphakanal sperren"
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr "Verwenden des Pinsels ändert die Deckkraft der Ebene nicht."
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr "Zeichenmodus: Einfärben"
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
@@ -4682,243 +5786,239 @@ msgstr ""
 "Farbe auf die aktuelle Ebene aufbringen ohne ihre Helligkeit oder Deckkraft "
 "zu beeinflussen."
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Datei"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "Beenden"
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr "Hauptfenster schließen und die Anwendung beenden."
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr "Aktuelles Malwerkzeug"
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "Farbe"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr "Farbe anpassen"
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr "Farbhistorie Popup"
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr "Zeigt am Cursor einen Zeitstrahl zuletzt verwendeter Farben."
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr "Farbdetails-Dialog"
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr "Einen Farbdetails-Dialog mit Texteintrag anzeigen."
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr "Nächste Palettenfarbe"
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr "Nächste Farbe der Palette als Zeichenfarbe festlegen."
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr "Vorherige Palettenfarbe"
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr "Vorherige Farbe der Palette als Zeichenfarbe festlegen."
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr "Farbe zur Palette hinzufügen"
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr "Die aktuelle Zeichenfarbe zur Palette hinzufügen."
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "Ebene"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr "Deckkraft"
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr "Ebene wechseln"
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr "Neue Ebene darunter"
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr "Eigenschaften"
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr "Notizblock"
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr "Neuer Notizblock"
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr "Den Standardnotizblock als neuen Notizblockbereich laden."
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr "Notizblock öffnen …"
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr "Ein Bild von der Festplatte in den Notizblock laden."
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr "Notizblock speichern"
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
-msgstr "Den Notizblock in seine vorhandenen Datei auf der Festplatte speichern."
+msgstr ""
+"Den Notizblock in seine vorhandenen Datei auf der Festplatte speichern."
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr "Notizblock exportieren als …"
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr "Den Notizblock in eine frei wählbare Datei exportieren."
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr "Notizblock zurücksetzen"
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr "Notizblock auf den zuletzt gespeicherten Status zurücksetzen."
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr "Notizblock als Standard speichern"
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr "Notizblock als Standard für „Neuer Notizblock“ speichern."
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr "Den Standardnotizblock leeren"
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr "Den Standardnotizblock für eine leere Arbeitsfläche leeren."
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr "Hintergrund der Hauptzeichnung zum Notizblock kopieren"
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr "Das Hintergrundbild vom Arbeitsdokument in den Notizblock kopieeren."
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "Fenster"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "Pinsel"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr "Tastenkürzel"
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr "Hilfe für Pinsel-Tastenkürzel"
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr "Eine Erklärung anzeigen wie die Tastenkürzel funktionieren."
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "Pinsel wechseln …"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr "Einen Pinselwechsler am Cursor anzeigen."
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "Farbe ändern …"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
@@ -4926,12 +6026,12 @@ msgstr ""
 "Einen Farbwechsler mit Auflistung aller möglichen Farbwähler unter dem "
 "Zeiger anzeigen."
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "Farbe ändern (Schnellauswahl) …"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
@@ -4940,208 +6040,212 @@ msgstr ""
 "Einen Farbwechsler mit Auflistung aller Einfachklick-Farbwähler unter dem "
 "Zeiger anzeigen."
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr "Weitere Pinsel herunterladen …"
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr "Pinselpakete vom MyPaint-Wiki herunterladen."
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr "Pinsel importieren …"
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr "Einen Pinselsatz von der Festplatte laden."
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Hilfe"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr "Online-Hilfe"
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr "Dokumentationswiki von MyPaint aufrufen."
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "Über MyPaint"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr "Lizenz, Versionsnummer und Mitwirkende von MyPaint anzeigen."
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Fehlersuche"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr "Speicherleck-Info auf der Konsole ausgeben (Langsam!)"
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr "Speicherlecks debuggen."
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr "Speicherbereinigung jetzt ausführen"
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr "Speicher nicht mehr genutzter Python-Objekte freigeben."
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr "„Python Profiling“ starten/stoppen …"
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr "„Python Profiling“ starten/stoppen (cProfile)"
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr "Einen Absturz simulieren …"
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 "Einen Python-Ausnahmefehler verursachen, um den Absturzdialog zu testen."
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "Ansicht"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr "Rückmeldung"
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr "Ansicht anpassen"
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
+#, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr "Kontexmenü"
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr "Das Hauptmenü als Popup zeigen."
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "Vollbild"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr "Zwischen Vollbild- und Fenstermodus umschalten."
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "Einstellungen"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr "MyPaints globale Einstellungen bearbeiten."
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr "Eingabegeräte testen"
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr "Einen Dialog anzeigen, der alle Ereignisse der Eingabegeräte erfasst."
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr "Hintergrundauswahl"
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr "Die Hintergrund-Papiertextur ändern."
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr "Pinseleinstellungen"
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr "Die Pinseleinstellungen des aktiven Pinsels bearbeiten."
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr "Pinselsymboleditor"
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr "Pinselsymbole bearbeiten."
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr "Ebenenleiste"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
-msgstr "Ebenenleiste ein-/ausschalten (Ebenen anordnen oder Modi zuweisen)."
+msgid "Dockable panel for managing layers."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr "Ebenenleiste anzeigen"
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr "Das Ebenenpanel anzeigen (Ebenen anordnen oder Modi zuweisen)."
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr "HCY-Farbkreis"
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid ""
@@ -5151,42 +6255,32 @@ msgstr ""
 "Andockbarer zylindrischer Farbton/Chrominanz/Luminanz-Farbwähler. Die "
 "kreisförmigen Scheiben sind equiluminant."
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "Farbpalette"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr "Andockbare Palette zur Farbauswahl."
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr "HSV-Farbkreis"
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr "Andockbares Menü für Sättigung und Farbwert."
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr "HSV-Dreieck"
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr "Andockbarer Farbwähler: das alte GTK-Farbdreieck."
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr "HSV-Würfel"
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid ""
@@ -5196,222 +6290,214 @@ msgstr ""
 "Andockbarer Farbwähler: HSV-Würfel, der rotiert werden kann, um verschiedene "
 "(planare) Scheiben anzuzeigen."
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr "HSV-Quadrat"
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
-msgstr ""
-"Andockbarer Farbwähler: HSV-Quadrat, das gedreht werden kann, um "
-"verschiedene Farbtöne anzuzeigen."
+msgid "Dockable color selector: HSV square with Hue ring."
+msgstr "Andockbarer Farbwähler mit konzentrischen HSV-Ringen."
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr "Farbkomponentenregler"
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 "Andockbarer Farbwähler, der die einzelnen Farbkomponenten der Farbe zeigt."
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr "Flüssige Tönung"
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 "Andockbarer Farbwähler, der eine flüssige Tönung benachbarter Farben zeigt."
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr "Konzentrische Ringe"
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr "Andockbarer Farbwähler mit konzentrischen HSV-Ringen."
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr "Farbschüssel"
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 "Andockbarer Farbwähler mit einer Farbschüssel und kreuzenden HSV-Rampen."
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr "Notizblockleiste"
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
-"Notizblockleiste ein-/ausschalten (Farben mischen und Skizzen zeichnen)."
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr "Neue Notizblockleiste"
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr "Notizblockleiste anzeigen (Farben mischen und Skizzen zeichnen)."
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr "Vorschauleiste"
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
-"Vorschaupanel ein-/ausschalten (Übersicht des kompletten Zeichenbereichs)."
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "Vorschau"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr "Vorschaupanel zeigen (Übersicht des kompletten Zeichenbereichs)."
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr "Werkzeugeinstellungsleiste"
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
-"Werkzeugeinstellungspanel ein-/ausschalten (Einstellungen des aktuellen "
-"Werkzeugs)."
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr "Werkzeugoptionen anzeigen"
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 "Werkzeugeinstellungspanel zeigen (Einstellungen des aktuellen Werkzeugs)."
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr "Pinsel- und Farbhistorienleiste"
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
-"Historienleiste ein-/ausschalten (kürzlich verwendete Pinsel und Farben)."
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr "Zuletzt verwendete Pinsel und Farben"
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr "Historienleiste zeigen (kürzlich verwendete Pinsel und Farben)."
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr "Menüs im Vollbildmodus verbergen"
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 "Automatisches Verstecken der Benutzeroberfläche bei Vollbild umschalten."
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr "Vergrößerung anzeigen"
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr "Vergrößerungsoverlay umschalten."
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr "Letzte Zeichenposition anzeigen"
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 "Letzte Zeichenposition zeigen (Ende des letzten Pinselstrichs) umschalten."
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr "Ansicht filtern"
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr "Farben normal darstellen"
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr "Farben filtern: Farben unverändert darstellen."
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr "Farben als Graustufen darstellen"
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr "Farben filtern: nur Leuchtdichte darstellen (HCY/YCbCr-Luminanz)"
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr "Farben invertiert darstellen"
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr "Farben filtern: invertieren. Schwarz ist weiß und rot ist cyan."
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr "Farben mit simulierter Insensitivität für Rot darstellen"
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
@@ -5419,269 +6505,269 @@ msgstr ""
 "Farben filtern, um Deuteranopie, eine gängige Form der Farbenblindheit, zu "
 "simulieren."
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr "Farben mit simulierter Insensitivität für Grün darstellen"
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 "Farben filtern, um Protanopie, eine gängige Form der Farbenblindheit, zu "
 "simulieren."
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr "Farben mit simulierter Insensitivität für Blau darstellen"
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 "Farben filtern, um Tritanopie, eine gängige Form der Farbenblindheit, zu "
 "simulieren."
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr "Freihandzeichnen"
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr "Freihandzeichnen"
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr "Freihandzeichnen: frei ohne geometrische Einschränkungen zeichnen."
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr "Freihandzeichnen"
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr "Freihandzeichnen: frei ohne geometrische Einschränkungen zeichnen."
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr "Ansicht verschieben"
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr "Verschieben"
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 "Ansicht verschieben: die Ansicht der Leinwand horizontal oder vertikal "
 "bewegen."
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr "Ansicht verschieben"
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr "Die Ansicht der Leinwand interaktiv horizontal oder vertikal bewegen."
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr "Ansicht drehen"
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr "Drehen"
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr "Ansicht drehen: die Ansicht der Leinwand drehen."
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr "Ansicht drehen"
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr "Interaktiv die Ansicht der Leinwand drehen."
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr "Ansicht zoomen"
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr "Vergrößerung"
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr "Ansicht vergrößern: in Leinwand hinein/heraus zoomen."
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr "Ansicht zoomen"
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr "Interaktiv in die Leinwand hinein oder heraus zoomen."
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr "Linien und Kurven"
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr "Linien"
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr "Linien und Kurven: gerade oder gekrümmte Linien zeichnen."
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr "Linien und Kurven"
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr "Gerade oder gekrümmte Linien zeichnen."
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr "Verbundene Linien"
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr "Verb. Linien"
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr "Verbundene Linien: Abfolge gerader oder gekrümmter Linien zeichnen."
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr "Verbundene Linien"
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr "Abfolgen von geraden oder gekrümmten Linien zeichnen."
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr "Ellipsen und Kreise"
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr "Ellipse"
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr "Ellipsen und Kreise: abgerundete Formen zeichnen."
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr "Ellipsen und Kreise"
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr "Kreise und Ellipsen zeichnen."
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr "Tusche"
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr "Tinte"
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr "Tusche: weiche kontrollierte Linien zeichnen."
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr "Tusche"
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr "Weiche kontrollierte Linien zeichnen."
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr "Ebene neu positionieren"
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr "Ebenen Pos."
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 "Ebene neu positionieren: die aktuelle Ebene auf der Leinwand verschieben."
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr "Ebene neu positionieren"
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr "Interaktiv die aktuelle Ebene auf der Zeichenfläche verschieben."
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr "Rahmen bearbeiten"
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr "Rahmen"
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
@@ -5689,12 +6775,12 @@ msgstr ""
 "Rahmen bearbeiten: dem Dokument durch einen Rahmen eine endliche Größe "
 "zuweisen."
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr "Rahmen bearbeiten"
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
@@ -5702,81 +6788,290 @@ msgstr ""
 "Rahmen bearbeiten: dem Dokument durch einen Rahmen eine endliche Größe "
 "zuweisen. Der Rahmen wird nur beim Exportieren verwendet."
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Symmetrieachse bearbeiten"
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr "Symmetrie"
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 "Symmetrieachse bearbeiten: die Achse für symmetrisches Zeichnen anpassen."
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Symmetrieachse bearbeiten"
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr "Interaktiv die Achse für symmetrisches Zeichnen anpassen."
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr "Farbpipette"
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr "Farb. wählen"
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr "Farbpipette: Zeichenfarbe eines Bildschirmpixels wählen."
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "Farbpipette"
+
+#: ../po/tmp/resources.xml.h:401
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr "Die Zeichenfarbe von Bildschirmpixeln festlegen."
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "Farbpipette"
+
+#: ../po/tmp/resources.xml.h:403
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr "Die Zeichenfarbe von Bildschirmpixeln festlegen."
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "Farbpipette"
+
+#: ../po/tmp/resources.xml.h:405
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr "Die Zeichenfarbe von Bildschirmpixeln festlegen."
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr "Farbpipette"
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr "Die Zeichenfarbe von Bildschirmpixeln festlegen."
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr "Füllen"
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr "Füllen"
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr "Füllen: einen Bereich mit Farbe füllen."
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr "Füllen"
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr "Eine Fläche mit Farbe füllen."
+
+#~ msgctxt "Accelerator map editor: action column markup"
+#~ msgid ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+#~ msgstr ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+
+#~ msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
+#~ msgid "{action_label} {action_desc} {accel_label}"
+#~ msgstr "{action_label} {action_desc} {accel_label}"
+
+#~ msgctxt "brush list context menu"
+#~ msgid "Delete"
+#~ msgstr "Löschen"
+
+#~ msgctxt "brush list commands"
+#~ msgid "Really delete brush from disk?"
+#~ msgstr "Pinsel wirklich löschen?"
+
+#~ msgid "HSV Triangle"
+#~ msgstr "HSV-Farbdreieck"
+
+#~ msgid "The standard GTK color selector"
+#~ msgstr "GTK-Farbwähler"
+
+#~ msgid "Pick a color from the screen"
+#~ msgstr "Farbe vom Bildschirm wählen"
+
+#~ msgid "Layer Name"
+#~ msgstr "Ebenenname"
+
+#~ msgid ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+#~ msgstr ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+
+#~ msgid "Save..."
+#~ msgstr "Speichern …"
+
+#~ msgid "Confirm"
+#~ msgstr "Bestätigen"
+
+#~ msgid "Open..."
+#~ msgstr "Öffnen …"
+
+#~ msgid "{default_name} at {path}"
+#~ msgstr "{default_name} unter {path}"
+
+#~ msgid "Type"
+#~ msgstr "Typ"
+
+#~ msgid "Mode:"
+#~ msgstr "Modus:"
+
+#~ msgid ""
+#~ "Blending mode: how the current layer combines with the layers underneath "
+#~ "it."
+#~ msgstr ""
+#~ "Blendmodus: wie die aktuelle Ebene mit den Ebenen darunter kombiniert "
+#~ "wird."
+
+#~ msgid ""
+#~ "Layer opacity: how much of the current layer to use. Smaller values make "
+#~ "it more transparent."
+#~ msgstr ""
+#~ "Ebenendeckkraft: kleinere Werte machen die aktuelle Ebene transparenter."
+
+#~ msgid "%s: edit properties"
+#~ msgstr "%s: Eigenschaften bearbeiten"
+
+#~ msgctxt "layer unique names: match regex (leave untranslated if unsure)"
+#~ msgid "^(.*?)\\s*(\\d+)$"
+#~ msgstr "^(.*?)\\s*(\\d+)$"
+
+#~ msgctxt "layer default names"
+#~ msgid "Unknown Bitmap Layer"
+#~ msgstr "Unbekannte Bitmapebene"
+
+#~ msgctxt "Autosave Recovery dialog|"
+#~ msgid "_Ignore for Now"
+#~ msgstr "_Im Moment ignorieren"
+
+#~ msgid "Setting name:"
+#~ msgstr "Name der Einstellung:"
+
+#~ msgid "Base value:"
+#~ msgstr "Ausgangswert:"
+
+#~ msgid "Reset the base value to its default"
+#~ msgstr "Den Ausgangswert auf seinen Standardwert zurücksetzen"
+
+#~ msgid "<ymin>"
+#~ msgstr "<ymin>"
+
+#~ msgid "<ymax>"
+#~ msgstr "<ymax>"
+
+#~ msgid "<xmin>"
+#~ msgstr "<xmin>"
+
+#~ msgid "<xmax>"
+#~ msgstr "<xmax>"
+
+#~ msgid "Edit Setting"
+#~ msgstr "Einstellungen bearbeiten"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Trim Layer to Frame"
+#~ msgstr "Ebene am Rahmen abschneiden"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Rename Layer…"
+#~ msgstr "Ebene umbenennen …"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Enter a new name for the current layer."
+#~ msgstr "Einen neuen Namen für die aktuelle Ebene eingeben."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Turn off mirroring of the view."
+#~ msgstr "Spiegelung der Ansicht abschalten."
+
+#~ msgctxt "Menu→Edit (labels)"
+#~ msgid "Current Tool"
+#~ msgstr "Aktuelles Malwerkzeug"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+#~ msgstr "Ebenenleiste ein-/ausschalten (Ebenen anordnen oder Modi zuweisen)."
+
+#~ msgctxt "Menu→Color (labels), Accel Editor (labels)"
+#~ msgid "HSV Triangle"
+#~ msgstr "HSV-Dreieck"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Dockable color selector: the old GTK color triangle."
+#~ msgstr "Andockbarer Farbwähler: das alte GTK-Farbdreieck."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid ""
+#~ "Dockable color selector: HSV square which can be rotated to show "
+#~ "different hues."
+#~ msgstr ""
+#~ "Andockbarer Farbwähler: HSV-Quadrat, das gedreht werden kann, um "
+#~ "verschiedene Farbtöne anzuzeigen."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+#~ msgstr ""
+#~ "Notizblockleiste ein-/ausschalten (Farben mischen und Skizzen zeichnen)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+#~ msgstr ""
+#~ "Vorschaupanel ein-/ausschalten (Übersicht des kompletten Zeichenbereichs)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+#~ msgstr ""
+#~ "Werkzeugeinstellungspanel ein-/ausschalten (Einstellungen des aktuellen "
+#~ "Werkzeugs)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the History panel (recently used brushes and colors)."
+#~ msgstr ""
+#~ "Historienleiste ein-/ausschalten (kürzlich verwendete Pinsel und Farben)."
 
 #~ msgid ""
 #~ "\"%s\" has an alpha channel. Background images with transparency are not "
@@ -5899,9 +7194,6 @@ msgstr "Eine Fläche mit Farbe füllen."
 #~ "Hinweise zu den Pinselparametern (Deckkraft, Härte, etc.) stehen in "
 #~ "Tooltips, die angezeigt erden wenn die Maus über der Beschriftung steht.\n"
 
-#~ msgid "Open Recent files"
-#~ msgstr "Zuletzt verwendete Dateien öffnen"
-
 #~ msgid "This will discard %d second of unsaved painting."
 #~ msgid_plural "This will discard %d seconds of unsaved painting."
 #~ msgstr[0] "Dies wird %d Sekunde nicht gespeicherter Arbeit verwerfen."
@@ -5909,9 +7201,6 @@ msgstr "Eine Fläche mit Farbe füllen."
 
 #~ msgid "Crop to Current Layer"
 #~ msgstr "Auf aktuelle Ebene zuschneiden"
-
-#~ msgid "Crop frame to the currently active layer"
-#~ msgstr "Den Rahmen auf die aktive Ebene zuschneiden"
 
 #~ msgid ""
 #~ "While the frame is enabled, it \n"
@@ -6016,9 +7305,6 @@ msgstr "Eine Fläche mit Farbe füllen."
 #~ msgid "Brush Blend Mode"
 #~ msgstr "Pinsel Überblendungs Modus"
 
-#~ msgid "Add Layer"
-#~ msgstr "Ebene hinzufügen"
-
 #~ msgid "Move Layer on Canvas"
 #~ msgstr "Ebene auf Leinwand bewegen"
 
@@ -6056,9 +7342,6 @@ msgstr "Eine Fläche mit Farbe füllen."
 #~ msgctxt "Menu|File|"
 #~ msgid "Save"
 #~ msgstr "Speichern"
-
-#~ msgid "Export to a file"
-#~ msgstr "Als Datei exportieren"
 
 #~ msgctxt "Menu|Brush|"
 #~ msgid "Bigger"

--- a/po/de.po
+++ b/po/de.po
@@ -531,17 +531,17 @@ msgstr "MyPaint Pinselpaket (*.zip)"
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr "Neue Gruppe …"
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr "Pinselsatz importieren …"
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr "Weitere Pinsel herunterladen …"
 
 #: ../gui/brushselectionwindow.py:554
@@ -1233,12 +1233,12 @@ msgstr "Typ"
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr "Verwenden für …"
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr "Scrollen …"
 
 #. Name and preview column: will be indented
@@ -1462,7 +1462,7 @@ msgid "_Quit"
 msgstr "Beenden"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr "Pinselsatz importieren …"
 
 #: ../gui/drawwindow.py:698
@@ -1520,7 +1520,7 @@ msgstr ""
 "„{type_name}“ ({content_type}) zu bearbeiten?"
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr "Öffnen mit …"
 
 #: ../gui/externalapp.py:123
@@ -1714,13 +1714,13 @@ msgstr "JPEG 90 % Qualität (*.jpg; *.jpeg)"
 
 #: ../gui/filehandling.py:576
 #, fuzzy
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr "Exportieren …"
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Speichern unter …"
 
@@ -1791,7 +1791,7 @@ msgstr "Zuletzt verwendete Dateien öffnen"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr "Notizblock öffnen …"
 
 #: ../gui/filehandling.py:1099
@@ -2249,12 +2249,12 @@ msgstr ""
 "falls ihn noch niemand gemeldet hat."
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr "Tracker suchen …"
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr "Melden …"
 
 #: ../gui/gtkexcepthook.py:180
@@ -2266,7 +2266,7 @@ msgid "Quit MyPaint"
 msgstr "MyPaint beenden"
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr "Einzelheiten …"
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2477,7 +2477,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr "Ebene im Stapel bewegen …"
 
 #: ../gui/layerswindow.py:110
@@ -2552,7 +2552,7 @@ msgid "Stroke trail-off beginning"
 msgstr "Strich Trail-Off Anfang"
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr "Druckveränderung …"
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/dz.po
+++ b/po/dz.po
@@ -512,17 +512,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1183,12 +1183,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1404,7 +1404,7 @@ msgid "_Quit"
 msgstr "སྤངས།"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1454,7 +1454,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1630,13 +1630,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "སྲུངས།"
 
@@ -1702,7 +1702,7 @@ msgstr "ཡིག་སྣོད།"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -2122,12 +2122,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2139,7 +2139,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2324,7 +2324,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2394,7 +2394,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/dz.po
+++ b/po/dz.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:18+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Dzongkha <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -19,27 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -47,39 +27,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -87,214 +67,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "དཔེ་གཞི།"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "ཚོས་གཞི།"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "སྲོལ་སྒྲིག"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -333,141 +323,176 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "སྲུངས།"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "གསརཔ།"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -475,58 +500,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -535,51 +560,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -589,137 +638,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -727,162 +776,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -890,373 +931,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "མིང༌། "
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "འབད་བཤོལ།"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "ལོག་འབད།"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1266,324 +1304,672 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "གསལ་གཞི་གངམ་"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "སྤངས།"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "སྤངས།"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
+msgstr ""
+
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
+msgstr ""
+
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "སྲུངས།"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
 #, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr ""
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "ཡིག་སྣོད།"
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1427
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1432
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr ""
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1591,130 +1977,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1723,35 +2121,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1775,45 +2173,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1821,153 +2223,217 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr ""
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr ""
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr ""
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1979,256 +2445,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2236,188 +2727,212 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+msgid "Import Layers"
+msgstr ""
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2426,13 +2941,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2442,7 +2957,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2450,13 +2965,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2464,7 +2979,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2472,7 +2987,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2483,7 +2998,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2491,7 +3006,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2501,7 +3021,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2512,285 +3032,394 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr ""
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2800,7 +3429,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2809,52 +3458,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2876,17 +3556,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2915,112 +3593,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3033,7 +3686,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3074,6 +3727,133 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "མིང༌། "
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3443,56 +4223,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3500,12 +4300,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3514,7 +4314,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3525,28 +4325,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3608,1828 +4408,2018 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "ནང་ན་ཟུམ།"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "ཡིག་སྣོད།"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/el.po
+++ b/po/el.po
@@ -528,17 +528,17 @@ msgstr "Πακέτο πινέλων MyPaint (*.zip)"
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
-msgstr "Νέα Ομάδα..."
+msgid "New Group…"
+msgstr "Νέα Ομάδα…"
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
-msgstr "Εισαγωγή Πινέλων..."
+msgid "Import Brushes…"
+msgstr "Εισαγωγή Πινέλων…"
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1200,12 +1200,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1388,7 +1388,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Open dragged file confirm dialog: continue button"
 msgid "_Open"
-msgstr "Άνοιγμα..."
+msgstr "Άνοιγμα…"
 
 #: ../gui/drawwindow.py:486
 msgid "Set current color"
@@ -1423,7 +1423,7 @@ msgid "_Quit"
 msgstr "Εγκατάλειψη"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1473,7 +1473,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1659,13 +1659,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr "JPEG (*.jpg; *.jpeg)"
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Αποθήκευση"
 
@@ -1732,7 +1732,7 @@ msgstr "Αρχείο"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -1750,7 +1750,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Άνοιγμα..."
+msgstr "Άνοιγμα…"
 
 #: ../gui/filehandling.py:1427
 #, fuzzy
@@ -1762,7 +1762,7 @@ msgstr "Άνοιγμα πρόσφατου"
 #, fuzzy
 msgctxt "File→Open Most Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Άνοιγμα..."
+msgstr "Άνοιγμα…"
 
 #: ../gui/filehandling.py:1446
 msgctxt "File→Open Next/Prev Scrap: error message"
@@ -1783,7 +1783,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
 msgid "_Open"
-msgstr "Άνοιγμα..."
+msgstr "Άνοιγμα…"
 
 #: ../gui/filehandling.py:1487
 msgctxt "File→Revert: status message: canvas has no filename yet"
@@ -2158,13 +2158,13 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
-msgstr "Αναφορά..."
+msgid "Report…"
+msgstr "Αναφορά…"
 
 #: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
@@ -2175,8 +2175,8 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
-msgstr "Λεπτομέρειες..."
+msgid "Details…"
+msgstr "Λεπτομέρειες…"
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
@@ -2362,7 +2362,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2433,7 +2433,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-23 08:01+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/mypaint/mypaint/el/"
@@ -19,27 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -47,39 +27,39 @@ msgstr ""
 msgid "Key combination"
 msgstr "Συνδιασμός Πλήκτρων"
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr "Επεξεργασία πλήκτρου για '%s'"
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "Τοποθεσία:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "Πλήκτρο:"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "Άγνωστη Εντολή"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr "Άνοιξε τον Φάκελο \"{folder_basename}\"…"
@@ -87,205 +67,215 @@ msgstr "Άνοιξε τον Φάκελο \"{folder_basename}\"…"
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "Εντάξει"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr "Δεν βρέθηκαν αντίγραφα στην μνήμη."
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr "Αντίγραφα μη διαθέσιμα"
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr "Άνοιξε τον Φάκελο Προσωρινής Μνήμης…"
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr "Η Επαναφορά Αντιγράφου Ασφαλείας Απέτυχε"
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr "Άνοιξε τον Φάκελο του Αντίγραφου Ασφαλείας…"
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr "Ανακτημένο αρχείο από {iso_datetime}.ora"
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "Σώσε ως προεπιλογή"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "Φόντο"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "Μοτίβο"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Χρώμα"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "Πρόσθεσε το χρώμα στα Μοτίβα"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr "Ένα ή περισσότερα φόντα δεν μπόρεσαν να φορτωθούν"
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr "Σφάλμα στο φόρτωμα των φόντων"
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 "Παρακαλώ αφαιρέστε τα μη φορτώσιμα αρχεία, ή ελέγξτε την εγκατάσταση του "
 "libgdkpixbuf."
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 "Το Gdk-Pixbuf δεν μπόρεσε να φορτώσει \"{filename}\", και ανέφερε \"{error}\""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr "{filename} έχει μηδενικό μέγεθος (w={w}, h={h})"
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr "Επεξεργαστής Ρυθμίσεων Πινέλου"
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr "Σχετικά"
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "Πειραματικό"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr "Βασικό"
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr "Αδιαφάνεια"
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "Μουτζούρα"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr "Ταχύτητα"
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr ""
+
+#: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr "Ανίχνευση"
 
-#: ../gui/brusheditor.py:359
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "Πινελιά"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr "Χρώμα"
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Εξατομικευμένα"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 "Κανένα πινέλο διαλεγμένο, αντί αυτού παρακαλώ χρησιμοποιήστε \"Προσθήκη ως "
 "Νέο\"."
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr "Κανένα πινέλο διαλεγμένο!"
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "Μετονομασία Πινέλου"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "Υπάρχει ήδη ένα πινέλο με αυτό το όνομα!"
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr "Κανένα πινέλο διαλεγμένο!"
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr "Σίγουρα να διαγραφεί το πινέλο “{brush_name}” από τον δίσκο;"
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr "(Πινέλο Χωρίς Ονομασία)"
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr "Εικονίδιο Πινέλου"
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr "Εικονίδιο Πινέλου (επεξεργασία)"
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr "Κανένα πινέλο διαλεγμένο"
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
@@ -294,14 +284,14 @@ msgstr ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Οι αλλαγές δεν έχουν ακόμα σωθεί</small>"
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -342,142 +332,181 @@ msgstr "Αυτόματο"
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Αποθήκευση"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr "Αγαπημένα"
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr "Μελάνι"
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr "Κλασσικό"
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr "Σετ#1"
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr "Σετ#2"
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr "Σετ#3"
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr "Σετ#4"
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr "Σετ#5"
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr "Πειραματικό"
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Νέο"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr "Άγνωστο Πινέλο"
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr "Προσθήκη στα Αγαπημένα"
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr "Αφαίρεση από τα Αγαπημένα"
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr "Επεξεργασία Ρυθμίσεων Πινέλου"
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
-msgstr "Διαγραφή"
+#: ../gui/brushselectionwindow.py:250
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
+msgstr "Μετονομασία Ομάδας"
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
 msgstr ""
 
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, fuzzy, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
+msgstr "Σίγουρα να διαγραφεί το πινέλο “{brush_name}” από τον δίσκο;"
+
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] "%d πινέλο"
 msgstr[1] "%d πινέλα"
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr "Ομάδα “{group_name}”"
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr "Μετονομασία Ομάδας"
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr "Εξαγωγή ως Συμπιεσμένο Σετ Πινέλων"
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr "Διαγραφή Ομάδας"
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr "Μετονομασία Ομάδας"
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "Υπάρχει ήδη μία ομάδα με αυτό το όνομα!"
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr "Σίγουρα να διαγραφεί η ομάδα “{group_name}”;"
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -487,58 +516,58 @@ msgstr ""
 "Δεν μπόρεσε να διαγραφεί η ομάδα “{group_name}”.\n"
 "Μερικές ειδικές ομάδες δεν γίνεται να διαγραφούν."
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr "Εξαγωγή Πινέλων"
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr "Πακέτο πινέλων MyPaint (*.zip)"
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "Νέα Ομάδα..."
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr "Εισαγωγή Πινέλων..."
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "Δημιουργία Ομάδας"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr "Πλήκτρο"
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr "Πληκ"
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -547,51 +576,76 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr "Επιλογή χρώματος"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "Επιλογή χρώματος"
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr "Λεπτομέρειες χρώματος"
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -601,137 +655,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr "Βοήθεια…"
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr "Φόρτωση μάσκας από ένα αρχείο παλέτας GIMP."
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr "Αποθήκευση μάσκας σε ένα αρχείο παλέτας GIMP."
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr "Διαγραφή μάσκας."
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr "Αποθήκευση Μάσκας ως μία GIMP Palette"
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr "Φόρτωση Μάσκας από μία GIMP Palette"
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -739,162 +793,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr "Ιδιότητες παλέτας"
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr "Παλέτα"
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr "Επεξεργαστής Παλέτας"
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr "Όνομα ή περιγραφή για αυτήν την παλέτα"
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr "Στήλες:"
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr "Αριθμός στηλών"
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr "Όνομα χρώματος:"
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr "Φόρτωση παλέτας"
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr "Αποθήκευση παλέτας"
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -902,373 +948,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr "Εισαγωγή Σειράς"
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr "Εισαγωγή Στήλης"
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "Αρχείο παλέτας GIMP (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr "Όλα τα αρχεία (*)"
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "Αρχείο παλέτας GIMP (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr "Όλα τα αρχεία (*)"
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr "Διάλεξε ένα χρώμα από την οθόνη"
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr "R"
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr "G"
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr "B"
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr "RGB Κόκκινο"
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr "RGB Πράσινο"
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr "RGB Μπλέ"
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr "σβήστρα"
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Όνομα"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Αναίρεση"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Επαναφορά"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1278,324 +1321,691 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Άνοιγμα..."
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Πλήρης οθόνη"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Εγκατάλειψη"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+#, fuzzy
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr "Να γίνει πραγματικά έξοδος;"
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Εγκατάλειψη"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr "Όλες οι αναγνωρίσιμες μορφές"
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr "OpenRaster (*.ora)"
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr "PNG (*.png)"
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr "JPEG (*.jpg; *.jpeg)"
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr "Διαφανές PNG (*.png)"
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "Αποθήκευση παλέτας"
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
+msgstr "Όλες οι αναγνωρίσιμες μορφές"
+
+#: ../gui/filehandling.py:432
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:437
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:442
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
+msgstr "JPEG (*.jpg; *.jpeg)"
+
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:494
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:502
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:506
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr "Διαφανές PNG (*.png)"
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:518
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr "JPEG (*.jpg; *.jpeg)"
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Άνοιγμα..."
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Αποθήκευση"
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+#, fuzzy
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr "Να γίνει πραγματικά έξοδος;"
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr ""
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr ""
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Αρχείο"
+
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Στρώματα"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Άνοιγμα..."
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Άνοιγμα πρόσφατου"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Άνοιγμα..."
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Άνοιγμα..."
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+#, fuzzy
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
-msgstr ""
+msgstr "Γέμισμα μιας περιοχής με χρώμα."
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Αδιαφάνεια:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1603,130 +2013,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr "Εντοπίσθηκε σφάλμα"
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr "<big><b>Εντοπίσθηκε ένα σφάλμα προγραμματισμού.</b></big>"
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1735,35 +2157,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr "Αναφορά..."
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr "Λεπτομέρειες..."
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1787,45 +2209,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1833,153 +2259,220 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+#, fuzzy
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr "Ιδιότητες παλέτας"
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Στρώματα"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Στρώματα"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Αδιαφάνεια:"
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "Μετονομασία Πινέλου"
 
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr ""
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr ""
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr ""
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr ""
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 msgid "Stroke lead-in end"
 msgstr ""
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr ""
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1991,256 +2484,282 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr "φορητότητα"
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr "εικονίδιο επιφάνειας εργασίας"
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
+msgstr "Συμμετρία"
+
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2248,188 +2767,214 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "Μετονομασία Ομάδας"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Στρώματα"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2438,13 +2983,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2454,7 +2999,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2462,13 +3007,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2476,7 +3021,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2484,7 +3029,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2495,7 +3040,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2503,7 +3048,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2513,7 +3063,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2524,285 +3074,396 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr "Άγνωστη Εντολή"
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "Μετονομασία Ομάδας"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2812,7 +3473,28 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+#, fuzzy
+msgid "Rotational"
+msgstr "Περιστροφή"
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2821,52 +3503,84 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr "Διαγραφή"
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2888,17 +3602,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2927,112 +3639,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr "<ymin>"
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr "<ymax>"
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr "<xmin>"
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr "<xmax>"
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3045,7 +3732,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3086,6 +3773,135 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+#, fuzzy
+msgid "Insert Point"
+msgstr "Εισαγωγή Σειράς"
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Όνομα"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Αδιαφάνεια"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3455,56 +4271,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3512,12 +4348,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3526,7 +4362,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3537,28 +4373,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3620,1828 +4456,2039 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
+#, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
-msgstr ""
+msgid "Layer Properties…"
+msgstr "Ιδιότητες παλέτας"
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Σμίκρυνση"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+#, fuzzy
+msgid "Delete Point"
+msgstr "Διαγραφή Ομάδας"
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Αρχείο"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Βοήθεια"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "Σχετικά με το MyPaint"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Αποσφαλμάτωση"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
-msgstr ""
+msgstr "Στρώματα"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr "Πρόσφατα Πινέλα & Χρώματα"
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr "Περιστροφή"
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr "Γραμμές και Καμπύλες"
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr "Γραμμές"
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr "Γραμμές και Καμπύλες"
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr "Ελλείψεις και Κύκλοι"
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr "Έλλειψη"
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr "Μελάνι"
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr "Επεξεργασία Πλαισίου"
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr "Πλαίσιο"
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr "Επεξεργασία Πλαισίου"
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr "Συμμετρία"
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr "Διάλεξε Χρώμα"
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "Επιλογή χρώματος"
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "Επιλογή χρώματος"
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "Επιλογή χρώματος"
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr "Διάλεξε Χρώμα"
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr "Γέμισμα μιας περιοχής με χρώμα."
+
+#~ msgid "Pick a color from the screen"
+#~ msgstr "Διάλεξε ένα χρώμα από την οθόνη"
+
+#~ msgid "<ymin>"
+#~ msgstr "<ymin>"
+
+#~ msgid "<ymax>"
+#~ msgstr "<ymax>"
+
+#~ msgid "<xmin>"
+#~ msgstr "<xmin>"
+
+#~ msgid "<xmax>"
+#~ msgstr "<xmax>"

--- a/po/en_CA.po
+++ b/po/en_CA.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.7.1-git\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2018-07-11 08:36+0000\n"
 "Last-Translator: sample text <sampletext32@bk.ru>\n"
 "Language-Team: English (Canada) <https://hosted.weblate.org/projects/mypaint/"
@@ -21,27 +21,7 @@ msgstr ""
 "X-Language: en_CA\n"
 "X-Source-Language: C\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -49,39 +29,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -89,207 +69,217 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Colour"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "Add colour to Patterns"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr "Colour"
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr ""
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
@@ -298,7 +288,7 @@ msgstr ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or colour</small>"
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -337,142 +327,180 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr "Favourites"
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr ""
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr "Add to favourites"
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr "Remove from favourites"
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
+msgstr "Remove from favourites"
+
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -480,58 +508,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -540,51 +568,79 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr "Pick Colour"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr "Set the colour used for painting"
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+#, fuzzy
+msgid "Set the color Hue used for painting"
+msgstr "Set the colour used for painting"
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "Pick Colour"
+
+#: ../gui/colorpicker.py:296
+#, fuzzy
+msgid "Set the color Chroma used for painting"
+msgstr "Set the colour used for painting"
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+#, fuzzy
+msgid "Set the color Luma used for painting"
+msgstr "Set the colour used for painting"
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr "Colour details"
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr "Current brush colour, and the colour most recently used for painting"
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -594,41 +650,41 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr "Weighted more strongly towards the dominant colour."
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
@@ -637,12 +693,12 @@ msgstr ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the colour wheel."
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
@@ -651,12 +707,12 @@ msgstr ""
 "One main range of colours, with a complementary accent for variation and "
 "highlights."
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
@@ -665,72 +721,72 @@ msgstr ""
 "Two analogous colours and a complement to them, with no secondary colours "
 "between them."
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -740,162 +796,154 @@ msgstr ""
 "are equiluminant."
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr "The standard GTK colour selector"
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr "Saturation and Value colour changer."
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr "Set the colour from a loadable, editable palette."
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr "Colour name:"
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr "Current colour's name"
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -906,373 +954,370 @@ msgstr ""
 "Drop colours here,\n"
 "drag them to organize."
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr "Empty palette slot (drag a colour here)"
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr "Pick a colour from the screen"
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr "Adjust individual components of the colour."
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr "Change colour using a liquid-like wash of nearby colours."
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr "Change colour using concentric HSV rings."
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr "Change colour with HSV ramps crossing a radial bowl of colour."
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr ""
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr ""
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr ""
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1282,267 +1327,491 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr "Set current colour"
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr ""
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr ""
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr ""
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
+msgstr ""
+
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
+msgstr ""
+
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr ""
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
 #, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr ""
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "File"
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1427
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1432
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+#, fuzzy
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr "Fill areas with colour"
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+#, fuzzy
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
@@ -1550,58 +1819,183 @@ msgstr ""
 "How much pixel colours are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr ""
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1609,130 +2003,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr "Colour:"
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr "Frame Colour"
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1741,35 +2147,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1793,45 +2199,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1839,153 +2249,217 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr ""
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr ""
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr ""
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1997,256 +2471,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr "Elliott Sales de Andrade"
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr "Pick brushstroke settings, stroke colour, and layer…"
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr "Pick colour…"
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr "Mix colours and make sketches on separate scrap pages"
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2254,188 +2753,212 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+msgid "Import Layers"
+msgstr ""
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2444,13 +2967,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2460,7 +2983,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2468,13 +2991,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2482,7 +3005,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2490,7 +3013,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2501,7 +3024,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2509,7 +3032,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2519,7 +3047,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2530,208 +3058,307 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr ""
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+#, fuzzy
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr "Reset and Centre View"
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr "The top layer only, without blending colours."
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr "Subtracts the darker colour from the lighter of the two."
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
@@ -2739,78 +3366,89 @@ msgstr ""
 "Applies the saturation of the top layer's colours to the hue and luminosity "
 "of the backdrop."
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2820,7 +3458,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2829,52 +3487,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2896,17 +3585,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2935,112 +3622,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr "<ymin>"
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr "<ymax>"
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr "<xmin>"
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr "<xmax>"
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3053,7 +3715,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3094,6 +3756,132 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr ""
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3476,13 +4264,33 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
@@ -3491,36 +4299,36 @@ msgstr ""
 "The set of colours to show as primary on disk-style colour wheels.\n"
 "Different traditions have different colour harmonies."
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
@@ -3530,7 +4338,7 @@ msgstr ""
 "since the 18th century, approximated with pure display colours evenly "
 "arranged around the circle. Green is opposite red."
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3541,12 +4349,12 @@ msgstr ""
 "since the 18th century, approximated with pure display colours evenly "
 "arranged around the circle. Green is opposite red."
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3560,7 +4368,7 @@ msgstr ""
 "and yellow is opposite blue. CIECAM02 and NCS present a similar model. Here "
 "we use pure display red, yellow etc. as the four primaries."
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3576,28 +4384,28 @@ msgstr ""
 "red, yellow etc. as the four primaries."
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr "<b>Colour Wheel</b>"
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr "Colour"
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3659,244 +4467,296 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr "Colour Adjusters"
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr "Colours"
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr "Available colour adjusters."
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
-msgstr "Lighten Painting Colour"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
+msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
-msgstr "Increase the lightness of the current painting colour."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
+msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
-msgstr "Darken Painting Colour"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
+msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
-msgstr "Decrease the lightness of the current painting colour."
+msgid "Make the working brush bigger."
+msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
-msgstr "Rotate the painting colour’s hue anticlockwise on the colour wheel."
+msgid "Make the working brush smaller."
+msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
-msgstr "Rotate the painting colour’s hue clockwise on the colour wheel."
+msgid "Make the working brush more opaque."
+msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
-msgstr "Make the painting colour more saturated (more colourful, purer)."
+msgid "Make the working brush less opaque."
+msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
-msgstr ""
+msgid "Lighten Painting Color"
+msgstr "Lighten Painting Colour"
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
-msgstr "Make the painting colour less saturated (greyer)."
+msgid "Increase the lightness of the current painting color."
+msgstr "Increase the lightness of the current painting colour."
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
-msgstr ""
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
+msgstr "Darken Painting Colour"
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
-msgstr ""
+msgid "Decrease the lightness of the current painting color."
+msgstr "Decrease the lightness of the current painting colour."
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
-msgstr "Pick a brushstroke from the canvas: restores brush, colour, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgstr "Rotate the painting colour’s hue clockwise on the colour wheel."
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr "Rotate the painting colour’s hue anticlockwise on the colour wheel."
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr "Make the painting colour more saturated (more colourful, purer)."
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr "Make the painting colour less saturated (greyer)."
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr "Pick a brushstroke from the canvas: restores brush, colour, and layer."
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr "Brush Shortcut Keys Restore Colour"
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
@@ -3905,525 +4765,649 @@ msgstr ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved colour."
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
+"Applies the saturation of the top layer's colours to the hue and luminosity "
+"of the backdrop."
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr "Reset and Centre View"
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr "Reset Zoom, Rotation and Mirroring, and recentre the document."
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr "Apply colour normally when painting."
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr "Paint Mode: Colourize"
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
@@ -4431,255 +5415,250 @@ msgstr ""
 "Apply colour to the current layer without affecting its brightness or "
 "opacity."
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "File"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "Edit"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "Colour"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr "Adjust Colour"
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr "Colour History Popup"
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr "Pop up a timeline of recent colours under the cursor."
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr "Colour Details Dialog"
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr "Show a colour details dialog with text entry."
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr "Next Palette Colour"
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr "Set painting colour to the next colour in the palette."
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr "Previous Palette Colour"
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr "Set painting colour to the previous colour in the palette."
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr "Add Colour to Palette"
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr "Append the current painting colour to the palette."
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "Change Colour…"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 "Pop up a colour changer under the cursor, with all colour selectors listed."
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "Change Colour (fast subset)…"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
@@ -4688,207 +5667,209 @@ msgstr ""
 "Pop up a colour changer under the cursor, with only single-click selectors "
 "listed."
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
@@ -4897,42 +5878,32 @@ msgstr ""
 "Dockable cylindrical hue/chroma/luma colour selector. The circular slices "
 "are equiluminant."
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "Colour Palette"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr "Dockable palette colour selector."
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr "Dockable saturation and Value colour changer."
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr "Dockable colour selector: the old GTK colour triangle."
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
@@ -4941,563 +5912,637 @@ msgstr ""
 "Dockable colour selector: HSV cube which can be rotated to show different "
 "planar slices."
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
-msgstr ""
-"Dockable colour selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
+msgstr "Dockable colour selector with concentric HSV rings."
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr "Dockable colour selector showing individual components of the colour."
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr "Dockable colour selector showing a liquid-like wash of nearby colours."
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr "Dockable colour selector with concentric HSV rings."
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 "Dockable colour selector with HSV ramps crossing a radial bowl of colour."
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
-msgstr "Toggle the Scratchpad dockpanel (mix colours and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr "Reveal the Scratchpad dockpanel (mix colours and make sketches)."
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr "Brush & Colour History Panel"
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
-msgstr "Toggle the History panel (recently used brushes and colours)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr "Recent Brushes & Colours"
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr "Reveal the History panel (recently used brushes and colours)."
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr "Display Colours Normally"
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr "Filter colours: show colours unchanged."
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr "Display Colours as Greyscale"
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr "Filter colours: show brightness only (HCY/YCbCr Luma)"
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr "Display Colours Inverted"
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr "Filter colours: inverse video. Black is white and red is cyan."
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr "Display Colours with Simulated Insensitivity to Red"
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 "Filter colours to simulate deuteranopia, a common form of colour blindness."
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr "Display Colours with Simulated Insensitivity to Green"
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 "Filter colours to simulate protanopia, a common form of colour blindness."
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr "Display Colours with Simulated Insensitivity to Blue"
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 "Filter colours to simulate tritanopia, a rare form of colour blindness."
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr "Pick Colour"
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr "Pick Colour: set the painting colour from screen pixels."
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "Pick Colour"
+
+#: ../po/tmp/resources.xml.h:401
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr "Set the painting colour from screen pixels."
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "Pick Colour"
+
+#: ../po/tmp/resources.xml.h:403
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr "Set the painting colour from screen pixels."
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "Pick Colour"
+
+#: ../po/tmp/resources.xml.h:405
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr "Set the painting colour from screen pixels."
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr "Pick Colour"
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr "Set the painting colour from screen pixels."
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr "Flood Fill: fill an area with colour."
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr "Fill an area with colour."
+
+#~ msgid "The standard GTK color selector"
+#~ msgstr "The standard GTK colour selector"
+
+#~ msgid "Pick a color from the screen"
+#~ msgstr "Pick a colour from the screen"
+
+#~ msgid "<ymin>"
+#~ msgstr "<ymin>"
+
+#~ msgid "<ymax>"
+#~ msgstr "<ymax>"
+
+#~ msgid "<xmin>"
+#~ msgstr "<xmin>"
+
+#~ msgid "<xmax>"
+#~ msgstr "<xmax>"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Dockable color selector: the old GTK color triangle."
+#~ msgstr "Dockable colour selector: the old GTK colour triangle."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid ""
+#~ "Dockable color selector: HSV square which can be rotated to show "
+#~ "different hues."
+#~ msgstr ""
+#~ "Dockable colour selector: HSV square which can be rotated to show "
+#~ "different hues."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+#~ msgstr "Toggle the Scratchpad dockpanel (mix colours and make sketches)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the History panel (recently used brushes and colors)."
+#~ msgstr "Toggle the History panel (recently used brushes and colours)."

--- a/po/en_CA.po
+++ b/po/en_CA.po
@@ -520,17 +520,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1206,12 +1206,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1426,7 +1426,7 @@ msgid "_Quit"
 msgstr ""
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1476,7 +1476,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1653,12 +1653,12 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr ""
 
@@ -1724,7 +1724,7 @@ msgstr "File"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -2148,12 +2148,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2165,7 +2165,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2350,7 +2350,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2420,7 +2420,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -533,18 +533,18 @@ msgstr "MyPaint brush package (*.zip)"
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
-msgstr "New Group..."
+msgid "New Group…"
+msgstr "New Group…"
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
-msgstr "Import Brushes..."
+msgid "Import Brushes…"
+msgstr "Import Brushes…"
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
-msgstr "Get More Brushes..."
+msgid "Get More Brushes…"
+msgstr "Get More Brushes…"
 
 #: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
@@ -1227,13 +1227,13 @@ msgstr "Type"
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
-msgstr "Use for..."
+msgid "Use for…"
+msgstr "Use for…"
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
-msgstr "Scroll..."
+msgid "Scroll…"
+msgstr "Scroll…"
 
 #. Name and preview column: will be indented
 #: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
@@ -1456,8 +1456,8 @@ msgid "_Quit"
 msgstr "Quit"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
-msgstr "Import Brush Package..."
+msgid "Import brush package…"
+msgstr "Import Brush Package…"
 
 #: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
@@ -1511,8 +1511,8 @@ msgstr ""
 "“{type_name}” ({content_type})?"
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
-msgstr "Open With..."
+msgid "Open With…"
+msgstr "Open With…"
 
 #: ../gui/externalapp.py:123
 msgid "Icon"
@@ -1702,13 +1702,13 @@ msgstr "JPEG 90% quality (*.jpg; *.jpeg)"
 
 #: ../gui/filehandling.py:576
 #, fuzzy
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr "Export…"
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Save As…"
 
@@ -1779,8 +1779,8 @@ msgstr "Open"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
-msgstr "Open Scratchpad..."
+msgid "Open Scratchpad…"
+msgstr "Open Scratchpad…"
 
 #: ../gui/filehandling.py:1099
 #, fuzzy
@@ -2236,13 +2236,13 @@ msgstr ""
 "has reported it yet."
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
-msgstr "Search Tracker..."
+msgid "Search Tracker…"
+msgstr "Search Tracker…"
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
-msgstr "Report..."
+msgid "Report…"
+msgstr "Report…"
 
 #: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
@@ -2253,8 +2253,8 @@ msgid "Quit MyPaint"
 msgstr "Quit MyPaint"
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
-msgstr "Details..."
+msgid "Details…"
+msgstr "Details…"
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
@@ -2463,8 +2463,8 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
-msgstr "Move layer in stack..."
+msgid "Move layer in stack…"
+msgstr "Move layer in stack…"
 
 #: ../gui/layerswindow.py:110
 msgid ""
@@ -2535,8 +2535,8 @@ msgid "Stroke trail-off beginning"
 msgstr "Stroke trail-off beginning"
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
-msgstr "Pressure variation..."
+msgid "Pressure variation…"
+msgstr "Pressure variation…"
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
@@ -3728,7 +3728,7 @@ msgstr "Delete this brush from the disk"
 #, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid "_Recover & Save…"
-msgstr "_Recover and Save..."
+msgstr "_Recover and Save…"
 
 #: ../po/tmp/autorecover.glade.h:12
 #, fuzzy

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0+git\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2017-07-21 00:13+0000\n"
 "Last-Translator: Bo Anderson <bo@toxicflames.co.uk>\n"
-"Language-Team: English (United Kingdom) "
-"<https://hosted.weblate.org/projects/mypaint/mypaint/en_GB/>\n"
+"Language-Team: English (United Kingdom) <https://hosted.weblate.org/projects/"
+"mypaint/mypaint/en_GB/>\n"
 "Language: en_GB\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -21,29 +21,7 @@ msgstr ""
 "X-Language: en_GB\n"
 "X-Source-Language: C\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr "<big><b>{accel_label}</b></big>"
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr "{action_label} {action_desc} {accel_label}"
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "Action"
 
@@ -51,32 +29,32 @@ msgstr "Action"
 msgid "Key combination"
 msgstr "Key combination"
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr "Edit Key for '%s'"
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "Action:"
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "Path:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "Key:"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr "Press keys to update this assignment"
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "Unknown Action"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
@@ -85,7 +63,7 @@ msgstr ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr "Open Folder “{folder_basename}”…"
@@ -93,194 +71,204 @@ msgstr "Open Folder “{folder_basename}”…"
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "OK"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr "No backups were found in the cache."
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr "No Available Backups"
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr "Open the Cache Folder…"
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr "Backup Recovery Failed"
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr "Open the Backup's Folder…"
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr "Recovered file from {iso_datetime}.ora"
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "Save as Default"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "Background"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "Pattern"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Colour"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "Add colour to Patterns"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr "One or more backgrounds could not be loaded"
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr "Error loading backgrounds"
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr "{filename} has zero size (w={w}, h={h})"
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr "Brush Settings Editor"
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr "About"
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "Experimental"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr "Basic"
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr "Opacity"
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr "Dabs"
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "Smudge"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr "Speed"
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr ""
+
+#: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr "Tracking"
 
-#: ../gui/brusheditor.py:359
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "Stroke"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr "Colour"
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Custom"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr "No brush selected, please use “Add As New” instead."
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr "No brush selected!"
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "Rename Brush"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "A brush with this name already exists!"
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr "No brush selected!"
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr "Really delete brush “{brush_name}” from disk?"
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr "(Unnamed brush)"
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr "{brush_name} [unsaved]"
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr "Brush Icon"
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr "Brush Icon (editing)"
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr "No brush selected"
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -289,7 +277,7 @@ msgstr ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
@@ -298,7 +286,7 @@ msgstr ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
@@ -307,7 +295,7 @@ msgstr ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or colour</small>"
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -348,142 +336,182 @@ msgstr "Auto"
 msgid "Use the default icon"
 msgstr "Use the default icon"
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Save"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr "Save this preview icon, and finish editing"
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr "Lost & Found"
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr "Deleted"
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr "Favourites"
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr "Ink"
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr "Classic"
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr "Set#1"
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr "Set#2"
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr "Set#3"
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr "Set#4"
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr "Set#5"
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr "Experimental"
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "New"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr "Unknown Brush"
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr "Add to Favourites"
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr "Remove from Favourites"
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr "Clone"
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr "Edit Brush Settings"
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
-msgstr "Delete"
+#: ../gui/brushselectionwindow.py:250
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
+msgstr "Rename Group"
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
-msgstr "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, fuzzy, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
+msgstr "Really delete brush “{brush_name}” from disk?"
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] "%d brush"
 msgstr[1] "%d brushes"
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr "Group “{group_name}”"
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr "Rename Group"
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr "Export as Zipped Brushset"
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr "Delete Group"
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr "Rename Group"
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "A group with this name already exists!"
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr "Really delete group “{group_name}”?"
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -493,58 +521,58 @@ msgstr ""
 "Could not delete group “{group_name}”.\n"
 "Some special groups cannot be deleted."
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr "Export Brushes"
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr "MyPaint brush package (*.zip)"
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "New Group..."
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr "Import Brushes..."
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr "Get More Brushes..."
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "Create Group"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr "Button"
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr "Btn"
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr "Button press"
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr "Add a new binding"
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr "Remove the current binding"
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr "Edit binding for '%s'"
@@ -553,7 +581,7 @@ msgstr "Edit binding for '%s'"
 msgid "Button press:"
 msgstr "Button press:"
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
@@ -561,47 +589,75 @@ msgstr ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr "{button_combination} is already bound to the action '{action_name}'"
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr "Pick Colour"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr "Set the colour used for painting"
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+#, fuzzy
+msgid "Set the color Hue used for painting"
+msgstr "Set the colour used for painting"
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "Pick Col."
+
+#: ../gui/colorpicker.py:296
+#, fuzzy
+msgid "Set the color Chroma used for painting"
+msgstr "Set the colour used for painting"
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+#, fuzzy
+msgid "Set the color Luma used for painting"
+msgstr "Set the colour used for painting"
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr "Colour details"
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr "Current brush colour, and the colour most recently used for painting"
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr "Gamut Mask Active"
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr "Limit your palette for specific moods using a gamut mask."
@@ -611,7 +667,7 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr "HCY hue and chroma."
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
@@ -620,12 +676,12 @@ msgstr ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr "Atmospheric Triad"
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
@@ -634,22 +690,22 @@ msgstr ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr "Shifted Triad"
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr "Weighted more strongly towards the dominant colour."
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr "Complementary"
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
@@ -658,12 +714,12 @@ msgstr ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the colour wheel."
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr "Mood and Accent"
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
@@ -672,12 +728,12 @@ msgstr ""
 "One main range of colours, with a complementary accent for variation and "
 "highlights."
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr "Split Complementary"
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
@@ -686,72 +742,72 @@ msgstr ""
 "Two analogous colours and a complement to them, with no secondary colours "
 "between them."
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr "New Gamut Mask from Template"
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr "Gamut Mask Editor"
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr "Active"
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr "Help…"
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr "Create mask from template."
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr "Load mask from a GIMP palette file."
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr "Save mask to a GIMP palette file."
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr "Erase the mask."
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr "Open the online help for this dialog in a web browser."
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr "Save Mask as a GIMP Palette"
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr "Load Mask from a GIMP Palette"
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr "Set gamut mask."
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr "HCY Wheel"
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -761,162 +817,154 @@ msgstr ""
 "are equiluminant."
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr "HSV Hue"
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr "HSV Saturation"
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr "HSV Value"
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr "HSV Saturation and Value"
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr "HSV Hue and Value"
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr "HSV Hue and Saturation"
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr "Rotate cube (show different axes)"
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr "HSV Cube"
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr "An HSV cube which can be rotated to show different planar slices."
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr "HSV Square"
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr "An HSV Square which can be rotated to show different hues."
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr "HSV Triangle"
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr "The standard GTK colour selector"
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr "HSV Wheel"
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr "Saturation and Value colour changer."
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr "Palette properties"
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr "Palette"
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr "Set the colour from a loadable, editable palette."
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr "Untitled Palette"
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr "Palette Editor"
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr "Load from a GIMP palette file"
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr "Save to a GIMP palette file"
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr "Add a new empty swatch"
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr "Remove the current swatch"
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr "Remove all swatches"
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr "Title:"
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr "Name or description for this palette"
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr "Columns:"
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr "Number of columns"
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr "Colour name:"
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr "Current colour's name"
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr "Empty palette slot"
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr "Load palette"
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr "Save palette"
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -927,379 +975,376 @@ msgstr ""
 "Drop colours here,\n"
 "drag them to organize."
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr "Empty palette slot (drag a colour here)"
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr "Add Empty Slot"
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr "Insert Row"
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr "Insert Column"
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr "Fill Gap (RGB)"
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr "Fill Gap (HCY)"
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr "Fill Gap (HSV)"
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "GIMP palette file (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr "All files (*)"
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "GIMP palette file (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr "All files (*)"
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr "Pick a colour from the screen"
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr "R"
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr "G"
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr "B"
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr "H"
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr "C"
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr "Y"
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr "Component Sliders"
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr "Adjust individual components of the colour."
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr "RGB Red"
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr "RGB Green"
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr "RGB Blue"
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr "HSV Hue"
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr "HSV Saturation"
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr "HSV Value"
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr "HCY Hue"
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr "HCY Chroma"
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr "HCY Luma (Y')"
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr "Liquid Wash"
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr "Change colour using a liquid-like wash of nearby colours."
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr "Concentric Rings"
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr "Change colour using concentric HSV rings."
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr "Crossed Bowl"
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr "Change colour with HSV ramps crossing a radial bowl of colour."
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr "Cursor/puck"
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr "Eraser"
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr "Keyboard"
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr "Mouse"
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr "Pen"
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr "Touchpad"
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr "Touchscreen"
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr "Ignore"
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr "Any task"
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr "Non-painting tasks"
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr "Navigation only"
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr "Zoom"
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr "Pan"
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr "Device"
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr "Axes"
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr "Type"
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr "Use for..."
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr "Scroll..."
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Name"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr "Overwrite Brush?"
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr "Replace"
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr "Rename"
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr "Replace All"
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr "Rename All"
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr "Imported brush"
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr "Existing brush"
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 "<b>A brush named ‘%s’ already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr "Overwrite Brush Group?"
 
-#: ../gui/dialogs.py:190
-#, python-brace-format
+#: ../gui/dialogs.py:220
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 "<b>A group named ‘{groupname}’ already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
 "‘{deleted_groupname}’."
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr "Import Brush Package?"
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, fuzzy, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr "<b>Do you really want to import package ‘%s’?</b>"
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr "Load brush settings from shortcut slot %d"
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr "Store brush settings in shortcut slot %d"
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr "Restore Brush %d"
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr "Save to Brush %d"
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr "Undo %s"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Undo"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr "Redo %s"
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Redo"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr "{button_combination} is {resultant_action}"
@@ -1309,274 +1354,530 @@ msgstr "{button_combination} is {resultant_action}"
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ";  "
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr "With {modifiers} held down:  {button_actions}."
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
-msgstr "Layer Name"
-
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
-#, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
-"<b>{name}</b>\n"
-"{description}"
+
+#: ../gui/document.py:909
+#, python-brace-format
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
+msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr "%s - MyPaint"
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr "MyPaint"
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Open"
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr "Set Current Colour"
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr "Leave Fullscreen Mode"
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr "Leave Fullscreen"
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr "Enter Fullscreen Mode"
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Fullscreen"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Quit"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+#, fuzzy
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr "Really quit?"
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Quit"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr "Import Brush Package..."
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr "MyPaint brush package (*.zip)"
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr "Launched {app_name} to edit layer “{layer_name}”"
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr "Updated layer “{layer_name}” with external edits"
 
-#: ../gui/externalapp.py:46
-#, python-brace-format
-msgid ""
-"MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
-"application should it use?"
-msgstr ""
-"MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
-"application should it use?"
-
-#: ../gui/externalapp.py:50
-#, python-brace-format
-msgid ""
-"What application should MyPaint use for editing files of type "
-"“{type_name}” ({content_type})?"
-msgstr ""
-"What application should MyPaint use for editing files of type “{type_name}” "
-"({content_type})?"
-
-#: ../gui/externalapp.py:56
-msgid "Open With..."
-msgstr "Open With..."
-
-#: ../gui/externalapp.py:107
-msgid "Icon"
-msgstr "Icon"
-
-#: ../gui/externalapp.py:150
-msgid "no description"
-msgstr "no description"
-
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr "All Recognized Formats"
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr "OpenRaster (*.ora)"
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr "PNG (*.png)"
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr "JPEG (*.jpg; *.jpeg)"
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr "By extension (prefer default format)"
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr "PNG solid with background (*.png)"
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr "PNG transparent (*.png)"
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr "Multiple PNG transparent (*.XXX.png)"
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr "JPEG 90% quality (*.jpg; *.jpeg)"
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr "Save..."
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr "Format to save as:"
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr "Confirm"
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr "Really continue?"
-
-#: ../gui/filehandling.py:234
-#, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
-msgstr "This will discard {abbreviated_time} of unsaved painting"
-
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr "_Save as Scrap"
-
-#: ../gui/filehandling.py:282
-#, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
-msgstr "Loading “{file_basename}”…"
-
-#: ../gui/filehandling.py:296
+#: ../gui/externalapp.py:48
 #, python-brace-format
 msgctxt "file handling: open failed (statusbar)"
 msgid "Could not load “{file_basename}”."
 msgstr "Could not load “{file_basename}”."
 
-#: ../gui/filehandling.py:321
+#: ../gui/externalapp.py:61
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
-msgstr "Loaded “{file_basename}”."
+msgid ""
+"MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
+"application should it use?"
+msgstr ""
+"MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
+"application should it use?"
 
-#: ../gui/filehandling.py:422
+#: ../gui/externalapp.py:65
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
-msgstr "Exporting to “{file_basename}”…"
+msgid ""
+"What application should MyPaint use for editing files of type "
+"“{type_name}” ({content_type})?"
+msgstr ""
+"What application should MyPaint use for editing files of type "
+"“{type_name}” ({content_type})?"
 
-#: ../gui/filehandling.py:427
+#: ../gui/externalapp.py:71
+msgid "Open With..."
+msgstr "Open With..."
+
+#: ../gui/externalapp.py:123
+msgid "Icon"
+msgstr "Icon"
+
+#: ../gui/externalapp.py:166
+msgid "no description"
+msgstr "no description"
+
+#: ../gui/filehandling.py:126
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
+msgstr "Loading “{file_basename}”…"
+
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:134
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr "Saving “{file_basename}”…"
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:138
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
+msgstr "Exporting to “{file_basename}”…"
+
+#: ../gui/filehandling.py:145
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
 msgstr "Failed to export to “{file_basename}”."
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:149
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
 msgstr "Failed to save “{file_basename}”."
 
-#: ../gui/filehandling.py:476
+#: ../gui/filehandling.py:153
 #, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr "Could not load “{file_basename}”."
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "Save palette"
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
 msgstr "Exported to “{file_basename}” successfully."
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:187
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
 msgstr "Saved “{file_basename}” successfully."
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Open..."
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:195
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr "Loaded “{file_basename}”."
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
+msgstr "Loaded “{file_basename}”."
+
+#: ../gui/filehandling.py:427
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
+msgstr "All Recognized Formats"
+
+#: ../gui/filehandling.py:432
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:437
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:442
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
+msgstr "JPEG (*.jpg; *.jpeg)"
+
+#: ../gui/filehandling.py:490
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
+msgstr "By extension (prefer default format)"
+
+#: ../gui/filehandling.py:494
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:498
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr "PNG solid with background (*.png)"
+
+#: ../gui/filehandling.py:502
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:506
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr "PNG transparent (*.png)"
+
+#: ../gui/filehandling.py:510
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr "Multiple PNG transparent (*.XXX.png)"
+
+#: ../gui/filehandling.py:514
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr "Multiple PNG transparent (*.XXX.png)"
+
+#: ../gui/filehandling.py:518
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr "JPEG 90% quality (*.jpg; *.jpeg)"
+
+#: ../gui/filehandling.py:576
+#, fuzzy
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr "Export…"
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Save As…"
+
+#: ../gui/filehandling.py:601
+#, fuzzy
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr "Format to save as:"
+
+#: ../gui/filehandling.py:668
+#, fuzzy
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr "Really continue?"
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+#, fuzzy
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr "_Save as Scrap"
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, fuzzy, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr "This will discard {abbreviated_time} of unsaved painting"
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr "Open…"
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Open"
+
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr "Open Scratchpad..."
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Imported brush"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Open"
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Open Most Recent"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Open"
+
+#: ../gui/filehandling.py:1446
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
 msgstr "There are no scrap files named \"%s\" yet."
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1455
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr "Open Next Scrap"
+
+#: ../gui/filehandling.py:1463
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr "Open Previous Scrap"
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Open"
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+#, fuzzy
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr "Revert"
+
+#: ../gui/fill.py:121
+#, fuzzy
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr "Flood Fill"
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+#, fuzzy
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr "Fill areas with colour"
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+#, fuzzy
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr "Tolerance:"
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+#, fuzzy
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
@@ -1584,19 +1885,36 @@ msgstr ""
 "How much pixel colours are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+#, fuzzy
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr "Source:"
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
-msgstr "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
+msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+#, fuzzy
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr "Sample Merged"
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+#, fuzzy
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
@@ -1606,19 +1924,50 @@ msgstr ""
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+#, fuzzy
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr "Fit to View"
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+#, fuzzy
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr "Target:"
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+#, fuzzy
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr "Where the output should go"
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr "New Layer (once)"
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+#, fuzzy
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
@@ -1626,21 +1975,108 @@ msgstr ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Opacity:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr "Reset"
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+#, fuzzy
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr "Reset options to their defaults"
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "Select Layer"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr "<b>{brush_name}</b>"
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1650,130 +2086,142 @@ msgstr ""
 "<b>{brush_name}</b>\n"
 "{brush_desc}"
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr "Edit Frame"
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr "Adjust the document frame"
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr "Frame Size"
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr "px"
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr "Height:"
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr "Width:"
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr "Resolution:"
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr "DPI"
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr "Dots Per Inch (really Pixels Per Inch)"
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr "Colour:"
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr "Frame Colour"
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr "<b>Frame dimensions</b>"
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr "<b>Pixel density</b>"
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr "Set Frame to Layer"
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr "Set frame to the extents of the current layer"
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr "Set Frame to Document"
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr "Set frame to the combination of all layers"
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr "Trim Layer to Frame"
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr "Trim parts of the current layer which lie outside the frame"
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr "Enabled"
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr "{width:g}×{height:g} {units}"
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr "inch"
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr "cm"
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr "mm"
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr "Freehand Drawing"
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr "Paint free-form brush strokes"
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr "Smooth:"
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr "Pressure:"
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr "Bug Detected"
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr "<big><b>A programming error has been detected.</b></big>"
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1787,35 +2235,35 @@ msgstr ""
 "Please tell the developers about this using the issue tracker if no-one else "
 "has reported it yet."
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr "Search Tracker..."
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr "Report..."
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr "Ignore Error"
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr "Quit MyPaint"
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr "Details..."
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr "Exception while analyzing the exception."
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1859,45 +2307,50 @@ msgstr ""
 "            #### Traceback\n"
 "        "
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr "Inking"
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr "Draw, and then adjust smooth lines"
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr "Input Device Test"
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr "(no pressure)"
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr "Pressure:"
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr "(no tilt)"
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr "Tilt:"
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr "(no device)"
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
 msgstr "Device:"
 
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+#, fuzzy
+msgid "Barrel Rotation:"
+msgstr "Reset Rotation"
+
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr "Move Layer"
 
@@ -1905,159 +2358,226 @@ msgstr "Move Layer"
 msgid "Move the current layer"
 msgstr "Move the current layer"
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
-msgstr "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
+msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
-msgstr "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
+msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+#, fuzzy
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr "Properties"
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr "Visible"
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Layer"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+#, fuzzy
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr "Locked"
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+#, fuzzy
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ", "
+
+#: ../gui/layers.py:990
+#, fuzzy, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr "Add {layer_default_name}"
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Layers"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr "Arrange layers and assign effects"
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr "Layer opacity: %d%%"
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr "Move layer in stack..."
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr "Layer"
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
-msgstr "Mode:"
+#: ../gui/layervis.py:53
+#, fuzzy, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
+msgstr "<b>{brush_name}</b>"
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
-"Blending mode: how the current layer combines with the layers underneath it."
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Opacity:"
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "Rotate View"
 
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-
-#: ../gui/linemode.py:37
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr "Entrance Pressure"
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr "Stroke entrance pressure for line tools"
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr "Midpoint Pressure"
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr "Mid-Stroke pressure for line tools"
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr "Exit Pressure"
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr "Stroke exit pressure for line tools"
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr "Head"
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 msgid "Stroke lead-in end"
 msgstr "Stroke lead-in end"
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr "Tail"
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr "Stroke trail-off beginning"
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr "Pressure variation..."
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr "Lines and Curves"
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr "Generic line/curve mode"
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr "Connected Lines"
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr "Ellipses and Circles"
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
+#, fuzzy
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 "Copyright (C) 2005-2015\n"
 "Martin Renold and the MyPaint Development Team"
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -2076,256 +2596,286 @@ msgstr ""
 "This program is distributed in the hope that it will be useful, but WITHOUT "
 "ANY WARRANTY. See the COPYING file for more details."
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr "programming"
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr "portability"
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr "project management"
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr "brushes"
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr "patterns"
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr "tool icons"
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr "desktop icon"
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr "palettes"
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr "documentation"
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr "support"
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr "outreach"
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr "community"
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ", "
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr "Andrew Chadwick"
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr "Size:"
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr "Opaque:"
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr "Sharp:"
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr "Gain:"
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr "Tool Options"
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr "Specialized settings for the current editing tool"
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr "<b>{mode_name}</b>"
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr "<i>No options available</i>"
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr "Zoom: %.01f%%"
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr "Pick brushstroke settings, stroke colour, and layer…"
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr "Pick colour…"
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr "Preferences"
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr "Preview"
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr "Show preview of the whole drawing area"
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr "Show Viewfinder"
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr "Scratchpad"
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr "Mix colours and make sketches on separate scrap pages"
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr "Previous item"
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr "Next item"
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
 msgstr "(Nothing to show)"
 
-#: ../gui/symmetry.py:76
+#: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Place axis"
 msgstr "Place axis"
 
-#: ../gui/symmetry.py:80
+#: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Move axis"
 msgstr "Move axis"
 
-#: ../gui/symmetry.py:84
+#: ../gui/symmetry.py:88
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr "Remove axis"
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr "Edit Symmetry Axis"
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr "Adjust the painting symmetry axis."
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
+#, fuzzy
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr "Position:"
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr "Position:"
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr "None"
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr "%d px"
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr "Alpha:"
 
-#: ../gui/symmetry.py:352
+#: ../gui/symmetry.py:376
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
+msgstr "Symmetry"
+
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+#, fuzzy
 msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+msgid "X axis Position"
 msgstr "Axis Position"
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:477
+#, fuzzy
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr "Axis Position"
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr "Enabled"
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr "File handling"
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr "Scraps switcher"
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr "Undo and Redo"
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr "Blend Modes"
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr "Line Modes"
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr "View (Main)"
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr "View (Alternative/Secondary)"
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr "View (Resetting)"
 
@@ -2333,188 +2883,214 @@ msgstr "View (Resetting)"
 msgid "<b>MyPaint</b>"
 msgstr "<b>MyPaint</b>"
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr "Scroll View"
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr "Drag the canvas view"
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr "Zoom View"
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr "Zoom the canvas view"
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr "Rotate View"
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr "Rotate the canvas view"
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, fuzzy, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr "%s: close tab"
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
-msgstr "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
+msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr "Unknown Command"
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr "Undefined (command not started yet)"
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr "{seconds:.01f}s of painting with {brush_name}"
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr "Flood Fill"
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr "Trim Layer"
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "Rename Group"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr "Clear Layer"
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr "Paste Layer"
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr "New Layer from Visible"
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr "Merge Visible Layers"
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr "Merge Down"
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr "Normalize Layer Mode"
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Imported brush"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr "Add {layer_default_name}"
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr "Remove Layer"
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr "Select Layer"
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr "Duplicate Layer"
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr "Move Layer Up"
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr "Move Layer Down"
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr "Move Layer in Stack"
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr "Rename Layer"
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr "Make Layer Visible"
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr "Make Layer Invisible"
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr "Lock Layer"
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr "Unlock Layer"
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr "Set Layer Opacity: %0.1f%%"
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr "Unknown Mode"
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr "Set Layer Mode: %s"
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr "Enable Frame"
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr "Disable Frame"
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr "Update Frame"
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr "Edit Layer Externally"
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr "Error loading “{basename}”."
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr "The logs may have more detail about this error."
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr "from now"
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr "ago"
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2526,13 +3102,13 @@ msgstr ""
 "Are you running more than once instance of MyPaint?\n"
 "Close app and wait {cache_update_interval}s to retry."
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr "Incomplete backup updated {last_modified_time} {ago}"
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2542,11 +3118,11 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 "Backup updated {last_modified_time} {ago}\n"
-"Size: {autosave.width}×{autosave.height} pixels, Layers: "
-"{autosave.num_layers}\n"
+"Size: {autosave.width}×{autosave.height} pixels, Layers: {autosave."
+"num_layers}\n"
 "Contains {unsaved_time} of unsaved painting."
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2556,13 +3132,13 @@ msgstr ""
 "Unable to write “{filename}”: {err}\n"
 "Do you have enough space left on the device?"
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr "Unable to write “{filename}”: {err}"
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2572,7 +3148,7 @@ msgstr ""
 "{error_loading_common}\n"
 "The file does not exist."
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2582,7 +3158,7 @@ msgstr ""
 "{error_loading_common}\n"
 "You do not have the permissions needed to open this file."
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2598,7 +3174,7 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2608,7 +3184,13 @@ msgstr ""
 "{error_loading_common}\n"
 "Unknown file format extension: “{ext}”"
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+#, fuzzy
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr "Imported brush"
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2622,7 +3204,7 @@ msgstr ""
 "Try saving in PNG format instead, if your machine doesn’t have a lot of "
 "memory. MyPaint’s PNG save function is more efficient."
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2638,98 +3220,207 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/helpers.py:402
-#, python-brace-format
+#: ../lib/floodfill.py:131
+#, fuzzy
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr "Fill"
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr "{days}d{hours}h"
 
-#: ../lib/helpers.py:404
-#, python-brace-format
+#: ../lib/helpers.py:537
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr "{hours}h{minutes}m"
 
-#: ../lib/helpers.py:406
-#, python-brace-format
+#: ../lib/helpers.py:539
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr "{minutes}m{seconds}s"
 
-#: ../lib/helpers.py:408
-#, python-brace-format
+#: ../lib/helpers.py:541
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr "{seconds}s"
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr "Layer"
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr "%(name)s %(number)d"
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr "^(.*?)\\s*(\\d+)$"
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
+#, fuzzy
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr "Vector Layer"
+
+#: ../lib/layer/data.py:1158
+#, fuzzy
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr "Vector Layer"
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
-msgstr "Unknown Bitmap Layer"
+msgid "Bitmap"
+msgstr ""
 
-#: ../lib/layer/data.py:1169
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1244
 msgctxt "layer default names"
-msgid "Unknown Data Layer"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
 msgstr "Unknown Data Layer"
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "New Painting Layer"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr "Group"
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "New Layer Group"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr "Placeholder"
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr "Root"
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ", "
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+#, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "View"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+#, fuzzy
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr "Layer Visible"
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+#, fuzzy
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr "Remove Layer"
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr "Lock Layer"
+
+#: ../lib/layervis.py:697
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr "Unlock Layer"
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr "Pass-through"
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr "Group contents apply directly to the group's backdrop"
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr "Normal"
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr "The top layer only, without blending colours."
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr "Multiply"
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
@@ -2737,11 +3428,11 @@ msgstr ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr "Screen"
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
@@ -2749,11 +3440,11 @@ msgstr ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr "Overlay"
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
@@ -2761,27 +3452,27 @@ msgstr ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr "Darken"
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr "The top layer is used where it is darker than the backdrop."
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr "Lighten"
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr "The top layer is used where it is lighter than the backdrop."
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr "Dodge"
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
@@ -2791,11 +3482,11 @@ msgstr ""
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr "Burn"
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
@@ -2805,43 +3496,43 @@ msgstr ""
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr "Hard Light"
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr "Similar to shining a harsh spotlight onto the backdrop."
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr "Soft Light"
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr "Like shining a diffuse spotlight onto the backdrop."
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr "Difference"
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr "Subtracts the darker colour from the lighter of the two."
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr "Exclusion"
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr "Similar to the 'Difference' mode, but lower in contrast."
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr "Hue"
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
@@ -2849,11 +3540,11 @@ msgstr ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr "Saturation"
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
@@ -2861,7 +3552,7 @@ msgstr ""
 "Applies the saturation of the top layer's colours to the hue and luminosity "
 "of the backdrop."
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
@@ -2869,11 +3560,11 @@ msgstr ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr "Luminosity"
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
@@ -2881,19 +3572,19 @@ msgstr ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr "Plus"
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr "This layer and its backdrop are simply added together."
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr "Destination In"
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
@@ -2901,11 +3592,11 @@ msgstr ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr "Destination Out"
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
@@ -2913,11 +3604,11 @@ msgstr ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr "Source Atop"
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
@@ -2925,11 +3616,11 @@ msgstr ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr "Destination Atop"
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
@@ -2937,7 +3628,18 @@ msgstr ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, fuzzy, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr "%(name)s %(number)d"
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
@@ -2946,7 +3648,7 @@ msgstr ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2960,7 +3662,30 @@ msgstr ""
 "Reason: {err}\n"
 "Target folder: “{dirname}”."
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+#, fuzzy
+msgid "Vertical"
+msgstr "Mirror Vertical"
+
+#: ../lib/tiledsurface.py:49
+#, fuzzy
+msgid "Horizontal"
+msgstr "Mirror Horizontal"
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+#, fuzzy
+msgid "Rotational"
+msgstr "Reset Rotation"
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr "PNG reader failed: %s"
@@ -2969,55 +3694,93 @@ msgstr "PNG reader failed: %s"
 msgid "Recover interrupted work?"
 msgstr "Recover interrupted work?"
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
-msgstr "_Recover and Save..."
+msgid "_Look for backups at startup"
+msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr "Delete"
+
+#: ../po/tmp/autorecover.glade.h:9
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr "Delete this brush from the disk"
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr "_Recover and Save..."
+
+#: ../po/tmp/autorecover.glade.h:12
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr "Save this backup to disk, then continue working on it."
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
-msgstr "_Ignore for Now"
+msgid "Decide _Later"
+msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr "Start work on a new canvas. These backups will be retained."
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
+#, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 "MyPaint crashed with unsaved work, but it made backups. You can recover a "
 "file now, or leave it till you start MyPaint again."
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr "Thumbnail"
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr "Description"
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
-msgstr "Copy to New"
+msgid "Live update"
+msgstr "Live update"
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
-msgstr "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
+msgstr ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
-msgstr "Rename this brush"
+msgid "Save these settings to the brush"
+msgstr "Save these settings to the brush"
 
 #: ../po/tmp/brusheditor.glade.h:5
 msgid "Edit Icon"
@@ -3040,20 +3803,16 @@ msgid "Delete this brush from the disk"
 msgstr "Delete this brush from the disk"
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
-msgstr "Live update"
+msgid "Copy to New"
+msgstr "Copy to New"
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
-msgstr ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
+msgstr "Copy these settings and the current brush's icon to a new brush"
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
-msgstr "Save these settings to the brush"
+msgid "Rename this brush"
+msgstr "Rename this brush"
 
 #: ../po/tmp/brusheditor.glade.h:13
 msgid "Brush Setting"
@@ -3081,31 +3840,23 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr "Notes:"
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr "Setting name:"
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
-msgstr "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+#, fuzzy
+msgid "Value:"
+msgstr "HSV Value"
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr "Reset the base value to its default"
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr "Reset this input to have no effect on the setting"
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
@@ -3113,11 +3864,7 @@ msgstr ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr "<ymin>"
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
@@ -3125,27 +3872,23 @@ msgstr ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr "<ymax>"
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr "Output"
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr "Input"
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr "Adjusts the maximum value"
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr "Adjusts the minimum value"
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
@@ -3153,11 +3896,7 @@ msgstr ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr "<xmin>"
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
@@ -3165,38 +3904,36 @@ msgstr ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr "<xmax>"
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr "Variation of the base value by stylus input and other criteria"
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr "Brush Dynamics"
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr "Basic details for this setting"
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr "Edit Setting"
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr "Adjust this input mapping in detail"
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr "{tooltip}"
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
 msgstr "{dname}:"
+
+#: ../po/tmp/brusheditor.glade.h:42
+#, fuzzy
+msgid "Brush dynamics are not available for this setting."
+msgstr "Basic details for this setting"
+
+#: ../po/tmp/brusheditor.glade.h:43
+#, fuzzy
+msgid "<big><b>No Brush Dynamics</b></big>"
+msgstr "<big><b>{accel_label}</b></big>"
 
 #: ../po/tmp/inktool.glade.h:1
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
@@ -3208,7 +3945,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr "Press:"
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3253,6 +3990,141 @@ msgstr "Delete Point"
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
 msgstr "Delete the currently selected point"
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+#, fuzzy
+msgid "Insert Point"
+msgstr "Insert Row"
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+#, fuzzy
+msgid "Cull Points"
+msgstr "Delete Point"
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Name"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr "Mode"
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Opacity"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr "The current layer's compositing mode."
+
+#: ../po/tmp/layervis.glade.h:2
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr "Rotate the canvas view"
+
+#: ../po/tmp/layervis.glade.h:3
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr "Rotate the canvas view"
+
+#: ../po/tmp/layervis.glade.h:4
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr "Which visible layers should be filled"
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
+msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
 msgctxt "footer: color picker button: tooltip"
@@ -3656,13 +4528,34 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr "Hide cursor while painting"
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+#, fuzzy
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr "Enabled"
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr "View"
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
@@ -3671,18 +4564,18 @@ msgstr ""
 "The set of colours to show as primary on disk-style colour wheels.\n"
 "Different traditions have different colour harmonies."
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr "Primaries are:"
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr "Standard digital Red/Green/Blue"
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
@@ -3690,7 +4583,7 @@ msgstr ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
@@ -3699,12 +4592,12 @@ msgstr ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr "Traditional artist's Red/Yellow/Blue"
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
@@ -3714,7 +4607,7 @@ msgstr ""
 "since the 18th century, approximated with pure display colours evenly "
 "arranged around the circle. Green is opposite red."
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3725,12 +4618,12 @@ msgstr ""
 "since the 18th century, approximated with pure display colours evenly "
 "arranged around the circle. Green is opposite red."
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr "Red-Green and Blue-Yellow opponent pairs"
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3744,7 +4637,7 @@ msgstr ""
 "and yellow is opposite blue. CIECAM02 and NCS present a similar model. Here "
 "we use pure display red, yellow etc. as the four primaries."
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3760,28 +4653,28 @@ msgstr ""
 "red, yellow etc. as the four primaries."
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr "<b>Colour Wheel</b>"
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr "Colour"
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr "Screen (normal)"
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr "Disabled (no pressure sensitivity)"
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr "Window (not recommended)"
@@ -3842,245 +4735,302 @@ msgid "Reload the file your current work was loaded from."
 msgstr "Reload the file your current work was loaded from."
 
 #: ../po/tmp/resources.xml.h:12
+#, fuzzy
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Import Layers…"
+msgstr "Import Brushes…"
+
+#: ../po/tmp/resources.xml.h:13
+msgctxt "Accel Editor (descriptions)"
+msgid "Import layers from one or more files."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save"
 msgstr "Save"
 
-#: ../po/tmp/resources.xml.h:13
+#: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file."
 msgstr "Save your work to a file."
 
-#: ../po/tmp/resources.xml.h:14
+#: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As…"
 msgstr "Save As…"
 
-#: ../po/tmp/resources.xml.h:15
+#: ../po/tmp/resources.xml.h:17
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file, assigning it a new name."
 msgstr "Save your work to a file, assigning it a new name."
 
-#: ../po/tmp/resources.xml.h:16
+#: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Export…"
 msgstr "Export…"
 
-#: ../po/tmp/resources.xml.h:17
+#: ../po/tmp/resources.xml.h:19
 msgid "Export your work to a file, but keep working on the same file."
 msgstr "Export your work to a file, but keep working on the same file."
 
-#: ../po/tmp/resources.xml.h:18
+#: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As Scrap"
 msgstr "Save As Scrap"
 
-#: ../po/tmp/resources.xml.h:19
+#: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
 msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr "Save to a new scrap file, or save a new revision if already a scrap."
 
-#: ../po/tmp/resources.xml.h:20
+#: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Previous Scrap"
 msgstr "Open Previous Scrap"
 
-#: ../po/tmp/resources.xml.h:21
+#: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file before the current one."
 msgstr "Load the scrap file before the current one."
 
-#: ../po/tmp/resources.xml.h:22
+#: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Next Scrap"
 msgstr "Open Next Scrap"
 
-#: ../po/tmp/resources.xml.h:23
+#: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file after the current one."
 msgstr "Load the scrap file after the current one."
 
-#: ../po/tmp/resources.xml.h:24
+#: ../po/tmp/resources.xml.h:26
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Recover File from an Automated Backup…"
 msgstr "Recover File from an Automated Backup…"
 
-#: ../po/tmp/resources.xml.h:25
+#: ../po/tmp/resources.xml.h:27
 msgctxt "Accel Editor (descriptions)"
 msgid "Try to save and resume interrupted unsaved work."
 msgstr "Try to save and resume interrupted unsaved work."
 
-#: ../po/tmp/resources.xml.h:26
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr "Brush Groups"
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr "Brushes"
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr "List of brush groups."
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr "Colour Adjusters"
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr "Colours"
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr "Available colour adjusters."
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr "Mode"
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr "Mode"
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr "The current layer's compositing mode."
 
-#: ../po/tmp/resources.xml.h:35
+#: ../po/tmp/resources.xml.h:37
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Pressure"
+msgstr "Entrance Pressure"
+
+#: ../po/tmp/resources.xml.h:38
+msgctxt "Accel Editor (descriptions)"
+msgid "Send harder pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:39
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Pressure"
+msgstr "Entrance Pressure"
+
+#: ../po/tmp/resources.xml.h:40
+msgctxt "Accel Editor (descriptions)"
+msgid "Send softer pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:41
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Rotation"
+msgstr "Increase Saturation"
+
+#: ../po/tmp/resources.xml.h:42
+msgctxt "Accel Editor (descriptions)"
+msgid "Increase barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:43
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
+msgstr "Decrease Saturation"
+
+#: ../po/tmp/resources.xml.h:44
+msgctxt "Accel Editor (descriptions)"
+msgid "Decrease barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:45
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Size"
 msgstr "Increase Brush Size"
 
-#: ../po/tmp/resources.xml.h:36
+#: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush bigger."
 msgstr "Make the working brush bigger."
 
-#: ../po/tmp/resources.xml.h:37
+#: ../po/tmp/resources.xml.h:47
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Size"
 msgstr "Decrease Brush Size"
 
-#: ../po/tmp/resources.xml.h:38
+#: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush smaller."
 msgstr "Make the working brush smaller."
 
-#: ../po/tmp/resources.xml.h:39
+#: ../po/tmp/resources.xml.h:49
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Opacity"
 msgstr "Increase Brush Opacity"
 
-#: ../po/tmp/resources.xml.h:40
+#: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush more opaque."
 msgstr "Make the working brush more opaque."
 
-#: ../po/tmp/resources.xml.h:41
+#: ../po/tmp/resources.xml.h:51
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Opacity"
 msgstr "Decrease Brush Opacity"
 
-#: ../po/tmp/resources.xml.h:42
+#: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush less opaque."
 msgstr "Make the working brush less opaque."
 
-#: ../po/tmp/resources.xml.h:43
+#: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Lighten Painting Color"
 msgstr "Lighten Painting Colour"
 
-#: ../po/tmp/resources.xml.h:44
+#: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase the lightness of the current painting color."
 msgstr "Increase the lightness of the current painting colour."
 
-#: ../po/tmp/resources.xml.h:45
+#: ../po/tmp/resources.xml.h:55
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Darken Painting Color"
 msgstr "Darken Painting Colour"
 
-#: ../po/tmp/resources.xml.h:46
+#: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease the lightness of the current painting color."
 msgstr "Decrease the lightness of the current painting colour."
 
-#: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
-msgstr "Change Hue Anticlockwise"
-
-#: ../po/tmp/resources.xml.h:48
-msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
-msgstr "Rotate the painting colour’s hue anticlockwise on the colour wheel."
-
-#: ../po/tmp/resources.xml.h:49
+#: ../po/tmp/resources.xml.h:57
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Change Hue Clockwise"
 msgstr "Change Hue Clockwise"
 
-#: ../po/tmp/resources.xml.h:50
+#: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
 msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr "Rotate the painting colour’s hue clockwise on the colour wheel."
 
-#: ../po/tmp/resources.xml.h:51
+#: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr "Change Hue Anticlockwise"
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr "Rotate the painting colour’s hue anticlockwise on the colour wheel."
+
+#: ../po/tmp/resources.xml.h:61
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Increase Saturation"
 msgstr "Increase Saturation"
 
-#: ../po/tmp/resources.xml.h:52
+#: ../po/tmp/resources.xml.h:62
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color more saturated (more colorful, purer)."
 msgstr "Make the painting colour more saturated (more colourful, purer)."
 
-#: ../po/tmp/resources.xml.h:53
+#: ../po/tmp/resources.xml.h:63
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Decrease Saturation"
 msgstr "Decrease Saturation"
 
-#: ../po/tmp/resources.xml.h:54
+#: ../po/tmp/resources.xml.h:64
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color less saturated (grayer)."
 msgstr "Make the painting colour less saturated (grayer)."
 
-#: ../po/tmp/resources.xml.h:55
+#: ../po/tmp/resources.xml.h:65
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Reload Brush Settings"
 msgstr "Reload Brush Settings"
 
-#: ../po/tmp/resources.xml.h:56
+#: ../po/tmp/resources.xml.h:66
 msgctxt "Accel Editor (descriptions)"
 msgid "Restore all brush settings to the current brush’s saved values."
 msgstr "Restore all brush settings to the current brush’s saved values."
 
-#: ../po/tmp/resources.xml.h:57
+#: ../po/tmp/resources.xml.h:67
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Pick Stroke and Layer"
 msgstr "Pick Stroke and Layer"
 
-#: ../po/tmp/resources.xml.h:58
+#: ../po/tmp/resources.xml.h:68
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
 msgstr "Pick a brushstroke from the canvas: restores brush, colour, and layer."
 
-#: ../po/tmp/resources.xml.h:59
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr "Brush Shortcut Keys Restore Colour"
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
@@ -4089,212 +5039,263 @@ msgstr ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved colour."
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr "Save Brush to Most Recent Shortcut Key"
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr "Save brush settings to the most recently used shortcut key."
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "Clear Layer"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr "Clear the current layer’s content."
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+#, fuzzy
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr "Tool Options"
+
+#: ../po/tmp/resources.xml.h:76
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr "Trim Layer to Frame"
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr "Erase parts of the current layer which lie outside the frame."
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr "Erase parts of the current layer which lie outside the frame."
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "New Layer Group Below"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "New Layer Group Below"
+
+#: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr "Copy Layer to Clipboard"
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr "Copy the current layer’s contents to the clipboard."
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr "Paste Layer from Clipboard"
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr "Replaces the current layer with the clipboard’s contents."
 
-#: ../po/tmp/resources.xml.h:71
+#: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Edit Layer in External App…"
 msgstr "Edit Layer in External App…"
 
-#: ../po/tmp/resources.xml.h:72
+#: ../po/tmp/resources.xml.h:90
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
+msgid "Edit the active layer in an external application."
 msgstr "Begin editing the current layer in an external application."
 
-#: ../po/tmp/resources.xml.h:73
+#: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Update Layer with External Edits"
 msgstr "Update Layer with External Edits"
 
-#: ../po/tmp/resources.xml.h:74
+#: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
 msgid "Commit changes saved from the external app (normally automatic)."
 msgstr "Commit changes saved from the external app (normally automatic)."
 
-#: ../po/tmp/resources.xml.h:75
+#: ../po/tmp/resources.xml.h:93
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer at Cursor"
 msgstr "Go to Layer at Cursor"
 
-#: ../po/tmp/resources.xml.h:76
+#: ../po/tmp/resources.xml.h:94
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr "Select a layer by picking an object on it."
 
-#: ../po/tmp/resources.xml.h:77
+#: ../po/tmp/resources.xml.h:95
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Above"
 msgstr "Go to Layer Above"
 
-#: ../po/tmp/resources.xml.h:78
+#: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer up in the layer stack."
 msgstr "Go one layer up in the layer stack."
 
-#: ../po/tmp/resources.xml.h:79
+#: ../po/tmp/resources.xml.h:97
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Below"
 msgstr "Go to Layer Below"
 
-#: ../po/tmp/resources.xml.h:80
+#: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer down in the layer stack."
 msgstr "Go one layer down in the layer stack."
 
-#: ../po/tmp/resources.xml.h:81
+#: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer"
 msgstr "New Painting Layer"
 
-#: ../po/tmp/resources.xml.h:82
+#: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer above the current layer."
 msgstr "Add a new painting layer above the current layer."
 
-#: ../po/tmp/resources.xml.h:83
+#: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer…"
 msgstr "New Vector Layer…"
 
-#: ../po/tmp/resources.xml.h:84
+#: ../po/tmp/resources.xml.h:102
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer above the current layer, and begin editing it."
 msgstr "Add a new vector layer above the current layer, and begin editing it."
 
-#: ../po/tmp/resources.xml.h:85
+#: ../po/tmp/resources.xml.h:103
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group"
 msgstr "New Layer Group"
 
-#: ../po/tmp/resources.xml.h:86
+#: ../po/tmp/resources.xml.h:104
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group above the current layer."
 msgstr "Add a new layer group above the current layer."
 
-#: ../po/tmp/resources.xml.h:87
+#: ../po/tmp/resources.xml.h:105
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer Below"
 msgstr "New Painting Layer Below"
 
-#: ../po/tmp/resources.xml.h:88
+#: ../po/tmp/resources.xml.h:106
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer below the current layer."
 msgstr "Add a new painting layer below the current layer."
 
-#: ../po/tmp/resources.xml.h:89
+#: ../po/tmp/resources.xml.h:107
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer Below…"
 msgstr "New Vector Layer Below…"
 
-#: ../po/tmp/resources.xml.h:90
+#: ../po/tmp/resources.xml.h:108
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer below the current layer, and begin editing it."
 msgstr "Add a new vector layer below the current layer, and begin editing it."
 
-#: ../po/tmp/resources.xml.h:91
+#: ../po/tmp/resources.xml.h:109
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group Below"
 msgstr "New Layer Group Below"
 
-#: ../po/tmp/resources.xml.h:92
+#: ../po/tmp/resources.xml.h:110
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group below the current layer."
 msgstr "Add a new layer group below the current layer."
 
-#: ../po/tmp/resources.xml.h:93
+#: ../po/tmp/resources.xml.h:111
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Layer Down"
 msgstr "Merge Layer Down"
 
-#: ../po/tmp/resources.xml.h:94
+#: ../po/tmp/resources.xml.h:112
 msgctxt "Accel Editor (descriptions)"
 msgid "Merge the current layer with the layer beneath it."
 msgstr "Merge the current layer with the layer beneath it."
 
-#: ../po/tmp/resources.xml.h:95
+#: ../po/tmp/resources.xml.h:113
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Visible Layers"
 msgstr "Merge Visible Layers"
 
-#: ../po/tmp/resources.xml.h:96
+#: ../po/tmp/resources.xml.h:114
 msgctxt "Accel Editor (descriptions)"
 msgid "Consolidate all visible layers, and delete the originals."
 msgstr "Consolidate all visible layers, and delete the originals."
 
-#: ../po/tmp/resources.xml.h:97
+#: ../po/tmp/resources.xml.h:115
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer from Visible"
 msgstr "New Layer from Visible"
 
-#: ../po/tmp/resources.xml.h:98
+#: ../po/tmp/resources.xml.h:116
 msgctxt "Accel Editor (descriptions)"
 msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
 msgstr "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
 
-#: ../po/tmp/resources.xml.h:99
+#: ../po/tmp/resources.xml.h:117
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Delete Layer"
 msgstr "Delete Layer"
 
-#: ../po/tmp/resources.xml.h:100
+#: ../po/tmp/resources.xml.h:118
 msgctxt "Accel Editor (descriptions)"
 msgid "Remove the current layer from the layer stack."
 msgstr "Remove the current layer from the layer stack."
 
-#: ../po/tmp/resources.xml.h:101
+#: ../po/tmp/resources.xml.h:119
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Convert to Normal Painting Layer"
 msgstr "Convert to Normal Painting Layer"
 
-#: ../po/tmp/resources.xml.h:102
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
@@ -4303,314 +5304,408 @@ msgstr ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr "Increase Layer’s Opacity"
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr "Make the layer less transparent."
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr "Reduce Layer’s Opacity"
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr "Make the layer more transparent."
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr "Raise Layer"
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr "Raise the current layer one step in the layer stack."
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr "Lower Layer"
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr "Lower the current layer one step in the layer stack."
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr "Duplicate Layer"
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr "Make an exact clone of the current layer."
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
+#, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
-msgstr "Rename Layer…"
+msgid "Layer Properties…"
+msgstr "Properties"
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
-msgstr "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr "Layer Locked"
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr "Layer Visible"
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr "Toggle the current layer’s visibility state, making it hidden."
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr "Show Background"
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr "Toggle the background layer’s visibility."
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr "Remove the current layer from the layer stack."
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr "Reset and Centre View"
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr "Reset Zoom, Rotation and Mirroring, and recentre the document."
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr "Fit to View"
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr "Switch between a fitted view and your working location and zoom."
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr "Reset"
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr "Reset Zoom"
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr "Restore the view’s zoom to its default."
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr "Reset Rotation"
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr "Restore the view’s rotation to 0°"
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr "Reset Mirroring"
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
-msgstr "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
+msgstr "Reset Mirroring"
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr "Zoom In"
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr "Increase magnification."
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Zoom Out"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr "Decrease magnification."
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
+#, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
-msgstr "Rotate Counterclockwise"
+msgid "Pan Left"
+msgstr "Pan View"
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
-msgstr "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
+msgstr "Rotate View: tilt your view of the canvas."
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr "Hard Light"
+
+#: ../po/tmp/resources.xml.h:159
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr "Pan View: move your view of the canvas horizontally or vertically."
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr "Rotate View: tilt your view of the canvas."
+
+#: ../po/tmp/resources.xml.h:162
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr "Pan View"
+
+#: ../po/tmp/resources.xml.h:163
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr "Rotate View: tilt your view of the canvas."
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr "Rotate Clockwise"
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr "Rotate the view clockwise."
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr "Rotate Counterclockwise"
+
+#: ../po/tmp/resources.xml.h:167
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr "Rotate the view counterclockwise."
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr "Mirror Horizontal"
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr "Flip the view left to right."
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr "Mirror Vertical"
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr "Flip the view upside-down."
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr "Layer Solo"
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr "Toggle whether only the current layer is shown."
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr "Symmetrical Painting Active"
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr "Mirror brushstrokes along the axis of symmetry"
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr "Frame Enabled"
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr "Toggle visibility of the document frame."
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr "Print Brush Input Values to Console"
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr "Show the brush engine’s internally generated inputs on the console."
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr "Visualize Rendering"
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr "Show rendering updates on-screen, for debugging."
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr "No Double Buffering"
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr "Turn off GTK’s double buffering, normally enabled."
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+#, fuzzy
+msgid "Delete Point"
+msgstr "Delete Point"
+
+#: ../po/tmp/resources.xml.h:187
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr "Delete the currently selected point"
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr "Paint Mode"
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr "Paint Mode: Normal"
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr "Apply colour normally when painting."
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr "Paint Mode: Eraser"
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr "Erase using the current brush."
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr "Paint Mode: Lock Alpha"
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr "Applying the brush doesn't change the layer’s opacity."
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr "Paint Mode: Colourize"
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
@@ -4618,256 +5713,251 @@ msgstr ""
 "Apply colour to the current layer without affecting its brightness or "
 "opacity."
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "File"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "Quit"
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr "Close main window and exit the app."
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "Edit"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr "Current Tool"
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "Colour"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr "Adjust Colour"
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr "Colour History Popup"
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr "Pop up a timeline of recent colours under the cursor."
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr "Colour Details Dialog"
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr "Show a colour details dialog with text entry."
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr "Next Palette Colour"
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr "Set painting colour to the next colour in the palette."
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr "Previous Palette Colour"
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr "Set painting colour to the previous colour in the palette."
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr "Add Colour to Palette"
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr "Append the current painting colour to the palette."
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "Layer"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr "Opacity"
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr "Go to Layer"
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr "New Layer Below"
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr "Properties"
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr "Scratchpad"
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr "New Scratchpad"
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr "Load the default scratchpad as a new scratchpad canvas."
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr "Open Scratchpad…"
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr "Load an image file on disk into the scratchpad."
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr "Save Scratchpad"
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr "Save the scratchpad to its existing file on disk."
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr "Export Scratchpad As…"
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr "Export the scratchpad to disk, under a file name of your choice."
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr "Revert Scratchpad"
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr "Revert the scratchpad to its last saved state."
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr "Save Scratchpad as Default"
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr "Save the scratchpad as the default for ‘New Scratchpad’."
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr "Clear Default Scratchpad"
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr "Clear the default scratchpad to a blank canvas."
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr "Copy Main Background to Scratchpad"
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 "Copy the background image from the working document into the Scratchpad."
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "Window"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "Brush"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr "Shortcut Keys"
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr "Brush Shortcut Keys Help"
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr "Show an explanation of how the shortcut keys work."
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "Change Brush…"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr "Pop up a brush changer under the cursor."
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "Change Colour…"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 "Pop up a colour changer under the cursor, with all colour selectors listed."
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "Change Colour (fast subset)…"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
@@ -4876,207 +5966,211 @@ msgstr ""
 "Pop up a colour changer under the cursor, with only single-click selectors "
 "listed."
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr "Get More Brushes…"
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr "Download brushpacks from the MyPaint wiki."
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr "Import Brushes…"
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr "Load a brushpack from disk."
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Help"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr "Online Help"
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr "Go to MyPaint’s documentation wiki."
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "About MyPaint"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr "Show MyPaint’s license, version number, and credits."
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Debug"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr "Print Memory Leak Info to Console (Slow!)"
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr "Debug memory leaks."
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr "Run Garbage Collector Now"
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr "Free memory used for Python objects which are no longer in use."
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr "Start/Stop Profiling…"
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr "Start or Stop Python Profiling (cProfile)"
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr "Simulate a Crash…"
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr "Raise a Python exception, to test the crash dialog."
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "View"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr "Feedback"
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr "Adjust View"
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
+#, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr "Popup Menu"
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr "Show the main menu as a popup."
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "Fullscreen"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr "Toggle between full-screen and windowed mode."
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "Edit Preferences"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr "Edit MyPaint’s global settings."
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr "Test Input Devices"
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr "Show a dialog which captures all events your input devices send."
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr "Background Chooser"
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr "Change the background paper texture."
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr "Brush Settings Editor"
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr "Edit the active brush’s settings."
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr "Brush Icon Editor"
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr "Edit brush icons."
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr "Layers Panel"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
-msgstr "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr "Show Layers Panel"
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr "HCY Wheel"
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
@@ -5085,42 +6179,32 @@ msgstr ""
 "Dockable cylindrical hue/chroma/luma colour selector. The circular slices "
 "are equiluminant."
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "Colour Palette"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr "Dockable palette colour selector."
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr "HSV Wheel"
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr "Dockable saturation and Value colour changer."
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr "HSV Triangle"
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr "Dockable colour selector: the old GTK colour triangle."
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr "HSV Cube"
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
@@ -5129,567 +6213,770 @@ msgstr ""
 "Dockable colour selector: HSV cube which can be rotated to show different "
 "planar slices."
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr "HSV Square"
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
-msgstr ""
-"Dockable colour selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
+msgstr "Dockable colour selector with concentric HSV rings."
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr "Component Sliders"
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr "Dockable colour selector showing individual components of the colour."
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr "Liquid Wash"
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr "Dockable colour selector showing a liquid-like wash of nearby colours."
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr "Concentric Rings"
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr "Dockable colour selector with concentric HSV rings."
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr "Crossed Bowl"
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 "Dockable colour selector with HSV ramps crossing a radial bowl of colour."
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr "Scratchpad Panel"
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
-msgstr "Toggle the Scratchpad dockpanel (mix colours and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr "Show Scratchpad Panel"
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr "Reveal the Scratchpad dockpanel (mix colours and make sketches)."
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr "Preview Panel"
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
-msgstr "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "Preview"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr "Reveal the Preview dockpanel (overview of the whole drawing area)."
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr "Tool Options Panel"
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
-msgstr "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr "Show Tool Options Panel"
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr "Reveal the Tool Options dockpanel (options for the current tool)."
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr "Brush & Colour History Panel"
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
-msgstr "Toggle the History panel (recently used brushes and colours)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr "Recent Brushes & Colours"
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr "Reveal the History panel (recently used brushes and colours)."
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr "Hide Controls in Fullscreen"
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr "Toggle automatic hiding of the user interface in fullscreen."
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr "Show Zoom Level"
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr "Toggle zoom level feedback."
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr "Show Last Painting Position"
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr "Toggle feedback showing where the last stroke ended."
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr "Display Filter"
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr "Display Colours Normally"
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr "Filter colours: show colours unchanged."
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr "Display Colours as Greyscale"
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr "Filter colours: show brightness only (HCY/YCbCr Luma)"
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr "Display Colours Inverted"
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr "Filter colours: inverse video. Black is white and red is cyan."
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr "Display Colours with Simulated Insensitivity to Red"
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 "Filter colours to simulate deuteranopia, a common form of colour blindness."
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr "Display Colours with Simulated Insensitivity to Green"
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 "Filter colours to simulate protanopia, a common form of colour blindness."
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr "Display Colours with Simulated Insensitivity to Blue"
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
-msgstr "Filter colours to simulate tritanopia, a rare form of colour blindness."
+msgstr ""
+"Filter colours to simulate tritanopia, a rare form of colour blindness."
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr "Slobodnom rukom"
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr "Freehand"
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr "Freehand: draw and paint freely, without geometric constraints."
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr "Freehand"
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr "Draw and paint freely, without geometric constraints."
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr "Pan View"
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr "Pan"
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr "Pan View: move your view of the canvas horizontally or vertically."
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr "Pan View"
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr "Interactively move your view of the canvas horizontally or vertically."
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr "Rotate View"
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr "Rotate"
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr "Rotate View: tilt your view of the canvas."
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr "Rotate View"
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr "Interactively rotate your view of the canvas."
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr "Zoom View"
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr "Zoom"
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr "Zoom View: zoom into or out of the canvas."
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr "Zoom View"
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr "Interactively zoom into or out of the canvas."
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr "Lines and Curves"
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr "Lines"
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr "Lines and Curves: draw straight or curved lines."
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr "Lines and Curves"
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr "Draw straight or curved lines."
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr "Connected Lines"
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr "Conn. Lines"
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr "Connected Lines: draw sequences of straight or curved lines."
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr "Connected Lines"
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr "Draw sequences of straight or curved lines."
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr "Ellipses and Circles"
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr "Ellipse"
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr "Ellipses and Circles: draw rounded shapes."
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr "Ellipses and Circles"
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr "Draw circles and ellipses."
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr "Inking"
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr "Ink"
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr "Inking: draw smooth controlled lines."
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr "Inking"
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr "Draw smooth controlled lines."
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr "Reposition Layer"
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr "Layer Pos."
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr "Reposition Layer: move the current layer on the canvas."
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr "Reposition Layer"
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr "Interactively move the current layer on the canvas."
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr "Edit Frame"
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr "Frame"
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 "Edit Frame: define a frame around the document to give it a finite size."
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr "Edit Frame"
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 "Interactively define a frame around the document to give it a finite size."
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Edit Painting Symmetry"
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr "Symmetry"
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Edit Painting Symmetry"
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr "Interactively adjust the axis used for symmetrical painting."
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr "Pick Colour"
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr "Pick Col."
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr "Pick Colour: set the painting colour from screen pixels."
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "Pick Colour"
+
+#: ../po/tmp/resources.xml.h:401
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr "Set the painting colour from screen pixels."
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "Pick Colour"
+
+#: ../po/tmp/resources.xml.h:403
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr "Set the painting colour from screen pixels."
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "Pick Colour"
+
+#: ../po/tmp/resources.xml.h:405
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr "Set the painting colour from screen pixels."
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr "Pick Colour"
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr "Set the painting colour from screen pixels."
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr "Flood Fill"
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr "Fill"
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr "Flood Fill: fill an area with colour."
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr "Flood Fill"
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr "Fill an area with colour."
+
+#~ msgctxt "Accelerator map editor: action column markup"
+#~ msgid ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+#~ msgstr ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+
+#~ msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
+#~ msgid "{action_label} {action_desc} {accel_label}"
+#~ msgstr "{action_label} {action_desc} {accel_label}"
+
+#~ msgctxt "brush list context menu"
+#~ msgid "Delete"
+#~ msgstr "Delete"
+
+#~ msgctxt "brush list commands"
+#~ msgid "Really delete brush from disk?"
+#~ msgstr "Really delete brush from disk?"
+
+#~ msgid "HSV Triangle"
+#~ msgstr "HSV Triangle"
+
+#~ msgid "The standard GTK color selector"
+#~ msgstr "The standard GTK colour selector"
+
+#~ msgid "Pick a color from the screen"
+#~ msgstr "Pick a colour from the screen"
+
+#~ msgid "Layer Name"
+#~ msgstr "Layer Name"
+
+#~ msgid ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+#~ msgstr ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+
+#~ msgid "Save..."
+#~ msgstr "Save..."
+
+#~ msgid "Confirm"
+#~ msgstr "Confirm"
+
+#~ msgid "Open..."
+#~ msgstr "Open..."
+
+#~ msgid "{default_name} at {path}"
+#~ msgstr "{default_name} at {path}"
+
+#~ msgid "Type"
+#~ msgstr "Type"
+
+#~ msgid "Mode:"
+#~ msgstr "Mode:"
+
+#~ msgid ""
+#~ "Blending mode: how the current layer combines with the layers underneath "
+#~ "it."
+#~ msgstr ""
+#~ "Blending mode: how the current layer combines with the layers underneath "
+#~ "it."
+
+#~ msgid ""
+#~ "Layer opacity: how much of the current layer to use. Smaller values make "
+#~ "it more transparent."
+#~ msgstr ""
+#~ "Layer opacity: how much of the current layer to use. Smaller values make "
+#~ "it more transparent."
+
+#~ msgid "%s: edit properties"
+#~ msgstr "%s: edit properties"
+
+#~ msgctxt "layer unique names: match regex (leave untranslated if unsure)"
+#~ msgid "^(.*?)\\s*(\\d+)$"
+#~ msgstr "^(.*?)\\s*(\\d+)$"
+
+#~ msgctxt "layer default names"
+#~ msgid "Unknown Bitmap Layer"
+#~ msgstr "Unknown Bitmap Layer"
+
+#~ msgctxt "Autosave Recovery dialog|"
+#~ msgid "_Ignore for Now"
+#~ msgstr "_Ignore for Now"
+
+#~ msgid "Setting name:"
+#~ msgstr "Setting name:"
+
+#~ msgid "Base value:"
+#~ msgstr "Base value:"
+
+#~ msgid "Reset the base value to its default"
+#~ msgstr "Reset the base value to its default"
+
+#~ msgid "<ymin>"
+#~ msgstr "<ymin>"
+
+#~ msgid "<ymax>"
+#~ msgstr "<ymax>"
+
+#~ msgid "<xmin>"
+#~ msgstr "<xmin>"
+
+#~ msgid "<xmax>"
+#~ msgstr "<xmax>"
+
+#~ msgid "Edit Setting"
+#~ msgstr "Edit Setting"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Trim Layer to Frame"
+#~ msgstr "Trim Layer to Frame"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Rename Layer…"
+#~ msgstr "Rename Layer…"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Enter a new name for the current layer."
+#~ msgstr "Enter a new name for the current layer."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Turn off mirroring of the view."
+#~ msgstr "Turn off mirroring of the view."
+
+#~ msgctxt "Menu→Edit (labels)"
+#~ msgid "Current Tool"
+#~ msgstr "Current Tool"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+#~ msgstr "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+
+#~ msgctxt "Menu→Color (labels), Accel Editor (labels)"
+#~ msgid "HSV Triangle"
+#~ msgstr "HSV Triangle"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Dockable color selector: the old GTK color triangle."
+#~ msgstr "Dockable colour selector: the old GTK colour triangle."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid ""
+#~ "Dockable color selector: HSV square which can be rotated to show "
+#~ "different hues."
+#~ msgstr ""
+#~ "Dockable colour selector: HSV square which can be rotated to show "
+#~ "different hues."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+#~ msgstr "Toggle the Scratchpad dockpanel (mix colours and make sketches)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+#~ msgstr "Toggle the Preview dockpanel (overview of the whole drawing area)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+#~ msgstr "Toggle the Tool Options dockpanel (options for the current tool)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the History panel (recently used brushes and colors)."
+#~ msgstr "Toggle the History panel (recently used brushes and colours)."
 
 #~ msgid "Colorize"
 #~ msgstr "Colorize"

--- a/po/eo.po
+++ b/po/eo.po
@@ -517,17 +517,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr "Nova grupo…"
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr "Importi penikojn…"
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1189,12 +1189,12 @@ msgstr "Tipo"
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr "Rulumo…"
 
 #. Name and preview column: will be indented
@@ -1411,7 +1411,7 @@ msgid "_Quit"
 msgstr "Ĉesi"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1461,7 +1461,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1647,13 +1647,13 @@ msgstr "JPEG (*.jpg; *.jpeg)"
 
 #: ../gui/filehandling.py:576
 #, fuzzy
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr "subteno"
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Konservi kiel…"
 
@@ -1721,7 +1721,7 @@ msgstr "Malfermi"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr "Notlibro"
 
 #: ../gui/filehandling.py:1099
@@ -2155,12 +2155,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2172,7 +2172,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2361,7 +2361,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2432,7 +2432,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:18+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/mypaint/"
@@ -19,29 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr "<big><b>{accel_label}</b></big>"
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr "{action_label} {action_desc} {accel_label}"
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "Ago"
 
@@ -49,39 +27,39 @@ msgstr "Ago"
 msgid "Key combination"
 msgstr "Klava kombino"
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "Ago:"
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "Vojo:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "Klavo:"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "Nekonata Ago"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr "Malfermi dosierujon “{folder_basename}”…"
@@ -89,214 +67,224 @@ msgstr "Malfermi dosierujon “{folder_basename}”…"
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "Bone"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "Konservi kiel defaŭlto"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "Fono"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Koloro"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr "Pri"
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "Eksperimenta"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr "Baza"
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr "Opakeco"
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "Stompilo"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr ""
+
+#: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr ""
 
-#: ../gui/brusheditor.py:359
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "Streko"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr "Koloro"
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Propra"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "Renomi penikon"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr "(Sennoma peniko)"
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr "{brush_name} [nekonservita]"
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -335,142 +323,181 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Konservi"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr "Forigita"
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr "Inko"
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr "Klasika"
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr "Aro#1"
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr "Aro#2"
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr "Aro#3"
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr "Aro#4"
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr "Aro#5"
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr "Eksperimenta"
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Nova"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr "Nekonata peniko"
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
-msgstr ""
+#: ../gui/brushselectionwindow.py:227
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
+msgstr "Forigi akson"
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr "Kloni"
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
+msgstr "Eksporti penikojn"
+
+#: ../gui/brushselectionwindow.py:250
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
+msgstr "Renomi grupon"
+
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
-msgstr "Forigi"
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] "%d peniko"
 msgstr[1] "%d penikoj"
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr "Grupo “{group_name}”"
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr "Renomi grupon"
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr "Forigi grupon"
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr "Renomi grupon"
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -478,58 +505,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr "Eksporti penikojn"
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "Nova grupo…"
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr "Importi penikojn…"
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "Krei grupon"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr "Butono"
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr "Btn"
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -538,52 +565,76 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -593,137 +644,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr "Helpilo…"
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -731,162 +782,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr "HSV tono"
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr "HSV satureco"
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr "HSV valoro"
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr "Paletro"
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr "Titolo:"
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr "Kolumnoj:"
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr "Kolornomo:"
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr "Konservi paletron"
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -894,373 +937,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr "Ĉiuj dosieroj (*)"
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr "Ĉiuj dosieroj (*)"
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr "R"
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr "V"
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr "B"
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr "RVB ruĝa"
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr "RVB verda"
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr "RVB blua"
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr "HSV tono"
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr "HSV satureco"
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr "HSV valoro"
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr "HCY tono"
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr "Skrapgumo"
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr "Klavaro"
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr "Muso"
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr "Tuŝplato"
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr "Tuŝekrano"
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr "Malatenti"
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr "Aparato"
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr "Aksoj"
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr "Tipo"
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr "Rulumo…"
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Nomo"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr "Anstataŭigi"
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr "Renomi"
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr "Anstataŭigi ĉiujn"
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr "Renomi ĉiujn"
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr "Malfari %s"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Malfari"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr "Refari %s"
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Refari"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr "{button_combination} estas {resultant_action}"
@@ -1270,326 +1310,697 @@ msgstr "{button_combination} estas {resultant_action}"
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ";  "
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
-msgstr "Tavola nomo"
-
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
-#, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
-"<b>{name}</b>\n"
-"{description}"
+
+#: ../gui/document.py:909
+#, python-brace-format
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
+msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr "%s - MyPaint"
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr "MyPaint"
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Malfermi"
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Tutekranumo"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Ĉesi"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Ĉesi"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr "Bildsimbolo"
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr "OpenRaster (*.ora)"
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr "PNG (*.png)"
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr "JPEG (*.jpg; *.jpeg)"
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr "Travidebla PNG (*.png)"
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr "Konservi…"
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr "Konfirmi"
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "Konservi paletron"
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:432
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:437
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:442
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
+msgstr "JPEG (*.jpg; *.jpeg)"
+
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:494
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:502
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:506
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr "Travidebla PNG (*.png)"
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Malfermi..."
+#: ../gui/filehandling.py:518
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr "JPEG (*.jpg; *.jpeg)"
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:576
+#, fuzzy
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr "subteno"
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Konservi kiel…"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr ""
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr "Malfermi…"
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Malfermi"
+
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
+msgstr "Notlibro"
+
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Forigi tavolon"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Malfermi"
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Malfermi lastajn"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Malfermi"
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Malfermi"
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+#, fuzzy
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr "Malfari"
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+#, fuzzy
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr "Tolero:"
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+#, fuzzy
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr "Fonto:"
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+#, fuzzy
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr "Kapabla al Vido"
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+#, fuzzy
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr "Celo:"
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
-msgstr ""
+msgstr "Nova Tavolo grupon"
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Travideblo:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr "Reŝargi"
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "Elekti tavolon"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr "<b>{brush_name}</b>"
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1599,130 +2010,142 @@ msgstr ""
 "<b>{brush_name}</b>\n"
 "{brush_desc}"
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr "Alto:"
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr "Larĝo:"
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr "Distingivo:"
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr "PEC"
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr "Punktoj en colo (vere pikseloj en colo)"
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr "Koloro:"
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr "Ŝaltita"
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr "{width:g}×{height:g} {units}"
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr "colo"
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr "cm"
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr "mm"
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1731,35 +2154,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr "Malatenti eraron"
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1783,45 +2206,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
 msgstr "Aparato:"
 
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
+msgstr ""
+
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr "Movi tavolon"
 
@@ -1829,155 +2256,225 @@ msgstr "Movi tavolon"
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
-msgstr "{default_name} ĉe {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
+msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
-msgstr "Tipo"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
+msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+#, fuzzy
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr "%s: redakti agordojn"
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr "Videbla"
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Tavolo"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+#, fuzzy
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr "Ŝlosita"
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+#, fuzzy
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ", "
+
+#: ../gui/layers.py:990
+#, fuzzy, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr "Aldoni {layer_default_name}"
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Tavoloj"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr "Tavola opakeco: %d%%"
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr "Tavolo"
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
-msgstr "Reĝimo:"
+#: ../gui/layervis.py:53
+#, fuzzy, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
+msgstr "<b>{brush_name}</b>"
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Travideblo:"
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "Renomi"
 
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr ""
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr ""
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr ""
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr ""
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 msgid "Stroke lead-in end"
 msgstr ""
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr ""
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr "Elipsoj kaj cirkloj"
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
+#, fuzzy
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 "Kopirajto (C) 2005-2015\n"
 "Martin Renold kaj la teamo de programistoj MyPaint"
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1989,256 +2486,286 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr "programado"
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr "porteblo"
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr "penikoj"
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr "paletroj"
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr "dokumentado"
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr "subteno"
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr "komunumo"
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ", "
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr "Nikolay Korotkiy <sikmir@gmail.com>"
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr "Grando:"
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr "<b>{mode_name}</b>"
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr "Agordoj"
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr "Notlibro"
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Place axis"
+msgstr ""
+
+#: ../gui/symmetry.py:84
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Move axis"
 msgstr "Movi akson"
 
-#: ../gui/symmetry.py:84
+#: ../gui/symmetry.py:88
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr "Forigi akson"
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
+#, fuzzy
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr "Pozicio:"
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr "Pozicio:"
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr "Nenio"
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
+msgstr "Simetrio"
+
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:446
+#, fuzzy
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr "Pozicio:"
+
+#: ../gui/symmetry.py:477
+#, fuzzy
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr "Pozicio:"
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr "Ŝaltita"
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr "Malfari kaj refari"
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2246,188 +2773,214 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr "<b>MyPaint</b>"
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, fuzzy, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr "%s: fermi langeton"
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
-msgstr "%s: redakti agordojn"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
+msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "Renomi grupon"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr "Vakigi tavolon"
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr "Alglui tavolon"
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Forigi tavolon"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr "Aldoni {layer_default_name}"
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr "Forigi tavolon"
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr "Elekti tavolon"
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr "Renomi tavolon"
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr "Ŝlosi tavolon"
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr "Malŝlosi tavolon"
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr "Nekonata reĝimo"
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2436,13 +2989,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2452,7 +3005,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2460,13 +3013,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2474,7 +3027,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2482,7 +3035,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2498,7 +3051,7 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2506,7 +3059,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2516,7 +3074,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2527,285 +3085,404 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
-#, python-brace-format
+#: ../lib/floodfill.py:131
+#, fuzzy
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr "Plenigi"
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr "{days}t{hours}h"
 
-#: ../lib/helpers.py:404
-#, python-brace-format
+#: ../lib/helpers.py:537
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr "{hours}h{minutes}m"
 
-#: ../lib/helpers.py:406
-#, python-brace-format
+#: ../lib/helpers.py:539
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr "{minutes}m{seconds}s"
 
-#: ../lib/helpers.py:408
-#, python-brace-format
+#: ../lib/helpers.py:541
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr "{seconds}s"
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr "Tavolo"
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr "%(name)s %(number)d"
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr "^(.*?)\\s*(\\d+)$"
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
+#, fuzzy
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr "Vektora tavolo"
+
+#: ../lib/layer/data.py:1158
+#, fuzzy
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr "Vektora tavolo"
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr "Nekonata Ago"
+
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "Nova Pentraĵo Tavolo"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr "Grupo"
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "Nova Tavolo grupon"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr "Lokokupilo"
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr "Radiko"
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ", "
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+#, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "Vido"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+#, fuzzy
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr "Forigi tavolon"
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr "Ŝlosi tavolon"
+
+#: ../lib/layervis.py:697
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr "Malŝlosi tavolon"
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr "Normala"
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr "Ekrano"
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr "Satureco"
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, fuzzy, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr "%(name)s %(number)d"
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2815,7 +3492,28 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+#, fuzzy
+msgid "Rotational"
+msgstr "Rotacio"
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2824,52 +3522,84 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr "Forigi"
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2891,17 +3621,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2930,113 +3658,90 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
-msgstr ""
+#: ../po/tmp/brusheditor.glade.h:22
+#, fuzzy
+msgid "Value:"
+msgstr "HSV valoro"
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr "<ymin>"
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr "<ymax>"
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr "<xmin>"
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr "<xmax>"
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
 msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+#, fuzzy
+msgid "<big><b>No Brush Dynamics</b></big>"
+msgstr "<big><b>{accel_label}</b></big>"
 
 #: ../po/tmp/inktool.glade.h:1
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
@@ -3048,7 +3753,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3089,6 +3794,135 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Nomo"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr "Reĝimo"
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Opakeco"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3458,56 +4292,77 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+#, fuzzy
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr "Ŝaltita"
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3515,12 +4370,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3529,7 +4384,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3540,28 +4395,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3623,1828 +4478,2076 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
-msgstr "Konservi"
+msgid "Import Layers…"
+msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
-msgstr "Konservi kiel…"
+msgid "Save"
+msgstr "Konservi"
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
-msgstr ""
+msgid "Save As…"
+msgstr "Konservi kiel…"
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr "Penikoj"
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr "Koloroj"
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr "Reĝimo"
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "Vakigi tavolon"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
-msgstr ""
+msgstr "Tavola nomo"
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "Nova Tavolo grupon"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "Nova Tavolo grupon"
+
+#: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:71
+#: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Edit Layer in External App…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
-msgstr "Nova Pentraĵo Tavolo"
-
-#: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:85
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
-msgstr "Nova Tavolo grupon"
-
-#: ../po/tmp/resources.xml.h:86
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:87
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:88
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:89
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
-msgstr "Forigi tavolon"
+msgid "New Painting Layer"
+msgstr "Nova Pentraĵo Tavolo"
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr "Nova Tavolo grupon"
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr "Forigi tavolon"
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr "Kapabla al Vido"
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Elzomi"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+#, fuzzy
+msgid "Delete Point"
+msgstr "Forigi grupon"
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Dosiero"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "Eliri"
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "Redakti"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "Koloro"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "Tavolo"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr "Skizlibro"
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "Fenestro"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "Peniko"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "Ŝanĝi Peniko…"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "Ŝanĝi Koloro…"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "Ŝanĝi Koloro (rapide)…"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr "Aldoni pli Penikojn…"
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Helpo"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr "Rete Helpo"
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "Pri MyPaint"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Senerarigo"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "Vido"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr "Prijuĝaj rimarkoj"
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "Tutekrana reĝimo"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "Redakti agordojn"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
-msgstr ""
+msgstr "Tavola nomo"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "Kolorpaletro"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "Antaŭrigardo"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr "Rotacio"
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr "Linioj kaj kurboj"
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr "Linioj"
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr "Linioj kaj kurboj"
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr "Elipsoj kaj cirkloj"
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr "Elipso"
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr "Elipsoj kaj cirkloj"
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr "Desegni cirklojn kaj elipsojn."
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr "Kadro"
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr "Simetrio"
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr "Plenigi"
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""
+
+#~ msgctxt "Accelerator map editor: action column markup"
+#~ msgid ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+#~ msgstr ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+
+#~ msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
+#~ msgid "{action_label} {action_desc} {accel_label}"
+#~ msgstr "{action_label} {action_desc} {accel_label}"
+
+#~ msgid ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+#~ msgstr ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+
+#~ msgid "Save..."
+#~ msgstr "Konservi…"
+
+#~ msgid "Confirm"
+#~ msgstr "Konfirmi"
+
+#~ msgid "Open..."
+#~ msgstr "Malfermi..."
+
+#~ msgid "{default_name} at {path}"
+#~ msgstr "{default_name} ĉe {path}"
+
+#~ msgid "Type"
+#~ msgstr "Tipo"
+
+#~ msgid "Mode:"
+#~ msgstr "Reĝimo:"
+
+#~ msgctxt "layer unique names: match regex (leave untranslated if unsure)"
+#~ msgid "^(.*?)\\s*(\\d+)$"
+#~ msgstr "^(.*?)\\s*(\\d+)$"
+
+#~ msgid "<ymin>"
+#~ msgstr "<ymin>"
+
+#~ msgid "<ymax>"
+#~ msgstr "<ymax>"
+
+#~ msgid "<xmin>"
+#~ msgstr "<xmin>"
+
+#~ msgid "<xmax>"
+#~ msgstr "<xmax>"

--- a/po/es.po
+++ b/po/es.po
@@ -534,18 +534,18 @@ msgstr "Paquete de brochas de MyPaint (*.zip)"
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
-msgstr "Grupo nuevo..."
+msgid "New Group…"
+msgstr "Grupo nuevo…"
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
-msgstr "Importar brochas..."
+msgid "Import Brushes…"
+msgstr "Importar brochas…"
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
-msgstr "Obtener más brochas..."
+msgid "Get More Brushes…"
+msgstr "Obtener más brochas…"
 
 #: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
@@ -1232,13 +1232,13 @@ msgstr "Tipo"
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr "Usar para…"
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
-msgstr "Desplazar..."
+msgid "Scroll…"
+msgstr "Desplazar…"
 
 #. Name and preview column: will be indented
 #: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
@@ -1461,8 +1461,8 @@ msgid "_Quit"
 msgstr "Salir"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
-msgstr "Importar paquete de brochas..."
+msgid "Import brush package…"
+msgstr "Importar paquete de brochas…"
 
 #: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
@@ -1517,8 +1517,8 @@ msgstr ""
 "“{type_name}” ({content_type})?"
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
-msgstr "Abrir con..."
+msgid "Open With…"
+msgstr "Abrir con…"
 
 #: ../gui/externalapp.py:123
 msgid "Icon"
@@ -1711,13 +1711,13 @@ msgstr "JPEG calidad 90% (*.jpg; *.jpeg)"
 
 #: ../gui/filehandling.py:576
 #, fuzzy
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr "Exportar…"
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Guardar como…"
 
@@ -1788,8 +1788,8 @@ msgstr "Abrir archivos recientes"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
-msgstr "Abrir hoja de pruebas..."
+msgid "Open Scratchpad…"
+msgstr "Abrir hoja de pruebas…"
 
 #: ../gui/filehandling.py:1099
 #, fuzzy
@@ -2245,13 +2245,13 @@ msgstr ""
 "incidencias si nadie más ha reportado aún."
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
-msgstr "Buscar Rastreador..."
+msgid "Search Tracker…"
+msgstr "Buscar Rastreador…"
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
-msgstr "Reportar..."
+msgid "Report…"
+msgstr "Reportar…"
 
 #: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
@@ -2262,8 +2262,8 @@ msgid "Quit MyPaint"
 msgstr "Salir de MyPaint"
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
-msgstr "Detalles..."
+msgid "Details…"
+msgstr "Detalles…"
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
@@ -2472,8 +2472,8 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
-msgstr "Mover la capa en la pila..."
+msgid "Move layer in stack…"
+msgstr "Mover la capa en la pila…"
 
 #: ../gui/layerswindow.py:110
 msgid ""
@@ -2544,8 +2544,8 @@ msgid "Stroke trail-off beginning"
 msgstr "Desde dónde viene la pincelada al inicio"
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
-msgstr "Variación de la presión..."
+msgid "Pressure variation…"
+msgstr "Variación de la presión…"
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
@@ -3742,7 +3742,7 @@ msgstr "Borrar este pincel del disco"
 #, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid "_Recover & Save…"
-msgstr "_Recuperar y Guardar..."
+msgstr "_Recuperar y Guardar…"
 
 #: ../po/tmp/autorecover.glade.h:12
 #, fuzzy

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MyPaint 0.7.1+git\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-08-20 10:23+0000\n"
 "Last-Translator: Adolfo Jayme Barrientos <fitojb@ubuntu.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -20,29 +20,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.8\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr "<big><b>{accel_label}</b></big>"
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr "{action_label} {action_desc} {accel_label}"
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "Acción"
 
@@ -50,32 +28,32 @@ msgstr "Acción"
 msgid "Key combination"
 msgstr "Combinación de teclas"
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr "Editar Tecla para '%s'"
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "Acción:"
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "Ruta:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "Tecla:"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr "Pulse las teclas para actualizar esta asignación"
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "Acción desconocida"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
@@ -84,7 +62,7 @@ msgstr ""
 "<b>{accel} ya esta en uso por '{action}'. La asignación actual sera "
 "reemplazada.</b>"
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr "Abrir Carpeta “{folder_basename}”…"
@@ -92,195 +70,206 @@ msgstr "Abrir Carpeta “{folder_basename}”…"
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "ACEPTAR"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr "No se encuentran copias de seguridad en la memoria cache."
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr "No hay disponibles Copias de Seguridad"
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr "Abrir la Carpeta de la Memoria Cache…"
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr "La recuperación de la Copia de Seguridad Fallo"
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr "Abrir la Carpeta de Copias de Seguridad…"
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr "Archivo recuperado desde {iso_datetime}.ora"
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "Guardar por defecto"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "Fondo"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "Patrón"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Color"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "Añadir color a los patrones"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr "No se han podido cargar uno o más fondos"
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr "Error al cargar fondos"
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 "Por favor quite los archivos que que no se han podido cargar, o chequee su "
 "instalación de libgdkpixbuf."
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr "Gdk-Pixbuf no pudo cargar \"{filename}\", y ha reportado \"{error}\""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr "{filename} tiene tamaño cero (w={w}, h={h})"
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr "Editor de Configuración de Brocha"
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr "Acerca de"
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "Experimental"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr "Básico"
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr "Opacidad"
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr "Pinceladas"
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "Difuminar"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr "Velocidad"
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr ""
+
+#: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr "Seguimiento"
 
-#: ../gui/brusheditor.py:359
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "Trazo"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr "Color"
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Personalizado"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
-msgstr "No hay una brocha seleccionada, use \"Agregar como nueva\" en su lugar."
+msgstr ""
+"No hay una brocha seleccionada, use \"Agregar como nueva\" en su lugar."
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr "¡No hay una brocha seleccionada!"
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "Renombrar Brocha"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "¡Ya existe una brocha con este nombre!"
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr "¡No hay una brocha seleccionada!"
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr "¿Desea borrar la brocha“{brush_name}” del disco?"
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr "(Brocha Sin Nombre)"
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr "{brush_name} [unsaved]"
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr "Icono de Brocha"
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr "Icono de Brocha (editado)"
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr "No hay brocha seleccionada"
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -289,7 +278,7 @@ msgstr ""
 "<b>%s</b>\n"
 "<small>Selecciona una brocha valida primero</small>"
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
@@ -298,7 +287,7 @@ msgstr ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Los cambios no serán salvados</small>"
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
@@ -307,7 +296,7 @@ msgstr ""
 "<b>%s</b> (editing)\n"
 "<small>Pinta con cualquier brocha o color</small>"
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -348,142 +337,182 @@ msgstr "Auto"
 msgid "Use the default icon"
 msgstr "Usar icono por defecto"
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Guardar"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr "Guardar icono de vista previa y finalizar edición"
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr "Perdidos y encontrados"
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr "Eliminado"
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr "Favoritos"
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr "Tinta"
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr "Clásico"
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr "Conjunto#1"
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr "Conjunto#2"
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr "Conjunto#3"
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr "Conjunto#4"
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr "Conjunto#5"
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr "Experimental"
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Nuevo"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr "Brocha desconocida"
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr "Añadir a Favoritos"
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr "Quitar de favoritos"
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr "Clonar"
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr "Editar configuración de brocha"
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
-msgstr "Eliminar"
+#: ../gui/brushselectionwindow.py:250
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
+msgstr "Renombrar grupo"
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
-msgstr "¿Desea borrar esta brocha del disco?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, fuzzy, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
+msgstr "¿Desea borrar la brocha“{brush_name}” del disco?"
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] "%d brocha"
 msgstr[1] "%d brochas"
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr "Grupo “{group_name}”"
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr "Renombrar grupo"
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr "Exportar como Brochas Zipeadas"
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr "Eliminar grupo"
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr "Renombrar grupo"
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "¡Ya existe un grupo con este nombre!"
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr "¿Desea realmente eliminar el grupo “{group_name}”?"
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -493,58 +522,58 @@ msgstr ""
 "No se puede eliminar el grupo “{group_name}”.\n"
 "Algunos grupos especiales no se pueden eliminar."
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr "Exportar brochas"
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr "Paquete de brochas de MyPaint (*.zip)"
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "Grupo nuevo..."
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr "Importar brochas..."
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr "Obtener más brochas..."
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "Crear grupo"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr "Botón"
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr "Btn"
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr "Botón a presionar"
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr "Añadir un atajo nuevo"
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr "Eliminar el atajo actual"
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr "Editar atajo para '%s'"
@@ -553,7 +582,7 @@ msgstr "Editar atajo para '%s'"
 msgid "Button press:"
 msgstr "Botón a presionar:"
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
@@ -561,7 +590,7 @@ msgstr ""
 "Mantenga presionadas las teclas de modificación, y presione un botón sobre "
 "este texto para crear un nuevo atajo."
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
@@ -569,41 +598,69 @@ msgstr ""
 "{button} no puede ser enlazado sin modificar teclas (esto significa que es "
 "fija, lo siento)"
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr "{button_combination} ya está vinculado a la acción '{action_name}'"
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr "Elija el Color"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr "Seleccionar el color usado para pintar"
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+#, fuzzy
+msgid "Set the color Hue used for painting"
+msgstr "Seleccionar el color usado para pintar"
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "Elegir Col."
+
+#: ../gui/colorpicker.py:296
+#, fuzzy
+msgid "Set the color Chroma used for painting"
+msgstr "Seleccionar el color usado para pintar"
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+#, fuzzy
+msgid "Set the color Luma used for painting"
+msgstr "Seleccionar el color usado para pintar"
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr "Detalles del color"
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 "El nuevo color seleccionado, y el color más recientemente usado para pintar"
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr "Máscara Gamut activa"
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -614,7 +671,7 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr "Tono HCY y croma."
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
@@ -623,12 +680,12 @@ msgstr ""
 "Editor de máscara Gamut. Clic en el medio para crear o manipular formas, o "
 "usar los ejes del disco para rotar la máscara."
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr "Tríada atmosférica"
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
@@ -637,22 +694,22 @@ msgstr ""
 "Intensa y subjetiva, defina por una dominante primaria y dos primarias de "
 "menor intensidad."
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr "Tríada desplazada"
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr "Ponderado con más fuerza hacia el color dominante."
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr "Complementarios"
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
@@ -661,12 +718,12 @@ msgstr ""
 "Opuestos que se contrastan, balancea para tener neutros centrales entre "
 "ellos, en la rueda de color."
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr "Sensación y acento"
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
@@ -675,12 +732,12 @@ msgstr ""
 "Un rango principal de colores, con un acento complementario para variar y "
 "remarcar."
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr "Complementarios Divididos"
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
@@ -689,73 +746,73 @@ msgstr ""
 "Dos colores análogos y el complemento de los mismos, sin colores secundarios "
 "entre ellos."
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr "Nueva Máscara Gamut desde Plantilla"
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr "Editor de Máscara Gamut"
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr "Activa"
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr "Ayuda…"
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr "Crear máscara desde plantilla."
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr "Cargar máscara desde un archivo de paleta de GIMP."
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr "Guardar máscara a un archivo de paleta de GIMP."
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr "Borrar la máscara."
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 "Abrir la ayuda en línea para este cuadro de diálogo en un explorador web."
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr "Guardar máscara como una paleta de Gimp"
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr "Cargar máscara desde un archivo de paleta de GIMP"
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr "Definir máscara Gamut."
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr "Rueda HCY"
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -765,162 +822,154 @@ msgstr ""
 "cortes circulares son equiluminantes."
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr "Tono HSV"
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr "Saturación HSV"
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr "Valor HSV"
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr "Saturación y valor HSV"
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr "Tono y valor HSV"
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr "Tono y saturación HSV"
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr "Rotar cubo (mostrar otros ejes)"
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr "Cubo HSV"
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr "Un cubo HSV que puede rotarse para mostrar distintos cortes planos."
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr "Cuadrado HSV"
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr "Un cubo HSV que puede ser rotado para mostrar tonalidades diferentes."
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr "Triángulo HSV"
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr "El selector de colores estándar de GTK"
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr "Rueda HSV"
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr "Seleccionador de color por saturación y valor."
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr "Propiedades de la paleta"
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr "Paleta"
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr "Ajuste el color desde una paleta, que puede cargarse y editarse."
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr "Paleta sin titulo"
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr "Editor de paleta"
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr "Cargar desde un archivo de paleta de GIMP"
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr "Guardar a un archivo de paleta de GIMP"
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr "Añadir una nueva muestra vacía"
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr "Quitar la muestra actual"
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr "Quitar todas las muestras"
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr "Título:"
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr "Nombre o descripción para esta paleta"
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr "Columnas:"
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr "Número de columnas"
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr "Nombre del color:"
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr "Nombre del color actual"
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr "Espacio de paleta vacía"
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr "Cargar paleta"
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr "Guardar paleta"
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -931,379 +980,376 @@ msgstr ""
 "Suelte los colores aquí,\n"
 "arrástrelos para organizarlos."
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr "Casilla de paleta vacía (arrastre un color aquí)"
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr "Añadir una Ranura Vacía"
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr "Insertar Fila"
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr "Insertar columna"
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr "Rellenar Hueco (RGB)"
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr "Rellenar Hueco (HCY)"
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr "Rellenar Hueco (HSV)"
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "Archivo de paleta de GIMP (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr "Todos los archivos (*)"
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "Archivo de paleta de GIMP (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr "Todos los archivos (*)"
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr "Recoger un color desde la pantalla"
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr "R"
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr "G"
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr "B"
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr "H"
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr "C"
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr "Y"
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr "Barras de control de componentes"
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr "Ajustar los componentes individuales del color."
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr "Rojo RGB"
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr "Verde RGB"
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr "Azul RGB"
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr "Tono HSV"
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr "Saturación HSV"
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr "Valor HSV"
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr "Tono HCY"
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr "Croma HCY"
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr "Luminancia (Y') HCY"
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr "Líquido de Lavado"
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr "Cambiar el color usando un líquido como lavado de colores cercanos."
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr "Anillos concéntricos"
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr "Cambiar color usando anillos HSV concéntricos."
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr "Tazón Cruzado"
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr "Cambian de color con rampas HSV cruzando un tazón radial de color."
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr "Cursor/disco"
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr "Goma de borrar"
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr "Teclado"
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr "Ratón"
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr "Pluma"
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr "Pantalla Táctil"
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr "Pantalla táctil"
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr "Ignorar"
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr "Cualquier Tarea"
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr "Tareas no-pintura"
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr "Navegación sólo"
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr "Ampliación"
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr "Encuadrar"
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr "Dispositivo"
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr "Ejes"
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr "Tipo"
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr "Usar para…"
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr "Desplazar..."
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Nombre"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr "¿Sobrescribir la brocha?"
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr "Reemplazar"
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr "Renombrar"
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr "Reemplazar todo"
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr "Renombrar todo"
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr "Brocha importada"
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr "Brocha existente"
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 "<b>Ya existe una brocha de nombre `%s' .</b>\n"
 "¿Desea reemplazarla, o renombrar la brocha nueva?"
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr "¿Sobreescribir el grupo de brochas?"
 
-#: ../gui/dialogs.py:190
-#, python-brace-format
+#: ../gui/dialogs.py:220
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 "<b>Ya existe un grupo llamado `{groupname}'.</b>\n"
 "¿Desea reemplazarlo, o renombrar el grupo nuevo?\n"
 "Si lo reemplaza, las brochas pueden ser movidas a un grupo llamado "
 "`{deleted_groupname}'."
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr "¿Importar paquete de brochas?"
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, fuzzy, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr "<b>Realmente desea importar el paquete `%s'?</b>"
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr "Cargar configuración de pincel de ranura de acceso directo %d"
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr "Almacena la configuración de pincel en la ranura de acceso directo %d"
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr "Restaurar la brocha %d"
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr "Guardar como la brocha %d"
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr "Deshacer %s"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Deshacer"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr "Rehacer %s"
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Rehacer"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr "{button_combination} es {resultant_action}"
@@ -1313,90 +1359,127 @@ msgstr "{button_combination} es {resultant_action}"
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ";  "
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr "Con {modifiers} mantener pulsada: {button_actions}."
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
-msgstr "Nombre de capa"
-
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
-#, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
-"<b>{name}</b>\n"
-"{description}"
+
+#: ../gui/document.py:909
+#, python-brace-format
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
+msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr "%s - MyPaint"
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr "MyPaint"
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Abrir"
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr "Escoger el color actual"
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr "Dejar modo a pantalla completa"
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr "Dejar modo a pantalla completa"
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr "Entrar al modo pantalla completa"
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Pantalla completa"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Salir"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+#, fuzzy
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr "¿Desea salir?"
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Salir"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr "Importar paquete de brochas..."
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr "Paquete de brochas de MyPaint (*.zip)"
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr "Lanzó {app_name} para editar capa\"{layer_name}\""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr "Error: error al iniciar {app_name} para editar capa \"{layer_name}\""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
@@ -1404,184 +1487,406 @@ msgstr ""
 "Edición cancelada. Todavía puede editar \"{layer_name}\" desde el menú de "
 "capas."
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr "Capa actualizada \"{layer_name}\" con ediciones externas"
 
-#: ../gui/externalapp.py:46
-#, python-brace-format
-msgid ""
-"MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
-"application should it use?"
-msgstr ""
-"MyPaint necesita editar un archivo de tipo “{type_name}” ({content_type}). ¿"
-"Qué aplicación debería utilizar?"
-
-#: ../gui/externalapp.py:50
-#, python-brace-format
-msgid ""
-"What application should MyPaint use for editing files of type "
-"“{type_name}” ({content_type})?"
-msgstr ""
-"¿Qué aplicación debe usar MyPaint para editar archivos de tipo “{type_name}” "
-"({content_type})?"
-
-#: ../gui/externalapp.py:56
-msgid "Open With..."
-msgstr "Abrir con..."
-
-#: ../gui/externalapp.py:107
-msgid "Icon"
-msgstr "Icono"
-
-#: ../gui/externalapp.py:150
-msgid "no description"
-msgstr "Sin descripción"
-
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr "Todos los formatos reconocibles"
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr "OpenRaster (*.ora)"
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr "PNG (*.png)"
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr "JPEG (*.jpg; *.jpeg)"
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr "Por extensión (preferentemente el formato por defecto)"
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr "PNG sólido con fondo (*.png)"
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr "PNG transparente (*.png)"
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr "Múltiples PNG transparentes (*.XXX.png)"
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr "JPEG calidad 90% (*.jpg; *.jpeg)"
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr "Guardar..."
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr "Formato a guardar:"
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr "Confirmar"
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr "¿Desea continuar?"
-
-#: ../gui/filehandling.py:234
-#, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
-msgstr "Esto descartará {abbreviated_time} lo pintado sin guardar"
-
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr "_Guardar como boceto"
-
-#: ../gui/filehandling.py:282
-#, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
-msgstr "Cargando \"{file_basename}\"…"
-
-#: ../gui/filehandling.py:296
+#: ../gui/externalapp.py:48
 #, python-brace-format
 msgctxt "file handling: open failed (statusbar)"
 msgid "Could not load “{file_basename}”."
 msgstr "No se pudo cargar \"{file_basename}\"."
 
-#: ../gui/filehandling.py:321
+#: ../gui/externalapp.py:61
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
-msgstr "Cargado \"{file_basename}\"."
+msgid ""
+"MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
+"application should it use?"
+msgstr ""
+"MyPaint necesita editar un archivo de tipo “{type_name}” ({content_type}). "
+"¿Qué aplicación debería utilizar?"
 
-#: ../gui/filehandling.py:422
+#: ../gui/externalapp.py:65
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
-msgstr "Exportar a \"{file_basename}\"…"
+msgid ""
+"What application should MyPaint use for editing files of type "
+"“{type_name}” ({content_type})?"
+msgstr ""
+"¿Qué aplicación debe usar MyPaint para editar archivos de tipo "
+"“{type_name}” ({content_type})?"
 
-#: ../gui/filehandling.py:427
+#: ../gui/externalapp.py:71
+msgid "Open With..."
+msgstr "Abrir con..."
+
+#: ../gui/externalapp.py:123
+msgid "Icon"
+msgstr "Icono"
+
+#: ../gui/externalapp.py:166
+msgid "no description"
+msgstr "Sin descripción"
+
+#: ../gui/filehandling.py:126
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
+msgstr "Cargando \"{file_basename}\"…"
+
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:134
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr "Salvando \"{file_basename}\"…"
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:138
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
+msgstr "Exportar a \"{file_basename}\"…"
+
+#: ../gui/filehandling.py:145
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
 msgstr "No se pudo exportar a \"{file_basename}\"."
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:149
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
 msgstr "Error al guardar \"{file_basename}\"."
 
-#: ../gui/filehandling.py:476
+#: ../gui/filehandling.py:153
 #, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr "No se pudo cargar \"{file_basename}\"."
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "Guardar paleta"
+
+#: ../gui/filehandling.py:168
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr "Exportar a un archivo"
+
+#: ../gui/filehandling.py:172
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr "Exportar a un archivo"
+
+#: ../gui/filehandling.py:176
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr "Abrir archivos recientes"
+
+#: ../gui/filehandling.py:183
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
 msgstr "Exportado a \"{file_basename}\" con éxito."
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:187
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
 msgstr "Guardado \"{file_basename}\" con éxito."
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Abrir..."
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:195
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr "Cargado \"{file_basename}\"."
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
+msgstr "Cargado \"{file_basename}\"."
+
+#: ../gui/filehandling.py:427
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
+msgstr "Todos los formatos reconocibles"
+
+#: ../gui/filehandling.py:432
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:437
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:442
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
+msgstr "JPEG (*.jpg; *.jpeg)"
+
+#: ../gui/filehandling.py:490
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
+msgstr "Por extensión (preferentemente el formato por defecto)"
+
+#: ../gui/filehandling.py:494
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:498
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr "PNG sólido con fondo (*.png)"
+
+#: ../gui/filehandling.py:502
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:506
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr "PNG transparente (*.png)"
+
+#: ../gui/filehandling.py:510
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr "Múltiples PNG transparentes (*.XXX.png)"
+
+#: ../gui/filehandling.py:514
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr "Múltiples PNG transparentes (*.XXX.png)"
+
+#: ../gui/filehandling.py:518
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr "JPEG calidad 90% (*.jpg; *.jpeg)"
+
+#: ../gui/filehandling.py:576
+#, fuzzy
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr "Exportar…"
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Guardar como…"
+
+#: ../gui/filehandling.py:601
+#, fuzzy
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr "Formato a guardar:"
+
+#: ../gui/filehandling.py:668
+#, fuzzy
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr "¿Desea continuar?"
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+#, fuzzy
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr "_Guardar como boceto"
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, fuzzy, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr "Esto descartará {abbreviated_time} lo pintado sin guardar"
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr "Abrir…"
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Abrir archivos recientes"
+
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr "Abrir hoja de pruebas..."
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Brocha importada"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Abrir"
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Abrir el más reciente"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Abrir"
+
+#: ../gui/filehandling.py:1446
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
 msgstr "Aún no hay archivos de boceto con nombre \"%s\"."
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1455
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr "Abrir Esbozo Siguiente"
+
+#: ../gui/filehandling.py:1463
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr "Abrir Esbozo Previo"
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Abrir"
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+#, fuzzy
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr "Revertir"
+
+#: ../gui/fill.py:121
+#, fuzzy
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr "Bote de pintura"
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+#, fuzzy
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr "Rellenar áreas con color"
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+#, fuzzy
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr "Tolerancia:"
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+#, fuzzy
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
@@ -1589,19 +1894,36 @@ msgstr ""
 "Cuántos pixeles de color se permiten variar desde el inicio\n"
 "antes de que el Bote de pintura se niegue a rellenarlos"
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+#, fuzzy
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr "Fuente:"
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
-msgstr "Que capas visibles deberían ser rellenadas"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
+msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+#, fuzzy
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr "Muestra Combinada"
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+#, fuzzy
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
@@ -1611,19 +1933,50 @@ msgstr ""
 "combinación temporal de todas las capas visibles\n"
 "por debajo de la capa actual"
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+#, fuzzy
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr "Ajustar a la Vista"
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+#, fuzzy
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr "Destino:"
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+#, fuzzy
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr "Donde debe ir la salida"
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr "Nueva capa (una vez)"
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+#, fuzzy
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
@@ -1631,21 +1984,108 @@ msgstr ""
 "Crear una nueva capa con los resultados del relleno.\n"
 "Esta se apaga automáticamente después de su uso."
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Opacidad:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr "Reiniciar"
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+#, fuzzy
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr "Reiniciar opciones a los valores por defecto"
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "Seleccionar capa"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr "<b>{brush_name}</b>"
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1655,130 +2095,142 @@ msgstr ""
 "<b>{brush_name}</b>\n"
 "{brush_desc}"
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr "Editar marco"
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr "Ajustar el marco del documento"
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr "Tamaño del Marco"
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr "px"
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr "Alto:"
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr "Ancho:"
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr "Resolución:"
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr "DPI"
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr "Puntos Por Pulgada (realmente Píxeles Por Pulgada)"
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr "Color:"
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr "Color del marco"
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr "<b>Dimensiones del Marco</b>"
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr "<b>Densidad de píxeles</b>"
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr "Ajustar el Marco a la Capa"
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr "Ajustar el marco a la extensión de la capa actual"
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr "Ajustar el Marco al Documento"
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr "Ajustar el marco a la combinación de todas las capas"
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr "Recortar la Capa al Marco"
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr "Recortar partes de la capa actual que se encuentran fuera del marco"
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr "Activado"
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr "{width:g}×{height:g} {units}"
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr "pulgadas"
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr "cm"
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr "mm"
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr "Dibujo a mano alzada"
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr "Pintar trazos de pincel de forma libre"
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr "Suavizado:"
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr "Presión:"
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr "Error detectado"
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr "<big><b>Se ha detectado un error de programación.</b></big>"
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1792,35 +2244,35 @@ msgstr ""
 "Por favor dígale a los desarrolladores sobre esto usando el control de "
 "incidencias si nadie más ha reportado aún."
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr "Buscar Rastreador..."
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr "Reportar..."
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr "Ignorar Error"
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr "Salir de MyPaint"
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr "Detalles..."
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr "Excepción al analizar la excepción."
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1864,45 +2316,50 @@ msgstr ""
 "            ### Rastreo\n"
 "        "
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr "Entintar"
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr "Dibujar, y luego ajustar líneas suaves"
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr "Prueba del dispositivo de entrada"
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr "(sin presión)"
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr "Presión:"
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr "(sin inclinación)"
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr "Inclinación:"
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr "(sin dispositivo)"
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
 msgstr "Dispositivo:"
 
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+#, fuzzy
+msgid "Barrel Rotation:"
+msgstr "Reiniciar Rotación"
+
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr "Mover Capa"
 
@@ -1910,160 +2367,227 @@ msgstr "Mover Capa"
 msgid "Move the current layer"
 msgstr "Mover la capa actual"
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
-msgstr "{default_name} en {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
+msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
-msgstr "Tipo"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
+msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+#, fuzzy
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr "Propiedades"
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr "Visible"
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Capa"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+#, fuzzy
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr "Bloqueado"
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+#, fuzzy
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ", "
+
+#: ../gui/layers.py:990
+#, fuzzy, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr "Agregar {layer_default_name}"
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Capas"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr "Organizar capas y asignar efectos"
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr "Opacidad de la capa: %d%%"
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr "Mover la capa en la pila..."
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 "Mover la capa en la pila (dejando en una capa normal creará un nuevo grupo)"
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr "Capa"
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
-msgstr "Modo:"
+#: ../gui/layervis.py:53
+#, fuzzy, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
+msgstr "<b>{brush_name}</b>"
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
-"Modo de mezcla: cómo se combina la capa con las que están debajo de la misma."
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Opacidad:"
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "Rotar vista"
 
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-"Opacidad de capa: qué cantidad de la capa actual usar. Valores más bajos la "
-"hacen más transparente."
-
-#: ../gui/linemode.py:37
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr "Presión de entrada"
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr "Presión al inicio para herramientas de línea"
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr "Presión del punto medio"
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr "Presión en el punto medio para herramientas de línea"
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr "Presión de salida"
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr "Presión al final para herramientas de línea"
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr "Cabeza"
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 msgid "Stroke lead-in end"
 msgstr "Hacia dónde va la pincelada al final"
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr "Cola"
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr "Desde dónde viene la pincelada al inicio"
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr "Variación de la presión..."
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr "Líneas y Curvas"
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr "Modo línea/curva Genérica"
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr "Dibujar líneas rectas; Mayús añade curvas, Ctrl restringe el ángulo"
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr "Líneas conectadas"
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 "Dibuja una secuencia de líneas; Mayús añade curvas, Ctrl restringe el ángulo"
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr "Elipses y Círculos"
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr "Dibujar elipses; Shift gira, Ctrl restringe el ángulo de proporción"
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
+#, fuzzy
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 "Copyright (C) 2005-2015\n"
 "Martin Renold y el equipo de desarrollo de MyPaint"
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -2084,256 +2608,286 @@ msgstr ""
 "IDONEIDAD PARA UN PROPÓSITO PARTICULAR. Vea la Licencia Pública General GNU "
 "para más detalles."
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr "programación"
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr "portabilidad"
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr "gestión de proyectos"
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr "brochas"
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr "patrones"
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr "Iconos de herramientas"
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr "Icono de escritorio"
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr "paletas"
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr "documentación"
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr "soporte"
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr "difusión"
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr "comunidad"
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ", "
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr "Créditos de traductores"
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr "Tamaño:"
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr "Opaco:"
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr "Afilado:"
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr "Ganancia:"
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr "iconos de herramientas"
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr "Configuración especializada de la herramienta de edición actual"
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr "<b>{mode_name}</b>"
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr "<i>No hay opciones disponibles</i>"
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr "Ampliación: %.01f%%"
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr "Elija Configuración de trazo, color de trazo y capa…"
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr "Elegir el color…"
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr "Preferencias"
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr "Vista previa"
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr "Mostrar vista previa de todo el área de dibujo"
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr "Mostrar visor de búsqueda"
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr "Libreta de Esbozos"
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr "Mezclar colores y hacer bocetos en hojas de prueba separadas"
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr "Elemento anterior"
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr "Elemento siguiente"
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
 msgstr "(Nada para mostrar)"
 
-#: ../gui/symmetry.py:76
+#: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Place axis"
 msgstr "Posicionar ejes"
 
-#: ../gui/symmetry.py:80
+#: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Move axis"
 msgstr "Mueva el eje"
 
-#: ../gui/symmetry.py:84
+#: ../gui/symmetry.py:88
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr "Quitar eje"
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr "Editar el eje de la simetría"
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr "Ajustar el eje de simetría de la pintura."
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
+#, fuzzy
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr "Posición:"
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr "Posición:"
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr "Ninguno"
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr "%d px"
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr "Alfa:"
 
-#: ../gui/symmetry.py:352
+#: ../gui/symmetry.py:376
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
+msgstr "Simetría"
+
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+#, fuzzy
 msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+msgid "X axis Position"
 msgstr "Posición del eje"
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:477
+#, fuzzy
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr "Posición del eje"
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr "Activado"
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr "Manejo de archivos"
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr "Intercambiar bocetos"
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr "Deshacer y rehacer"
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr "Modos de mezcla"
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr "Modos de línea"
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr "Ver (principal)"
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr "Ver (alternativa/secundaria)"
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr "Ver (reiniciando)"
 
@@ -2341,188 +2895,214 @@ msgstr "Ver (reiniciando)"
 msgid "<b>MyPaint</b>"
 msgstr "<b>MyPaint</b>"
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr "Vista de desplazamiento"
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr "Arrastrar Vista de lienzo"
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr "Vista de zoom"
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr "Ampliar Vista de lienzo"
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr "Rotar vista"
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr "Girar la vista del lienzo"
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, fuzzy, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr "%s: Cerrar pestaña"
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
-msgstr "%s: editar propiedades"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
+msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr "Acción desconocida"
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr "Sin definir (comando aun no empezado)"
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr "{seconds:.01f}s de pintado con {brush_name}"
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr "Bote de pintura"
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr "Recortar la capa"
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "Renombrar grupo"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr "Limpiar capa"
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr "Pegar Capa"
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr "Nueva Capa desde Visible"
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr "Combinar las Capas Visibles"
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr "Combinar hacia abajo"
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr "Normalizar el modo de capa"
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Brocha importada"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr "Agregar {layer_default_name}"
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr "Quitar capa"
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr "Seleccionar capa"
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr "Duplicar capa"
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr "Mover capa hacia arriba"
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr "Mover capa hacia abajo"
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr "Mover la capa en la pila"
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr "Renombrar capa"
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr "Hacer la capa visible"
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr "Hacer la capa invisible"
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr "Bloquear capa"
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr "Desbloquear capa"
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr "Ajustar la opacidad de capa: %0.1f%%"
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr "Modo desconocido"
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr "Ajustar Modo de capa: %s"
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr "Habilitar el Marco"
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr "Desactivar Marco"
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr "Actualizar Marco"
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr "Editar Capa Externa"
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr "Error al cargar “{basename}”."
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr "Los registros pueden tener más detalles sobre este error."
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr "desde ahora"
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr "hace"
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2534,13 +3114,13 @@ msgstr ""
 "¿Esta ejecutando más de una instancia de MyPaint?\n"
 "Cerrar la aplicación y esperar {cache_update_interval}s para reintentar."
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr "Copia de seguridad incompleta actualizado {last_modified_time} {ago}"
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2550,11 +3130,11 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 "Copia de seguridad actualizada {last_modified_time} {ago}\n"
-"Tamaño: {autosave.width}×{autosave.height} píxeles, Capas: "
-"{autosave.num_layers}\n"
+"Tamaño: {autosave.width}×{autosave.height} píxeles, Capas: {autosave."
+"num_layers}\n"
 "Contiene {unsaved_time} de pintura sin guardar."
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2564,13 +3144,13 @@ msgstr ""
 "No se puede escribir “{filename}”: {err}\n"
 "¿Usted tiene suficiente espacio en el dispositivo?"
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr "No se puede escribir “{filename}”: {err}"
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2580,7 +3160,7 @@ msgstr ""
 "{error_loading_common}\n"
 "El archivo no existe."
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2590,7 +3170,7 @@ msgstr ""
 "{error_loading_common}\n"
 "No tienes los permisos necesarios para abrir este archivo."
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2606,7 +3186,7 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2616,7 +3196,13 @@ msgstr ""
 "{error_loading_common}\n"
 "Extensión de formato de archivo desconocida: \"{ext}\""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+#, fuzzy
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr "Brocha importada"
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2630,7 +3216,7 @@ msgstr ""
 "Intente guardar en formato PNG en su lugar, si su máquina no tiene mucha "
 "memoria. El modo de salvado PNG de MyPaint es más eficiente."
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2646,98 +3232,207 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/helpers.py:402
-#, python-brace-format
+#: ../lib/floodfill.py:131
+#, fuzzy
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr "Relleno"
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr "{days}d{hours}h"
 
-#: ../lib/helpers.py:404
-#, python-brace-format
+#: ../lib/helpers.py:537
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr "{hours}h{minutes}m"
 
-#: ../lib/helpers.py:406
-#, python-brace-format
+#: ../lib/helpers.py:539
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr "{minutes}m{seconds}s"
 
-#: ../lib/helpers.py:408
-#, python-brace-format
+#: ../lib/helpers.py:541
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr "{seconds}s"
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr "Capa"
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr "%(name)s %(number)d"
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr "^(.*?)\\s*(\\d+)$"
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
+#, fuzzy
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr "Capa Vectorial"
+
+#: ../lib/layer/data.py:1158
+#, fuzzy
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr "Capa Vectorial"
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
-msgstr "Capa de mapa de bits desconocida"
+msgid "Bitmap"
+msgstr ""
 
-#: ../lib/layer/data.py:1169
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1244
 msgctxt "layer default names"
-msgid "Unknown Data Layer"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
 msgstr "Capa de datos desconocida"
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "Nueva capa de pintura"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr "Grupo"
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "Nueva Capa de Grupo"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr "Marcador de posición"
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr "Raíz"
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ", "
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+#, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "Ver"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+#, fuzzy
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr "Agregar capa"
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+#, fuzzy
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr "Quitar capa"
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr "Bloquear capa"
+
+#: ../lib/layervis.py:697
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr "Desbloquear capa"
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr "Paso a través"
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr "El contenido de grupo se aplica directamente al fondo del grupo"
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr "Normal"
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr "Sólo la capa de arriba, sin mezcla de colores."
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr "Multiplicar"
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
@@ -2745,11 +3440,11 @@ msgstr ""
 "Similar a la carga de dos diapositivas en un proyector y proyectar el "
 "resultado combinado."
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr "Pantalla"
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
@@ -2757,11 +3452,11 @@ msgstr ""
 "Como proyectar con dos proyectores dos diapositivas distintas, "
 "simultáneamente en una misma pantalla.  Es lo inverso de 'Multiplicar'."
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr "Solapar"
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
@@ -2769,30 +3464,30 @@ msgstr ""
 "Solapa lo que hay debajo con la capa de arriba, preservando las intensidades "
 "y las sombras de lo que hay debajo.  Es la inversa de 'Claridad fuerte'."
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr "Oscurecer"
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 "La capa de arriba se usa solamente cuando es más oscura que lo que hay "
 "debajo."
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr "Clarear"
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 "La capa de arriba se usa solamente cuando es más clara que lo que hay debajo."
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr "Blanquear"
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
@@ -2802,11 +3497,11 @@ msgstr ""
 "la técnica fotográfica del cuarto oscuro que se usa para mejorar el "
 "contraste en las sombras."
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr "Ennegrecer"
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
@@ -2816,43 +3511,43 @@ msgstr ""
 "la técnica fotográfica del cuarto oscuro que se usa para reducir los puntos "
 "de demasiado brillo."
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr "Claridad fuerte"
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr "Similar a iluminar con una luz spot dura lo que hay debajo."
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr "Claridad suave"
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr "Como iluminar con una luz spot difusa lo que hay debajo."
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr "Diferencia"
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr "Sustrae el color más oscuro de el más claro de los dos."
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr "Exclusión"
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr "Similar al modo 'Diferencia', pero con menos contraste."
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr "Tono"
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
@@ -2860,11 +3555,11 @@ msgstr ""
 "Combina el tono de la capa de arriba con la saturación y la luminosidad de "
 "lo que hay debajo."
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr "Saturación"
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
@@ -2872,7 +3567,7 @@ msgstr ""
 "Aplica la saturación de los colores de la capa de arriba al tono y "
 "luminosidad de lo que hay debajo."
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
@@ -2880,11 +3575,11 @@ msgstr ""
 "Aplica el tono y la saturación de la capa de arriba a la luminosidad de lo "
 "que hay debajo."
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr "Luminosidad"
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
@@ -2892,30 +3587,30 @@ msgstr ""
 "Aplica la luminosidad de la capa de arriba al tono y saturación de lo que "
 "hay debajo."
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr "Más"
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr "Esta capa y su fondo simplemente se agregan juntos."
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr "Destino en"
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 "Utiliza el fondo solo donde esta capa la cubra. Todo lo demás se ignora."
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr "Destino fuera"
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
@@ -2923,11 +3618,11 @@ msgstr ""
 "Utiliza el fondo solamente solo donde esta capa no la cubra. Todo lo demás "
 "se ignora."
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr "Fuente a la cima"
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
@@ -2935,11 +3630,11 @@ msgstr ""
 "La fuente se superpone al destino, sustituye el destino. El Destino se "
 "coloca en otro lugar."
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr "Destino a la cima"
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
@@ -2947,7 +3642,18 @@ msgstr ""
 "El Destino superpone a la fuente, sustituye a la fuente. La Fuente se coloca "
 "en otro lugar."
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, fuzzy, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr "%(name)s %(number)d"
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
@@ -2956,7 +3662,7 @@ msgstr ""
 "No se puede construir un objeto interno vital. Su sistema quizás no tenga "
 "memoria suficiente para realizar esta operación."
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2970,7 +3676,30 @@ msgstr ""
 "Razón: {err}\n"
 "Carpeta de Destino: “{dirname}”."
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+#, fuzzy
+msgid "Vertical"
+msgstr "Espejado Vertical"
+
+#: ../lib/tiledsurface.py:49
+#, fuzzy
+msgid "Horizontal"
+msgstr "Espejado Horizontal"
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+#, fuzzy
+msgid "Rotational"
+msgstr "Reiniciar Rotación"
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr "Fallo en el lector de PNG: %s"
@@ -2979,59 +3708,97 @@ msgstr "Fallo en el lector de PNG: %s"
 msgid "Recover interrupted work?"
 msgstr "¿Recuperar el trabajo interrumpido?"
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
-msgstr "_Recuperar y Guardar..."
+msgid "_Look for backups at startup"
+msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr "Eliminar"
+
+#: ../po/tmp/autorecover.glade.h:9
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr "Borrar este pincel del disco"
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr "_Recuperar y Guardar..."
+
+#: ../po/tmp/autorecover.glade.h:12
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 "Guardar esta copia de seguridad en el disco, luego seguir trabajando en él."
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
-msgstr "_Ignorar por Ahora"
+msgid "Decide _Later"
+msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 "Empezar a trabajar en un nuevo lienzo. Se conservarán las copias de "
 "seguridad."
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
+#, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 "MyPaint se colgó y cerro con trabajo no guardado, pero se han hecho copias "
 "de seguridad. Usted puede recuperar el archivo ahora, o dejarlo hasta que "
 "vuelve a iniciar MyPaint."
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr "Miniatura"
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr "Descripción"
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
-msgstr "Copiar al nuevo"
+msgid "Live update"
+msgstr "Actualización en vivo"
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
-msgstr "Copia estas opciones y el icono del pincel actual a un nuevo pincel"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
+msgstr ""
+"Actualización del último trazo en el lienzo con la configuración en esta "
+"ventana, en tiempo real"
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
-msgstr "Renombrar este pincel"
+msgid "Save these settings to the brush"
+msgstr "Guardar estas configuraciones en el pincel"
 
 #: ../po/tmp/brusheditor.glade.h:5
 msgid "Edit Icon"
@@ -3054,20 +3821,16 @@ msgid "Delete this brush from the disk"
 msgstr "Borrar este pincel del disco"
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
-msgstr "Actualización en vivo"
+msgid "Copy to New"
+msgstr "Copiar al nuevo"
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
-msgstr ""
-"Actualización del último trazo en el lienzo con la configuración en esta "
-"ventana, en tiempo real"
+msgid "Copy these settings and the current brush's icon to a new brush"
+msgstr "Copia estas opciones y el icono del pincel actual a un nuevo pincel"
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
-msgstr "Guardar estas configuraciones en el pincel"
+msgid "Rename this brush"
+msgstr "Renombrar este pincel"
 
 #: ../po/tmp/brusheditor.glade.h:13
 msgid "Brush Setting"
@@ -3095,12 +3858,7 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr "Notas:"
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr "Nombre del ajuste:"
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
@@ -3108,19 +3866,16 @@ msgstr ""
 "consecuencia."
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
-msgstr "Valor de base:"
+#: ../po/tmp/brusheditor.glade.h:22
+#, fuzzy
+msgid "Value:"
+msgstr "Valor HSV"
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr "Restablecer el valor de base predeterminado"
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr "Restablecer esta entrada para no tener ningún efecto sobre el ajuste"
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
@@ -3128,11 +3883,7 @@ msgstr ""
 "Valor mínimo del eje de salida.\n"
 "Se puede definir usando el regulador principal por {dname}."
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr "<ymin>"
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
@@ -3140,27 +3891,23 @@ msgstr ""
 "Valor máximo del eje de salida.\n"
 "Se puede definir usando el regulador principal por {dname}."
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr "<ymax>"
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr "Salida"
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr "Entrada"
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr "Ajusta el valor máximo"
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr "Ajusta el valor mínimo"
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
@@ -3168,11 +3915,7 @@ msgstr ""
 "Valor mínimo del eje de entrada.\n"
 "Utilice la escala del elemento emergente para ajustarlo."
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr "<xmin>"
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
@@ -3180,38 +3923,36 @@ msgstr ""
 "Valor máximo para el eje de entrada.\n"
 "Utilice la escala del elemento emergente para ajustarlo."
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr "<xmax>"
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr "Variación del valor base de entrada de lápiz óptico y otros criterios"
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr "Dinámica de pincel"
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr "Detalles básicos para esta opción"
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr "Editar configuración"
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr "Ajustar este mapeado de entrada en detalle"
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr "{tooltip}"
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
 msgstr "{dname}:"
+
+#: ../po/tmp/brusheditor.glade.h:42
+#, fuzzy
+msgid "Brush dynamics are not available for this setting."
+msgstr "Detalles básicos para esta opción"
+
+#: ../po/tmp/brusheditor.glade.h:43
+#, fuzzy
+msgid "<big><b>No Brush Dynamics</b></big>"
+msgstr "<big><b>{accel_label}</b></big>"
 
 #: ../po/tmp/inktool.glade.h:1
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
@@ -3223,7 +3964,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr "Presión:"
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3268,6 +4009,141 @@ msgstr "Borrar punto"
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
 msgstr "Eliminar el actual punto seleccionado"
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+#, fuzzy
+msgid "Insert Point"
+msgstr "Insertar Fila"
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+#, fuzzy
+msgid "Cull Points"
+msgstr "Borrar punto"
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Nombre"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr "Modo"
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Opacidad"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr "Recorta el marco a la capa actualmente activa"
+
+#: ../po/tmp/layervis.glade.h:2
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr "Girar la vista del lienzo"
+
+#: ../po/tmp/layervis.glade.h:3
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr "Girar la vista del lienzo"
+
+#: ../po/tmp/layervis.glade.h:4
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr "Que capas visibles deberían ser rellenadas"
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
+msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
 msgctxt "footer: color picker button: tooltip"
@@ -3679,13 +4555,34 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr "Ocultar el cursor mientras se pinta"
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+#, fuzzy
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr "Activado"
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr "Ver"
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
@@ -3695,18 +4592,18 @@ msgstr ""
 "disco-estilo.\n"
 "Diferentes tradiciones tienen armonías de color diferentes."
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr "Los primarios son:"
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr "Estándar digital Rojo/Verde/Azul"
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
@@ -3714,7 +4611,7 @@ msgstr ""
 "El rojo, verde y azul primarios de 'monitor de ordenador', dispuestos "
 "uniformemente alrededor del círculo. El verde es el opuesto al magenta."
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
@@ -3723,12 +4620,12 @@ msgstr ""
 "El rojo, verde y azul primarios del 'monitor del ordenador', dispuestos "
 "uniformemente alrededor del círculo. El verde es el opuesto al magenta."
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr "Rojo/Amarillo/Azul del artista tradicional"
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
@@ -3739,7 +4636,7 @@ msgstr ""
 "colores de pantalla puros uniformemente dispuestos alrededor del círculo. El "
 "verde es opuesto al rojo."
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3751,12 +4648,12 @@ msgstr ""
 "colores de pantalla puros uniformemente dispuestos alrededor del círculo. El "
 "verde es opuesto al rojo."
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr "Pares de opositor Rojo-Verde y Azul-Amarillo"
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3770,7 +4667,7 @@ msgstr ""
 "opuesto al azul. CIECAM02 y NCS presentan un modelo similar. Aquí usamos "
 "rojo pantalla puro, amarillo etc como los cuatro primarios."
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3786,28 +4683,28 @@ msgstr ""
 "rojo pantalla puro, amarillo etc como los cuatro primarios."
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr "<b>Rueda de color</b>"
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr "Color"
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr "Pantalla (normal)"
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr "Deshabilitado (sin sensibilidad a la presión)"
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr "Ventana (no recomendado)"
@@ -3869,253 +4766,311 @@ msgstr ""
 "Vuelva a cargar el archivo de su trabajo actual desde donde fue cargado."
 
 #: ../po/tmp/resources.xml.h:12
+#, fuzzy
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Import Layers…"
+msgstr "Importar Pinceles…"
+
+#: ../po/tmp/resources.xml.h:13
+msgctxt "Accel Editor (descriptions)"
+msgid "Import layers from one or more files."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save"
 msgstr "Guardar"
 
-#: ../po/tmp/resources.xml.h:13
+#: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file."
 msgstr "Guardar tu trabajo en un archivo."
 
-#: ../po/tmp/resources.xml.h:14
+#: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As…"
 msgstr "Guardar como…"
 
-#: ../po/tmp/resources.xml.h:15
+#: ../po/tmp/resources.xml.h:17
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file, assigning it a new name."
 msgstr "Guarde el trabajo en un archivo, asignándole un nuevo nombre."
 
-#: ../po/tmp/resources.xml.h:16
+#: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Export…"
 msgstr "Exportar…"
 
-#: ../po/tmp/resources.xml.h:17
+#: ../po/tmp/resources.xml.h:19
 msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 "Exporte su trabajo a un archivo, pero seguir trabajando en el mismo archivo."
 
-#: ../po/tmp/resources.xml.h:18
+#: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As Scrap"
 msgstr "Guardar como Esbozo"
 
-#: ../po/tmp/resources.xml.h:19
+#: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
 msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 "Guardar en un archivo nuevo de esbozo, o guardar una nueva revisión si ya "
 "hay un esbozo."
 
-#: ../po/tmp/resources.xml.h:20
+#: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Previous Scrap"
 msgstr "Abrir Esbozo Previo"
 
-#: ../po/tmp/resources.xml.h:21
+#: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file before the current one."
 msgstr "Cargue el archivo de Esbozo antes del actual."
 
-#: ../po/tmp/resources.xml.h:22
+#: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Next Scrap"
 msgstr "Abrir Esbozo Siguiente"
 
-#: ../po/tmp/resources.xml.h:23
+#: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file after the current one."
 msgstr "Cargue el archivo de Esbozo después del actual."
 
-#: ../po/tmp/resources.xml.h:24
+#: ../po/tmp/resources.xml.h:26
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Recover File from an Automated Backup…"
 msgstr "Recuperar archivos desde una copia de seguridad automatizada…"
 
-#: ../po/tmp/resources.xml.h:25
+#: ../po/tmp/resources.xml.h:27
 msgctxt "Accel Editor (descriptions)"
 msgid "Try to save and resume interrupted unsaved work."
 msgstr "Intentar guardar y reanudar el trabajo interrumpido no guardado."
 
-#: ../po/tmp/resources.xml.h:26
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr "Grupos de Pinceles"
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr "Pinceles"
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr "Lista de grupos de pinceles."
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr "Ajustadores de color"
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr "Colores"
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr "Ajustadores de color disponible."
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr "Modo"
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr "Modo"
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr "Modo de composición de la capa actual."
 
-#: ../po/tmp/resources.xml.h:35
+#: ../po/tmp/resources.xml.h:37
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Pressure"
+msgstr "Presión de entrada"
+
+#: ../po/tmp/resources.xml.h:38
+msgctxt "Accel Editor (descriptions)"
+msgid "Send harder pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:39
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Pressure"
+msgstr "Presión de entrada"
+
+#: ../po/tmp/resources.xml.h:40
+msgctxt "Accel Editor (descriptions)"
+msgid "Send softer pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:41
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Rotation"
+msgstr "Aumenta la saturación"
+
+#: ../po/tmp/resources.xml.h:42
+msgctxt "Accel Editor (descriptions)"
+msgid "Increase barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:43
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
+msgstr "Reducir la saturación del color"
+
+#: ../po/tmp/resources.xml.h:44
+msgctxt "Accel Editor (descriptions)"
+msgid "Decrease barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:45
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Size"
 msgstr "Aumentar el tamaño del pincel"
 
-#: ../po/tmp/resources.xml.h:36
+#: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush bigger."
 msgstr "Hacer el pincel de trabajo más grande."
 
-#: ../po/tmp/resources.xml.h:37
+#: ../po/tmp/resources.xml.h:47
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Size"
 msgstr "Disminuir el tamaño del pincel"
 
-#: ../po/tmp/resources.xml.h:38
+#: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush smaller."
 msgstr "Hacer el pincel de trabajo más pequeño."
 
-#: ../po/tmp/resources.xml.h:39
+#: ../po/tmp/resources.xml.h:49
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Opacity"
 msgstr "Aumentar la opacidad del pincel"
 
-#: ../po/tmp/resources.xml.h:40
+#: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush more opaque."
 msgstr "Hacer el pincel de trabajo más opaco."
 
-#: ../po/tmp/resources.xml.h:41
+#: ../po/tmp/resources.xml.h:51
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Opacity"
 msgstr "Disminuir la opacidad del pincel"
 
-#: ../po/tmp/resources.xml.h:42
+#: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush less opaque."
 msgstr "Hacer que el cepillo de trabajo menos opaco."
 
-#: ../po/tmp/resources.xml.h:43
+#: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Lighten Painting Color"
 msgstr "Aclarar el Color de pintura"
 
-#: ../po/tmp/resources.xml.h:44
+#: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase the lightness of the current painting color."
 msgstr "Aumentar la luminosidad del color de la pintura actual."
 
-#: ../po/tmp/resources.xml.h:45
+#: ../po/tmp/resources.xml.h:55
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Darken Painting Color"
 msgstr "Oscurecer el Color de la pintura"
 
-#: ../po/tmp/resources.xml.h:46
+#: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease the lightness of the current painting color."
 msgstr "Disminución de la luminosidad del color de la pintura actual."
 
-#: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
-msgstr "Cambiar tono en sentido antihorario"
-
-#: ../po/tmp/resources.xml.h:48
-msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
-msgstr ""
-"Gire el tono del color de la pintura en sentido antihorario en la rueda de "
-"color."
-
-#: ../po/tmp/resources.xml.h:49
+#: ../po/tmp/resources.xml.h:57
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Change Hue Clockwise"
 msgstr "Cambiar el tono del color (en sentido horario)"
 
-#: ../po/tmp/resources.xml.h:50
+#: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
 msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 "Gire el matiz del color de la pintura en el sentido de las agujas del reloj "
 "en la rueda de color."
 
-#: ../po/tmp/resources.xml.h:51
+#: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr "Cambiar tono en sentido antihorario"
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+"Gire el tono del color de la pintura en sentido antihorario en la rueda de "
+"color."
+
+#: ../po/tmp/resources.xml.h:61
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Increase Saturation"
 msgstr "Aumenta la saturación"
 
-#: ../po/tmp/resources.xml.h:52
+#: ../po/tmp/resources.xml.h:62
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color more saturated (more colorful, purer)."
 msgstr "Hacer el color de pintura más saturado (más colorido, más puro)."
 
-#: ../po/tmp/resources.xml.h:53
+#: ../po/tmp/resources.xml.h:63
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Decrease Saturation"
 msgstr "Reducir la saturación del color"
 
-#: ../po/tmp/resources.xml.h:54
+#: ../po/tmp/resources.xml.h:64
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color less saturated (grayer)."
 msgstr "Hacer el color de la pintura menos saturado (grisáceo)."
 
-#: ../po/tmp/resources.xml.h:55
+#: ../po/tmp/resources.xml.h:65
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Reload Brush Settings"
 msgstr "Volver a cargar ajustes de pincel"
 
-#: ../po/tmp/resources.xml.h:56
+#: ../po/tmp/resources.xml.h:66
 msgctxt "Accel Editor (descriptions)"
 msgid "Restore all brush settings to the current brush’s saved values."
-msgstr "Reinicia todos los ajustes de la brocha actual a sus valores guardados."
+msgstr ""
+"Reinicia todos los ajustes de la brocha actual a sus valores guardados."
 
-#: ../po/tmp/resources.xml.h:57
+#: ../po/tmp/resources.xml.h:67
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Pick Stroke and Layer"
 msgstr "Elegir Trazo y Capa"
 
-#: ../po/tmp/resources.xml.h:58
+#: ../po/tmp/resources.xml.h:68
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
 msgstr ""
 "Escoger una pincelada del lienzo: restaura el pincel, el color y la capa."
 
-#: ../po/tmp/resources.xml.h:59
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr "Atajo de teclado para Restaurar el Color del Pincel"
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
@@ -4124,219 +5079,270 @@ msgstr ""
 "Cambiar si al restaurar el pincel desde de una tecla de acceso directo "
 "también restauras el color guardado."
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr "Guardar pincel en tecla de método abreviado más reciente"
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 "Guardar ajustes de pincel en el atajo de teclado más utilizado recientemente."
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "Limpiar capa"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr "Borrar el contenido de la capa actual."
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+#, fuzzy
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr "iconos de herramientas"
+
+#: ../po/tmp/resources.xml.h:76
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr "Recortar la Capa al Marco"
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr "Borrar partes de la capa actual que se encuentran fuera del marco."
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr "Borrar partes de la capa actual que se encuentran fuera del marco."
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "Nueva Capa de Grupo a continuación de"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "Nueva Capa de Grupo a continuación de"
+
+#: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr "Copiar Capa al portapapeles"
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr "Copiar el contenido de la capa actual en el portapapeles."
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr "Pegar Capa desde el portapapeles"
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr "Reemplaza la capa actual con el contenido del portapapeles."
 
-#: ../po/tmp/resources.xml.h:71
+#: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Edit Layer in External App…"
 msgstr "Editar la capa en una aplicación externa…"
 
-#: ../po/tmp/resources.xml.h:72
+#: ../po/tmp/resources.xml.h:90
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
+msgid "Edit the active layer in an external application."
 msgstr "Empezar a editar la capa actual en una aplicación externa."
 
-#: ../po/tmp/resources.xml.h:73
+#: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Update Layer with External Edits"
 msgstr "Actualizar capa con Ediciones Externas"
 
-#: ../po/tmp/resources.xml.h:74
+#: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
 msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 "Confirmar los cambios guardados desde la aplicación externa (normalmente "
 "automática)."
 
-#: ../po/tmp/resources.xml.h:75
+#: ../po/tmp/resources.xml.h:93
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer at Cursor"
 msgstr "Ir a la capa en el Cursor"
 
-#: ../po/tmp/resources.xml.h:76
+#: ../po/tmp/resources.xml.h:94
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr "Seleccione una capa eligiendo un objeto en él."
 
-#: ../po/tmp/resources.xml.h:77
+#: ../po/tmp/resources.xml.h:95
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Above"
 msgstr "Ir a la capa superior"
 
-#: ../po/tmp/resources.xml.h:78
+#: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer up in the layer stack."
 msgstr "Subir una capa en la pila de capas."
 
-#: ../po/tmp/resources.xml.h:79
+#: ../po/tmp/resources.xml.h:97
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Below"
 msgstr "Ir a la capa inferior"
 
-#: ../po/tmp/resources.xml.h:80
+#: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer down in the layer stack."
 msgstr "Bajar una capa en la pila de capas."
 
-#: ../po/tmp/resources.xml.h:81
+#: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer"
 msgstr "Nueva capa de pintura"
 
-#: ../po/tmp/resources.xml.h:82
+#: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer above the current layer."
 msgstr "Añadir una nueva capa de pintura encima de la capa actual."
 
-#: ../po/tmp/resources.xml.h:83
+#: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer…"
 msgstr "Nueva capa vectorial…"
 
-#: ../po/tmp/resources.xml.h:84
+#: ../po/tmp/resources.xml.h:102
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer above the current layer, and begin editing it."
 msgstr ""
 "Añadir una nueva capa vectorial por encima de la capa actual y comenzar a "
 "editarlo."
 
-#: ../po/tmp/resources.xml.h:85
+#: ../po/tmp/resources.xml.h:103
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group"
 msgstr "Nueva Capa de Grupo"
 
-#: ../po/tmp/resources.xml.h:86
+#: ../po/tmp/resources.xml.h:104
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group above the current layer."
 msgstr "Agregar un nueva capa de grupo sobre la capa actual."
 
-#: ../po/tmp/resources.xml.h:87
+#: ../po/tmp/resources.xml.h:105
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer Below"
 msgstr "Nueva Capa de Pintura Debajo"
 
-#: ../po/tmp/resources.xml.h:88
+#: ../po/tmp/resources.xml.h:106
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer below the current layer."
 msgstr "Añadir una nueva capa de pintura debajo de la capa actual."
 
-#: ../po/tmp/resources.xml.h:89
+#: ../po/tmp/resources.xml.h:107
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer Below…"
 msgstr "Nueva Capa Vectorial a continuación de…"
 
-#: ../po/tmp/resources.xml.h:90
+#: ../po/tmp/resources.xml.h:108
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer below the current layer, and begin editing it."
 msgstr ""
 "Añadir una nueva capa vectorial debajo de la capa actual y comenzar a "
 "editarlo."
 
-#: ../po/tmp/resources.xml.h:91
+#: ../po/tmp/resources.xml.h:109
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group Below"
 msgstr "Nueva Capa de Grupo a continuación de"
 
-#: ../po/tmp/resources.xml.h:92
+#: ../po/tmp/resources.xml.h:110
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group below the current layer."
 msgstr "Agregar una nueva capa de grupo debajo de la capa actual."
 
-#: ../po/tmp/resources.xml.h:93
+#: ../po/tmp/resources.xml.h:111
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Layer Down"
 msgstr "Combinar capas hacia abajo"
 
-#: ../po/tmp/resources.xml.h:94
+#: ../po/tmp/resources.xml.h:112
 msgctxt "Accel Editor (descriptions)"
 msgid "Merge the current layer with the layer beneath it."
 msgstr "Combinar la capa actual con la capa debajo de ella."
 
-#: ../po/tmp/resources.xml.h:95
+#: ../po/tmp/resources.xml.h:113
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Visible Layers"
 msgstr "Combinar las Capas Visibles"
 
-#: ../po/tmp/resources.xml.h:96
+#: ../po/tmp/resources.xml.h:114
 msgctxt "Accel Editor (descriptions)"
 msgid "Consolidate all visible layers, and delete the originals."
 msgstr "Consolidar todas las capas visibles y eliminar las originales."
 
-#: ../po/tmp/resources.xml.h:97
+#: ../po/tmp/resources.xml.h:115
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer from Visible"
 msgstr "Nueva Capa desde Visible"
 
-#: ../po/tmp/resources.xml.h:98
+#: ../po/tmp/resources.xml.h:116
 msgctxt "Accel Editor (descriptions)"
 msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
 msgstr "Como 'Combinar las capas visibles', pero no borras las originales."
 
-#: ../po/tmp/resources.xml.h:99
+#: ../po/tmp/resources.xml.h:117
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Delete Layer"
 msgstr "Eliminar capa"
 
-#: ../po/tmp/resources.xml.h:100
+#: ../po/tmp/resources.xml.h:118
 msgctxt "Accel Editor (descriptions)"
 msgid "Remove the current layer from the layer stack."
 msgstr "Borrar la capa actual de la pila de capas."
 
-#: ../po/tmp/resources.xml.h:101
+#: ../po/tmp/resources.xml.h:119
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Convert to Normal Painting Layer"
 msgstr "Convertir a Capa de pintura Normal"
 
-#: ../po/tmp/resources.xml.h:102
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
@@ -4345,72 +5351,74 @@ msgstr ""
 "Convertir la capa actual o el grupo a una capa de pintura en el modo "
 "'Normal', conservando su aspecto."
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr "Aumentar la Opacidad de la Capa"
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr "Hacer la capa menos transparente."
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr "Reducir la Opacidad de la Capa"
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr "Hacer la capa más transparente."
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr "Elevar Capa"
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr "Eleva la capa actual un nivel en la pila de capas."
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr "Bajar Capa"
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr "Bajar la capa actual un nivel en la pila de capas."
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr "Duplicar Capa"
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr "Hacer un duplicado exacto de la capa actual."
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
+#, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
-msgstr "Renombrar capa…"
+msgid "Layer Properties…"
+msgstr "Propiedades"
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
-msgstr "Ingrese un nuevo nombre para la capa actual."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr "Capa bloqueada"
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
@@ -4418,496 +5426,586 @@ msgstr ""
 "Cambiar estado de bloqueado de la capa actual. Las capas bloqueadas no "
 "pueden ser modificadas."
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr "Capa Visible"
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr "Cambiar el estado de visibilidad de la capa actual, haciéndola oculta."
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr "Mostrar Fondo"
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr "Alternar la visibilidad de la capa de fondo."
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr "Borrar la capa actual de la pila de capas."
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr "Reiniciar y Centrar Vista"
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr "Restablecer Zoom, Rotación y Espejado, y recentrar el documento."
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr "Ajustar a la Vista"
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr "Cambiar entre la vista ajustada y su lugar de trabajo, y ampliar."
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr "Reiniciar"
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr "Reiniciar ampliación"
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr "Restaurar el zoom de la vista a su valor predeterminado."
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr "Reiniciar Rotación"
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr "Restablecer la rotación de la vista a 0°"
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr "Restablecer el Espejado"
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
-msgstr "Apague el espejado de la vista."
+msgid "Reset the view's mirroring."
+msgstr "Restablecer el Espejado"
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr "Acercar"
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr "Aumentar la magnificación."
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Alejar"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr "Disminuir la magnificación."
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
+#, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
-msgstr "Rotar en sentido antihorario"
+msgid "Pan Left"
+msgstr "Vista de encuadre"
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
-msgstr "Rotar la vista en sentido antihorario."
+msgid "Move your view of the canvas to the left."
+msgstr "Rotar vista: inclinar la vista del lienzo."
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr "Claridad fuerte"
+
+#: ../po/tmp/resources.xml.h:159
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+"Vista del Encuadre: mover su vista del lienzo horizontalmente o "
+"verticalmente."
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr "Rotar vista: inclinar la vista del lienzo."
+
+#: ../po/tmp/resources.xml.h:162
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr "Vista de encuadre"
+
+#: ../po/tmp/resources.xml.h:163
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr "Rotar vista: inclinar la vista del lienzo."
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr "Rotar en sentido horario"
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr "Rotar la vista en sentido horario."
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr "Rotar en sentido antihorario"
+
+#: ../po/tmp/resources.xml.h:167
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr "Rotar la vista en sentido antihorario."
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr "Espejado Horizontal"
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr "Espejar la vista de izquierda a derecha."
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr "Espejado Vertical"
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr "Invierte la vista de arriba a abajo."
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr "Sólo la capa actual"
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr "Alternar si se muestra sólo la capa actual."
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr "Activar Pintura Simétrica"
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr "Pinceladas espejadas a lo largo del eje de simetría"
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr "Marco activado"
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr "Mostrar/ocultar marco del documento."
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr "Imprimir los valores de entrada del pincel a la consola"
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 "Mostrar las entradas del pincel generadas internamente por el motor en la "
 "consola."
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr "Visualizar el Renderizado"
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 "Mostrar las actualizaciones del renderizado, para corrección de errores."
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr "Desactivar doble búfer"
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr "Apagar el búfer doble de GTK, normalmente activado."
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+#, fuzzy
+msgid "Delete Point"
+msgstr "Borrar punto"
+
+#: ../po/tmp/resources.xml.h:187
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr "Eliminar el actual punto seleccionado"
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr "Modo de Pintura"
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr "Modo de Pintura: Normal"
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr "Aplicar color normalmente al pintar."
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr "Modo Pintar: Goma de borrar"
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr "Borrar con el pincel actual."
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr "Modo Pintar: Bloqueo de Alfa"
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr "Aplicando el pincel no cambia la opacidad de la capa."
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr "Modo Pintar: Colorear"
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr "Aplicar color a la capa actual no afecta a su brillo u opacidad."
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Archivo"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "Salir"
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr "Cerrar la ventana principal y salir de la aplicación."
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "Editar"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr "Herramienta actual"
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "Color"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr "Ajustar color"
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr "Historial de color Desplegable"
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 "Dialogo emergente de línea de tiempo de los colores recientes bajo el cursor."
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr "Diálogo de Detalles de Color"
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
-msgstr "Mostrar un cuadro de diálogo de detalles de color con entrada de texto."
+msgstr ""
+"Mostrar un cuadro de diálogo de detalles de color con entrada de texto."
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr "Color siguiente de la paleta"
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr "Establece el color de pintura para el siguiente color en la paleta."
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr "Color anterior de paleta"
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr "Establece el color de pintura para el anterior color en la paleta."
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr "Añadir color a la paleta"
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr "Adjuntar el color de la pintura actual a la paleta."
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "Capa"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr "Opacidad"
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr "Ir a capa"
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr "Nueva Capa Abajo"
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr "Propiedades"
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr "Libreta de Esbozos"
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr "Nueva Libreta de Esbozos"
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 "Carga la Libreta de Esbozos predeterminada como un nuevo lienzo de la "
 "Libreta de Esbozos."
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr "Abrir Libreta de Esbozos…"
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr "Cargar un archivo de imagen en el disco en la Libreta de Esbozos."
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr "Guardar Libreta de Esbozos"
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr "Guardar la Libreta de Esbozos en su archivo existente en el disco."
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr "Exportar Libreta de Esbozos Como…"
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 "Exportar la Libreta de Esbozos al disco, bajo un nombre de archivo de su "
 "elección."
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr "Revertir Libreta de Esbozos"
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr "Revertir la Libreta de Esbozos a su último estado de guardado."
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr "Guardar Libreta de Esbozos como Predeterminado"
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 "Guardar la Libreta de Esbozos como predeterminada para 'Nueva Libreta de "
 "Esbozos'."
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr "Limpiar Libreta de Esbozos por Defecto"
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr "Limpiar la Libreta de Esbozos predeterminada a un lienzo en blanco."
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr "Copiar Fondo Principal a la Libreta de Esbozos"
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 "Copiar la imagen de fondo del documento de trabajo en la Libreta de Esbozos."
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "Ventana"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "Pincel"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr "Atajos del teclado"
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr "Ayuda de Atajos del teclado de Pincel"
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 "Muestrar una explicación de cómo funcionan las teclas de acceso directo."
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "Cambiar Pincel…"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr "Diálogo emergente con un cambiador de pincel bajo el cursor."
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "Cambiar Color…"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
@@ -4915,12 +6013,12 @@ msgstr ""
 "Dialogo emergente con un cambiador de color bajo el cursor, con todos los "
 "selectores de color listados."
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "Cambiar Color (subconjunto rápido)…"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
@@ -4929,212 +6027,216 @@ msgstr ""
 "Dialogo emergente con un cambiador de color bajo el cursor, con un sólo clic "
 "listado de selectores."
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr "Obtener Más Pinceles…"
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr "Descargar paquetes de pinceles desde la wiki de MyPaint."
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr "Importar Pinceles…"
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr "Cargar un paquete de pinceles del disco."
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Ayuda"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr "Ayuda en línea"
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr "Ir a la wiki de documentación de MyPaint."
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "Acerca de MyPaint"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr "Mostrar la licencia de MyPaint, el número de versión y los créditos."
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Depurar"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr "Imprimir información de Fugas de Memoria en la consola (¡lento!)"
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr "Depuración de pérdidas de memoria."
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr "Ejecutar el recolector de basura ahora"
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr "Memoria libre utilizada para objetos de Python que ya no están en uso."
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr "Iniciar/Detener el perfilado…"
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr "Iniciar o Detener el perfilado de Python (cProfile)"
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr "Simular un error…"
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 "Provocar una excepción de Python, para probar el cuadro de diálogo de "
 "bloqueo."
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "Ver"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr "Comentarios"
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr "Ajustar Vista"
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
+#, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr "Menú Desplegable"
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr "Mostrar el menú principal como una ventana emergente."
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "Pantalla completa"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr "Alternar entre modo de pantalla completa y ventana."
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "Editar preferencias"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr "Editar las configuraciones globales de MyPaint."
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr "Probar dispositivos de entrada"
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 "Mostrar un cuadro de diálogo que captura todos los eventos que envían sus "
 "dispositivos de entrada."
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr "Selector de fondo"
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr "Cambia la textura de papel de fondo."
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr "Editor de ajustes de pincel"
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr "Editar la configuración del pincel activo."
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr "Editor de icono de pincel"
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr "Editar iconos de pinceles."
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr "Panel Capas"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
-"Alternar el panel acoplable de Capas (organizar capas, o asignar modos)."
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr "Mostrar Panel Capas"
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
-msgstr "Revelar el panel acoplable de Capas (organizar capas, o asignar modos)."
+msgstr ""
+"Revelar el panel acoplable de Capas (organizar capas, o asignar modos)."
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr "Rueda HCY"
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
@@ -5143,42 +6245,32 @@ msgstr ""
 "Selector de color de tonalidad/croma/luma cilíndrica acoplable. Los cortes "
 "circulares son equiluminantes."
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "Paleta de colores"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr "Selector de color de paleta acoplable."
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr "Rueda HSV"
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr "Cambiador de color Saturación y Valor acoplable."
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr "Triángulo HSV"
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr "Selector de color acoplable: el triángulo de color viejo de GTK."
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr "Cubo HSV"
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
@@ -5187,229 +6279,220 @@ msgstr ""
 "Selector de color acoplable: Cubo HSV que puede rotarse para mostrar "
 "distintos cortes planos."
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr "Cuadrado HSV"
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
-msgstr ""
-"Selector de color acoplable: Cubo HSV que puede rotarse para mostrar "
-"distintos cortes planos."
+msgid "Dockable color selector: HSV square with Hue ring."
+msgstr "Selector de color acoplable con anillos concéntricos de HSV."
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr "Deslizadores de componente"
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 "Selector de color acoplable mostrando los componentes individuales del color."
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr "Líquido de Lavado"
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 "Selector de color acoplable que muestra los colores cercanos del lavado de "
 "tipo-líquido."
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr "Anillos concéntricos"
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr "Selector de color acoplable con anillos concéntricos de HSV."
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr "Tazón Cruzado"
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 "Selector de color acoplable con rampas HSV cruzando un tazón radial de color."
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr "Panel de Libreta de Esbozos"
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
-"Muestra el panel acoplable de Libreta de Esbozos (mezcla de colores y hacer "
-"bocetos)."
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr "Mostrar Panel de Libreta de Esbozos"
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 "Revela el panel acoplable de Libreta de Esbozos (mezcla de colores y hacer "
 "dibujos)."
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr "Panel de vista previa"
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
-"Muestra el panel acoplable de la Vista Previa (Resumen de todo el área de "
-"dibujo)."
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "Vista previa"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 "Revela el panel acoplable de la Vista Previa (Resumen de todo el área de "
 "dibujo)."
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr "Panel Opciones de herramienta"
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
-"Muestra el panel acoplable de la opciones de la herramienta (opciones para "
-"la herramienta actual)."
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr "Mostrar el Panel Opciones de herramienta"
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 "Revela el panel acoplable de la opciones de la herramienta (opciones para la "
 "herramienta actual)."
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr "Panel del Historial de Color y Pincel"
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
-msgstr "Mostrar el panel Historial (colores y pinceles usados recientemente)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr "Pinceles y Colores Recientes"
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr "Revela el panel Historial (colores y pinceles usados recientemente)."
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr "Ocultar controles en pantalla completa"
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 "Activar la ocultación automática de la interfaz de usuario a pantalla "
 "completa."
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr "Mostrar Nivel de ampliación"
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr "Mostrar información de nivel de zoom."
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr "Mostrar la Última Posición Pintada"
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr "Activar visualización de donde finalizo el ultimo trazado."
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr "Visualizar Filtro"
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr "Visualizar Colores Normalmente"
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr "Filtrar Colores: mostrar colores sin cambios."
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr "Visualizar Colores como escala de grises"
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr "Filtrar Colores: mostrar solamente brillo (luminancia HCY/YCbCr)"
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr "Visualizar Colores invertidos"
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr "Filtrar Colores: vídeo inverso. Negro es blanco y rojo es cian."
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr "Visualizar Colores con insensibilidad Simulada al rojo"
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
@@ -5417,271 +6500,271 @@ msgstr ""
 "Filtro de color para simular la deuteranopía, una forma común de ceguera "
 "para los colores."
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr "Visualizar Colores con insensibilidad simulada al verde"
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 "Filtro de color para simular la protanopia, una forma común de ceguera para "
 "los colores."
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr "Visualizar Colores con insensibilidad simulada azul"
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 "Filtro de color para simular la Tritanopía, una forma rara de ceguera para "
 "los colores."
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr "Dibujo a mano alzada"
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr "Dibujo a mano alzada"
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 "Dibujo a mano alzada: dibujar y pintar libremente, sin restricciones "
 "geométricas."
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr "Dibujo a mano alzada"
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr "Dibujar y pintar libremente, sin restricciones geométricas."
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr "Vista de encuadre"
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr "Encuadrar"
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 "Vista del Encuadre: mover su vista del lienzo horizontalmente o "
 "verticalmente."
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr "Encuadrar Vista"
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 "Mover interactivamente su vista del lienzo horizontalmente o verticalmente."
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr "Rotar vista"
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr "Rotar"
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr "Rotar vista: inclinar la vista del lienzo."
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr "Rotar vista"
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr "Gire interactivamente la vista del lienzo."
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr "Ampliar vista"
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr "Ampliación"
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr "Vista de zoom: zoom dentro o fuera del lienzo."
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr "Ampliar vista"
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr "Zoom interactivo dentro o fuera del lienzo."
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr "Líneas y curvas"
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr "Líneas"
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr "Líneas y curvas: dibujar líneas rectas o curvas."
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr "Líneas y Curvas"
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr "Dibujar líneas rectas o curvas."
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr "Líneas Conectadas"
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr "Líneas Conectadas"
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr "Líneas conectadas: dibujar secuencias de líneas rectas o curvas."
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr "Líneas Conectadas"
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr "Dibujar secuencias de líneas rectas o curvas."
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr "Elipses y Círculos"
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr "Elipse"
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr "Elipses y Círculos: dibujar formas redondeadas."
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr "Elipses y Círculos"
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr "Dibujar círculos y elipses."
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr "Entintar"
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr "Tinta"
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr "Entintado: dibujar líneas suaves controladas."
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr "Entintar"
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr "Dibujar líneas suaves controladas."
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr "Reposicionar Capa"
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr "Capa Pos."
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr "Reposicionar Capa: mover la capa actual en el lienzo."
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr "Reposicionar Capa"
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr "Mover Interactivamente la capa actual en el lienzo."
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr "Editar Marco"
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr "Marco"
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
@@ -5689,12 +6772,12 @@ msgstr ""
 "Editar marco: definir un marco alrededor del documento para darle un tamaño "
 "finito."
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr "Editar marco"
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
@@ -5702,82 +6785,295 @@ msgstr ""
 "interactivamente definir un marco alrededor del documento para darle un "
 "tamaño finito."
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Editar Pintado Simétrico"
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr "Simetría"
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 "Editar Pintado Simétrico: ajustar el eje utilizado para pintura simétrica."
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Editar Pintado Simétrico"
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr "Ajustar interactivamente el eje utilizado para pintura simétrica."
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr "Elegir Color"
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr "Elegir Col."
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 "Elegir Color: establece el color de pintura desde píxeles de la pantalla."
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "Elija el Color"
+
+#: ../po/tmp/resources.xml.h:401
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr "Establece el color de pintura desde píxeles de la pantalla."
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "Elija el Color"
+
+#: ../po/tmp/resources.xml.h:403
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr "Establece el color de pintura desde píxeles de la pantalla."
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "Elija el Color"
+
+#: ../po/tmp/resources.xml.h:405
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr "Establece el color de pintura desde píxeles de la pantalla."
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr "Elegir Color"
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr "Establece el color de pintura desde píxeles de la pantalla."
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr "Bote de pintura"
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr "Relleno"
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr "Bote de pintura: llenar un área con color."
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr "Bote de pintura"
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr "Rellenar un área con color."
+
+#~ msgctxt "Accelerator map editor: action column markup"
+#~ msgid ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+#~ msgstr ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+
+#~ msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
+#~ msgid "{action_label} {action_desc} {accel_label}"
+#~ msgstr "{action_label} {action_desc} {accel_label}"
+
+#~ msgctxt "brush list context menu"
+#~ msgid "Delete"
+#~ msgstr "Eliminar"
+
+#~ msgctxt "brush list commands"
+#~ msgid "Really delete brush from disk?"
+#~ msgstr "¿Desea borrar esta brocha del disco?"
+
+#~ msgid "HSV Triangle"
+#~ msgstr "Triángulo HSV"
+
+#~ msgid "The standard GTK color selector"
+#~ msgstr "El selector de colores estándar de GTK"
+
+#~ msgid "Pick a color from the screen"
+#~ msgstr "Recoger un color desde la pantalla"
+
+#~ msgid "Layer Name"
+#~ msgstr "Nombre de capa"
+
+#~ msgid ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+#~ msgstr ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+
+#~ msgid "Save..."
+#~ msgstr "Guardar..."
+
+#~ msgid "Confirm"
+#~ msgstr "Confirmar"
+
+#~ msgid "Open..."
+#~ msgstr "Abrir..."
+
+#~ msgid "{default_name} at {path}"
+#~ msgstr "{default_name} en {path}"
+
+#~ msgid "Type"
+#~ msgstr "Tipo"
+
+#~ msgid "Mode:"
+#~ msgstr "Modo:"
+
+#~ msgid ""
+#~ "Blending mode: how the current layer combines with the layers underneath "
+#~ "it."
+#~ msgstr ""
+#~ "Modo de mezcla: cómo se combina la capa con las que están debajo de la "
+#~ "misma."
+
+#~ msgid ""
+#~ "Layer opacity: how much of the current layer to use. Smaller values make "
+#~ "it more transparent."
+#~ msgstr ""
+#~ "Opacidad de capa: qué cantidad de la capa actual usar. Valores más bajos "
+#~ "la hacen más transparente."
+
+#~ msgid "%s: edit properties"
+#~ msgstr "%s: editar propiedades"
+
+#~ msgctxt "layer unique names: match regex (leave untranslated if unsure)"
+#~ msgid "^(.*?)\\s*(\\d+)$"
+#~ msgstr "^(.*?)\\s*(\\d+)$"
+
+#~ msgctxt "layer default names"
+#~ msgid "Unknown Bitmap Layer"
+#~ msgstr "Capa de mapa de bits desconocida"
+
+#~ msgctxt "Autosave Recovery dialog|"
+#~ msgid "_Ignore for Now"
+#~ msgstr "_Ignorar por Ahora"
+
+#~ msgid "Setting name:"
+#~ msgstr "Nombre del ajuste:"
+
+#~ msgid "Base value:"
+#~ msgstr "Valor de base:"
+
+#~ msgid "Reset the base value to its default"
+#~ msgstr "Restablecer el valor de base predeterminado"
+
+#~ msgid "<ymin>"
+#~ msgstr "<ymin>"
+
+#~ msgid "<ymax>"
+#~ msgstr "<ymax>"
+
+#~ msgid "<xmin>"
+#~ msgstr "<xmin>"
+
+#~ msgid "<xmax>"
+#~ msgstr "<xmax>"
+
+#~ msgid "Edit Setting"
+#~ msgstr "Editar configuración"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Trim Layer to Frame"
+#~ msgstr "Recortar la Capa al Marco"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Rename Layer…"
+#~ msgstr "Renombrar capa…"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Enter a new name for the current layer."
+#~ msgstr "Ingrese un nuevo nombre para la capa actual."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Turn off mirroring of the view."
+#~ msgstr "Apague el espejado de la vista."
+
+#~ msgctxt "Menu→Edit (labels)"
+#~ msgid "Current Tool"
+#~ msgstr "Herramienta actual"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+#~ msgstr ""
+#~ "Alternar el panel acoplable de Capas (organizar capas, o asignar modos)."
+
+#~ msgctxt "Menu→Color (labels), Accel Editor (labels)"
+#~ msgid "HSV Triangle"
+#~ msgstr "Triángulo HSV"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Dockable color selector: the old GTK color triangle."
+#~ msgstr "Selector de color acoplable: el triángulo de color viejo de GTK."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid ""
+#~ "Dockable color selector: HSV square which can be rotated to show "
+#~ "different hues."
+#~ msgstr ""
+#~ "Selector de color acoplable: Cubo HSV que puede rotarse para mostrar "
+#~ "distintos cortes planos."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+#~ msgstr ""
+#~ "Muestra el panel acoplable de Libreta de Esbozos (mezcla de colores y "
+#~ "hacer bocetos)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+#~ msgstr ""
+#~ "Muestra el panel acoplable de la Vista Previa (Resumen de todo el área de "
+#~ "dibujo)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+#~ msgstr ""
+#~ "Muestra el panel acoplable de la opciones de la herramienta (opciones "
+#~ "para la herramienta actual)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the History panel (recently used brushes and colors)."
+#~ msgstr ""
+#~ "Mostrar el panel Historial (colores y pinceles usados recientemente)."
 
 #~ msgid ""
 #~ "\"%s\" has an alpha channel. Background images with transparency are not "
@@ -5991,9 +7287,6 @@ msgstr "Rellenar un área con color."
 #~ "de las brochas (opacidad, dureza, etc.) y sobre las entradas (presión, "
 #~ "velocidad, etc.). Posicione el ratón sobre una palabra para verlos.\n"
 
-#~ msgid "Open Recent files"
-#~ msgstr "Abrir archivos recientes"
-
 #~ msgid "This will discard %d second of unsaved painting."
 #~ msgid_plural "This will discard %d seconds of unsaved painting."
 #~ msgstr[0] "Esto descartará %d segundo de pintado sin guardar."
@@ -6001,9 +7294,6 @@ msgstr "Rellenar un área con color."
 
 #~ msgid "Crop to Current Layer"
 #~ msgstr "Recortar a la capa actual"
-
-#~ msgid "Crop frame to the currently active layer"
-#~ msgstr "Recorta el marco a la capa actualmente activa"
 
 #~ msgid ""
 #~ "While the frame is enabled, it \n"
@@ -6112,9 +7402,6 @@ msgstr "Rellenar un área con color."
 #~ msgid "Brush Blend Mode"
 #~ msgstr "Modo de mezcla de brocha"
 
-#~ msgid "Add Layer"
-#~ msgstr "Agregar capa"
-
 #~ msgid "Move Layer on Canvas"
 #~ msgstr "Mover capa en el lienzo"
 
@@ -6152,9 +7439,6 @@ msgstr "Rellenar un área con color."
 #~ msgctxt "Menu|File|"
 #~ msgid "Save"
 #~ msgstr "Guardar"
-
-#~ msgid "Export to a file"
-#~ msgstr "Exportar a un archivo"
 
 #~ msgid ""
 #~ "Saves to a new scrap file. If the drawing is currently saved as a scrap, "

--- a/po/et.po
+++ b/po/et.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-23 08:18+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Estonian <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -19,27 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -47,39 +27,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -87,214 +67,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "Tagataust"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "Muster"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Värv"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Kohandatud"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -333,142 +323,177 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Salvesta"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Uus"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -476,58 +501,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -536,51 +561,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -590,137 +639,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -728,162 +777,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -891,373 +932,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Nimi"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Võta tagasi"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Tee uuesti"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1267,324 +1305,679 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Ava..."
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Täisekraanvaade"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Välju"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Välju"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Ava..."
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Salvesta"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr ""
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr ""
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Fail"
+
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Kihid"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Ava..."
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Ava viimati kasutatud"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Ava..."
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Ava..."
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Läbipaistmatus:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1592,130 +1985,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1724,35 +2129,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1776,45 +2181,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1822,153 +2231,218 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Kihid"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Kihid"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Läbipaistmatus:"
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1980,256 +2454,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2237,188 +2736,213 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Kihid"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2427,13 +2951,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2443,7 +2967,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2451,13 +2975,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2465,7 +2989,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2473,7 +2997,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2484,7 +3008,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2492,7 +3016,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2502,7 +3031,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2513,285 +3042,394 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr ""
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2801,7 +3439,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2810,52 +3468,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2877,17 +3566,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2916,112 +3603,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3034,7 +3696,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3075,6 +3737,134 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Nimi"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Läbipaistmatus:"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3444,56 +4234,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3501,12 +4311,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3515,7 +4325,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3526,28 +4336,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3609,1828 +4419,2019 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Vähendamine"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Fail"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Abi"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Silumine"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
-msgstr ""
+msgstr "Kihid"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/et.po
+++ b/po/et.po
@@ -513,17 +513,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1184,12 +1184,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1372,7 +1372,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Open dragged file confirm dialog: continue button"
 msgid "_Open"
-msgstr "Ava..."
+msgstr "Ava…"
 
 #: ../gui/drawwindow.py:486
 msgid "Set current color"
@@ -1406,7 +1406,7 @@ msgid "_Quit"
 msgstr "Välju"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1456,7 +1456,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1633,13 +1633,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Salvesta"
 
@@ -1705,7 +1705,7 @@ msgstr "Fail"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -1723,7 +1723,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Ava..."
+msgstr "Ava…"
 
 #: ../gui/filehandling.py:1427
 #, fuzzy
@@ -1735,7 +1735,7 @@ msgstr "Ava viimati kasutatud"
 #, fuzzy
 msgctxt "File→Open Most Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Ava..."
+msgstr "Ava…"
 
 #: ../gui/filehandling.py:1446
 msgctxt "File→Open Next/Prev Scrap: error message"
@@ -1756,7 +1756,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
 msgid "_Open"
-msgstr "Ava..."
+msgstr "Ava…"
 
 #: ../gui/filehandling.py:1487
 msgctxt "File→Revert: status message: canvas has no filename yet"
@@ -2130,12 +2130,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2147,7 +2147,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2333,7 +2333,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2403,7 +2403,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/eu.po
+++ b/po/eu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-23 08:18+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Basque <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -19,27 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -47,39 +27,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -87,214 +67,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "Eredua"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Kolorea"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Pertsonalizatua"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -333,142 +323,177 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Gorde"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Berria"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -476,58 +501,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -536,51 +561,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -590,137 +639,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -728,162 +777,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -891,373 +932,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Izena"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Desegin"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Berregin"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1267,324 +1305,679 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Ireki..."
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Pantaila osoa"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Irten"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Irten"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Ireki..."
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Gorde"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr ""
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr ""
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Fitxategia"
+
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Geruzak"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Ireki..."
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Ireki oraintsukoa"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Ireki..."
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Ireki..."
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Opakutasuna:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1592,130 +1985,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1724,35 +2129,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1776,45 +2181,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1822,153 +2231,218 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Geruzak"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Geruzak"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Opakutasuna:"
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1980,256 +2454,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2237,188 +2736,213 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Geruzak"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2427,13 +2951,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2443,7 +2967,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2451,13 +2975,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2465,7 +2989,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2473,7 +2997,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2484,7 +3008,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2492,7 +3016,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2502,7 +3031,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2513,285 +3042,394 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr ""
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2801,7 +3439,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2810,52 +3468,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2877,17 +3566,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2916,112 +3603,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3034,7 +3696,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3075,6 +3737,134 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Izena"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Opakutasuna:"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3444,56 +4234,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3501,12 +4311,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3515,7 +4325,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3526,28 +4336,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3609,1828 +4419,2019 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Zooma txikiagotu"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Fitxategia"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Laguntza"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Arazketa"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
-msgstr ""
+msgstr "Geruzak"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/eu.po
+++ b/po/eu.po
@@ -513,17 +513,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1184,12 +1184,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1372,7 +1372,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Open dragged file confirm dialog: continue button"
 msgid "_Open"
-msgstr "Ireki..."
+msgstr "Ireki…"
 
 #: ../gui/drawwindow.py:486
 msgid "Set current color"
@@ -1406,7 +1406,7 @@ msgid "_Quit"
 msgstr "Irten"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1456,7 +1456,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1633,13 +1633,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Gorde"
 
@@ -1705,7 +1705,7 @@ msgstr "Fitxategia"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -1723,7 +1723,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Ireki..."
+msgstr "Ireki…"
 
 #: ../gui/filehandling.py:1427
 #, fuzzy
@@ -1735,7 +1735,7 @@ msgstr "Ireki oraintsukoa"
 #, fuzzy
 msgctxt "File→Open Most Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Ireki..."
+msgstr "Ireki…"
 
 #: ../gui/filehandling.py:1446
 msgctxt "File→Open Next/Prev Scrap: error message"
@@ -1756,7 +1756,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
 msgid "_Open"
-msgstr "Ireki..."
+msgstr "Ireki…"
 
 #: ../gui/filehandling.py:1487
 msgctxt "File→Revert: status message: canvas has no filename yet"
@@ -2130,12 +2130,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2147,7 +2147,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2333,7 +2333,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2403,7 +2403,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/fa.po
+++ b/po/fa.po
@@ -64,7 +64,7 @@ msgstr ""
 #: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
-msgstr "باز کردن پوشه “{folder_basename}” …"
+msgstr "باز کردن پوشه “{folder_basename}”…"
 
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
@@ -534,18 +534,18 @@ msgstr "مجموعه قلم مای پینت"
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
-msgstr "ایجاد گروه جدید..."
+msgid "New Group…"
+msgstr "ایجاد گروه جدید…"
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
-msgstr "وارد کردن قلم های خارجی..."
+msgid "Import Brushes…"
+msgstr "وارد کردن قلم های خارجی…"
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
-msgstr "دریافت قلم های بیشتر..."
+msgid "Get More Brushes…"
+msgstr "دریافت قلم های بیشتر…"
 
 #: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
@@ -1210,12 +1210,12 @@ msgstr "نوع"
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
-msgstr "استفاده برای..."
+msgid "Use for…"
+msgstr "استفاده برای…"
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1433,8 +1433,8 @@ msgid "_Quit"
 msgstr "خروج"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
-msgstr "وارد کردن بسته های قلم..."
+msgid "Import brush package…"
+msgstr "وارد کردن بسته های قلم…"
 
 #: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
@@ -1483,8 +1483,8 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
-msgstr "باز کردن با..."
+msgid "Open With…"
+msgstr "باز کردن با…"
 
 #: ../gui/externalapp.py:123
 msgid "Icon"
@@ -1510,7 +1510,7 @@ msgstr ""
 #, fuzzy, python-brace-format
 msgctxt "Document I/O: message shown while working"
 msgid "Saving {files_summary}…"
-msgstr "ذخیره“{file_basename}” …"
+msgstr "ذخیره“{file_basename}”…"
 
 #: ../gui/filehandling.py:138
 #, fuzzy, python-brace-format
@@ -1670,15 +1670,15 @@ msgstr "JPEG کیفیت%90 (*.jpg; *.jpeg)"
 
 #: ../gui/filehandling.py:576
 #, fuzzy
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr "صادر کردن…"
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
-msgstr "ذخیره کردن در …"
+msgstr "ذخیره کردن در…"
 
 #: ../gui/filehandling.py:601
 #, fuzzy
@@ -1747,8 +1747,8 @@ msgstr "باز کردن"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
-msgstr "باز کردن چرک نویس..."
+msgid "Open Scratchpad…"
+msgstr "باز کردن چرک نویس…"
 
 #: ../gui/filehandling.py:1099
 #, fuzzy
@@ -2186,13 +2186,13 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
-msgstr "جستجوی رهگیر ها..."
+msgid "Search Tracker…"
+msgstr "جستجوی رهگیر ها…"
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
-msgstr "گزارش..."
+msgid "Report…"
+msgstr "گزارش…"
 
 #: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
@@ -2203,8 +2203,8 @@ msgid "Quit MyPaint"
 msgstr "خروج ازMyPaint"
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
-msgstr "جزئیات..."
+msgid "Details…"
+msgstr "جزئیات…"
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
@@ -2392,7 +2392,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2463,7 +2463,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777
@@ -3596,7 +3596,7 @@ msgstr "حذف قلم از روی رایانه"
 #, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid "_Recover & Save…"
-msgstr "ـگرفتن پشتیبان و ذخیره کردن..."
+msgstr "ـگرفتن پشتیبان و ذخیره کردن…"
 
 #: ../po/tmp/autorecover.glade.h:12
 #, fuzzy
@@ -4534,7 +4534,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Import Layers…"
-msgstr "وارد کردن مجموعه قلم …"
+msgstr "وارد کردن مجموعه قلم…"
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
@@ -4554,7 +4554,7 @@ msgstr "ذخیره کردن کار در یک پرونده جدید."
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As…"
-msgstr "ذخیره کردن در …"
+msgstr "ذخیره کردن در…"
 
 #: ../po/tmp/resources.xml.h:17
 msgctxt "Accel Editor (descriptions)"
@@ -5637,7 +5637,7 @@ msgstr "برگشت قاب چرک نویس به حالت پیش فرض"
 #: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
-msgstr "باز کردن چرک نویس …"
+msgstr "باز کردن چرک نویس…"
 
 #: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
@@ -5777,7 +5777,7 @@ msgstr ""
 #: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
-msgstr "وارد کردن مجموعه قلم …"
+msgstr "وارد کردن مجموعه قلم…"
 
 #: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2017-01-04 15:07+0000\n"
 "Last-Translator: hamed nasib <cghamed752@chmail.ir>\n"
-"Language-Team: Persian "
-"<https://hosted.weblate.org/projects/mypaint/mypaint/fa/>\n"
+"Language-Team: Persian <https://hosted.weblate.org/projects/mypaint/mypaint/"
+"fa/>\n"
 "Language: fa\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,29 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 2.11-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr "<big><b>{accel_label}</b></big>"
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr "{action_label} {action_desc} {accel_label}"
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "عمل"
 
@@ -49,32 +27,32 @@ msgstr "عمل"
 msgid "Key combination"
 msgstr "دکمه ترکیبی"
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr "ویرایش دکمه برای '%s'"
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "عمل:"
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "مسیر:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "کلید:"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr "دکمه های دلخواه را برای انتساب به این عمل  فشار دهید"
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "عمل ناشناخته"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
@@ -83,7 +61,7 @@ msgstr ""
 "<b>{accel}قبلا مورد استفاده قرار گرفته برای '{action}'. این انتساب جدید "
 "جایگزین قبلی میشود.</b>"
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr "باز کردن پوشه “{folder_basename}” …"
@@ -91,200 +69,208 @@ msgstr "باز کردن پوشه “{folder_basename}” …"
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "تایید"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr "فایل پشتیبانی در ذخیرهگاه وجود ندارد."
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr "فایل پشتیبان در دسترس نیست"
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr "باز کردن محل ذخیره…"
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr "بازیابی فایل پشتیبان شکست خورد"
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr "باز کردن پوشه فایل های پشتیبان…"
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr "بازیابی کن پرونده را با کمک پرونده {iso_datetime}.ora"
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "ذخیره به پیش فرض"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "پس زمینه"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "الگو"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "رنگ"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "افزودن رنگ به الگو"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr "یک یا چند پس زمینه نمی تواند بارگزاری شود"
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr "خطا در بارگیری پس زمینه ها"
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 "لطفا پرونده های غیرقابل بارگزاری را حذف کنید؛ یا از نصب بودن پرونده "
 "libgdkpixbuf اطمینان حاصل کنید."
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 "Gdk-Pixbuf نمی تواند \"{filename}\"را بارگزاری کند, و خطای\"{error}\"گزارش "
 "شده"
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, fuzzy, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr "{filename} 1 هیچ حجمی ندارد (w={w} 2, h={h} 3)"
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr "ویرایشگر تنظیمات قلم"
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr "درباره"
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "آزمایشی"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr "پایه"
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr "شفافیت"
 
-#: ../gui/brusheditor.py:312
-#, fuzzy
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 #, fuzzy
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "لکه"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr "سرعت"
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr "ره گیری"
-
-#: ../gui/brusheditor.py:359
-#, fuzzy
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr "ره گیری"
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr "رنگ"
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "سفارشی"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr "هیچ قلمی انتخاب نشده،لطفا از \"اضافه کردن بعنوان جدید\" استفاده کنید."
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr "قلمی انتخاب نشده!"
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "تغییر نام قلم مو"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "یک قلم موی با این نام از قبل وجود دارد!"
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr "هیچ قلم موی انتخاب نشده!"
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr "میخواهید قلم “{brush_name}”حذف کنید از رایانه؟"
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr "قلم بی نام"
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr "[ذخیره نشد]{brush_name}"
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr "آیکون قلم"
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr "آیکون قلم(ویرایش)"
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr "قلمی انتخاب نشده"
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -293,7 +279,7 @@ msgstr ""
 "<b>%s</b>\n"
 "<small>انتخاب یک قلم اولیه معتبر</small>"
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
@@ -302,7 +288,7 @@ msgstr ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>تغییراتی تا کنون ذخیره نشده</small>"
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
@@ -311,7 +297,7 @@ msgstr ""
 "<b>%s</b> (editing)\n"
 "<small>نقاشی با هر قلم یا رنگی</small>"
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -352,145 +338,181 @@ msgstr "خودکار"
 msgid "Use the default icon"
 msgstr "استفاده از آیکون پیش فرض"
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "ذخیره کردن"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr "ذخیره آیکون پیش نمایش و پایان دادن ویرایش"
 
-#: ../gui/brushmanager.py:98
-#, fuzzy
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr "حذف شده"
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr "محبوب ها"
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr "برداری"
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr "قدیمی"
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr "مجموعه۱"
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr "مجموعه۲"
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr "مجموعه۳"
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr "مجموعه۴"
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr "مجموعه۵"
 
-#: ../gui/brushmanager.py:108
-#, fuzzy
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "جدید"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr "قلم ناشناخته"
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr "اضافه کردن به محبوب ها"
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr "حذف از محبوب ها"
 
-#: ../gui/brushselectionwindow.py:192
-#, fuzzy
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr "ویرایش تنظیمات قلم"
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
-msgstr "حذف"
+#: ../gui/brushselectionwindow.py:250
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
+msgstr "تغییر نام گروه"
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
-msgstr "میخواهید این قلم را از رایانه حذف کنید؟"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, fuzzy, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
+msgstr "میخواهید قلم “{brush_name}”حذف کنید از رایانه؟"
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] "%d قلم"
 msgstr[1] "%d قلم ها"
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr "گروه“{group_name}”"
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr "تغییر نام گروه"
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr "صدور فایل فشرده مجموعه قلم ها"
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr "حذف گروه"
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr "تغییر نام گروه"
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "یک گروه با این نام از قبل وجود دارد!"
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr "واقعا می خواهید “{group_name}”را حذف کنید؟"
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -500,58 +522,58 @@ msgstr ""
 "نمی تواند گروه“{group_name}” را حذف کند.\n"
 "بعضی از گروه های خاص نمی توانند حذف شوند."
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr "خروجی دادن قلم ها"
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr "مجموعه قلم مای پینت"
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "ایجاد گروه جدید..."
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr "وارد کردن قلم های خارجی..."
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr "دریافت قلم های بیشتر..."
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "ایجاد گروه"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr "دکمه"
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr "دکمه"
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr "فشردن دکمه"
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr "افزودن کلید میانبر"
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr "حذف کلید میانبر موجود"
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr "ویرایش کلید میانبر داده شده برای '%s'"
@@ -560,55 +582,80 @@ msgstr "ویرایش کلید میانبر داده شده برای '%s'"
 msgid "Button press:"
 msgstr "فشردن دکمه:"
 
-#: ../gui/buttonmap.py:537
-#, fuzzy
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, fuzzy, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 "{button} بدون کلید میانبر انتساب داده نمیشود (its meaning is fixed, sorry)"
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr "{button_combination} قبلا به عمل '{action_name}' نسبت داده شده"
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr "انتخاب رنگ"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr "انتخاب رنگ استفاده شده برای نقاشی"
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+#, fuzzy
+msgid "Set the color Hue used for painting"
+msgstr "انتخاب رنگ استفاده شده برای نقاشی"
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "تشخیص رنگ."
+
+#: ../gui/colorpicker.py:296
+#, fuzzy
+msgid "Set the color Chroma used for painting"
+msgstr "انتخاب رنگ استفاده شده برای نقاشی"
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+#, fuzzy
+msgid "Set the color Luma used for painting"
+msgstr "انتخاب رنگ استفاده شده برای نقاشی"
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr "جزئیات رنگ"
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr "زنگ های موجود قلم و رنگ های استفاده شده برای نقاشی"
 
-#: ../gui/colors/hcywheel.py:48
-#, fuzzy
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr "قالب رنگ بندی فعال"
 
-#: ../gui/colors/hcywheel.py:90
-#, fuzzy
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -618,150 +665,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr "HCY طیف و مشخصه ها رنگ."
 
-#: ../gui/colors/hcywheel.py:411
-#, fuzzy
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
-#, fuzzy
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
-#, fuzzy
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
-#, fuzzy
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr "مکمل یک دیگر"
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
-#, fuzzy
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr "مکمل دو بخشی"
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr "دو رنگ مشابه و یک رنگ مکمل بین آنها , با رنگ های غیر ثانویه بین آنها."
 
-#: ../gui/colors/hcywheel.py:969
-#, fuzzy
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr "ویرایشگر قالب رنگ بندی"
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr "فعال"
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr "راهنما…"
 
-#: ../gui/colors/hcywheel.py:1091
-#, fuzzy
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
-#, fuzzy
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
-#, fuzzy
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
-#, fuzzy
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr "باز کردن تالار گقت و گو  در مرورگر وب برای راهنمای بیشتر."
 
-#: ../gui/colors/hcywheel.py:1174
-#, fuzzy
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
-#, fuzzy
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
-#, fuzzy
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -769,173 +803,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr "HSV طیف"
 
-#: ../gui/colors/hsvcube.py:38
-#, fuzzy
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
-#, fuzzy
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
-#, fuzzy
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
-#, fuzzy
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
-#, fuzzy
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
-#, fuzzy
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr "مربعHSV"
 
-#: ../gui/colors/hsvcube.py:78
-#, fuzzy
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr "مربعHSV"
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr "دارای طیف حلقوی که انتخاب رنگ را آسانتر می کند."
 
-#: ../gui/colors/hsvtriangle.py:47
-#, fuzzy
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-#, fuzzy
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr "دایرهHSV"
 
-#: ../gui/colors/hsvwheel.py:93
-#, fuzzy
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr "مشخصات پالت"
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr "جعبه رنگ"
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr "جعبه رنگ بدون نام"
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr "ویرایشگر پالت"
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr "بارگیری پالت های گیمپ"
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr "ذخیره به عنوان پالت گیمپ"
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr "اضافه کردن یک نمونه جدید"
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr "حذف همه نمونه ها"
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr "عنوان:"
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr "نام یا توضیحاتی برای جعبه رنگ"
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr "ستون ها:"
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr "شماره از ستون ها"
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr "نام رنگ:"
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr "نام رنگ فعلی"
 
-#: ../gui/colors/paletteview.py:328
-#, fuzzy
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr "بارگیری جعبه رنگ"
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr "ذخیره جعبه رنگ"
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -943,384 +958,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
-#, fuzzy
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
-#, fuzzy
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr "وارد کردن ردیف"
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr "وارد کردن ستون"
 
-#: ../gui/colors/paletteview.py:812
-#, fuzzy
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
-#, fuzzy
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
-#, fuzzy
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "جعبه رنگ گیمپ(*.gpl)"
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr "همه فایل ها(*)"
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "جعبه رنگ گیمپ(*.gpl)"
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr "همه فایل ها(*)"
 
-#: ../gui/colors/picker.py:100
-#, fuzzy
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr "قرمز"
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr "سبز"
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr "آبی"
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr "طیف"
 
-#: ../gui/colors/sliders.py:60
-#, fuzzy
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
-#, fuzzy
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr "موئلفه های نواری"
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr "انتخاب رنگ با تنظیم جز به جز موئلف های رنگ."
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr "RGB قرمز"
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr "RGB سبز"
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr "RGB آبی"
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr "طیفHSV"
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr "اشباعHSV"
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr "ارزشHSV"
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr "طیفHCY"
 
-#: ../gui/colors/sliders.py:262
-#, fuzzy
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
-#, fuzzy
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr "مایع مواج"
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr "انتخاب رنگ از شانه های یک جعبه مایع مواج جالب."
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr "حلقه های هم مرکز"
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr "انتخاب رنگ از میان حلقه های هم مرکز HSV."
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr "جعبه رنگ چلیپای"
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
-#, fuzzy
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr "پاک کن"
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr "صفحه کلید"
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr "موشواره"
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr "خودکار"
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr "صفحه لمسی"
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr "صفحه نمایش لمسی"
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr "رد کن"
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr "هیچ وظیفه ای"
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr "فقط ناوبری"
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr "بزرگ نمای"
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr "دستگاه"
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr "محور ها"
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr "نوع"
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr "استفاده برای..."
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "نام"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr "جایگزین"
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr "تغییر نام"
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr "جایگزینی همه"
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr "تغییر نام همه"
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr "قلم خارجی"
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr "قلم موجود"
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr "مجموعه قلم وارد نرم افزار شود؟"
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
-#, fuzzy, python-format
+#: ../gui/document.py:453
+#, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
-#, fuzzy, python-format
+#: ../gui/document.py:454
+#, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr "برگشت %s"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "خنثی کردن عمل"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr "رفتن به%s"
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "رفتن"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr "{button_combination}هست {resultant_action}"
@@ -1330,335 +1331,707 @@ msgstr "{button_combination}هست {resultant_action}"
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
-#, fuzzy
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
-msgstr "نام لایه"
-
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
-#, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
-"<b>{name}</b>\n"
-"{description}"
+
+#: ../gui/document.py:909
+#, python-brace-format
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
+msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
-#, fuzzy, python-format
+#: ../gui/drawwindow.py:269
+#, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
-#, fuzzy
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "باز کردن"
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr "خروج از حالت تمام صفحه"
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr "خروج از تمام صفحه"
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr "ورود به حالت تمام صفحه"
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "تمام صفحه"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "خروج"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+#, fuzzy
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr "واقعا از برنامه خارج می شوید؟"
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "خروج"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr "وارد کردن بسته های قلم..."
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr "بروز شد لایه“{layer_name}” با ویرایش های خارجی"
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr "نمی تواند “{file_basename}”را بارگزاری کند."
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr "باز کردن با..."
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr "آکون"
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr "بدون توضیحات"
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
+#: ../gui/filehandling.py:126
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
+msgstr "بارگزاری“{file_basename}”…"
+
+#: ../gui/filehandling.py:130
+#, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:134
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
+msgstr "ذخیره“{file_basename}” …"
+
+#: ../gui/filehandling.py:138
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
+msgstr "صادر کردن“{file_basename}”…"
+
+#: ../gui/filehandling.py:145
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr "فرایند صادر کردن“{file_basename}” شکست خورد."
+
+#: ../gui/filehandling.py:149
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr "فرایند ذخیره کردن “{file_basename}” شکست خورد."
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr "نمی تواند “{file_basename}”را بارگزاری کند."
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "ذخیره جعبه رنگ"
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr "“{file_basename}” صادر شد."
+
+#: ../gui/filehandling.py:187
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr "“{file_basename}”ذخیره شد."
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr "“{file_basename}”بارگزاری شد."
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
+msgstr "“{file_basename}”بارگزاری شد."
+
+#: ../gui/filehandling.py:427
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "All Recognized Formats"
 msgstr "همه قالب های رسمی"
 
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
+#: ../gui/filehandling.py:432
 #, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "OpenRaster (*.ora)"
-msgstr ""
+msgstr "OpenRaster (*.ora)"
 
-#: ../gui/filehandling.py:95
+#: ../gui/filehandling.py:437
 #, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "PNG (*.png)"
-msgstr ""
+msgstr "PNG شفاف (*.png)"
 
-#: ../gui/filehandling.py:96
+#: ../gui/filehandling.py:442
 #, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
+msgstr "JPEG کیفیت%90 (*.jpg; *.jpeg)"
 
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
+#: ../gui/filehandling.py:490
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "By extension (prefer default format)"
 msgstr "به وسیله قالب(قالب پیش فرض)"
 
-#: ../gui/filehandling.py:110
+#: ../gui/filehandling.py:494
 #, fuzzy
-msgid "PNG solid with background (*.png)"
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
 msgstr "PNG شفاف (*.png)"
 
-#: ../gui/filehandling.py:112
-#, fuzzy
-msgid "Multiple PNG transparent (*.XXX.png)"
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:113
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr "JPEG کیفیت%90 (*.jpg; *.jpeg)"
 
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr "ذخیره..."
+#: ../gui/filehandling.py:576
+#, fuzzy
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr "صادر کردن…"
 
-#: ../gui/filehandling.py:177
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "ذخیره کردن در …"
+
+#: ../gui/filehandling.py:601
+#, fuzzy
+msgctxt "save dialogs: formats and options: (label)"
 msgid "Format to save as:"
 msgstr "ذخیره با قالب:"
 
-#: ../gui/filehandling.py:203
+#: ../gui/filehandling.py:668
 #, fuzzy
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
 msgstr "واقعا می خواهید ادامه دهید؟"
 
-#: ../gui/filehandling.py:234
-#, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
+#: ../gui/filehandling.py:705
+#, fuzzy
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
 msgstr "_ذخیره کرده ورقه"
 
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
-msgstr "بارگزاری“{file_basename}”…"
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr ""
 
-#: ../gui/filehandling.py:296
-#, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
-msgstr "نمی تواند “{file_basename}”را بارگزاری کند."
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
 
-#: ../gui/filehandling.py:321
-#, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
-msgstr "“{file_basename}”بارگزاری شد."
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
 
-#: ../gui/filehandling.py:422
-#, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
-msgstr "صادر کردن“{file_basename}”…"
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
 
-#: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
-msgstr "ذخیره“{file_basename}” …"
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr "باز کردن…"
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
-msgstr "فرایند صادر کردن“{file_basename}” شکست خورد."
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "باز کردن"
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
-msgstr "فرایند ذخیره کردن “{file_basename}” شکست خورد."
-
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
-msgstr "“{file_basename}” صادر شد."
-
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
-msgstr "“{file_basename}”ذخیره شد."
-
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "باز کردن..."
-
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr "باز کردن چرک نویس..."
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "قلم خارجی"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "باز کردن"
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "باز کردن بسیار اخیر"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "باز کردن"
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr "باز کردن ورقه بعدی"
+
+#: ../gui/filehandling.py:1463
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr "باز کردن ورقه قبلی"
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "باز کردن"
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+#, fuzzy
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr "برگشت"
+
+#: ../gui/fill.py:121
+#, fuzzy
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr "سیل رنگ"
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+#, fuzzy
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr "پر کردن همه جا با رنگ"
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+#, fuzzy
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr "انحراف مجاز:"
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+#, fuzzy
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr "منبع:"
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
-#, fuzzy
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+#, fuzzy
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr "نمایش کل نقاشی"
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+#, fuzzy
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr "هدف:"
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr "لایه جدید(یک بار)"
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "شفافیت:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr "راه اندازی مجدد"
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+#, fuzzy
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr "بازنشانی تنظیمات به حالت پیش فرض"
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "انتخاب لایه"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr "<b>{brush_name}</b>"
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1668,130 +2041,142 @@ msgstr ""
 "<b>{brush_name}</b>\n"
 "{brush_desc}"
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr "قاب ویرایش"
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr "اندازه قاب"
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr "پیکسل"
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr "ارتفاع:"
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr "طول:"
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr "وضوح:"
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr "DPI(تعداد نقطه در هر اینچ)"
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr "رنگ:"
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr "رنگ قاب"
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr "<b>ابعاد قاب</b>"
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr "<b>تراکم پیکسل</b>"
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr "همسان کردن اندازه قاب و نقاشی لایه"
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr "اندازه قاب را به اندازه لایه انتخابی موجود تغییر می دهد"
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr "همسان کردن اندازه قاب و کل طراحی"
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr "اندازه قاب را به اندازه کل سند طراحی تغییر می دهد(تمام لایه ها)"
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr "برش لایه به اندازه قاب"
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr "بخش های از طراحی(درون لایه انتخابی) که خارج از قاب هست را حذف می کند"
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr "فعال"
 
-#: ../gui/framewindow.py:695
-#, fuzzy, python-brace-format
+#: ../gui/framewindow.py:718
+#, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr "اینچ"
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr "سانتی متر"
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr "میلیمتر"
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr "طراحی با دست آزاد"
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr "فشار:"
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr "خطای شناخته شده"
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr "<big><b>یک خطای برنامه نویسی پیدا شده.</b></big>"
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1800,35 +2185,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr "جستجوی رهگیر ها..."
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr "گزارش..."
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr "خطا را نادیده بگیر"
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr "خروج ازMyPaint"
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr "جزئیات..."
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1852,47 +2237,50 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr "طراحی برداری"
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr "آزمیش دستگاه های ورودی"
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr "(بدون فشار)"
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr "فشار:"
-
-#: ../gui/inputtestwindow.py:60
-#, fuzzy
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
-#, fuzzy
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr "(نبود دستگاه)"
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
 msgstr "دستگاه:"
 
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+#, fuzzy
+msgid "Barrel Rotation:"
+msgstr "بازنشاندن چرخش"
+
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr "حرکت دادن لایه"
 
@@ -1900,153 +2288,221 @@ msgstr "حرکت دادن لایه"
 msgid "Move the current layer"
 msgstr "حرکت دادن لایه موجود"
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, fuzzy, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
-msgstr "نوع"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
+msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+#, fuzzy
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr "مشخصات"
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr "مرئی"
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "لایه"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+#, fuzzy
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr "قفل شده"
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, fuzzy, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr "اضافه کردن{layer_default_name}"
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "لایه ها"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr "ردیف کننده لایه ها و تاثیرات انتسابی"
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr "شفافت لایه: %d%%"
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr "لایه"
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
-msgstr "حالت:"
+#: ../gui/layervis.py:53
+#, fuzzy, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
+msgstr "<b>{brush_name}</b>"
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "شفافیت:"
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "نمایش چرخان"
 
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr ""
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr ""
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr ""
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr "سر"
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 msgid "Stroke lead-in end"
 msgstr ""
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr "دم"
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr "خط ها و منحنی ها"
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr "خطوط متصل"
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr "دایره ها و بیضی ها"
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -2058,446 +2514,501 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr "برنامه نویس"
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr "قابلیت انتقال"
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr "مدیریت پروژه"
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr "قلم ها"
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr "الگو ها"
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr "آیکون های ابزار"
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr "آیکون دسکتاپ"
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr "جعبه های رنگ"
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr "اسناد"
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr "حمایت"
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr "جامعه کاربران"
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr "سید حامد نصیب"
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr "اندازه:"
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr "مات:"
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr "تنظیمات ابزار"
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr "<b>{mode_name}</b>"
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr "<i>تنظیماتی در دسترس نیست</i>"
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr "بزرگنمایی:%.01f%%"
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr "تنظیمات"
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr "پیش نمایش"
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr "نمایش منظره یاب"
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr "چرک نویس"
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr "بخش قبلی"
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr "بخش بعدی"
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
 msgstr "(نبود طراحی برای نمایش)"
 
-#: ../gui/symmetry.py:76
+#: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Place axis"
 msgstr "محور مکان"
 
-#: ../gui/symmetry.py:80
+#: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Move axis"
 msgstr "جابجای محور"
 
-#: ../gui/symmetry.py:84
+#: ../gui/symmetry.py:88
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr "حذف محور"
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr "ویرایش محور تقارن"
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr "تنظیم محور تقارن برای طراحی."
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
+#, fuzzy
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr "موقعیت:"
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr "موقعیت:"
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr "هیچ"
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr "پیکسل %d"
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr "آلفا:"
 
-#: ../gui/symmetry.py:352
+#: ../gui/symmetry.py:376
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
+msgstr "تقارن"
+
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+#, fuzzy
 msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+msgid "X axis Position"
 msgstr "محور مکان"
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:477
+#, fuzzy
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr "محور مکان"
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr "فعال"
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr "برگشت دادن و خنثی سازی"
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr "حالت های ترکیبی"
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr "حالت های خط"
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr "نمایش (اصلی)"
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr "نمایش(با تنظیمات اولیه)"
 
 #: ../gui/topbar.py:91
-#, fuzzy
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr "نمایش بزرگنمای"
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr "نمایش چرخان"
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, fuzzy, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr "بستن زبانه:%s"
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
-msgstr "ویرایش مشخصات:%s"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
+msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr "دستور ناشناخته"
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr "تعریف نشده(این دستور هنوز اجرا نشده)"
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr "سیل رنگ"
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "تغییر نام گروه"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr "پاک کردن لایه"
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr "چسپاندن لایه"
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr "ترکیب کردن لایه های مرئی"
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr "ترکیب به پایینی"
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr "طبیعی کردن حالت لایه"
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "قلم خارجی"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr "اضافه کردن{layer_default_name}"
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr "حذف لایه"
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr "انتخاب لایه"
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr "تکثیر لایه"
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr "حرکت لایه به بالا"
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr "حرکت لایه به پایین"
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr "تغییر نام لایه"
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr "ایجاد لایه مرئی"
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr "ایجاد لایه نامرئی"
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr "لایه قفل"
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr "لایه باز"
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr "حالت ناشناخته"
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr "غیرفعال کردن قاب"
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr "به روز کردن قاب"
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr "خطا در بارگزاری “{basename}”."
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr "قبل"
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2506,13 +3017,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr "بروزرسانی فایل پشتیبان کامل نشد {last_modified_time} {ago}"
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2522,7 +3033,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2530,13 +3041,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2544,7 +3055,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2552,7 +3063,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2568,7 +3079,7 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2578,7 +3089,13 @@ msgstr ""
 "{error_loading_common}\n"
 "پسوند این قالب ناشناخته است:“{ext}”"
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+#, fuzzy
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr "قلم خارجی"
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2588,7 +3105,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2599,304 +3116,398 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
-#, fuzzy, python-brace-format
+#: ../lib/floodfill.py:131
+#, fuzzy
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr "پر کردن"
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
+#, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
-#, fuzzy, python-brace-format
+#: ../lib/helpers.py:537
+#, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
-#, fuzzy, python-brace-format
+#: ../lib/helpers.py:539
+#, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
-#, fuzzy, python-brace-format
+#: ../lib/helpers.py:541
+#, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr "لایه"
 
-#: ../lib/layer/core.py:85
-#, fuzzy, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
+#: ../lib/layer/data.py:1153
 #, fuzzy
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr "لایه برداری"
+
+#: ../lib/layer/data.py:1158
+#, fuzzy
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr "لایه برداری"
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr "عمل ناشناخته"
+
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "ایجاد لایه نقاشی"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr "گروه"
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "ایجاد گروه لایه ها"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr "ریشه"
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
 #, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "نمایش"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+#, fuzzy
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr "مرئی بودن"
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+#, fuzzy
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr "حذف لایه"
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr "لایه قفل"
+
+#: ../lib/layervis.py:697
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr "لایه باز"
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
-#, fuzzy
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr "طبیعی"
 
-#: ../lib/modes.py:42
-#, fuzzy
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
-#, fuzzy
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
-#, fuzzy
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
-#, fuzzy
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
-#, fuzzy
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
-#, fuzzy
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
-#, fuzzy
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr "تیره کردن"
 
-#: ../lib/modes.py:58
-#, fuzzy
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr "روشن کردن"
 
-#: ../lib/modes.py:62
-#, fuzzy
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
-#, fuzzy
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
-#, fuzzy
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr "سوخته"
 
-#: ../lib/modes.py:71
-#, fuzzy
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr "روشنی سخت"
 
-#: ../lib/modes.py:76
-#, fuzzy
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr "روشنی نرم"
 
-#: ../lib/modes.py:79
-#, fuzzy
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr "اختلاف"
 
-#: ../lib/modes.py:82
-#, fuzzy
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
-#, fuzzy
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
-#, fuzzy
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr "طیف"
 
-#: ../lib/modes.py:89
-#, fuzzy
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr "اشباع"
 
-#: ../lib/modes.py:93
-#, fuzzy
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
-#, fuzzy
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
-#, fuzzy
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
-#, fuzzy
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr "اضافی"
 
-#: ../lib/modes.py:106
-#, fuzzy
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
@@ -2905,7 +3516,7 @@ msgstr ""
 "ناتوان در شکل دادن یکی از عناصر داخلی.رایانه شما ممکن است حافظه مورد نیاز "
 "برای انجام این عملیات را نداشته باشد."
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2919,7 +3530,30 @@ msgstr ""
 "دلیل:{err}.\n"
 "مسیر پوشه:“{dirname}”."
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+#, fuzzy
+msgid "Vertical"
+msgstr "چرخش تصویر روی محور عمودی"
+
+#: ../lib/tiledsurface.py:49
+#, fuzzy
+msgid "Horizontal"
+msgstr "چرخش تصویر روی محور افقی"
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+#, fuzzy
+msgid "Rotational"
+msgstr "بازنشاندن چرخش"
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr "PNGخوان شکست خورد:%s"
@@ -2928,56 +3562,92 @@ msgstr "PNGخوان شکست خورد:%s"
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
-msgstr "ـگرفتن پشتیبان و ذخیره کردن..."
+msgid "_Look for backups at startup"
+msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr "حذف"
+
+#: ../po/tmp/autorecover.glade.h:9
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr "حذف قلم از روی رایانه"
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr "ـگرفتن پشتیبان و ذخیره کردن..."
+
+#: ../po/tmp/autorecover.glade.h:12
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr "ذخیره پشتیبان روی رایانه و ادامه دادن کار."
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
-msgstr "ـرد کردن برای جدید"
+msgid "Decide _Later"
+msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
+#, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 "برنامه بدون ذخیره کردن کار متوقف شده اما یک فایل پشتیبان از آن تهیه شده . "
 "شما میتوانید بازیابی کنید فایل پشتیبان را یا ترک کنید برنامه رو و دوباره "
 "شروع کنید."
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr "توصیف"
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
-msgstr "چسباندن به پرونده جدید"
+msgid "Live update"
+msgstr "بروز رسانی زنده"
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
-msgstr "یک قلم جدید ایجاد کن و این تنظیمات و آیکون را به آن اختصاص بده"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
+msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
-msgstr "تغییر نام این قلم"
+msgid "Save these settings to the brush"
+msgstr "ذخیره این تنظیمات در این قلم"
 
 #: ../po/tmp/brusheditor.glade.h:5
 msgid "Edit Icon"
@@ -3000,18 +3670,16 @@ msgid "Delete this brush from the disk"
 msgstr "حذف قلم از روی رایانه"
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
-msgstr "بروز رسانی زنده"
+msgid "Copy to New"
+msgstr "چسباندن به پرونده جدید"
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
-msgstr ""
+msgid "Copy these settings and the current brush's icon to a new brush"
+msgstr "یک قلم جدید ایجاد کن و این تنظیمات و آیکون را به آن اختصاص بده"
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
-msgstr "ذخیره این تنظیمات در این قلم"
+msgid "Rename this brush"
+msgstr "تغییر نام این قلم"
 
 #: ../po/tmp/brusheditor.glade.h:13
 msgid "Brush Setting"
@@ -3039,113 +3707,90 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr "نکات:"
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr "تنظیمات نام:"
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
-msgstr "ارزش پایه:"
+#: ../po/tmp/brusheditor.glade.h:22
+#, fuzzy
+msgid "Value:"
+msgstr "ارزشHSV"
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr "<ymin>"
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr "<ymax>"
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr "خروجی"
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr "ورودی"
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr "<xmin>"
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr "<xmax>"
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr "ویرایش تنظیمات"
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr "{tooltip}"
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
 msgstr "{dname}:"
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+#, fuzzy
+msgid "<big><b>No Brush Dynamics</b></big>"
+msgstr "<big><b>{accel_label}</b></big>"
 
 #: ../po/tmp/inktool.glade.h:1
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
@@ -3157,7 +3802,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr "فشار:"
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3167,19 +3812,16 @@ msgid ""
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:7
-#, fuzzy
 msgctxt "Inking tool options: point value sliders: labels"
 msgid "X-tilt:"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:8
-#, fuzzy
 msgctxt "Inking tool options: point value sliders: labels"
 msgid "Y-tilt:"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:9
-#, fuzzy
 msgid "Tilt in the canvas Y axis"
 msgstr ""
 
@@ -3202,6 +3844,138 @@ msgstr "حذف گره"
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
 msgstr "حذف گره انتخاب شده موجود"
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+#, fuzzy
+msgid "Insert Point"
+msgstr "وارد کردن ردیف"
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+#, fuzzy
+msgid "Cull Points"
+msgstr "حذف گره"
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "نام"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr "حالت"
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "شفافیت"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr "حذف کلید میانبر موجود"
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
+msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
 msgctxt "footer: color picker button: tooltip"
@@ -3243,7 +4017,6 @@ msgid "OpenRaster (*.ora)"
 msgstr "OpenRaster (*.ora)"
 
 #: ../po/tmp/preferenceswindow.glade.h:2
-#, fuzzy
 msgctxt "Prefs Dialog|Saving|Save Formats and Locations|Default|"
 msgid "PNG solid with background (*.png)"
 msgstr ""
@@ -3573,56 +4346,77 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr "مخفی کردن نشانگر هنگام شروع نقاشی"
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+#, fuzzy
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr "فعال"
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr "نمایش"
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr "رنگ های اصلی:"
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr "استاندارد (قرمز /سبز /آبی) RGB"
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3630,12 +4424,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3644,7 +4438,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3655,28 +4449,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr "<b>دایره رنگ</b>"
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr "رنگ"
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr "غیرفعال(عدم حساسیت به فشار)"
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr "پنجره(توصیه نمی شود)"
@@ -3737,471 +4531,575 @@ msgid "Reload the file your current work was loaded from."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
+#, fuzzy
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Import Layers…"
+msgstr "وارد کردن مجموعه قلم …"
+
+#: ../po/tmp/resources.xml.h:13
+msgctxt "Accel Editor (descriptions)"
+msgid "Import layers from one or more files."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save"
 msgstr "ذخیره کردن"
 
-#: ../po/tmp/resources.xml.h:13
+#: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file."
 msgstr "ذخیره کردن کار در یک پرونده جدید."
 
-#: ../po/tmp/resources.xml.h:14
+#: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As…"
 msgstr "ذخیره کردن در …"
 
-#: ../po/tmp/resources.xml.h:15
+#: ../po/tmp/resources.xml.h:17
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file, assigning it a new name."
 msgstr "ذخیره کار در یک پرونده با اختصاص دادن نام جدید."
 
-#: ../po/tmp/resources.xml.h:16
+#: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Export…"
 msgstr "صادر کردن…"
 
-#: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:18
-msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
-msgstr "ذخیره کردن ورقه"
-
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Save As Scrap"
+msgstr "ذخیره کردن ورقه"
+
+#: ../po/tmp/resources.xml.h:21
+msgctxt "Accel Editor (descriptions)"
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:22
+msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Previous Scrap"
 msgstr "باز کردن ورقه قبلی"
 
-#: ../po/tmp/resources.xml.h:21
+#: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file before the current one."
 msgstr "بارگزاری ورقه ی قبل از این ورقه جاری در پرده نقاشی."
 
-#: ../po/tmp/resources.xml.h:22
+#: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Next Scrap"
 msgstr "باز کردن ورقه بعدی"
 
-#: ../po/tmp/resources.xml.h:23
+#: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file after the current one."
 msgstr "بارگزاری ورقه ی بعد از این ورقه جاری در پرده نقاشی."
 
-#: ../po/tmp/resources.xml.h:24
+#: ../po/tmp/resources.xml.h:26
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Recover File from an Automated Backup…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:25
+#: ../po/tmp/resources.xml.h:27
 msgctxt "Accel Editor (descriptions)"
 msgid "Try to save and resume interrupted unsaved work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:26
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr "مجموعه قلم ها"
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr "قلم ها"
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr "لیستی از مجموعه های قلم."
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr "جعبه های رنگ"
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr "رنگ ها"
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr "جعبه های رنگ در دسترس."
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr "حالت"
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr "حالت"
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
+#: ../po/tmp/resources.xml.h:37
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Pressure"
+msgstr "فشار ورودی"
+
+#: ../po/tmp/resources.xml.h:38
+msgctxt "Accel Editor (descriptions)"
+msgid "Send harder pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:39
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Pressure"
+msgstr "فشار قلم"
+
+#: ../po/tmp/resources.xml.h:40
+msgctxt "Accel Editor (descriptions)"
+msgid "Send softer pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:41
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Rotation"
+msgstr "افزایش اشباع بودن"
+
+#: ../po/tmp/resources.xml.h:42
+msgctxt "Accel Editor (descriptions)"
+msgid "Increase barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:43
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
+msgstr "کاهش اشباع بودن"
+
+#: ../po/tmp/resources.xml.h:44
+msgctxt "Accel Editor (descriptions)"
+msgid "Decrease barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:45
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Size"
 msgstr "افزایش اندازه قلم"
 
-#: ../po/tmp/resources.xml.h:36
+#: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush bigger."
 msgstr "اندازه نوک قلم را بزرگتر میکند."
 
-#: ../po/tmp/resources.xml.h:37
+#: ../po/tmp/resources.xml.h:47
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Size"
 msgstr "کاهش اندازه قلم"
 
-#: ../po/tmp/resources.xml.h:38
+#: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush smaller."
 msgstr "اندازه نوک قلم را کوچکتر میکند."
 
-#: ../po/tmp/resources.xml.h:39
+#: ../po/tmp/resources.xml.h:49
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Opacity"
 msgstr "کاهش شفافیت قلم"
 
-#: ../po/tmp/resources.xml.h:40
+#: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush more opaque."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:41
+#: ../po/tmp/resources.xml.h:51
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Opacity"
 msgstr "افزایش شفافیت قلم"
 
-#: ../po/tmp/resources.xml.h:42
+#: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush less opaque."
 msgstr "شفافیت را افزایش می دهد."
 
-#: ../po/tmp/resources.xml.h:43
+#: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Lighten Painting Color"
 msgstr "افزایش روشنی رنگ"
 
-#: ../po/tmp/resources.xml.h:44
+#: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase the lightness of the current painting color."
 msgstr ""
 "با افزایش نور تابیده شده روی رنگ؛رنگ را روشنتر می کند ولی به سمت رنگ سفید "
 "حرکت نمی دهد."
 
-#: ../po/tmp/resources.xml.h:45
+#: ../po/tmp/resources.xml.h:55
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Darken Painting Color"
 msgstr "افزایش تیرگی رنگ"
 
-#: ../po/tmp/resources.xml.h:46
+#: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease the lightness of the current painting color."
 msgstr ""
 "با کاهش میزان نور تابیده شده روی رنگ ؛رنگ را به سمت رنگ سیاه انتقال می دهد."
 
-#: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
-msgstr "تغییر طیف رنگ پاد ساعتگرد"
-
-#: ../po/tmp/resources.xml.h:48
-msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
-msgstr ""
-"طیف انتخابی رنگ را(آبی -زرد- و ...) با سمت چپ طیف حرکت داده و رنگ دیگری را "
-"انتخاب میکند.مقدار تغییر رنگ اندک خواهد بود."
-
-#: ../po/tmp/resources.xml.h:49
+#: ../po/tmp/resources.xml.h:57
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Change Hue Clockwise"
 msgstr "تغییر طیف رنگ (ساعتگرد)"
 
-#: ../po/tmp/resources.xml.h:50
+#: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
 msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 "طیف انتخابی رنگ را(آبی -زرد- و ...) با سمت راست طیف حرکت داده و رنگ دیگری را "
 "انتخاب میکند.مقدار تغییر رنگ اندک خواهد بود."
 
-#: ../po/tmp/resources.xml.h:51
+#: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr "تغییر طیف رنگ پاد ساعتگرد"
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+"طیف انتخابی رنگ را(آبی -زرد- و ...) با سمت چپ طیف حرکت داده و رنگ دیگری را "
+"انتخاب میکند.مقدار تغییر رنگ اندک خواهد بود."
+
+#: ../po/tmp/resources.xml.h:61
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Increase Saturation"
 msgstr "افزایش اشباع بودن"
 
-#: ../po/tmp/resources.xml.h:52
+#: ../po/tmp/resources.xml.h:62
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color more saturated (more colorful, purer)."
 msgstr "ایجاد رنگ با درجه اشباع بیشتر(افزایش درجه رنگ و خلوص آن)."
 
-#: ../po/tmp/resources.xml.h:53
+#: ../po/tmp/resources.xml.h:63
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Decrease Saturation"
 msgstr "کاهش اشباع بودن"
 
-#: ../po/tmp/resources.xml.h:54
+#: ../po/tmp/resources.xml.h:64
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color less saturated (grayer)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:55
+#: ../po/tmp/resources.xml.h:65
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Reload Brush Settings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:56
+#: ../po/tmp/resources.xml.h:66
 msgctxt "Accel Editor (descriptions)"
 msgid "Restore all brush settings to the current brush’s saved values."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:57
+#: ../po/tmp/resources.xml.h:67
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Pick Stroke and Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:58
+#: ../po/tmp/resources.xml.h:68
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:59
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "پاک کردن لایه"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+#, fuzzy
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr "تنظیمات ابزار"
+
+#: ../po/tmp/resources.xml.h:76
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
-msgstr ""
+msgstr "برش لایه به اندازه قاب"
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr "بخش های از طراحی(درون لایه انتخابی) که خارج از قاب هست را حذف می کند"
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "ایجاد لایه گروهی در پایین"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "ایجاد لایه گروهی در پایین"
+
+#: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr "رونوشت لایه به حافظه موقت"
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr "چسباندن لایه از حافظه موقت"
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:71
+#: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Edit Layer in External App…"
 msgstr "ویرایش لایه در برنامه خارجی…"
 
-#: ../po/tmp/resources.xml.h:72
+#: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:73
+#: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Update Layer with External Edits"
 msgstr "بروز رسانی لایه با ویرایش خارجی"
 
-#: ../po/tmp/resources.xml.h:74
+#: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
 msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 "اعمال تغییرات ذخیره شده به وسیله ویرایشگر های خارجی در برنامه(انجام خودکار)."
 
-#: ../po/tmp/resources.xml.h:75
+#: ../po/tmp/resources.xml.h:93
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer at Cursor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:76
+#: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:77
+#: ../po/tmp/resources.xml.h:95
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Above"
 msgstr "برو به لایه بالای"
 
-#: ../po/tmp/resources.xml.h:78
+#: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer up in the layer stack."
 msgstr "انتخاب لایه بالاتر از لایه جاری."
 
-#: ../po/tmp/resources.xml.h:79
+#: ../po/tmp/resources.xml.h:97
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Below"
 msgstr "برو به لایه پایینی"
 
-#: ../po/tmp/resources.xml.h:80
+#: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer down in the layer stack."
 msgstr "انتخاب لایه پایین تر از لایه جاری."
 
-#: ../po/tmp/resources.xml.h:81
+#: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer"
 msgstr "ایجاد لایه نقاشی"
 
-#: ../po/tmp/resources.xml.h:82
+#: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer above the current layer."
 msgstr "افزودن یک لایه نقاشی به بالای لایه انتخابی."
 
-#: ../po/tmp/resources.xml.h:83
+#: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer…"
 msgstr "ایجاد لایه برداری…"
 
-#: ../po/tmp/resources.xml.h:84
+#: ../po/tmp/resources.xml.h:102
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer above the current layer, and begin editing it."
 msgstr ""
 "افزودن یک لایه بُرداری جدید به بالای لایه انتخابی و انتخاب آن برای شروع "
 "ویرایش."
 
-#: ../po/tmp/resources.xml.h:85
+#: ../po/tmp/resources.xml.h:103
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group"
 msgstr "ایجاد گروه لایه ها"
 
-#: ../po/tmp/resources.xml.h:86
+#: ../po/tmp/resources.xml.h:104
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group above the current layer."
 msgstr "افزودن یک گروه لایه به بالای لایه انتخابی."
 
-#: ../po/tmp/resources.xml.h:87
+#: ../po/tmp/resources.xml.h:105
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer Below"
 msgstr "ایجاد لایه نقاشی در پایین"
 
-#: ../po/tmp/resources.xml.h:88
+#: ../po/tmp/resources.xml.h:106
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer below the current layer."
 msgstr "افزودن لایه نقاشی در پایین لایه انتخابی."
 
-#: ../po/tmp/resources.xml.h:89
+#: ../po/tmp/resources.xml.h:107
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer Below…"
 msgstr "ایجاد لایه برداری در پایین…"
 
-#: ../po/tmp/resources.xml.h:90
+#: ../po/tmp/resources.xml.h:108
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer below the current layer, and begin editing it."
 msgstr ""
 "افزودن یک لایه بُرداری جدید به پایین لایه انتخابی و انتخاب آن برای شروع "
 "ویرایش."
 
-#: ../po/tmp/resources.xml.h:91
+#: ../po/tmp/resources.xml.h:109
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group Below"
 msgstr "ایجاد لایه گروهی در پایین"
 
-#: ../po/tmp/resources.xml.h:92
+#: ../po/tmp/resources.xml.h:110
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group below the current layer."
 msgstr "افزودن گروه لایه یه پایینتر از لایه انتخابی."
 
-#: ../po/tmp/resources.xml.h:93
+#: ../po/tmp/resources.xml.h:111
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Layer Down"
 msgstr "ترکیب لایه با پایینی"
 
-#: ../po/tmp/resources.xml.h:94
+#: ../po/tmp/resources.xml.h:112
 msgctxt "Accel Editor (descriptions)"
 msgid "Merge the current layer with the layer beneath it."
 msgstr "ترکیب لایه انتخابی با لایه پایین تر از خود."
 
-#: ../po/tmp/resources.xml.h:95
+#: ../po/tmp/resources.xml.h:113
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Visible Layers"
 msgstr "ترکیب تمام لایه های مرئی"
 
-#: ../po/tmp/resources.xml.h:96
+#: ../po/tmp/resources.xml.h:114
 msgctxt "Accel Editor (descriptions)"
 msgid "Consolidate all visible layers, and delete the originals."
 msgstr "حذف همه لایه ها به جزی لایه های مرئی.."
 
-#: ../po/tmp/resources.xml.h:97
+#: ../po/tmp/resources.xml.h:115
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer from Visible"
 msgstr "ایجاد یک لایه مرئی"
 
-#: ../po/tmp/resources.xml.h:98
+#: ../po/tmp/resources.xml.h:116
 msgctxt "Accel Editor (descriptions)"
 msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
 msgstr ""
 "همه لایه های مرئی را با هم ترکیب میکند و لایه جدیدی میسازد.ولی لایه های اصلی "
 "را دست نخورده میگزارد."
 
-#: ../po/tmp/resources.xml.h:99
+#: ../po/tmp/resources.xml.h:117
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Delete Layer"
 msgstr "حذف لایه"
 
-#: ../po/tmp/resources.xml.h:100
+#: ../po/tmp/resources.xml.h:118
 msgctxt "Accel Editor (descriptions)"
 msgid "Remove the current layer from the layer stack."
 msgstr "حذف لایه انتخابی از میان لایه ها."
 
-#: ../po/tmp/resources.xml.h:101
+#: ../po/tmp/resources.xml.h:119
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Convert to Normal Painting Layer"
 msgstr "تبدیل به لایه نقاشی عادی"
 
-#: ../po/tmp/resources.xml.h:102
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
@@ -4209,1377 +5107,1584 @@ msgid ""
 msgstr ""
 "تبدیل لایه یا گروه لایه جاری به یک لایه نقاشی در حالت عادی.با حفظ ظاهر آن."
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr "افزایش شفافیت لایه ها"
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr "کاهش شفافیت لایه ها"
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr "انتقال به بالا"
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr "بالا بردن لایه انتخابی نسبت به لایه بالای خود در پنجره مدیریت لایه ها."
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr "انتقال به پایین"
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 "پایین بردن لایه انتخابی نسبت به لایه پایینی خود در پنجره مدیریت لایه ها."
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr "تکثیر کردن"
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
+#, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
-msgstr "تغییر نام لایه…"
+msgid "Layer Properties…"
+msgstr "مشخصات"
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
-msgstr "وارد کردن یک نام جدید برای لایه موجود."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr "قفل بودن"
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr "مرئی بودن"
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr "نمایش پس زمینه"
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr "حذف لایه انتخابی از میان لایه ها."
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr "نمایش کل نقاشی"
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr "باز نشاندن"
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr "بازنشاندن بزرگ نمای"
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr "مقدار بزرگنمای را به حالت پیشفرض برمیگرداند."
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr "بازنشاندن چرخش"
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr "باز گرداندن میزان چرخش حالت نمایش به صفر درجه"
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr "بازنشاندن حالت تقارن"
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
-msgstr "غیر فعال کردن حالت تقارن."
+msgid "Reset the view's mirroring."
+msgstr "بازنشاندن حالت تقارن"
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr "بزرگنمای به داخل"
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr "افزایش بزرگ نمای."
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "بزرگنمای به بیرون"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr "کاهش بزرگنمای."
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
+#, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
-msgstr "چرخش از راست به چب"
+msgid "Pan Left"
+msgstr "نمایش سراسری"
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
+msgstr "نمایش چرخشی: حالت شیب دار دید شما روی بوم نقاشی."
+
+#: ../po/tmp/resources.xml.h:158
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr "روشنی سخت"
+
+#: ../po/tmp/resources.xml.h:159
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr "نمایش سراسری: حرکت تعاملی دید شما به صورت عمودی یا افقی روی بوم نقاشی."
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:161
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr "نمایش چرخشی: حالت شیب دار دید شما روی بوم نقاشی."
+
+#: ../po/tmp/resources.xml.h:162
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr "نمایش سراسری"
+
+#: ../po/tmp/resources.xml.h:163
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr "نمایش چرخشی: حالت شیب دار دید شما روی بوم نقاشی."
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr "چرخش از چپ به راست"
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
-msgstr ""
+msgid "Rotate the canvas clockwise."
+msgstr "چرخش از راست به چب"
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr "چرخش از راست به چب"
+
+#: ../po/tmp/resources.xml.h:167
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr "چرخش از راست به چب"
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr "چرخش تصویر روی محور افقی"
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr "چرخش تصویر روی محور عمودی"
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr "فقط نمایش این لایه"
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr "فعال بودن حالت نقاشی متقارن"
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr "نمایش قاب"
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr "نمایش تصویری پردازش قلم"
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+#, fuzzy
+msgid "Delete Point"
+msgstr "حذف گره"
+
+#: ../po/tmp/resources.xml.h:187
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr "حذف گره انتخاب شده موجود"
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr "حالت نقاشی"
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr "حالت نقاشی: عادی"
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr "حالت نقاشی: پاک کن"
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr "پاک کن از قلم جاری استفاده می کند."
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr "حالت نقاشی:قفل آلفا"
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr "اعمال قلم روی صفحه تغییری در شفافیت ایجاد نمی کند."
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr "حالت نقاشی:رنگ آمیزی"
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr "اعمال رنگ روی لایه بدون تاثیر گذاشتن بر شفافیت و درخشندگی صفحه."
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "پرونده"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "خروج"
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr "بستن پنجره اصلی و خروج از برنامه."
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "ویرایش"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr "ابزار جاری"
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "رنگ"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr "تنظیم رنگ"
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr "پنجره واشو تاریخچه رنگ"
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr "جعبه رنگ بعدی"
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr "جعبه رنگ قبلی"
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr "افزودن  رنگ به جعبه رنگ"
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "لایه"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr "شفافیت"
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr "رفتن به لایه"
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr "ایجاد لایه جدید در پایین"
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr "مشخصات"
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr "چرک نویس"
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr "چرک نویس جدید"
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr "برگشت قاب چرک نویس به حالت پیش فرض"
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr "باز کردن چرک نویس …"
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr "بارگزاری یک تصویر در پس زمینه پنجره چرک نویس."
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr "ذخیره چرک نویس"
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr "ذخیره چرک نویس"
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr "صادر کردن چرک نویس با قالب…"
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr "خروجی گرفتن از چرک نویس بر روی دیسک حافظه با نام دلخواه"
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr "برگشت به حالت اولیه"
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr "برگشت چرکنویس به حالت ذخیره شده اولیه."
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr "ذخیره چرک نویس به پیشفرض"
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr "پاک کردن چرک نویس پیشفرض"
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr "رونوشت پسزمینه به چرک نویس"
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 #, fuzzy
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "پنجره"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "قلم مو"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr "کلید های میانبر"
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr "راهنمای کلید های قلم ها"
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "تعویض قلم…"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "تغییر رنگ…"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "تغیر سریع رنگ…"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr "دریافت قلم…"
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr "وارد کردن مجموعه قلم …"
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr "بارگزاری مجموعه قلم از روی رایانه."
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "راهنما"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr "راهنمای برخط"
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "درباره"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "خطا یابی نرم افزار"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "نمایش"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr "بازخورد"
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr "تنظیمات زاویه دید"
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
+#, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr "پنجره منو ها"
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "تمام صفحه"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "ویرایش ترجیحات"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr "آزمایش دستگاه های ورودی"
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 "نمایش یک پنجره که در آن همه رویداد های مربوط به دستگاه های ورودی شما را نشان "
 "می دهد."
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr "انتخاب پس زمینه"
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr "تغییر دادن تصویر پس زمینه روی پرده نقاشی."
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 #, fuzzy
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr "ویرایشگر تنظیمات قلم"
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr "ویرایشگر آیکون قلم"
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr "ویرایش آیکون قلم."
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr "پنل لایه ها"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr "نمایش پنل لایه ها"
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr "دایره HCY"
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "پالت رنگ"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr "دایرهHSV"
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr "مثلثHSV"
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr "مکعبHSV"
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr "موئلفه های رنگ"
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr "مایع مواج"
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr "دوایر هم مرکز"
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr "جعبه رنگ چلیپای"
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr "پنل چرک نویس"
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr "نمایش پنل چرک نویس"
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr "پنل پیش نمایش"
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "پیش نمایش"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr "پنل تنظیمات ابزار"
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr "نمایش پنل تنظیمات ابزار"
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr "پنل تاریخچه رنگ ها و قلم ها"
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr "رنگ ها و قلم های اخیر"
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr "مخفی بودن کنترلگر ها در حالت تمام صفحه"
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr "نمایش مقدار"
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr "نمیش آخرین نقطه اتصال قلم و بوم"
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr "صافی های نمایش"
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr "نمیش رنگ ها به صورت طبیعی"
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr "صافی رنگ ها: نمایش رنگ های تغییر نیافته."
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr "نمایش رنگ ها در مقیاس خاکستری"
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr "نمایش معکوس رنگ ها"
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr "شبیه سازی رنگ ها بدون حساسیت به قرمز"
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr "شبیه سازی رنگ ها بدون حساسیت به سبز"
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr "شبیه سازی رنگ ها بدون حساسیت به آبی"
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr "دست آزاد"
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr "دست آزاد"
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr "دست آزاد :رسم و نقاشی به صورت آزاد, بدون محدودیت هندسی."
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr "دست آزاد"
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr "رسم و نقاشی به صورت آزاد, بدون محدودیت هندسی."
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr "نمایش سراسری"
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr "سراسری"
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr "نمایش سراسری: حرکت تعاملی دید شما به صورت عمودی یا افقی روی بوم نقاشی."
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr "نمایش سراسری"
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr "حرکت تعاملی دید شما به صورت عمودی یا افقی روی بوم نقاشی."
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr "نمایش چرخشی"
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr "چرخش"
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr "نمایش چرخشی: حالت شیب دار دید شما روی بوم نقاشی."
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr "نمایش چرخشی"
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr "چرخش تعاملی دید شما روی بوم نقاشی."
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr "نمیش دره بینی"
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr "بزرگنمای"
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr "نمایش بزرگنمای: بزرگنمای تعاملی به داخل یا خارج بوم نقاشی."
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr "نمایش ذره بینی"
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr "بزرگنمای تعاملی به داخل یا خارج بوم نقاشی."
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr "خط ها و منحنی ها"
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr "خط ها"
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr "خطوط و منحنی ها: کشیدن خطوط مستقیم یا منحنی شکل."
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr "خط ها و منحنی ها"
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr "کشیدن خطوط مستقیم یا منحنی شکل."
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr "خطوط متصل"
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr "خطوط متصل: کشیدن خط های مستقیم یا منحنی شکل متصل به هم."
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr "خطوط متصل"
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr "کشیدن خط های مستقیم یا منحنی شکل متصل به هم."
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr "دایره و بیضی"
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr "بیضی"
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr "منحنی ها و دایره ها: کشیدن اشکال گرد شده."
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr "رسم دایره و بیضی"
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr "کشیدن دایره ها و منحنی ها."
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr "طراحی برداری"
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr "بردار"
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr "طراحی برداری: کشیدا خطوط کنترل شده صاف."
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr "رسم برداری"
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr "کشیدن خطوط کنترل شده صاف."
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr "جابجای طرح لایه"
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr "جابجای طرح لایه."
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr "جابجای طرح لایه: حرکت دادن طراحی درون لایه روی بوم نقاشی."
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr "جابجای طرح لایه"
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr "ویرایش قاب"
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr "قاب"
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr "قاب ویرایش"
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "ویرایش نقاشی متقارن"
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr "تقارن"
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr "ویرایش نقاشی متقارن: adjust the axis used for symmetrical painting."
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "نقاشی متقارن"
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr "تشخیص رنگ"
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr "تشخیص رنگ."
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "انتخاب رنگ"
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "انتخاب رنگ"
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "انتخاب رنگ"
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr "انتخاب رنگ"
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr "پر کردن(سطل)"
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr "پر کردن"
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr "پر کردن: پرکردن یک ناحیه با رنگ."
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr "پر کردن(سطل)"
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr "پر کردن یک ناحیه با رنگ."
+
+#~ msgctxt "Accelerator map editor: action column markup"
+#~ msgid ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+#~ msgstr ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+
+#~ msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
+#~ msgid "{action_label} {action_desc} {accel_label}"
+#~ msgstr "{action_label} {action_desc} {accel_label}"
+
+#~ msgctxt "brush list context menu"
+#~ msgid "Delete"
+#~ msgstr "حذف"
+
+#~ msgctxt "brush list commands"
+#~ msgid "Really delete brush from disk?"
+#~ msgstr "میخواهید این قلم را از رایانه حذف کنید؟"
+
+#~ msgid "Layer Name"
+#~ msgstr "نام لایه"
+
+#~ msgid ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+#~ msgstr ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+
+#~ msgid "Save..."
+#~ msgstr "ذخیره..."
+
+#~ msgid "Open..."
+#~ msgstr "باز کردن..."
+
+#~ msgid "Type"
+#~ msgstr "نوع"
+
+#~ msgid "Mode:"
+#~ msgstr "حالت:"
+
+#~ msgid "%s: edit properties"
+#~ msgstr "ویرایش مشخصات:%s"
+
+#~ msgctxt "Autosave Recovery dialog|"
+#~ msgid "_Ignore for Now"
+#~ msgstr "ـرد کردن برای جدید"
+
+#~ msgid "Setting name:"
+#~ msgstr "تنظیمات نام:"
+
+#~ msgid "Base value:"
+#~ msgstr "ارزش پایه:"
+
+#~ msgid "<ymin>"
+#~ msgstr "<ymin>"
+
+#~ msgid "<ymax>"
+#~ msgstr "<ymax>"
+
+#~ msgid "<xmin>"
+#~ msgstr "<xmin>"
+
+#~ msgid "<xmax>"
+#~ msgstr "<xmax>"
+
+#~ msgid "Edit Setting"
+#~ msgstr "ویرایش تنظیمات"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Rename Layer…"
+#~ msgstr "تغییر نام لایه…"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Enter a new name for the current layer."
+#~ msgstr "وارد کردن یک نام جدید برای لایه موجود."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Turn off mirroring of the view."
+#~ msgstr "غیر فعال کردن حالت تقارن."
+
+#~ msgctxt "Menu→Edit (labels)"
+#~ msgid "Current Tool"
+#~ msgstr "ابزار جاری"
+
+#~ msgctxt "Menu→Color (labels), Accel Editor (labels)"
+#~ msgid "HSV Triangle"
+#~ msgstr "مثلثHSV"

--- a/po/fi.po
+++ b/po/fi.po
@@ -534,17 +534,17 @@ msgstr "MyPaint sivellinpaketti (*.zip)"
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr "Uusi ryhmä…"
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr "Tuo siveltimiä…"
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr "Hanki lisää siveltimiä…"
 
 #: ../gui/brushselectionwindow.py:554
@@ -1207,12 +1207,12 @@ msgstr "Tyyppi"
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1429,7 +1429,7 @@ msgid "_Quit"
 msgstr "Lopeta"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1479,7 +1479,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1664,13 +1664,13 @@ msgstr "JPEG (*.jpg; *.jpeg)"
 
 #: ../gui/filehandling.py:576
 #, fuzzy
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr "Vie…"
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Tallenna nimellä…"
 
@@ -1738,7 +1738,7 @@ msgstr "Avaa"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr "Luonnoslehtiö"
 
 #: ../gui/filehandling.py:1099
@@ -2170,12 +2170,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2187,7 +2187,7 @@ msgid "Quit MyPaint"
 msgstr "Lopeta MyPaint"
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2374,7 +2374,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2445,7 +2445,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-23 08:18+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -19,27 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr "<b>{action_label}</b><small>{action_desc}</small>"
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr "<big><b>{accel_label}</b></big>"
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr "{action_label} {action_desc} {accel_label}"
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "Toiminto"
 
@@ -47,32 +27,32 @@ msgstr "Toiminto"
 msgid "Key combination"
 msgstr "Näppäinyhdistelmä"
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr "Valitse Näppäin Toiminnolle '%s'"
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "Toiminto:"
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "Polku:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "Näppäin:"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr "Paina näppäimiä päivittääksesi tämän asetuksen"
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "Tuntematon Toiminto"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
@@ -81,7 +61,7 @@ msgstr ""
 "<b>{accel} on jo käytössä toiminnolle '{action}'. Tämän hetkinen asetus "
 "korvataan.</b>"
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr "Avaa Kansio \"{folder_basename}\"…"
@@ -89,196 +69,206 @@ msgstr "Avaa Kansio \"{folder_basename}\"…"
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "OK"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr "Välimuistista ei löytynyt varmuuskopioita."
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr "Varmuuskopioita ei löytynyt"
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr "Avaa Välimuistikansio…"
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr "Varmuuskopion Palauttaminen Epäonnistui"
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr "Avaa Varmuuskopion Kansio…"
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr "Palautettu tiedosto {iso_datetime}.ora:sta"
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "Tallenna oletuksena"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "Tausta"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "Kuvio"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Väri"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "Lisää väri Kuvioihin"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr "Yhden tai useamman taustan lataaminen epäonnistui"
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr "Virhe ladattaessa taustoja"
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 "Poista tiedostot joita ei voitu ladata tai tarkista libgdkpixbuf-asennus."
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
-"Gdk-Pixbuf ei voinut ladata \"{filename}\"-tiedostoa ja ilmoitti virheestä \""
-"{error}\""
+"Gdk-Pixbuf ei voinut ladata \"{filename}\"-tiedostoa ja ilmoitti virheestä "
+"\"{error}\""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr "Tiedoston {filename} koko on nolla (l={w}, k={h})"
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr "Siveltimen Asetusmuokkain"
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr "Tietoja"
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "Kokeellinen"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr "Yleinen"
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr "Peittokyky"
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr "Täplät"
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "Suttaus"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr "Nopeus"
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr ""
+
+#: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr "Seuranta"
 
-#: ../gui/brusheditor.py:359
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "Siveltimenveto"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr "Väri"
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Mukautettu"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr "Ei valittua sivellintä, käytä \"Lisää Uutena\"."
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr "Ei valittua sivellintä!"
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "Tallenna Sivellin Nimellä"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "Siveltimen nimi on jo käytössä!"
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr "Ei valittua sivellintä!"
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr "Haluatko todella poistaa siveltimen \"{brush_name}\" kovalevyltä?"
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr "(Nimetön sivellin)"
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr "{brush_name} [ei tallennettu]"
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr "Sivellin Kuvake"
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr "Sivellin Kuvake (muokkaus)"
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr "Sivellintä ei valittu"
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -287,7 +277,7 @@ msgstr ""
 "<b>%s</b>\n"
 "<small>Valitse sopiva sivellin ensin</small>"
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
@@ -296,7 +286,7 @@ msgstr ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Muutoksia ei ole vielä tallennettu</small>"
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
@@ -305,7 +295,7 @@ msgstr ""
 "<b>%s</b> (editing)\n"
 "<small>Maalaa millä tahansa siveltimellä tai värillä</small>"
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -347,142 +337,182 @@ msgstr "Auto"
 msgid "Use the default icon"
 msgstr "Käytä oletus kuvaketta"
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Tallenna"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr "Tallenna tämä esikatselukuvake ja lopeta muokkaus"
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr "Löytötavaralaatikko"
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr "Poistettu"
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr "Suosikit"
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr "Muste"
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr "Klassinen"
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr "Aseta#1"
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr "Aseta#2"
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr "Aseta#3"
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr "Aseta#4"
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr "Aseta#5"
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr "Kokeellinen"
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Uusi"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr "Tuntematon sivellin"
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr "Lisää suosikkeihin"
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr "Poista suosikeista"
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr "Kloonaa"
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr "Muokkaa siveltimien asetuksia"
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
-msgstr "Poista"
+#: ../gui/brushselectionwindow.py:250
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
+msgstr "Nimeä ryhmä uudelleen"
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
-msgstr "Poista sivellin lopullisesti kiintolevyltä?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, fuzzy, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
+msgstr "Haluatko todella poistaa siveltimen \"{brush_name}\" kovalevyltä?"
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] "%d sivellin"
 msgstr[1] "%d sivellintä"
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr "Ryhmä “{group_name}”"
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr "Nimeä ryhmä uudelleen"
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr "Vie Zipattuna sivellinpakkana"
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr "Poista ryhmä"
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr "Nimeä ryhmä uudelleen"
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "Samanniminen ryhmä on jo olemassa!"
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr "Poista ryhmä “{group_name}” lopullisesti?"
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -492,58 +522,58 @@ msgstr ""
 "Ryhmää “{group_name}” ei voitu poistaa.\n"
 "Joitain tiettyjä ryhmiä ei voida poistaa."
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr "Vie siveltimet"
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr "MyPaint sivellinpaketti (*.zip)"
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "Uusi ryhmä…"
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr "Tuo siveltimiä…"
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr "Hanki lisää siveltimiä…"
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "Luo ryhmä"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr "Painike"
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr "Pnk"
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr "Painikkeen painallus"
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr "Lisää uusi näppäinkomento"
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr "Poista tämänhetkinen näppäinkomento"
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -552,52 +582,77 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr "Poimi väri"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "Poimi väri"
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr "Värin yksityiskohdat"
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -607,137 +662,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr "Aktiivinen"
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr "Ohje…"
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr "Luo maski mallineesta."
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr "Pyyhi maski."
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -745,162 +800,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr "Värin nimi:"
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -908,373 +955,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr "Kaikki tiedostot (*)"
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr "Kaikki tiedostot (*)"
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr "RGB-punainen"
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr "RGB-vihreä"
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr "RGB-sininen"
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr "Kosketuslevy"
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr "Kosketusnäyttö"
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr "Laite"
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr "Akselit"
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr "Tyyppi"
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Nimi"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr "Korvaa"
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr "Nimeä uudelleen"
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr "Korvaa kaikki"
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr "Nimeä kaikki uudeleen"
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr "Kumoa %s"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Kumoa"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr "Tee %s uudelleen"
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Tee uudelleen"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr "{button_combination} on {resultant_action}"
@@ -1284,326 +1328,694 @@ msgstr "{button_combination} on {resultant_action}"
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ";  "
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
 msgstr ""
-"<b>{name}</b>\n"
-"{description}"
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
+msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr "%s - MyPaint"
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr "MyPaint"
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Avaa"
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Kokoruutu"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Lopeta"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Lopeta"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr "Kuvake"
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr "ei kuvausta"
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr "OpenRaster (*.ora)"
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr "PNG (*.png)"
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr "JPEG (*.jpg; *.jpeg)"
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr "Tallenna…"
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr "Vahvista"
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "Tallenna oletuksena"
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:432
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:437
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:442
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
+msgstr "JPEG (*.jpg; *.jpeg)"
+
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:494
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:502
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr "JPEG (*.jpg; *.jpeg)"
+
+#: ../gui/filehandling.py:576
+#, fuzzy
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr "Vie…"
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Tallenna nimellä…"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr ""
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
 msgstr "Avaa…"
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Avaa"
+
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
+msgstr "Luonnoslehtiö"
+
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Tasot"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Avaa"
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Avaa vanha"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Avaa"
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Avaa"
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+#, fuzzy
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr "Palaa"
+
+#: ../gui/fill.py:121
+#, fuzzy
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
-msgstr ""
+msgstr "Täyttö"
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+#, fuzzy
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr "Sovita Kuva Ikkunaan"
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
-msgstr ""
+msgstr "Uusi Tasoryhmä"
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Läpinäkymättömyys:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "Tyhjennä Taso"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr "<b>{brush_name}</b>"
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1613,130 +2025,142 @@ msgstr ""
 "<b>{brush_name}</b>\n"
 "{brush_desc}"
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr "px"
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr "Korkeus:"
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr "Leveys:"
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr "Erotuskyky:"
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr "DPI"
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr "Väri:"
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr "Käytössä"
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr "{width:g}×{height:g} {units}"
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr "sm"
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr "mm"
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1745,35 +2169,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr "Lopeta MyPaint"
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1797,45 +2221,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr "(ei laitetta)"
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
 msgstr "Laite:"
 
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
+msgstr ""
+
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1843,155 +2271,223 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
-msgstr "Tyyppi"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
+msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Taso"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+#, fuzzy
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ", "
+
+#: ../gui/layers.py:990
+#, fuzzy, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr "Lisää {layer_default_name}"
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Tasot"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, fuzzy, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
+msgstr "<b>{brush_name}</b>"
+
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
-msgstr ""
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "Nimeä uudelleen"
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Läpinäkymättömyys:"
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr ""
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr ""
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr ""
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr ""
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 msgid "Stroke lead-in end"
 msgstr ""
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr ""
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
+#, fuzzy
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 "Tekijänoikeus (C) 2005-2015\n"
 "Martin Renold ja MyPaint- kehitystiimi"
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -2003,256 +2499,283 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr "ohjelmointi"
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr "projektinhallinta"
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr "yhteisö"
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ", "
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr "Nikolay Korotkiy <sikmir@gmail.com>"
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr "Koko:"
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr "<b>{mode_name}</b>"
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr "Valitse väri…"
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr "Asetukset"
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
+#, fuzzy
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
-msgstr ""
+msgid "X Position:"
+msgstr "Kuvaus:"
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr "Kuvaus:"
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr "Ei mitään"
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr "%d px"
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr "Käytössä"
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr "Kumoa ja tee uudelleen"
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2260,188 +2783,214 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr "<b>MyPaint</b>"
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "Nimeä ryhmä uudelleen"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Tasot"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr "Lisää {layer_default_name}"
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2450,13 +2999,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2466,7 +3015,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2474,13 +3023,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2490,7 +3039,7 @@ msgstr ""
 "{error_loading_common}\n"
 "Tiedostoa ei ole olemassa."
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2498,7 +3047,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2509,7 +3058,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2517,7 +3066,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2527,7 +3081,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2538,285 +3092,399 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
-msgctxt "layer default names"
-msgid "Vector Layer"
-msgstr ""
-
 #: ../lib/layer/data.py:1153
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Vectors"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
+#: ../lib/layer/data.py:1158
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Vector Layer"
+msgstr "Tyhjennä Taso"
+
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Data Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr "Tuntematon Toiminto"
+
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "Uusi maalaustaso"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "Uusi Tasoryhmä"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+#, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "Näytä"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2826,7 +3494,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2835,52 +3523,84 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr "Poista"
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr "Kuvaus"
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2902,17 +3622,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2941,113 +3659,89 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr "<ymin>"
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr "<ymax>"
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr "<xmin>"
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr "<xmax>"
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr "{tooltip}"
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
 msgstr "{dname}:"
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+#, fuzzy
+msgid "<big><b>No Brush Dynamics</b></big>"
+msgstr "<big><b>{accel_label}</b></big>"
 
 #: ../po/tmp/inktool.glade.h:1
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
@@ -3059,7 +3753,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3100,6 +3794,137 @@ msgstr "Poista piste"
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+#, fuzzy
+msgid "Insert Point"
+msgstr "Poista piste"
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+#, fuzzy
+msgid "Cull Points"
+msgstr "Poista piste"
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Nimi"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Peittokyky"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr "Poista tämänhetkinen näppäinkomento"
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3471,56 +4296,77 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+#, fuzzy
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr "Käytössä"
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3528,12 +4374,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3542,7 +4388,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3553,28 +4399,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr "Väri"
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3636,1828 +4482,2074 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
-msgstr "Tallenna"
+msgid "Import Layers…"
+msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
-msgstr "Tallenna nimellä…"
+msgid "Save"
+msgstr "Tallenna"
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
-msgstr "Vie…"
+msgid "Save As…"
+msgstr "Tallenna nimellä…"
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
-msgstr ""
+msgid "Export…"
+msgstr "Vie…"
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr "Värit"
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "Tyhjennä Taso"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "Uusi Tasoryhmä"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "Uusi Tasoryhmä"
+
+#: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:71
+#: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Edit Layer in External App…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
-msgstr "Uusi maalaustaso"
-
-#: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:85
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
-msgstr "Uusi Tasoryhmä"
-
-#: ../po/tmp/resources.xml.h:86
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:87
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:88
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:89
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
-msgstr "Tyhjennä Taso"
+msgid "New Painting Layer"
+msgstr "Uusi maalaustaso"
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr "Uusi Tasoryhmä"
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr "Tyhjennä Taso"
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr "Sovita Kuva Ikkunaan"
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Loitonna"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+#, fuzzy
+msgid "Delete Point"
+msgstr "Poista piste"
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr "Pyyhi käyttäen nykyistä sivellintä."
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Tiedosto"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "Lopeta"
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "Muokkaa"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "Väri"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "Taso"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr "Luonnoslehtiö"
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "Ikkuna"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "Sivellin"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "Vaihda Sivellin…"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "Vaihda väri…"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "Vaihda väri (pikapaletti)…"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr "Hae Lisää Siveltimiä…"
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Ohje"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr "Online-tuki"
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "Tietoja MyPaint:istä"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Virheenjäljitys"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "Näytä"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "Kokoruutu"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "Muokkaa Asetuksia"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr "Siveltimen asetusmuokkain"
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr "Tasot-ikkuna"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr "Näytä Tasoruutu"
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "Väripaletti"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr "Näytä luonnoslehtiöikkuna"
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr "Esikatseluruutu"
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "Esikatselu"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr "Työkaluasetusruutu"
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr "Näytä työkaluasetusruutu"
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr "Sivellin- & värihistoriaruutu"
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr "Viimeisimmät siveltimet & värit"
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr "Vapaa Piirto"
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr "Vapaa Piirto"
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr "Viivat ja Käyrät"
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr "Yhdistetyt Viivat"
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr "Ellipsi"
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr "Ellipsit ja Ympyrät"
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr "Tussaus"
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr "Siirrä Tasoa"
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr "Muokkaa Kehystä"
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Muokkaa Maalauksen Symmetriaa"
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr "Valitse väri"
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "Poimi väri"
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "Poimi väri"
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "Poimi väri"
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr "Valitse väri"
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr "Täyttö"
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""
+
+#~ msgctxt "Accelerator map editor: action column markup"
+#~ msgid ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+#~ msgstr "<b>{action_label}</b><small>{action_desc}</small>"
+
+#~ msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
+#~ msgid "{action_label} {action_desc} {accel_label}"
+#~ msgstr "{action_label} {action_desc} {accel_label}"
+
+#~ msgctxt "brush list context menu"
+#~ msgid "Delete"
+#~ msgstr "Poista"
+
+#~ msgctxt "brush list commands"
+#~ msgid "Really delete brush from disk?"
+#~ msgstr "Poista sivellin lopullisesti kiintolevyltä?"
+
+#~ msgid ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+#~ msgstr ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+
+#~ msgid "Save..."
+#~ msgstr "Tallenna…"
+
+#~ msgid "Confirm"
+#~ msgstr "Vahvista"
+
+#~ msgid "Open..."
+#~ msgstr "Avaa…"
+
+#~ msgid "Type"
+#~ msgstr "Tyyppi"
+
+#~ msgid "<ymin>"
+#~ msgstr "<ymin>"
+
+#~ msgid "<ymax>"
+#~ msgstr "<ymax>"
+
+#~ msgid "<xmin>"
+#~ msgstr "<xmin>"
+
+#~ msgid "<xmax>"
+#~ msgstr "<xmax>"

--- a/po/fr.po
+++ b/po/fr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.7.1-git\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-23 08:18+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -20,29 +20,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr "<big><b>{accel_label}</b></big>"
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr "{action_label} {action_desc} {accel_label}"
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "Action"
 
@@ -50,32 +28,32 @@ msgstr "Action"
 msgid "Key combination"
 msgstr "Combinaison de touches"
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr "Éditer la touche pour '%s'"
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "Action :"
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "Chemin:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "Touche :"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr "Appuyez sur la touche pour mettre à jour cette nouvelle fonction"
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "Action inconnue"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
@@ -84,7 +62,7 @@ msgstr ""
 "<b>{accel} est déjà utilisé pour la fonction '{action}'. L'affectation "
 "actuelle sera remplacée.</b>"
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr "Ouvrir le dossier “{folder_basename}”…"
@@ -92,196 +70,206 @@ msgstr "Ouvrir le dossier “{folder_basename}”…"
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "OK"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr "Aucune sauvegarde n'a été trouvé dans la dossier Cache."
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr "Aucune sauvegarde disponible"
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr "Ouvrir le dossier Cache…"
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr "La restauration de la sauvegarde a échoué"
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr "Ouvrir le dossier de Sauvegarde…"
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr "Restaurer le fichier depuis {iso_datetime}.ora"
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "Enregistrer comme défaut"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "Fond"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "Motif"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Couleur"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "Ajouter une couleur aux motifs"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr "Un ou plusieurs fonds n'ont pas pu être ouverts"
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr "Erreur lors du chargement des fonds"
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 "Veuillez s'il vous plaît, supprimer les fichiers impossibles à charger ou "
 "vérifier l'installation de libgdkpixbuf."
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr "Gdk-Pixbuf n'a pu ouvrir « {filename} », et a retourné « {error} »"
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr "{filename} est vide (w={w}, h={h})"
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr "Éditeur de brosses"
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr "A propos de"
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "Expérimental"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr "Basique"
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr "Opacité"
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr "Touches de peinture"
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "Barbouiller"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr "Vitesse"
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr ""
+
+#: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr "But"
 
-#: ../gui/brusheditor.py:359
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "Trait"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr "Couleur"
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Personnalisé"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 "Aucune brosse n'est sélectionnée, utilisez plutôt « Ajouter comme nouveau »."
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr "Aucune brosse n'est sélectionnée !"
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "Renommez la brosse"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "Une brosse existe déjà avec ce nom !"
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr "Aucune brosse n'est sélectionnée !"
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr "Effacer cette brosse “{brush_name}” ?"
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr "(Brosse sans nom)"
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr "{brush_name} [non enregistré]"
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr "Icône de la brosse"
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr "Icône pour Edition de la brosse"
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr "Aucune brosse n'est sélectionnée !"
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -290,7 +278,7 @@ msgstr ""
 "<b>%s</b>\n"
 "<small>D'abord sélectionner une brosse valide</small>"
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
@@ -299,7 +287,7 @@ msgstr ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Les modifications ne sont pas enregistrés</small>"
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
@@ -308,7 +296,7 @@ msgstr ""
 "<b>%s</b> (editing)\n"
 "<small>Peindre avec n'importe quelle brosse et couleur</small>"
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -349,142 +337,182 @@ msgstr "Auto"
 msgid "Use the default icon"
 msgstr "Remettre à la valeur par défaut pour l'icône"
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Enregistrer"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr "Enregistrer l'aperçu d'icône"
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr "Perdu & trouvé"
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr "Effacée"
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr "Favoris"
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr "Encre"
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr "Classique"
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr "Ensemble n°1"
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr "Ensemble n°2"
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr "Ensemble n°3"
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr "Ensemble n°4"
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr "Ensemble n°5"
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr "Expérimental"
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Nouveau"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr "Brosse inconnue"
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr "Ajouter aux Favoris"
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr "Supprimer des favoris"
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr "Cloner"
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr "Éditer les Réglages de la Brosse"
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
-msgstr "Supprimer"
+#: ../gui/brushselectionwindow.py:250
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
+msgstr "Renommer un groupe"
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
-msgstr "Effacer cette brosse réellement ?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, fuzzy, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
+msgstr "Effacer cette brosse “{brush_name}” ?"
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] "%d brosse"
 msgstr[1] "%d brosses"
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr "Groupe “{group_name}”"
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr "Renommer un groupe"
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr "Export les brosses sous forme de fichier au format zip"
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr "Supprimer le groupe"
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr "Renommer un groupe"
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "Un groupe porte déjà ce nom !"
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr "Effacer le groupe “{group_name}” ?"
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -494,58 +522,58 @@ msgstr ""
 "Impossible d'effacer le groupe “{group_name}”.\n"
 "Certains groupes ne peuvent être effacés."
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr "Exporter les brosses"
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr "Paquet de brosses MyPaint (au format .zip)"
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "Nouveau groupe…"
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr "Importer des brosses…"
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr "Récupérer d'autres brosses…"
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "Créer un groupe"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr "Bouton"
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr "Btn"
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr "Bouton appuyé"
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr "Ajoute un nouveau raccourci"
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr "Supprimer le raccourci actuel"
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr "Éditer le raccourci pour '%s'"
@@ -554,7 +582,7 @@ msgstr "Éditer le raccourci pour '%s'"
 msgid "Button press:"
 msgstr "Bouton appuyé :"
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
@@ -562,7 +590,7 @@ msgstr ""
 "Garder pressé la touche modificatrice, puis presser un bouton au dessus de "
 "ce texte pour configurer un nouveau raccourci."
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
@@ -570,42 +598,70 @@ msgstr ""
 "{button} ne peut pas être utilisé sans touches modificatrices (elle a une "
 "utilisation fixe)"
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr "{button_combination} est déjà utilisé pour l'action '{action_name}'"
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr "Pipette à couleurs"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr "Définir la couleur utiliser pour peindre"
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+#, fuzzy
+msgid "Set the color Hue used for painting"
+msgstr "Définir la couleur utiliser pour peindre"
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "Pipette à couleur"
+
+#: ../gui/colorpicker.py:296
+#, fuzzy
+msgid "Set the color Chroma used for painting"
+msgstr "Définir la couleur utiliser pour peindre"
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+#, fuzzy
+msgid "Set the color Luma used for painting"
+msgstr "Définir la couleur utiliser pour peindre"
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr "Détails de la couleur"
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 "Couleur nouvellement choisie, et couleur la plus récemment utilisée pour "
 "peindre"
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr "Masque de Gamut actif"
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -617,7 +673,7 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr "Teinte et saturation HCY."
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
@@ -626,12 +682,12 @@ msgstr ""
 "Éditeur de masque de Gamut. Cliquer au milieu pour créer ou manipuler des "
 "formes, ou bien tourner le masque en utilisant les bords du cercle."
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr "Triade atmosphérique"
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
@@ -640,23 +696,23 @@ msgstr ""
 "Ambiance dominante et subjectivité, définie par une primaire dominante et "
 "deux autres moins intenses."
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 #, fuzzy
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr "Triade décalée"
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr "Pondérer d'avantage vers la couleur dominante."
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr "Complémentaire"
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
@@ -665,12 +721,12 @@ msgstr ""
 "Contraster les opposés, balancer en ayant des centrales neutres  entre elles "
 "sur le cercle chromatique."
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr "Atmosphère et accentuation"
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
@@ -679,12 +735,12 @@ msgstr ""
 "Un éventail principal de couleur, avec une accentuation complémentaire pour "
 "les variations et rehauts."
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr "Complémentaire divisée"
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
@@ -693,74 +749,74 @@ msgstr ""
 "Deux couleurs analogues et leur complémentaire, sans couleur secondaires "
 "entre elles."
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr "Nouveau masque de Gamut depuis un gabarit"
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr "Éditeur de masque de Gamut"
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr "Actif"
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr "Aide…"
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr "Créer un masque depuis un gabarit."
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr "Charger un masque depuis un fichier de palette GIMP."
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr "Enregistrer le masque dans un fichier de palette GIMP."
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr "Effacer le masque."
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 "Ouvrir l'aide en ligne pour cette boîte de dialogue dans un navigateur "
 "internet."
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr "Sauvegarder le masque comme palette pour GIMP"
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr "Charger un masque depuis un fichier de palette pour GIMP"
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr "Régler le masque de Gamut."
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr "Cercle chromatique HCY"
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 #, fuzzy
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
@@ -771,164 +827,156 @@ msgstr ""
 "tranches circulaires ont la même luminosité."
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr "Teinte TSV"
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr "Saturation TSV"
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr "Valeur TSV"
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr "Saturation et valeur TSV"
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr "Teinte et valeur TSV"
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr "Teinte et saturation TSV"
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr "Tourner le cube (montre des axes différents)"
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr "Cube TSV"
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 "Un cube TSV pouvant être tourné affin d'afficher différentes coupes planes."
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr "Carré TSV"
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 "Un cube TSV pouvant être tourné affin d'afficher différentes coupes planes."
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr "Triangle TSV"
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr "Sélecteur de couleur standard GTK"
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr "Cercle chromatique TSV"
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr "Modificateur de couleur « Saturation et valeur »."
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr "Propriétés de la palette"
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr "Palette"
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr "Régler la couleur depuis une palette éditable, chargeable."
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr "Palette sans-titre"
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr "Éditeur de palette"
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr "Charger depuis un fichier de palette GIMP"
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr "Enregistrer comme un fichier de palette GIMP"
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr "Ajouter un nouvel échantillon de couleur vide"
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr "Supprimer l'échantillon courant"
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr "Supprimer tous les échantillons"
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr "Titre :"
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr "Nom ou description pour cette palette"
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr "Colonnes :"
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr "Nombre de colonnes"
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr "Nom de la couleur :"
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr "Nom de la couleur courante"
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr "Emplacement de palette vide"
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr "Charger la palette"
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr "Enregistrer la palette"
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -939,387 +987,384 @@ msgstr ""
 "Déposez les couleurs ici,\n"
 "déplacez les pour les organiser."
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr "Emplacement de palette vide (glisser une couleur ici)"
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr "Ajouter un emplacement vide"
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr "Insérer une Rangée"
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr "Insérer une colonne"
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr "Remplir l'espace (RGB)"
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 #, fuzzy
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr "Remplir l'espace (HCY)"
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr "Remplir l'espace (HSV)"
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "Fichier de palette GIMP (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr "Tous les fichiers (*)"
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "Fichier de palette GIMP (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr "Tous les fichiers (*)"
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr "Récupérer une couleur à l'écran"
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr "R"
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr "G"
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr "B"
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr "H"
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr "C"
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr "Y"
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 #, fuzzy
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr "Curseurs de composantes"
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr "Ajuster individuellement les composantes de la couleur."
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr "Rouge RVB"
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr "Vert RVB"
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr "Bleu RVB"
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr "Teinte TSV"
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr "Saturation TSV"
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr "Valeur TSV"
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr "Teinte HCY"
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr "Chromaticité HCY"
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr "Luminance HCY (Y')"
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 #, fuzzy
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr "Adoucir"
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 #, fuzzy
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr "Change la couleur par un adoucissement des couleurs proches."
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr "Cercles concentriques"
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 #, fuzzy
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr "fenêtre modale de modificateur de couleur (cercles concentriques)"
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr "curseur"
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr "Gomme"
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr "Clavier"
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr "Souris"
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr "Stylet"
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr "Pavé tactile"
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr "Ecran tactile"
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr "Ignorer"
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr "Toute tâche"
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr "Toute tâche (non dessin)"
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr "Navigation uniquement"
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr "Zoom"
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 #, fuzzy
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr "Déplacer"
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr "Périphérique"
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr "Axes"
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr "Type"
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr "Utiliser pour..."
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr "Défilement..."
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Nom"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr "Écraser la Brosse ?"
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr "Remplacer"
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr "Renommer"
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr "Tout remplacer"
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr "Tout renommer"
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr "Brosse importée"
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr "Brosse existante"
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 "<b>Une brosse nommée « %s » existe déjà.</b>\n"
 "Désirez vous la remplacer ou la nouvelle brosse doit-elle être renommée ?"
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr "Remplacer le groupe de brosse ?"
 
-#: ../gui/dialogs.py:190
-#, python-brace-format
+#: ../gui/dialogs.py:220
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 "<b>Un groupe nommé « {groupname} » existe déjà.</b>\n"
 "Désirez vous le remplacer ou bien le nouveau groupe doit-il être renommé ?\n"
 "Si vous le remplacez, les brosses pourraient être déplacées dans un groupe "
 "appelé « {deleted_groupname} »."
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr "Importer un paquet de brosses ?"
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, fuzzy, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr "<b>Souhaitez-vous vraiment importer le paquet « %s » ?</b>"
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 "Charger les paramètres de la brosse depuis l'emplacement presse-papier n°%d"
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 "Enregistrer les paramètres de la brosse dans l’emplacement presse-papier n°%d"
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr "Restaurer la brosse %d"
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr "Enregistrer comme brosse %d"
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr "Annuler %s"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Annuler"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr "Refaire %s"
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Refaire"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, fuzzy, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr "{button_combination} est {resultant_action}"
@@ -1329,92 +1374,129 @@ msgstr "{button_combination} est {resultant_action}"
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ";  "
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr "Avec {modifiers} enfoncé: {button_actions}."
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
-msgstr "Nom du calque"
-
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
-#, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
-"<b>{name}</b>\n"
-"{description}"
+
+#: ../gui/document.py:909
+#, python-brace-format
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
+msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr "%s - MyPaint"
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr "MyPaint"
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Ouvrir"
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr "Choisir la couleur actuelle"
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr "Quitter le mode plein écran"
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr "Quitter le mode plein écran"
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr "Passer en mode plein écran"
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Plein écran"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Quitter"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+#, fuzzy
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr "Désirez-vous vraiment quitter ?"
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Quitter"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr "Importer un paquet de brosses…"
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr "Paquet de brosses MyPaint (*.zip)"
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr "{app_name}  lancé pour éditer le calque “{layer_name}”"
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 "Erreur : échec du lancement de {app_name} pour éditer le calque "
 "“{layer_name}”"
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
@@ -1422,13 +1504,19 @@ msgstr ""
 "Édition annulé. Vous pouvez toujours éditer “{layer_name}” dans le menu "
 "Calques."
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 "Le calque “{layer_name}” a été mise à jour avec les modifications externes"
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
@@ -1437,7 +1525,7 @@ msgstr ""
 "MyPaint a besoin d'éditer un fichier de type “{type_name}” ({content_type}). "
 "Quelle application doit-il utiliser ?"
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
@@ -1446,218 +1534,564 @@ msgstr ""
 "Quelle application MyPaint doit-il utiliser pour éditer des fichiers de type "
 "“{type_name}” ({content_type})?"
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr "Ouvrir avec…"
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr "Icône"
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr "sans description"
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
+#: ../gui/filehandling.py:126
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
+msgstr "Chargement  de “{file_basename}”…"
+
+#: ../gui/filehandling.py:130
+#, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:134
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
+msgstr "Sauvegarde de “{file_basename}”…"
+
+#: ../gui/filehandling.py:138
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
+msgstr "Exportation jusque “{file_basename}”…"
+
+#: ../gui/filehandling.py:145
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr "Échec de l'export vers “{file_basename}”."
+
+#: ../gui/filehandling.py:149
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr "Échec de la sauvegarde de “{file_basename}”."
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "Enregistrer la palette"
+
+#: ../gui/filehandling.py:168
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr "Exporter dans un fichier"
+
+#: ../gui/filehandling.py:172
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr "Exporter dans un fichier"
+
+#: ../gui/filehandling.py:176
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr "Ouvrir un fichier récent"
+
+#: ../gui/filehandling.py:183
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr "Exporté jusque “{file_basename}” avec succés."
+
+#: ../gui/filehandling.py:187
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr "“{file_basename}” sauvegardé avec succès."
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
+msgstr "Erreur lors du chargement de “{basename}”."
+
+#: ../gui/filehandling.py:427
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "All Recognized Formats"
 msgstr "Tous les formats reconnus"
 
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
+#: ../gui/filehandling.py:432
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "OpenRaster (*.ora)"
 msgstr "OpenRaster (*.ora)"
 
-#: ../gui/filehandling.py:95
+#: ../gui/filehandling.py:437
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "PNG (*.png)"
 msgstr "PNG (*.png)"
 
-#: ../gui/filehandling.py:96
+#: ../gui/filehandling.py:442
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "JPEG (*.jpg; *.jpeg)"
 msgstr "JPEG (*.jpg; *.jpeg)"
 
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
+#: ../gui/filehandling.py:490
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "By extension (prefer default format)"
 msgstr "Par extension (préfère le format par défaut)"
 
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
+#: ../gui/filehandling.py:494
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:498
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
 msgstr "PNG avec fond non transparent (*.png)"
 
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
+#: ../gui/filehandling.py:502
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:506
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
 msgstr "PNG transparent (*.png)"
 
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
+#: ../gui/filehandling.py:510
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
 msgstr "Multiple PNG transparent (*.XXX.png)"
 
-#: ../gui/filehandling.py:113
+#: ../gui/filehandling.py:514
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr "Multiple PNG transparent (*.XXX.png)"
+
+#: ../gui/filehandling.py:518
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr "JPEG qualité 90% (*.jpg, *.jpeg)"
 
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr "Enregistrer…"
+#: ../gui/filehandling.py:576
+#, fuzzy
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr "Exporter…"
 
-#: ../gui/filehandling.py:177
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Enregistrer sous…"
+
+#: ../gui/filehandling.py:601
+#, fuzzy
+msgctxt "save dialogs: formats and options: (label)"
 msgid "Format to save as:"
 msgstr "Format d'enregistrement :"
 
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr "Confirmer"
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
+#: ../gui/filehandling.py:668
+#, fuzzy
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
 msgstr "Désirez-vous vraiment continuer ?"
 
-#: ../gui/filehandling.py:234
-#, fuzzy, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
-msgstr "Cela va détruire {abbreviated_time} d'actions non-enregistrée."
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
+#: ../gui/filehandling.py:705
+#, fuzzy
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
 msgstr "Enregistrer comme Croquis"
 
-#: ../gui/filehandling.py:282
-#, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
-msgstr "Chargement  de “{file_basename}”…"
-
-#: ../gui/filehandling.py:296
-#, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
 msgstr ""
 
-#: ../gui/filehandling.py:321
-#, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+#: ../gui/filehandling.py:734
+#, fuzzy, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr "Cela va détruire {abbreviated_time} d'actions non-enregistrée."
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
 msgstr ""
 
-#: ../gui/filehandling.py:422
-#, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
-msgstr "Exportation jusque “{file_basename}”…"
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
 
-#: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
-msgstr "Sauvegarde de “{file_basename}”…"
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
-msgstr "Échec de l'export vers “{file_basename}”."
-
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
-msgstr "Échec de la sauvegarde de “{file_basename}”."
-
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
-msgstr "Exporté jusque “{file_basename}” avec succés."
-
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
-msgstr "“{file_basename}” sauvegardé avec succès."
-
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
 msgstr "Ouvrir…"
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Ouvrir un fichier récent"
+
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr "Ouvrir un carnet de croquis…"
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
-msgstr "Il n'y a pas encore de fichier de croquis nommé « %s »."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Brosse importée"
 
-#: ../gui/fill.py:75 ../lib/command.py:459
-msgid "Flood Fill"
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Ouvrir"
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Ouvrir le plus récent"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Ouvrir"
+
+#: ../gui/filehandling.py:1446
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr "Il n'y a pas encore de fichier de croquis nommé « %s »."
+
+#: ../gui/filehandling.py:1455
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr "Ouvrir le Croquis suivant"
+
+#: ../gui/filehandling.py:1463
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr "Ouvrir le Croquis précédent"
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Ouvrir"
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+#, fuzzy
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr "Annuler"
+
+#: ../gui/fill.py:121
+#, fuzzy
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
+msgid "Flood Fill"
+msgstr "Pot de Peinture"
+
+#: ../gui/fill.py:127
+#, fuzzy
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr "Remplir la zone avec la couleur"
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+#, fuzzy
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr "Tolérance :"
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+#, fuzzy
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr "Source :"
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
-msgstr "Quel calque visible doit être rempli"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
+msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+#, fuzzy
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr "Adapter la vue"
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+#, fuzzy
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr "Cible :"
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
-msgstr ""
+msgstr "Nouveau Groupe de Calques"
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Opacité :"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr "Réinitialiser"
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+#, fuzzy
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr "Remettre à la valeur par défaut"
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "Sélectionner un calque"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1665,132 +2099,144 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr "Éditer le cadre"
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr "Ajuster le cadre du document"
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr "Taille du Cadre"
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr "px"
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr "Hauteur :"
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr "Largeur :"
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr "Résolution :"
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr "Couleur :"
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr "Couleur du cadre"
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr "<b>Dimension du cadre</b>"
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr "<b>Densité des pixels</b>"
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 #, fuzzy
 msgid "Set Frame to Layer"
 msgstr "Appliquer le Cadre au Calque"
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 #, fuzzy
 msgid "Set frame to the extents of the current layer"
 msgstr "Créer une duplication exacte du calque actuel"
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr "Rogné selon le document"
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr "Rogner le cadre depuis la combinaison de tous les calques"
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr "Rogner le calque en fonction du cadre"
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr "Activé"
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr "pouce"
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr "cm"
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr "mm"
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr "Dessin à main levée"
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr "Pression :"
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr "Bogue détecté"
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr "<big><b>Une erreur de programmation à été détectée.</b></big>"
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1799,35 +2245,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr "Reporter..."
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr "Ignorer l'erreur"
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr "Quittez MyPaint"
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr "Détails…"
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr "Exception lors de l'analyse de l'exception."
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1851,45 +2297,50 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr "Encrage"
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr "Test du périphérique d'entrée"
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr "(pas de pression)"
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr "Pression :"
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr "(pas d'inclinaison)"
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr "Inclinaison :"
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr "(pas de périphérique)"
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
 msgstr "Périphérique :"
 
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+#, fuzzy
+msgid "Barrel Rotation:"
+msgstr "Rotation"
+
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr "Déplacer le calque"
 
@@ -1897,163 +2348,230 @@ msgstr "Déplacer le calque"
 msgid "Move the current layer"
 msgstr "Déplacer le calque courant"
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
-msgstr "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
+msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+#, fuzzy
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr "Propriétés de la palette"
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr "Visible"
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Calque"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+#, fuzzy
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr "Verrouillé"
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+#, fuzzy
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ", "
+
+#: ../gui/layers.py:990
+#, fuzzy, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr "Ajouter {layer_default_name}"
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Calques"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr "Opacité du calque : %d%%"
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr "Réordonner les calques en pile..."
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr "Calque"
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
-msgstr "Mode :"
-
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
-"Mode de fusion : Méthode de combinaison du calque avec ceux du dessous."
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Opacité :"
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
-"Opacité du calque : Quelle proportion du calque actuel utiliser. Des valeur "
-"faibles le rendent plus transparent."
 
-#: ../gui/linemode.py:37
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "Tourner la vue"
+
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr "Pression d'entrée"
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr "Pression d'entrée de tracé pour les outils de ligne"
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr "Pression médiane"
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr "Pression de milieu de tracé pour les outils de ligne"
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr "Pression de sortie"
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr "Pression de sortie de tracé pour les outils de ligne"
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr "Tête"
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 msgid "Stroke lead-in end"
 msgstr "Fin de l'introduction du tracé"
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr "queue"
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr "Début de la queue du tracé"
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr "Variation de pression..."
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr "Lignes et courbes"
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 #, fuzzy
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 "Dessiner des lignes droites; Shift ajouter des courbes, Ctrl contraindre sur "
 "les angles"
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr "Lignes connectées"
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 "Dessiner une séquence de lignes; Shift ajouter des courbes, Ctrl contraindre "
 "sur les angles"
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr "Ellipses et cercles"
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
+#, fuzzy
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 "Copyright (C) 2005-2012\n"
 "Martin Renold et l'équipe de développement de MyPaint"
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -2072,260 +2590,290 @@ msgstr ""
 "Ce programme est distribué dans l'espoir d'être utile, mais SANS AUCUNE "
 "GARANTIE. Voir le fichier COPYING pour plus de détails."
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr "programmation"
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr "portabilité"
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr "management du projet"
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr "Brosses"
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr "Motifs"
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr "icône des outils"
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr "icône de bureau"
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr "Palettes"
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr "Documentation"
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr "support"
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr "communauté"
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 #, fuzzy
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr "Crédit de traduction"
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr "Taille :"
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr "Opaque :"
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr "options d'outils"
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr "Paramètres spécialisés pour l'outil d'édition courant"
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr "Agrandissement : %.01f%%"
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 "Récupérer les paramètres d'un tracé de brosse, couleurs du tracé, calque…"
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr "Pipette à couleur…"
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr "Préférences"
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr "Aperçu"
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr "Montrer Viseur"
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr "Carnet de croquis"
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 "Mélanger les couleurs et effectuer des croquis sur des pages de croquis "
 "séparées"
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr "Élément précédent"
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr "Élément suivant"
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
 msgstr "(Rien à montrer)"
 
-#: ../gui/symmetry.py:76
+#: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Place axis"
 msgstr "Placer les axes"
 
-#: ../gui/symmetry.py:80
+#: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Move axis"
 msgstr "Déplacer les axes"
 
-#: ../gui/symmetry.py:84
+#: ../gui/symmetry.py:88
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr "Enlever les axes"
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr "Éditer l'axe de symétrie"
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr "Ajuster l'axe de symétrie."
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
+#, fuzzy
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr "Position :"
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr "Position :"
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr "Aucun"
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr "%d px"
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr "Alpha :"
 
-#: ../gui/symmetry.py:352
+#: ../gui/symmetry.py:376
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
+msgstr "Axe de symétrie"
+
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+#, fuzzy
 msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+msgid "X axis Position"
 msgstr "Position des axes"
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:477
+#, fuzzy
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr "Position des axes"
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr "Activé"
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr "Gestionnaire de fichier"
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr "de croquis"
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr "Défaire et Refaire"
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr "Modes de fusion"
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr "Modes de la ligne"
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr "Vue (principale)"
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr "Vue (alternative/secondaire)"
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr "Vue (remise à zéro"
 
@@ -2333,191 +2881,217 @@ msgstr "Vue (remise à zéro"
 msgid "<b>MyPaint</b>"
 msgstr "<b>MyPaint</b>"
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr "Défilement de la vue"
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr "Agrandir la vue"
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr "Tourner la vue"
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr "Tourner la vue"
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, fuzzy, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr "%s: Fermer l'onglet"
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
-msgstr "%s: édition des propriétés"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
+msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr "Action inconnue"
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr "Rogner le calque"
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "Renommer un groupe"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr "Nettoyer le calque"
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr "Coller le calque"
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr "Nouveau calque à partir de ce qui est visible"
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr "fusionner les calques visibles"
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr "Fusionner vers le bas"
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 #, fuzzy
 msgid "Normalize Layer Mode"
 msgstr "Convertir le mode de calque"
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Brosse importée"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr "Ajouter {layer_default_name}"
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr "Détruire un calque"
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr "Sélectionner un calque"
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr "Dupliquer le calque"
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr "Déplacer le calque vers le haut"
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr "Déplacer le calque vers le bas"
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr "Réordonner les calques en pile"
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr "Renommer le calque"
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr "Rendre le calque visible"
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr "Rendre le calque invisible"
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr "Verrouiller le calque"
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr "Déverrouiller le calque"
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr "Opacité du calque : %0.1f%%"
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr "Mode inconnu"
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr "Convertir le mode de calque : %s"
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr "Activer le cadre"
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr "Désactiver le cadre"
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr "Mettre à jour le cadre"
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr "Éditer le claque extérieurement"
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr "Erreur lors du chargement de “{basename}”."
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 "Le journal des erreurs contient peut-être plus d'informations à propos de "
 "cette erreur."
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2526,13 +3100,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2542,7 +3116,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2552,13 +3126,13 @@ msgstr ""
 "Impossible d'enregistrer “{filename}”: {err}\n"
 "Vous reste-t-il assez d'espace libre sur le périphérique ?"
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr "Impossible de sauver  “{filename}”: {err}"
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2568,7 +3142,7 @@ msgstr ""
 "{error_loading_common}\n"
 "Ce fichier n'existe pas."
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2578,7 +3152,7 @@ msgstr ""
 "{error_loading_common}\n"
 "Vous ne possédez pas les droits pour ouvrir le fichier."
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2594,7 +3168,7 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2604,7 +3178,13 @@ msgstr ""
 "{error_loading_common}\n"
 "extension de format de fichier inconnu : “{ext}”"
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+#, fuzzy
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr "Brosse importée"
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2618,7 +3198,7 @@ msgstr ""
 "Essayez d'enregistrer plutôt en PNG si votre ordinateur n'a pas beaucoup de "
 "mémoire. L'enregistrement des PNG dans MyPaint est plus efficace."
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2634,98 +3214,207 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/helpers.py:402
-#, python-brace-format
+#: ../lib/floodfill.py:131
+#, fuzzy
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr "Remplir"
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr "{days}d{hours}h"
 
-#: ../lib/helpers.py:404
-#, python-brace-format
+#: ../lib/helpers.py:537
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr "{hours}h{minutes}m"
 
-#: ../lib/helpers.py:406
-#, python-brace-format
+#: ../lib/helpers.py:539
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr "{minutes}m{seconds}s"
 
-#: ../lib/helpers.py:408
-#, python-brace-format
+#: ../lib/helpers.py:541
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr "{seconds}s"
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr "Calque"
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr "%(name)s %(number)d"
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
+#, fuzzy
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr "Calque vectoriel"
+
+#: ../lib/layer/data.py:1158
+#, fuzzy
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr "Calque vectoriel"
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
-msgstr "Calque Bitmap inconnu"
+msgid "Bitmap"
+msgstr ""
 
-#: ../lib/layer/data.py:1169
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1244
 msgctxt "layer default names"
-msgid "Unknown Data Layer"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
 msgstr "Information de calque inconnue"
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "Nouveau Calque pour Peinture"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr "Groupe"
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "Nouveau Groupe de Calques"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr "Racine"
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ", "
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+#, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "Affichage"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+#, fuzzy
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr "Ajouter un calque"
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+#, fuzzy
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr "Détruire un calque"
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr "Verrouiller le calque"
+
+#: ../lib/layervis.py:697
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr "Déverrouiller le calque"
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr "Normal"
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr "Le calque du haut seul, sans couleurs mélangées."
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr "Multiplier"
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
@@ -2733,11 +3422,11 @@ msgstr ""
 "Similaire au chargement de plusieurs diapositives dans un seul emplacement "
 "d'un projecteur et à la projection de leur résultat."
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr "Écran"
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
@@ -2745,11 +3434,11 @@ msgstr ""
 "Comme projeter deux projecteurs de diapositives simultanément sur un même "
 "écran. C'est l'inverse de « Multiplier »."
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr "Superposer"
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
@@ -2757,31 +3446,31 @@ msgstr ""
 "Superpose le fond avec le calque le plus haut, préservant l'illumination et "
 "les ombres du fond. C'est l'inverse de « Lumière dure »."
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr "Assombrir"
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 "Le calque du haut est uniquement utilisé aux endroits où il est plus sombre "
 "que le fond."
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr "Éclaircir"
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 "Le calque du haut est uniquement utilisé aux endroits où plus lumineux que "
 "le fond."
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr "Éclaircir"
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
@@ -2791,11 +3480,11 @@ msgstr ""
 "technique de chambre noire photographique du même nom, qui est utilisée pour "
 "améliorer les contrastes dans les ombres."
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr "Assombrir"
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
@@ -2805,44 +3494,44 @@ msgstr ""
 "technique de chambre noire photographique du même nom, qui est utilisé pour "
 "réduire les saturations lumineuses."
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr "Lumière dure"
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr "Similaire à éclairer projecteur lumineux net sur le fond."
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr "Lumière douce"
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 "Comme éclairer à l'aide d'un projecteur à luminosité diffuse sur le fond."
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr "Différence"
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr "Soustraire la couleur la plus sombre de la plus lumineuse des deux."
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr "Exclusion"
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr "Similaire au mode « Différence », mais avec un plus faible contraste."
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr "Teinte"
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
@@ -2850,11 +3539,11 @@ msgstr ""
 "Combiner la teinte du calque du dessus avec la saturation et la luminosité "
 "du fond."
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr "Saturation"
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
@@ -2862,7 +3551,7 @@ msgstr ""
 "Appliquer la saturation de la couleur du calque du dessus à la teinte et la "
 "luminosité du fond."
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
@@ -2870,11 +3559,11 @@ msgstr ""
 "Appliquer la teinte et la saturation du calque du dessus à la luminosité du "
 "fond."
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr "Luminosité"
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
@@ -2882,62 +3571,73 @@ msgstr ""
 "Appliquer la luminosité du calque du dessus à la teinte et la saturation du "
 "fond."
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr "Addition"
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, fuzzy, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr "%(name)s %(number)d"
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2947,7 +3647,30 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+#, fuzzy
+msgid "Vertical"
+msgstr "Miroir vertical"
+
+#: ../lib/tiledsurface.py:49
+#, fuzzy
+msgid "Horizontal"
+msgstr "Miroir horizontal"
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+#, fuzzy
+msgid "Rotational"
+msgstr "Rotation"
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr "Le lecteur de PNG a échoué: %s"
@@ -2956,62 +3679,97 @@ msgstr "Le lecteur de PNG a échoué: %s"
 msgid "Recover interrupted work?"
 msgstr "Récupérer le travail interrompu ?"
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
-msgstr "_Récupérer et Enregistrer..."
+msgid "_Look for backups at startup"
+msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr "Supprimer"
+
+#: ../po/tmp/autorecover.glade.h:9
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr "Supprimer cette brosse du disque"
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr "_Récupérer et Enregistrer..."
+
+#: ../po/tmp/autorecover.glade.h:12
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 "Enregistrer cette sauvegarde sur le disque, puis continuer à travailler."
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
-msgstr "_Ignorer pour le moment"
+msgid "Decide _Later"
+msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 "Commencer à travailler sur un nouveau canevas. Ces sauvegardes seront "
 "conservés."
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
+#, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 "MyPaint a crashé alors que votre travail n'était pas enregistré mais il a "
 "fait des fichiers de sauvegarde. Vous pouvez récupérer un fichier maintenant "
 "ou lorsque vous relancerez MyPaint."
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr "Vignette"
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr "Déscription"
 
 #: ../po/tmp/brusheditor.glade.h:1
-#, fuzzy
-msgid "Copy to New"
-msgstr "Copie de %s"
+msgid "Live update"
+msgstr "Mise à jour automatique"
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
-"Copie les paramètres et l'icône actuelle de la brosse dans une nouvelle "
-"brosse"
+"Mettre à jour en direct le dernier tracé sur la toile avec les paramètres de "
+"cette fenêtre"
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
-msgstr "Renommer cette brosse"
+msgid "Save these settings to the brush"
+msgstr "Enregistrer ces réglages à la brosse"
 
 #: ../po/tmp/brusheditor.glade.h:5
 msgid "Edit Icon"
@@ -3034,20 +3792,19 @@ msgid "Delete this brush from the disk"
 msgstr "Supprimer cette brosse du disque"
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
-msgstr "Mise à jour automatique"
+#, fuzzy
+msgid "Copy to New"
+msgstr "Copie de %s"
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
-"Mettre à jour en direct le dernier tracé sur la toile avec les paramètres de "
-"cette fenêtre"
+"Copie les paramètres et l'icône actuelle de la brosse dans une nouvelle "
+"brosse"
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
-msgstr "Enregistrer ces réglages à la brosse"
+msgid "Rename this brush"
+msgstr "Renommer cette brosse"
 
 #: ../po/tmp/brusheditor.glade.h:13
 msgid "Brush Setting"
@@ -3075,12 +3832,7 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr "Notes :"
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr "Nom du réglage :"
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
@@ -3088,103 +3840,86 @@ msgstr ""
 "interagissent avec."
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
-msgstr "Valeur de base :"
+#: ../po/tmp/brusheditor.glade.h:22
+#, fuzzy
+msgid "Value:"
+msgstr "Valeur TSV"
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr "Rétablir les paramètres par défaut"
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 "Réinitialiser cette entrée pour qu'elle n'aie aucun effet sur le réglage"
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr "<ymin>"
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr "<ymax>"
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr "Sortie du stylet"
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr "Entrée"
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr "Ajuster la valeur maximale"
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr "Ajuster la valeur minimale"
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr "<xmin>"
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr "<xmax>"
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr "Dynamique de la brosse"
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr "Détails de base pour ce paramètre"
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr "Editer les réglages"
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
 msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+#, fuzzy
+msgid "Brush dynamics are not available for this setting."
+msgstr "Détails de base pour ce paramètre"
+
+#: ../po/tmp/brusheditor.glade.h:43
+#, fuzzy
+msgid "<big><b>No Brush Dynamics</b></big>"
+msgstr "<big><b>{accel_label}</b></big>"
 
 #: ../po/tmp/inktool.glade.h:1
 #, fuzzy
@@ -3198,7 +3933,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr "Pression :"
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3243,6 +3978,141 @@ msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
 msgstr "supprimer le calque actuel"
 
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+#, fuzzy
+msgid "Insert Point"
+msgstr "Insérer une Rangée"
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+#, fuzzy
+msgid "Cull Points"
+msgstr "Supprimer le groupe"
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Nom"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr "Mode"
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Opacité"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr "Rogner le cadre depuis le calque actif actuel"
+
+#: ../po/tmp/layervis.glade.h:2
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr "Tourner la vue"
+
+#: ../po/tmp/layervis.glade.h:3
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr "Tourner la vue"
+
+#: ../po/tmp/layervis.glade.h:4
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr "Quel calque visible doit être rempli"
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
+msgstr ""
+
 #: ../po/tmp/mypaint.glade.h:2
 #, fuzzy
 msgctxt "footer: color picker button: tooltip"
@@ -3277,7 +4147,8 @@ msgstr ""
 #: ../po/tmp/mypaint.glade.h:10
 msgctxt "footer: context picker button: tooltip"
 msgid "Pick brushstroke settings, stroke color, and layer"
-msgstr "Récupérer les paramètres du tracé de brosse, couleur du tracé et calque"
+msgstr ""
+"Récupérer les paramètres du tracé de brosse, couleur du tracé et calque"
 
 #: ../po/tmp/preferenceswindow.glade.h:1
 msgctxt "Prefs Dialog|Saving|Save Formats and Locations|Default|"
@@ -3622,38 +4493,59 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr "Cacher le curseur tant que vous peignez"
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+#, fuzzy
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr "Activé"
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 #, fuzzy
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr "Affichage"
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr "Les couleurs primaires sont :"
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr "Standards numériques Rouge/Vert/Bleu"
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
@@ -3662,20 +4554,20 @@ msgstr ""
 "Le rouge, vert et bleu 'écran d'ordinateur' primaire, sont disposés autour "
 "d'un cercle. Le vert est l'opposé du magenta."
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 #, fuzzy
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr "Rouge/Jaune/Bleu artistique traditionnel"
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3687,13 +4579,13 @@ msgstr ""
 "faites avec les couleurs d'affichage pure arrangées uniformément autour du "
 "cercle.  Le Vert est en opposition au Rouge."
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 #, fuzzy
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr "Changer les composantes Rouge, Verte et Bleue"
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3702,7 +4594,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3713,28 +4605,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr "<b>Cercle Chromatique</b>"
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr "Couleur"
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr "Écran (normal)"
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr "Désactivé (pas de sensibilité à la pression)"
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr "Fenêtre (peu recommandé)"
@@ -3795,242 +4687,297 @@ msgid "Reload the file your current work was loaded from."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
+#, fuzzy
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Import Layers…"
+msgstr "Importer des brosses…"
+
+#: ../po/tmp/resources.xml.h:13
+msgctxt "Accel Editor (descriptions)"
+msgid "Import layers from one or more files."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save"
 msgstr "Enregistrer"
 
-#: ../po/tmp/resources.xml.h:13
+#: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file."
 msgstr "Enregistrer dans un fichier."
 
-#: ../po/tmp/resources.xml.h:14
+#: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As…"
 msgstr "Enregistrer sous…"
 
-#: ../po/tmp/resources.xml.h:15
+#: ../po/tmp/resources.xml.h:17
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file, assigning it a new name."
 msgstr "Sauvegarder dans un fichier au nom nouveau."
 
-#: ../po/tmp/resources.xml.h:16
+#: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Export…"
 msgstr "Exporter…"
 
-#: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:18
-msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
-msgstr "Enregistrer comme Croquis"
-
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Save As Scrap"
+msgstr "Enregistrer comme Croquis"
+
+#: ../po/tmp/resources.xml.h:21
+msgctxt "Accel Editor (descriptions)"
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:22
+msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Previous Scrap"
 msgstr "Ouvrir le Croquis précédent"
 
-#: ../po/tmp/resources.xml.h:21
+#: ../po/tmp/resources.xml.h:23
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file before the current one."
 msgstr "Charger le croquis suivant, remplace l'image actuelle"
 
-#: ../po/tmp/resources.xml.h:22
+#: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Next Scrap"
 msgstr "Ouvrir le Croquis suivant"
 
-#: ../po/tmp/resources.xml.h:23
+#: ../po/tmp/resources.xml.h:25
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file after the current one."
 msgstr "Charger le croquis suivant, remplace l'image actuelle"
 
-#: ../po/tmp/resources.xml.h:24
+#: ../po/tmp/resources.xml.h:26
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Recover File from an Automated Backup…"
 msgstr "Récupére les fichiers d'une sauvegarde automatique…"
 
-#: ../po/tmp/resources.xml.h:25
+#: ../po/tmp/resources.xml.h:27
 msgctxt "Accel Editor (descriptions)"
 msgid "Try to save and resume interrupted unsaved work."
 msgstr ""
 "Essaye de sauvegarder et de reprendre le travail interrompu non sauvegardé."
 
-#: ../po/tmp/resources.xml.h:26
+#: ../po/tmp/resources.xml.h:28
 #, fuzzy
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr "Brosses"
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr "Brosses"
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 #, fuzzy
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr "Écraser un groupe de brosse ?"
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr "Ajusteurs de couleur"
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr "Couleurs"
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr "Mode"
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr "Mode"
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 #, fuzzy
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr "État de visibilité du calque actuel"
 
-#: ../po/tmp/resources.xml.h:35
-#, fuzzy
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr "Augmenter le rayon de la brosse"
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 #, fuzzy
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
-msgstr "Réduire le rayon de la brosse"
+msgid "Increase Fake Pressure"
+msgstr "Pression d'entrée"
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 #, fuzzy
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
-msgstr "Augmenter l'opacité de la brosse"
+msgid "Decrease Fake Pressure"
+msgstr "Pression d'entrée"
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 #, fuzzy
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Rotation"
+msgstr "Augmenter la Saturation"
+
+#: ../po/tmp/resources.xml.h:42
+msgctxt "Accel Editor (descriptions)"
+msgid "Increase barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:43
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
+msgstr "Diminuer la Saturation"
+
+#: ../po/tmp/resources.xml.h:44
+msgctxt "Accel Editor (descriptions)"
+msgid "Decrease barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:45
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
+msgstr "Augmenter le rayon de la brosse"
+
+#: ../po/tmp/resources.xml.h:46
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the working brush bigger."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:47
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
+msgstr "Réduire le rayon de la brosse"
+
+#: ../po/tmp/resources.xml.h:48
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the working brush smaller."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:49
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
+msgstr "Augmenter l'opacité de la brosse"
+
+#: ../po/tmp/resources.xml.h:50
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the working brush more opaque."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:51
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Opacity"
 msgstr "Réduire l'opacité de la brosse"
 
-#: ../po/tmp/resources.xml.h:42
+#: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush less opaque."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:43
+#: ../po/tmp/resources.xml.h:53
 #, fuzzy
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Lighten Painting Color"
 msgstr "Dernière position peinte"
 
-#: ../po/tmp/resources.xml.h:44
+#: ../po/tmp/resources.xml.h:54
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase the lightness of the current painting color."
 msgstr "Ouvrir un fichier, remplaçant ainsi la peinture actuelle"
 
-#: ../po/tmp/resources.xml.h:45
+#: ../po/tmp/resources.xml.h:55
 #, fuzzy
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Darken Painting Color"
 msgstr "Dernière position peinte"
 
-#: ../po/tmp/resources.xml.h:46
+#: ../po/tmp/resources.xml.h:56
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease the lightness of the current painting color."
 msgstr "Ouvrir un fichier, remplaçant ainsi la peinture actuelle"
 
-#: ../po/tmp/resources.xml.h:47
-#, fuzzy
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
-msgstr "Teinte sens anti-horaire"
-
-#: ../po/tmp/resources.xml.h:48
-#, fuzzy
-msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
-msgstr "Tourner la teinte de couleur dans le sens anti-horaire"
-
-#: ../po/tmp/resources.xml.h:49
+#: ../po/tmp/resources.xml.h:57
 #, fuzzy
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Change Hue Clockwise"
 msgstr "Changer la teinte de la couleur (sens des aiguilles d'une montre) "
 
-#: ../po/tmp/resources.xml.h:50
+#: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
 msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:51
+#: ../po/tmp/resources.xml.h:59
+#, fuzzy
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr "Teinte sens anti-horaire"
+
+#: ../po/tmp/resources.xml.h:60
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr "Tourner la teinte de couleur dans le sens anti-horaire"
+
+#: ../po/tmp/resources.xml.h:61
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Increase Saturation"
 msgstr "Augmenter la Saturation"
 
-#: ../po/tmp/resources.xml.h:52
+#: ../po/tmp/resources.xml.h:62
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color more saturated (more colorful, purer)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:53
+#: ../po/tmp/resources.xml.h:63
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Decrease Saturation"
 msgstr "Diminuer la Saturation"
 
-#: ../po/tmp/resources.xml.h:54
+#: ../po/tmp/resources.xml.h:64
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color less saturated (grayer)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:55
+#: ../po/tmp/resources.xml.h:65
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Reload Brush Settings"
 msgstr "Recharger les paramètres de la brosse"
 
-#: ../po/tmp/resources.xml.h:56
+#: ../po/tmp/resources.xml.h:66
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Restore all brush settings to the current brush’s saved values."
@@ -4038,330 +4985,385 @@ msgstr ""
 "Réinitialisation de tous les réglages de la brosse aux valeurs sauvegardée "
 "pour la brosse actuelle"
 
-#: ../po/tmp/resources.xml.h:57
+#: ../po/tmp/resources.xml.h:67
 #, fuzzy
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Pick Stroke and Layer"
 msgstr "Récupérer un tracé et un calque"
 
-#: ../po/tmp/resources.xml.h:58
+#: ../po/tmp/resources.xml.h:68
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
 msgstr ""
+"Récupérer les paramètres du tracé de brosse, couleur du tracé et calque"
 
-#: ../po/tmp/resources.xml.h:59
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 #, fuzzy
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr "Enregistrer la brosse dans le raccourci le plus récent"
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr "Enregistrer la brosse dans le raccourci le plus récent"
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "Nettoyer le calque"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr "Effacer le contenu du calque actif."
 
-#: ../po/tmp/resources.xml.h:65
+#: ../po/tmp/resources.xml.h:75
 #, fuzzy
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Trim Layer to Frame"
-msgstr "Nom du calque"
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr "options d'outils"
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:76
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Trim Layer to Frame"
+msgstr "Rogner le calque en fonction du cadre"
+
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr ""
+"Appliquer la saturation de la couleur du calque du dessus à la teinte et la "
+"luminosité du fond."
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "Nouveau Groupe de Calques"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "Nouveau Groupe de Calques"
+
+#: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr "Copier le calque vers le presse-papier"
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr "Copiez le contenu du calque actif dans le presse-papiers."
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr "Coller le calque depuis le presse-papiers"
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr "Remplace le calque actif par le contenu du presse-papiers."
 
-#: ../po/tmp/resources.xml.h:71
+#: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Edit Layer in External App…"
 msgstr "Éditer le calque dans une application externe…"
 
-#: ../po/tmp/resources.xml.h:72
+#: ../po/tmp/resources.xml.h:90
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
+msgid "Edit the active layer in an external application."
 msgstr "Déplacer le calque : Repositionner le calque actuel sur la toile"
 
-#: ../po/tmp/resources.xml.h:73
+#: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Update Layer with External Edits"
 msgstr "Mettre à jour le calque avec les modifications externes"
 
-#: ../po/tmp/resources.xml.h:74
+#: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
 msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:75
+#: ../po/tmp/resources.xml.h:93
 #, fuzzy
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer at Cursor"
 msgstr "Sélectionner le calque sous le curseur"
 
-#: ../po/tmp/resources.xml.h:76
+#: ../po/tmp/resources.xml.h:94
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr "Sélectionner un calque en attrapant un de ses tracés "
 
-#: ../po/tmp/resources.xml.h:77
+#: ../po/tmp/resources.xml.h:95
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Above"
 msgstr "Aller au calque supérieure"
 
-#: ../po/tmp/resources.xml.h:78
+#: ../po/tmp/resources.xml.h:96
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer up in the layer stack."
 msgstr "Remonter d'un calque dans la pile de calques"
 
-#: ../po/tmp/resources.xml.h:79
+#: ../po/tmp/resources.xml.h:97
 #, fuzzy
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Below"
 msgstr "Aller au calque"
 
-#: ../po/tmp/resources.xml.h:80
+#: ../po/tmp/resources.xml.h:98
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer down in the layer stack."
 msgstr "Descendre d'un calque dans la pile de calques"
 
-#: ../po/tmp/resources.xml.h:81
+#: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer"
 msgstr "Nouveau Calque pour Peinture"
 
-#: ../po/tmp/resources.xml.h:82
+#: ../po/tmp/resources.xml.h:100
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer above the current layer."
 msgstr "Ajouter un calque au dessus de l'actuel"
 
-#: ../po/tmp/resources.xml.h:83
+#: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer…"
 msgstr "Nouveau calque vectoriel…"
 
-#: ../po/tmp/resources.xml.h:84
+#: ../po/tmp/resources.xml.h:102
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer above the current layer, and begin editing it."
 msgstr "Ajouter un calque au dessus de l'actuel"
 
-#: ../po/tmp/resources.xml.h:85
+#: ../po/tmp/resources.xml.h:103
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group"
 msgstr "Nouveau Groupe de Calques"
 
-#: ../po/tmp/resources.xml.h:86
+#: ../po/tmp/resources.xml.h:104
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group above the current layer."
 msgstr "Ajouter un nouveau groupe de calque au-dessus du calque actif."
 
-#: ../po/tmp/resources.xml.h:87
+#: ../po/tmp/resources.xml.h:105
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:88
+#: ../po/tmp/resources.xml.h:106
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer below the current layer."
 msgstr "Ajouter un calque sous l'actuel"
 
-#: ../po/tmp/resources.xml.h:89
+#: ../po/tmp/resources.xml.h:107
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer Below…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:90
+#: ../po/tmp/resources.xml.h:108
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer below the current layer, and begin editing it."
 msgstr "Ajouter un calque sous l'actuel"
 
-#: ../po/tmp/resources.xml.h:91
+#: ../po/tmp/resources.xml.h:109
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:92
+#: ../po/tmp/resources.xml.h:110
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group below the current layer."
 msgstr "Ajouter un calque sous l'actuel"
 
-#: ../po/tmp/resources.xml.h:93
+#: ../po/tmp/resources.xml.h:111
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Layer Down"
 msgstr "fusionner les calques"
 
-#: ../po/tmp/resources.xml.h:94
+#: ../po/tmp/resources.xml.h:112
 msgctxt "Accel Editor (descriptions)"
 msgid "Merge the current layer with the layer beneath it."
 msgstr "Fusionner le calque actuel avec le calque situé en dessous."
 
-#: ../po/tmp/resources.xml.h:95
+#: ../po/tmp/resources.xml.h:113
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Visible Layers"
 msgstr "Fusionner les calques visibles"
 
-#: ../po/tmp/resources.xml.h:96
+#: ../po/tmp/resources.xml.h:114
 msgctxt "Accel Editor (descriptions)"
 msgid "Consolidate all visible layers, and delete the originals."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:97
+#: ../po/tmp/resources.xml.h:115
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer from Visible"
 msgstr "Rendre le calque visible"
 
-#: ../po/tmp/resources.xml.h:98
+#: ../po/tmp/resources.xml.h:116
 msgctxt "Accel Editor (descriptions)"
 msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:99
+#: ../po/tmp/resources.xml.h:117
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Delete Layer"
 msgstr "Supprimer le Calque"
 
-#: ../po/tmp/resources.xml.h:100
+#: ../po/tmp/resources.xml.h:118
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Remove the current layer from the layer stack."
 msgstr "Monter le calque actuel d'un niveau dans la pile des calques"
 
-#: ../po/tmp/resources.xml.h:101
+#: ../po/tmp/resources.xml.h:119
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Convert to Normal Painting Layer"
 msgstr "Convertir en mode normal"
 
-#: ../po/tmp/resources.xml.h:102
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr "Augmenter l'opacité du calque"
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr "Réduire l'opacité du calque"
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr "Renommer le calque"
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr "Monter le calque actuel d'un niveau dans la pile des calques"
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr "Charger le calque"
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr "Descendre le calque actuel d'un niveau dans la pile des calques"
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr "Dupliquer le calque"
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr "Créer une duplication exacte du calque actuel"
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
+#, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
-msgstr "Renommer le calque…"
+msgid "Layer Properties…"
+msgstr "Propriétés de la palette"
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
-msgstr "Entrer un nouveau nom pour le calque actuel."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr "Calque verrouillé"
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid ""
@@ -4370,759 +5372,846 @@ msgstr ""
 "État verrouillé du calque actuel : Il n'est pas possible de dessiner sur les "
 "calques verrouillés"
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr "Rendre le calque visible"
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr "État de visibilité du calque actuel"
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr "Voir l’arrière-plan"
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr "État de visibilité du calque actuel"
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr "Monter le calque actuel d'un niveau dans la pile des calques"
+
+#: ../po/tmp/resources.xml.h:141
 #, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr "Réinitialiser et centrer"
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr "Réinitialise les Zoom, Rotation et Miroir, et recentre le document"
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr "Adapter la vue"
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr "Réinitialiser"
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr "Réinitialiser le Zoom"
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
-msgstr ""
+msgid "Reset view zoom level to default."
+msgstr "Rétablir les paramètres par défaut"
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 #, fuzzy
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr "Rotation"
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 #, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr "Agrandir"
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr "Augmenter l'agrandissement"
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Zoom arrière"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr "Diminuer l'agrandissement"
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
+#, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
-msgstr "Tourner sens anti-horaire"
+msgid "Pan Left"
+msgstr "Déplacer la vue"
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
-msgstr "Tourner la vue dans le sens anti-horaire"
+msgid "Move your view of the canvas to the left."
+msgstr "Tourner la vue : incline la vue de la toile."
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr "Lumière dure"
+
+#: ../po/tmp/resources.xml.h:159
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+"Déplacer la vue : déplace interactivement la vue de la toile horizontalement "
+"et verticalement."
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr "Tourner la vue : incline la vue de la toile."
+
+#: ../po/tmp/resources.xml.h:162
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr "Déplacer la vue"
+
+#: ../po/tmp/resources.xml.h:163
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr "Tourner la vue : incline la vue de la toile."
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr "Tourner sens horaire"
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr "Tourner la vue dans le sens horaire"
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr "Tourner sens anti-horaire"
+
+#: ../po/tmp/resources.xml.h:167
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr "Tourner la vue dans le sens anti-horaire"
+
+#: ../po/tmp/resources.xml.h:168
 #, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr "Miroir horizontal"
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr "Retourner la vue de gauche à droite"
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 #, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr "Miroir vertical"
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr "Retourner la vue de haut en bas"
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr "Calque seul"
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr "supprimer le calque actuel"
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 #, fuzzy
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr "Peinture symétrique"
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 #, fuzzy
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr "Cadre activé"
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr "Commuter le cadre du document"
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 #, fuzzy
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr "Écrire les valeurs d'entrée de la brosse sur la console"
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr "Visualiser le rendu"
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr "Afficher les mises à jour du rendu à l'écran, pour déboguer"
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 #, fuzzy
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr "Désactiver le double tampon GTK"
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+#, fuzzy
+msgid "Delete Point"
+msgstr "Supprimer le groupe"
+
+#: ../po/tmp/resources.xml.h:187
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr "supprimer le calque actuel"
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 #, fuzzy
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr "Mode de la ligne"
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 #, fuzzy
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr "Peindre normalement"
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr "Gomme"
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr "Retire les tracés en utilisant la brosse actuelle."
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Fichier"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "Quitter"
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "Édition"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr "outil actif"
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "Couleur"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 #, fuzzy
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr "Ajuster la couleur"
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 #, fuzzy
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr "Historique de couleur"
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 #, fuzzy
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr "Détails de la couleur"
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr "Dialogue des détails de couleur avec champs de saisie texte."
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 #, fuzzy
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr "Couleur de la palette suivante "
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr "Couleur suivante de la palette"
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 #, fuzzy
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr "Couleur de la palette précédente"
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr "Couleur précédente de la palette"
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 #, fuzzy
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr "Ajouter une couleur à la palette"
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "Calque"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 #, fuzzy
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr "Opacité"
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 #, fuzzy
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr "Aller au calque"
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 #, fuzzy
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr "Calque seul"
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 #, fuzzy
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr "Propriétés de la palette"
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr "Carnet de croquis"
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 #, fuzzy
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr "Nouveau carnet de croquis"
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr "Charger un nouveau carnet de croquis par défaut."
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 #, fuzzy
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr "Ouvrir un carnet de croquis…"
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr "Charger un fichier image du disque dans le carnet de croquis."
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 #, fuzzy
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr "Enregistrer le carnet de croquis maintenant"
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr "Enregistrer ce carnet de croquis en écrasant le fichier précédent."
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr "Exporter le carnet de croquis en tant que…"
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr "Exporter le carnet de croquis en choisissant l'extension..."
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 #, fuzzy
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr "Revenir au carnet de croquis précédent"
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr "Restaurer le carnet de croquis à sa précédente sauvegarde."
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 #, fuzzy
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr "Enregistrer comme carnet de croquis par défaut"
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 #, fuzzy
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr "Nettoyer le carnet de croquis par défaut"
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr "Nettoyer le carnet de croquis par défaut"
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 #, fuzzy
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr "Copier le fond vers le carnet de croquis"
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr "Copier l'image de fond du document en cours dans le carnet de croquis."
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "Fenêtre"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "Brosse"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr "Raccourcis clavier"
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 #, fuzzy
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr "Raccourcis claviers"
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "Changer de Brosse…"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "Changer la couleur…"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "Changer la Couleur (sous-ensemble rapide)…"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr "Plus de Brosses…"
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr "Télécharger des packs de brosses sur le wiki MyPaint."
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr "Importer des brosses…"
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr "Charger un pack de brosses sur le disque..."
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Aide"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr "Aide en ligne"
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "À propos de MyPaint"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr "A propos de MyPaint...license, version, crédits..."
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Débogage"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 #, fuzzy
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr "Écrire les informations de fuite mémoire dans la console (lent !)"
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 #, fuzzy
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr "Lancer le ramasse-miette maintenant"
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 #, fuzzy
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr "Démarrer/Arrêter le profilage Python (cProfile)"
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr "Démarrer/Arrêter le profilage Python (cProfile)"
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "Vue"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 #, fuzzy
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr "Retour visuel"
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr "Ajuster la vue"
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 #, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr "Menu contextuel"
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "Plein écran"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "Préférences"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr "Paramètres généraux."
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr "Test les périphériques d'entrée"
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr "Fond"
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr "Éditer la Brosse"
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr "Éditer les réglages de la brosse actuelle."
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 #, fuzzy
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr "Éditeur de liste de brosses"
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr "Éditer l'icône de la brosse"
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr "Liste des Calques"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
-"Activer/Désactiver le menu des calques (disposition, ou mode de fusion)."
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr "Afficher la fenêtre des Calques"
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr "Afficher le menu des calques (disposition, ou mode de fusion)."
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 #, fuzzy
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr "Cercle chromatique HCY (TCL)"
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid ""
@@ -5132,46 +6221,35 @@ msgstr ""
 "Régler les couleurs par l'espace teinte/chrominance/luminance cylindrique. "
 "Les tranches circulaires ont la même luminosité."
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "Palette de Couleurs"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 #, fuzzy
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr "Cercle chromatique TSV"
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr "Modificateur de couleur « Saturation et valeur »"
 
-#: ../po/tmp/resources.xml.h:260
-#, fuzzy
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr "Triangle TSV"
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 #, fuzzy
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr "Cube TSV"
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
@@ -5179,218 +6257,216 @@ msgid ""
 msgstr ""
 "Un cube TSV pouvant être tourné afin d'afficher différentes coupes planes."
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 #, fuzzy
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr "Carré"
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 "Un cube TSV pouvant être tourné affin d'afficher différentes coupes planes"
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 #, fuzzy
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr "Curseurs de composantes"
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr "Ajuster les composantes individuelles de la couleur."
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 #, fuzzy
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr "Carnet de croquis"
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr "Afficher le carnet de croquis"
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr "Afficher le menu carnet de croquis."
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr "Fenête de Prévisualisation"
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
-msgstr "Affiche l'Aperçu (Aperçu de l'ensemble de la zone de dessin)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "Prévisualisation"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr "Révèle l'Aperçu (Aperçu de l'ensemble de la zone de dessin)."
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr "Fenêtre d'options de l'outil"
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
-msgstr "Affiche les options de l'outil (options pour l'outil actuel)."
+msgid "Dockable panel for adjusting the options with the activated tool."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr "Afficher les options de l'outil"
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr "Révèle les options de l'outil (options pour l'outil actuel)."
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr "Historique des couleur & brosses"
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
-msgstr "Affiche l'Historique (couleurs et brosses récemment utilisées)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr "Brosses & Couleurs récentes"
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr "Révèle l'Historique (couleurs et brosses récemment utilisées)."
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr "Cacher les contrôles en plein écran"
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr "Cacher automatiquement l'interface en plein écran."
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 #, fuzzy
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr "Niveau d'agrandissement"
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr "Affiche les niveaux de zoom."
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 #, fuzzy
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr "Dernière position peinte"
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr "Affiche l'endroit de la fin du dernier trait."
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr "Afficher les filtres"
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr "Afficher les couleurs normalement"
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr "Filtrer les couleurs : afficher les couleurs inchangées."
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr "Afficher les couleurs en niveaux de gris"
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr "Afficher les couleurs en negatif"
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 "Filtrer les couleurs : inverser. Le noir devient blanc et le rouge cyan."
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr "Afficher les couleurs avec une simulation de rouge moins intense"
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
@@ -5398,53 +6474,53 @@ msgstr ""
 "Filtrer les couleurs pour simuler l'achloropsie, une forme commune de "
 "daltonisme."
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr "Afficher les couleurs avec une simulation du vert plus intense"
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 "Filtrer les couleurs pour simuler l'anérythropsie, une forme commune de "
 "daltonisme."
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr "Afficher les couleurs avec une simulation de bleu moins intense"
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 "Filtrer les couleurs pour simuler la tritanopie, une forme rare de "
 "daltonisme."
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr "Main levée"
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr "Main levée"
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 "Dessin à main levée : Dessiner et peindre librement, sans contraintes "
 "géométriques."
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr "Main levée"
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
@@ -5452,230 +6528,230 @@ msgstr ""
 "Dessin à main levée : Dessiner et peindre librement, sans contraintes "
 "géométriques"
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr "Déplacer la vue"
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr "Déplacer"
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 "Déplacer la vue : déplace interactivement la vue de la toile horizontalement "
 "et verticalement."
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr "Déplacer la vue"
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 "Déplace interactivement la vue de la toile horizontalement et verticalement."
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr "Tourner la vue"
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr "Tourner"
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr "Tourner la vue : incline la vue de la toile."
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr "Tourner la vue"
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr "Tourne interactivement la vue de la toile."
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr "Agrandir la vue"
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr "Zoom"
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr "Agrandir la vue : zoom dans ou en dehors de la toile."
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 #, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr "Agrandir la vue"
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr "Zoom intéractif dans ou en dehors de la toile."
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr "Lignes et courbes"
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr "Lignes"
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr "Lignes et courbes : trace des lignes droites ou courbées."
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr "Lignes et courbes"
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr "Trace des lignes droites ou courbées."
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 #, fuzzy
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr "Lignes connectées"
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr "Lignes connectées"
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr "Lignes connectées : Trace des séquences de lignes droites ou courbes."
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr "Lignes connectées"
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr "Trace des séquences de lignes droites ou courbées."
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr "Ellipses et cercles"
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr "Ellipse"
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr "Ellipses et Cercles : dessiner des formes arrondies."
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr "Ellipses et cercles"
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr "Trace des cercles et ellipses."
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr "Encre"
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr "Encre"
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr "Encre: Trace des lignes douces et contrôlées."
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr "Encre"
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr "Trace des lignes douces et contrôlées."
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 #, fuzzy
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr "Aller au calque"
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr "Calques"
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 #, fuzzy
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr "Déplacer le calque : Repositionner le calque actuel sur la toile"
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr "Repositionner le calque"
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 #, fuzzy
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr "Déplacer le calque : Repositionner le calque actuel sur la toile"
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 #, fuzzy
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr "Éditer le cadre"
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr "Cadre"
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 #, fuzzy
 msgctxt "Toolbar (tooltips)"
 msgid ""
@@ -5684,12 +6760,12 @@ msgstr ""
 "Éditer le cadre : Défini un cadre autour du document afin de lui donner une "
 "taille déterminée. Le cadre est utilisé lors de l'exportation."
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr "Éditer le cadre"
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid ""
@@ -5698,83 +6774,260 @@ msgstr ""
 "Éditer le cadre : Défini un cadre autour du document afin de lui donner une "
 "taille déterminée. Le cadre est utilisé lors de l'exportation."
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr "Axe de symétrie"
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr "Édition de la peinture de symétrie : Ajuster l'axe de symétrie."
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Éditer la symétrie"
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr "Ajuster interactivement les axes de symétrie."
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 #, fuzzy
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr "Pipette à couleur"
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr "Pipette à couleur"
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr "Pipette à couleur : prends la couleur du pixel de l'écran."
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "Pipette à couleurs"
+
+#: ../po/tmp/resources.xml.h:401
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr "Prends la couleur du pixel de l'écran."
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "Pipette à couleurs"
+
+#: ../po/tmp/resources.xml.h:403
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr "Prends la couleur du pixel de l'écran."
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "Pipette à couleurs"
+
+#: ../po/tmp/resources.xml.h:405
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr "Prends la couleur du pixel de l'écran."
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr "Sélecteur de couleur"
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr "Prends la couleur du pixel de l'écran."
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr "Remplir"
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr "Pot de Peinture"
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr "Remplir une zone avec la couleur."
+
+#~ msgctxt "Accelerator map editor: action column markup"
+#~ msgid ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+#~ msgstr ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+
+#~ msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
+#~ msgid "{action_label} {action_desc} {accel_label}"
+#~ msgstr "{action_label} {action_desc} {accel_label}"
+
+#~ msgctxt "brush list context menu"
+#~ msgid "Delete"
+#~ msgstr "Supprimer"
+
+#~ msgctxt "brush list commands"
+#~ msgid "Really delete brush from disk?"
+#~ msgstr "Effacer cette brosse réellement ?"
+
+#~ msgid "HSV Triangle"
+#~ msgstr "Triangle TSV"
+
+#~ msgid "The standard GTK color selector"
+#~ msgstr "Sélecteur de couleur standard GTK"
+
+#~ msgid "Pick a color from the screen"
+#~ msgstr "Récupérer une couleur à l'écran"
+
+#~ msgid "Layer Name"
+#~ msgstr "Nom du calque"
+
+#~ msgid ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+#~ msgstr ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+
+#~ msgid "Save..."
+#~ msgstr "Enregistrer…"
+
+#~ msgid "Confirm"
+#~ msgstr "Confirmer"
+
+#~ msgid "Open..."
+#~ msgstr "Ouvrir…"
+
+#~ msgid "Type"
+#~ msgstr "Type"
+
+#~ msgid "Mode:"
+#~ msgstr "Mode :"
+
+#~ msgid ""
+#~ "Blending mode: how the current layer combines with the layers underneath "
+#~ "it."
+#~ msgstr ""
+#~ "Mode de fusion : Méthode de combinaison du calque avec ceux du dessous."
+
+#~ msgid ""
+#~ "Layer opacity: how much of the current layer to use. Smaller values make "
+#~ "it more transparent."
+#~ msgstr ""
+#~ "Opacité du calque : Quelle proportion du calque actuel utiliser. Des "
+#~ "valeur faibles le rendent plus transparent."
+
+#~ msgid "%s: edit properties"
+#~ msgstr "%s: édition des propriétés"
+
+#~ msgctxt "layer default names"
+#~ msgid "Unknown Bitmap Layer"
+#~ msgstr "Calque Bitmap inconnu"
+
+#~ msgctxt "Autosave Recovery dialog|"
+#~ msgid "_Ignore for Now"
+#~ msgstr "_Ignorer pour le moment"
+
+#~ msgid "Setting name:"
+#~ msgstr "Nom du réglage :"
+
+#~ msgid "Base value:"
+#~ msgstr "Valeur de base :"
+
+#~ msgid "<ymin>"
+#~ msgstr "<ymin>"
+
+#~ msgid "<ymax>"
+#~ msgstr "<ymax>"
+
+#~ msgid "<xmin>"
+#~ msgstr "<xmin>"
+
+#~ msgid "<xmax>"
+#~ msgstr "<xmax>"
+
+#~ msgid "Edit Setting"
+#~ msgstr "Editer les réglages"
+
+#, fuzzy
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Trim Layer to Frame"
+#~ msgstr "Nom du calque"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Rename Layer…"
+#~ msgstr "Renommer le calque…"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Enter a new name for the current layer."
+#~ msgstr "Entrer un nouveau nom pour le calque actuel."
+
+#~ msgctxt "Menu→Edit (labels)"
+#~ msgid "Current Tool"
+#~ msgstr "outil actif"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+#~ msgstr ""
+#~ "Activer/Désactiver le menu des calques (disposition, ou mode de fusion)."
+
+#, fuzzy
+#~ msgctxt "Menu→Color (labels), Accel Editor (labels)"
+#~ msgid "HSV Triangle"
+#~ msgstr "Triangle TSV"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+#~ msgstr "Affiche l'Aperçu (Aperçu de l'ensemble de la zone de dessin)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+#~ msgstr "Affiche les options de l'outil (options pour l'outil actuel)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the History panel (recently used brushes and colors)."
+#~ msgstr "Affiche l'Historique (couleurs et brosses récemment utilisées)."
 
 #~ msgid ""
 #~ "\"%s\" has an alpha channel. Background images with transparency are not "
@@ -5988,9 +7241,6 @@ msgstr "Remplir une zone avec la couleur."
 #~ "et d'entrée (pression, vitesse, etc.) sont disponibles comme des bulles "
 #~ "d'astuce. Placez le curseur au dessus d'un label pour les voir.\n"
 
-#~ msgid "Open Recent files"
-#~ msgstr "Ouvrir un fichier récent"
-
 #~ msgid "This will discard %d second of unsaved painting."
 #~ msgid_plural "This will discard %d seconds of unsaved painting."
 #~ msgstr[0] "Cela va détruire %d seconde d'actions non-enregistrée."
@@ -5998,9 +7248,6 @@ msgstr "Remplir une zone avec la couleur."
 
 #~ msgid "Crop to Current Layer"
 #~ msgstr "Rogner selon le calque actuel"
-
-#~ msgid "Crop frame to the currently active layer"
-#~ msgstr "Rogner le cadre depuis le calque actif actuel"
 
 #~ msgid ""
 #~ "While the frame is enabled, it \n"
@@ -6109,9 +7356,6 @@ msgstr "Remplir une zone avec la couleur."
 #~ msgid "Brush Blend Mode"
 #~ msgstr "Mode de fusion de la brosse"
 
-#~ msgid "Add Layer"
-#~ msgstr "Ajouter un calque"
-
 #~ msgid "Move Layer on Canvas"
 #~ msgstr "Déplacer le calque sur la toile"
 
@@ -6149,9 +7393,6 @@ msgstr "Remplir une zone avec la couleur."
 #~ msgctxt "Menu|File|"
 #~ msgid "Save"
 #~ msgstr "Enregistrer"
-
-#~ msgid "Export to a file"
-#~ msgstr "Exporter dans un fichier"
 
 #~ msgid ""
 #~ "Saves to a new scrap file. If the drawing is currently saved as a scrap, "

--- a/po/fr.po
+++ b/po/fr.po
@@ -534,17 +534,17 @@ msgstr "Paquet de brosses MyPaint (au format .zip)"
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr "Nouveau groupe…"
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr "Importer des brosses…"
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr "Récupérer d'autres brosses…"
 
 #: ../gui/brushselectionwindow.py:554
@@ -1245,13 +1245,13 @@ msgstr "Type"
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
-msgstr "Utiliser pour..."
+msgid "Use for…"
+msgstr "Utiliser pour…"
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
-msgstr "Défilement..."
+msgid "Scroll…"
+msgstr "Défilement…"
 
 #. Name and preview column: will be indented
 #: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
@@ -1476,7 +1476,7 @@ msgid "_Quit"
 msgstr "Quitter"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr "Importer un paquet de brosses…"
 
 #: ../gui/drawwindow.py:698
@@ -1535,7 +1535,7 @@ msgstr ""
 "“{type_name}” ({content_type})?"
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr "Ouvrir avec…"
 
 #: ../gui/externalapp.py:123
@@ -1729,13 +1729,13 @@ msgstr "JPEG qualité 90% (*.jpg, *.jpeg)"
 
 #: ../gui/filehandling.py:576
 #, fuzzy
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr "Exporter…"
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Enregistrer sous…"
 
@@ -1806,7 +1806,7 @@ msgstr "Ouvrir un fichier récent"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr "Ouvrir un carnet de croquis…"
 
 #: ../gui/filehandling.py:1099
@@ -2246,13 +2246,13 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
-msgstr "Reporter..."
+msgid "Report…"
+msgstr "Reporter…"
 
 #: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
@@ -2263,7 +2263,7 @@ msgid "Quit MyPaint"
 msgstr "Quittez MyPaint"
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr "Détails…"
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2453,8 +2453,8 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
-msgstr "Réordonner les calques en pile..."
+msgid "Move layer in stack…"
+msgstr "Réordonner les calques en pile…"
 
 #: ../gui/layerswindow.py:110
 msgid ""
@@ -2524,8 +2524,8 @@ msgid "Stroke trail-off beginning"
 msgstr "Début de la queue du tracé"
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
-msgstr "Variation de pression..."
+msgid "Pressure variation…"
+msgstr "Variation de pression…"
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
@@ -3713,7 +3713,7 @@ msgstr "Supprimer cette brosse du disque"
 #, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid "_Recover & Save…"
-msgstr "_Récupérer et Enregistrer..."
+msgstr "_Récupérer et Enregistrer…"
 
 #: ../po/tmp/autorecover.glade.h:12
 #, fuzzy
@@ -5891,7 +5891,7 @@ msgstr "Exporter le carnet de croquis en tant que…"
 #: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
-msgstr "Exporter le carnet de croquis en choisissant l'extension..."
+msgstr "Exporter le carnet de croquis en choisissant l'extension…"
 
 #: ../po/tmp/resources.xml.h:231
 #, fuzzy
@@ -6016,7 +6016,7 @@ msgstr "Importer des brosses…"
 #: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
-msgstr "Charger un pack de brosses sur le disque..."
+msgstr "Charger un pack de brosses sur le disque…"
 
 #: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
@@ -6041,7 +6041,7 @@ msgstr "À propos de MyPaint"
 #: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
-msgstr "A propos de MyPaint...license, version, crédits..."
+msgstr "A propos de MyPaint...license, version, crédits…"
 
 #: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"

--- a/po/fy.po
+++ b/po/fy.po
@@ -513,17 +513,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1184,12 +1184,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1372,7 +1372,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Open dragged file confirm dialog: continue button"
 msgid "_Open"
-msgstr "Iepenje..."
+msgstr "Iepenje…"
 
 #: ../gui/drawwindow.py:486
 msgid "Set current color"
@@ -1406,7 +1406,7 @@ msgid "_Quit"
 msgstr "Ofslúte"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1456,7 +1456,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1633,13 +1633,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Bewarje"
 
@@ -1705,7 +1705,7 @@ msgstr "Triem"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -1722,7 +1722,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Iepenje..."
+msgstr "Iepenje…"
 
 #: ../gui/filehandling.py:1427
 #, fuzzy
@@ -1734,7 +1734,7 @@ msgstr "Resint iepene"
 #, fuzzy
 msgctxt "File→Open Most Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Iepenje..."
+msgstr "Iepenje…"
 
 #: ../gui/filehandling.py:1446
 msgctxt "File→Open Next/Prev Scrap: error message"
@@ -1755,7 +1755,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
 msgid "_Open"
-msgstr "Iepenje..."
+msgstr "Iepenje…"
 
 #: ../gui/filehandling.py:1487
 msgctxt "File→Revert: status message: canvas has no filename yet"
@@ -2129,12 +2129,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2146,7 +2146,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2331,7 +2331,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2401,7 +2401,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/fy.po
+++ b/po/fy.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:18+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Frisian <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -19,27 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -47,39 +27,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -87,214 +67,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Oanpast"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -333,142 +323,177 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Bewarje"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Nij"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -476,58 +501,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -536,51 +561,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -590,137 +639,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -728,162 +777,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -891,373 +932,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Namme"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Ungedien meitsje"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Op 'e nij"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1267,324 +1305,678 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Iepenje..."
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr ""
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Ofslúte"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Ofslúte"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Iepenje..."
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Bewarje"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr ""
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr ""
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Triem"
+
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Iepenje..."
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Resint iepene"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Iepenje..."
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Iepenje..."
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr ""
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1592,130 +1984,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1724,35 +2128,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1776,45 +2180,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1822,153 +2230,217 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr ""
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr ""
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr ""
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1980,256 +2452,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2237,188 +2734,212 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+msgid "Import Layers"
+msgstr ""
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2427,13 +2948,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2443,7 +2964,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2451,13 +2972,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2465,7 +2986,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2473,7 +2994,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2484,7 +3005,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2492,7 +3013,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2502,7 +3028,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2513,285 +3039,394 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr ""
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2801,7 +3436,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2810,52 +3465,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2877,17 +3563,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2916,112 +3600,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3034,7 +3693,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3075,6 +3734,133 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Namme"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3444,56 +4230,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3501,12 +4307,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3515,7 +4321,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3526,28 +4332,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3609,1828 +4415,2018 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Utzoome"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Triem"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Help"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/ga.po
+++ b/po/ga.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:19+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Irish <https://hosted.weblate.org/projects/mypaint/mypaint/ga/"
@@ -16,31 +16,11 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=5; plural=n==1 ? 0 : n==2 ? 1 : (n>2 && n<7) ? 2 :(n>"
-"6 && n<11) ? 3 : 4;\n"
+"Plural-Forms: nplurals=5; plural=n==1 ? 0 : n==2 ? 1 : (n>2 && n<7) ? 2 :"
+"(n>6 && n<11) ? 3 : 4;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -48,39 +28,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -88,214 +68,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Dath"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Saincheaptha"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -334,98 +324,133 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Sábháil"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Nua"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
@@ -435,44 +460,44 @@ msgstr[2] ""
 msgstr[3] ""
 msgstr[4] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -480,58 +505,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -540,51 +565,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -594,137 +643,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -732,162 +781,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -895,373 +936,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Ainm"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Cealaigh"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Athdhéan"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1271,324 +1309,682 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Oscail..."
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr ""
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Scoir"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Scoir"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Oscail..."
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Sábháil"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr ""
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr ""
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Comhad"
+
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Sraitheanna"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Oscail..."
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Oscail Rudaí Deireanacha"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Oscail..."
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Oscail..."
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Teimhneacht:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1596,130 +1992,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1728,35 +2136,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1780,45 +2188,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1826,153 +2238,218 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Sraitheanna"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Sraitheanna"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Teimhneacht:"
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1984,256 +2461,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2241,188 +2743,213 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Sraitheanna"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2431,13 +2958,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2447,7 +2974,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2455,13 +2982,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2469,7 +2996,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2477,7 +3004,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2488,7 +3015,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2496,7 +3023,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2506,7 +3038,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2517,285 +3049,394 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr ""
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2805,7 +3446,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2814,52 +3475,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2881,17 +3573,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2920,112 +3610,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3038,7 +3703,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3079,6 +3744,134 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Ainm"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Teimhneacht:"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3448,56 +4241,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3505,12 +4318,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3519,7 +4332,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3530,28 +4343,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3613,1828 +4426,2019 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Súmáil Amach"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Comhad"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Cabhair"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Dífhabhtaigh"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
-msgstr ""
+msgstr "Sraitheanna"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/ga.po
+++ b/po/ga.po
@@ -517,17 +517,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1188,12 +1188,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1376,7 +1376,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Open dragged file confirm dialog: continue button"
 msgid "_Open"
-msgstr "Oscail..."
+msgstr "Oscail…"
 
 #: ../gui/drawwindow.py:486
 msgid "Set current color"
@@ -1410,7 +1410,7 @@ msgid "_Quit"
 msgstr "Scoir"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1460,7 +1460,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1640,13 +1640,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Sábháil"
 
@@ -1712,7 +1712,7 @@ msgstr "Comhad"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -1730,7 +1730,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Oscail..."
+msgstr "Oscail…"
 
 #: ../gui/filehandling.py:1427
 #, fuzzy
@@ -1742,7 +1742,7 @@ msgstr "Oscail Rudaí Deireanacha"
 #, fuzzy
 msgctxt "File→Open Most Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Oscail..."
+msgstr "Oscail…"
 
 #: ../gui/filehandling.py:1446
 msgctxt "File→Open Next/Prev Scrap: error message"
@@ -1763,7 +1763,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
 msgid "_Open"
-msgstr "Oscail..."
+msgstr "Oscail…"
 
 #: ../gui/filehandling.py:1487
 msgctxt "File→Revert: status message: canvas has no filename yet"
@@ -2137,12 +2137,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2154,7 +2154,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2340,7 +2340,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2410,7 +2410,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/gl.po
+++ b/po/gl.po
@@ -513,17 +513,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
-msgstr "Novo grupo..."
+msgid "New Group…"
+msgstr "Novo grupo…"
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1185,12 +1185,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1373,7 +1373,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Open dragged file confirm dialog: continue button"
 msgid "_Open"
-msgstr "Abrir..."
+msgstr "Abrir…"
 
 #: ../gui/drawwindow.py:486
 msgid "Set current color"
@@ -1408,7 +1408,7 @@ msgid "_Quit"
 msgstr "Saír"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1458,7 +1458,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1646,13 +1646,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr "JPEG calidade 90% (*.jpg; *.jpeg)"
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Gardar"
 
@@ -1721,7 +1721,7 @@ msgstr "Ficheiro"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr "Abrir o bocexo seguinte"
 
 #: ../gui/filehandling.py:1099
@@ -1739,7 +1739,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Abrir..."
+msgstr "Abrir…"
 
 #: ../gui/filehandling.py:1427
 #, fuzzy
@@ -1751,7 +1751,7 @@ msgstr "Abrir un recente"
 #, fuzzy
 msgctxt "File→Open Most Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Abrir..."
+msgstr "Abrir…"
 
 #: ../gui/filehandling.py:1446
 #, fuzzy
@@ -1775,7 +1775,7 @@ msgstr "Abrir o bocexo anterior"
 #, fuzzy
 msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
 msgid "_Open"
-msgstr "Abrir..."
+msgstr "Abrir…"
 
 #: ../gui/filehandling.py:1487
 msgctxt "File→Revert: status message: canvas has no filename yet"
@@ -2149,13 +2149,13 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
-msgstr "Informe..."
+msgid "Report…"
+msgstr "Informe…"
 
 #: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
@@ -2166,8 +2166,8 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
-msgstr "Detalles..."
+msgid "Details…"
+msgstr "Detalles…"
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
@@ -2352,7 +2352,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2423,7 +2423,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/gl.po
+++ b/po/gl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-23 08:18+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Galician <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -19,27 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -47,39 +27,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -87,214 +67,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "gardar como predeterminado"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "Fondo"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "Patrón"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Cor"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "engadir cor aos patróns"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "borrancho"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr ""
+
+#: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr ""
 
-#: ../gui/brusheditor.py:359
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "Trazo"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Personalizado"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "Renomear o pincel"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "Xa existe un pincel con ese nome! "
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -333,142 +323,177 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Gardar"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Novo"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
-msgstr "Confirma que quere eliminar este pincel do disco?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
+msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "Xa existe un grupo con ese nome! "
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -476,58 +501,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "Novo grupo..."
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "Crear un grupo"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -536,51 +561,76 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr "Escolla unha cor"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "Escolla unha cor"
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -590,137 +640,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -728,162 +778,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -891,373 +933,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr "goma de borrar"
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Nome"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr "Restaurar o pincel %d"
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr "Gardar como o pincel %d"
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Desfacer"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Refacer"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1267,324 +1306,697 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Abrir..."
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Pantalla completa"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Saír"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+#, fuzzy
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr "Confirma que quere saír?"
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Saír"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr "Todos os formatos recoñecíbeis"
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr "OpenRaster (*.ora)"
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr "PNG (*.png)"
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr "JPEG (*.jpg; *.jpeg)"
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr "PNG transparente (*.png)"
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr "Múltiplos PNG transparentes (*.XXX.png)"
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr "JPEG calidade 90% (*.jpg; *.jpeg)"
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr "_Gardar como bocexo"
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "gardar como predeterminado"
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
+msgstr "Todos os formatos recoñecíbeis"
+
+#: ../gui/filehandling.py:432
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:437
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:442
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
+msgstr "JPEG (*.jpg; *.jpeg)"
+
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:494
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:502
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:506
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr "PNG transparente (*.png)"
+
+#: ../gui/filehandling.py:510
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr "Múltiplos PNG transparentes (*.XXX.png)"
+
+#: ../gui/filehandling.py:514
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr "Múltiplos PNG transparentes (*.XXX.png)"
+
+#: ../gui/filehandling.py:518
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr "JPEG calidade 90% (*.jpg; *.jpeg)"
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Gardar"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:668
+#, fuzzy
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr "Confirma que quere saír?"
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
+#: ../gui/filehandling.py:705
+#, fuzzy
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr "_Gardar como bocexo"
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr ""
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr ""
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Ficheiro"
+
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
+msgid "Open Scratchpad..."
+msgstr "Abrir o bocexo seguinte"
+
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Capas"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
 msgstr "Abrir..."
 
-#: ../gui/filehandling.py:552
-msgid "Open Scratchpad..."
-msgstr ""
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Abrir un recente"
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Abrir..."
+
+#: ../gui/filehandling.py:1446
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
 msgstr "Aínda non hai ficheiros de bocexo co nome «%s»."
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1455
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr "Abrir o bocexo seguinte"
+
+#: ../gui/filehandling.py:1463
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr "Abrir o bocexo anterior"
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Abrir..."
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Opacidade:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1592,130 +2004,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr "Fallo detectado"
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr "<big><b>Detectouse un erro de programación.</b></big>"
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1724,35 +2148,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr "Informe..."
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr "Detalles..."
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1776,45 +2200,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1822,153 +2250,219 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Capas"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Capas"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Opacidade:"
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "Renomear o pincel"
 
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr ""
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr ""
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr ""
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr ""
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 msgid "Stroke lead-in end"
 msgstr ""
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr ""
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1987,256 +2481,281 @@ msgstr ""
 "Este programa distribúese coa esperanza de que sexa útil, mais SEN NINGUNHA "
 "GARANTÍA. Vexa o ficheiro COPYING para ter máis detalles."
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr "programación"
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr "portabilidade"
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr "icona de escritorio"
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2244,188 +2763,214 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "Crear un grupo"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr "Combinar cara abaixo"
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Capas"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2434,13 +2979,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2450,7 +2995,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2458,13 +3003,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2472,7 +3017,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2480,7 +3025,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2491,7 +3036,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2499,7 +3044,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2509,7 +3059,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2520,285 +3070,395 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "Crear un grupo"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2808,7 +3468,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2817,52 +3497,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2884,17 +3595,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2923,112 +3632,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3041,7 +3725,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3082,6 +3766,134 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Nome"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Opacidade:"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3451,56 +4263,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3508,12 +4340,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3522,7 +4354,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3533,28 +4365,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3616,1828 +4448,2028 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
-msgstr "Gardar como bocexo"
+msgid "Export…"
+msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
-msgstr "Abrir o bocexo anterior"
+msgid "Save As Scrap"
+msgstr "Gardar como bocexo"
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
-msgstr "Abrir o bocexo seguinte"
+msgid "Open Previous Scrap"
+msgstr "Abrir o bocexo anterior"
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Open Next Scrap"
+msgstr "Abrir o bocexo seguinte"
+
+#: ../po/tmp/resources.xml.h:25
+msgctxt "Accel Editor (descriptions)"
+msgid "Load the scrap file after the current one."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Recover File from an Automated Backup…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:25
+#: ../po/tmp/resources.xml.h:27
 msgctxt "Accel Editor (descriptions)"
 msgid "Try to save and resume interrupted unsaved work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:26
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Reducir"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
-msgstr "Rotar en sentido antihorario"
-
-#: ../po/tmp/resources.xml.h:137
-msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:157
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the left."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr "Rotar en sentido horario"
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
-msgstr ""
+msgid "Rotate the canvas clockwise."
+msgstr "Rotar en sentido antihorario"
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr "Rotar en sentido antihorario"
+
+#: ../po/tmp/resources.xml.h:167
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr "Rotar en sentido antihorario"
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr "Só a capa actual"
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr "Visualizar o renderizado"
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Ficheiro"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "Pincel"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Axuda"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "Sobre o MyPaint"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Depurar"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
-msgstr ""
+msgstr "Capas"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "Escolla unha cor"
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "Escolla unha cor"
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "Escolla unha cor"
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""
+
+#~ msgctxt "brush list commands"
+#~ msgid "Really delete brush from disk?"
+#~ msgstr "Confirma que quere eliminar este pincel do disco?"

--- a/po/gu.po
+++ b/po/gu.po
@@ -513,17 +513,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1184,12 +1184,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1405,7 +1405,7 @@ msgid "_Quit"
 msgstr "બહાર નીકળો"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1455,7 +1455,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1632,13 +1632,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "આ રીતે સંગ્રહિત કરો"
 
@@ -1704,7 +1704,7 @@ msgstr "ફાઈલ"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -2125,12 +2125,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2142,7 +2142,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2328,7 +2328,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2398,7 +2398,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/gu.po
+++ b/po/gu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:18+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Gujarati <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -19,27 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -47,39 +27,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -87,214 +67,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "પ્રકાર"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "રંગ"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "વૈવિધ્ય"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -333,142 +323,177 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "આ રીતે સંગ્રહિત કરો"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "નવું"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -476,58 +501,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -536,51 +561,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -590,137 +639,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -728,162 +777,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -891,373 +932,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "નામ"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "છેલ્લી ક્રિયા રદ કરો"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "ફરી કરો"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1267,324 +1305,674 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "પૂર્ણ સ્ક્રીન"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "બહાર નીકળો"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "બહાર નીકળો"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
+msgstr ""
+
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
+msgstr ""
+
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "આ રીતે સંગ્રહિત કરો"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
 #, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr ""
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "ફાઈલ"
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "સ્તરો"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1412
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1427
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1432
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr ""
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1592,130 +1980,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1724,35 +2124,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1776,45 +2176,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1822,153 +2226,218 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "સ્તરો"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "સ્તરો"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr ""
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1980,256 +2449,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2237,188 +2731,213 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "સ્તરો"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2427,13 +2946,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2443,7 +2962,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2451,13 +2970,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2465,7 +2984,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2473,7 +2992,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2484,7 +3003,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2492,7 +3011,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2502,7 +3026,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2513,285 +3037,394 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr ""
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2801,7 +3434,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2810,52 +3463,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2877,17 +3561,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2916,112 +3598,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3034,7 +3691,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3075,6 +3732,133 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "નામ"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3444,56 +4228,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3501,12 +4305,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3515,7 +4319,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3526,28 +4330,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3609,1828 +4413,2019 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "નાનું કરો"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "ફાઈલ"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "મદદ"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "ડિબગ"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
-msgstr ""
+msgstr "સ્તરો"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/he.po
+++ b/po/he.po
@@ -82,7 +82,7 @@ msgstr "אין אפשרויות גיבוי זמינות"
 
 #: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
-msgstr "פתח את תיקיית המטמון …"
+msgstr "פתח את תיקיית המטמון…"
 
 #: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
@@ -522,18 +522,18 @@ msgstr "חבילת מברשות MyPaint (*.zip)"
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
-msgstr "קבוצה חדשה..."
+msgid "New Group…"
+msgstr "קבוצה חדשה…"
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
-msgstr "ייבוא מברשות..."
+msgid "Import Brushes…"
+msgstr "ייבוא מברשות…"
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
-msgstr "קבל עוד מברשות ..."
+msgid "Get More Brushes…"
+msgstr "קבל עוד מברשות…"
 
 #: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
@@ -1198,13 +1198,13 @@ msgstr "סוג"
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
-msgstr "השתמש עבור..."
+msgid "Use for…"
+msgstr "השתמש עבור…"
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
-msgstr "גלול..."
+msgid "Scroll…"
+msgstr "גלול…"
 
 #. Name and preview column: will be indented
 #: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
@@ -1386,7 +1386,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Open dragged file confirm dialog: continue button"
 msgid "_Open"
-msgstr "פתיחה..."
+msgstr "פתיחה…"
 
 #: ../gui/drawwindow.py:486
 msgid "Set current color"
@@ -1421,7 +1421,7 @@ msgid "_Quit"
 msgstr "יציאה"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1471,7 +1471,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1656,13 +1656,13 @@ msgstr ""
 
 #: ../gui/filehandling.py:576
 #, fuzzy
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr "תמיכה"
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "שמירה בשם…"
 
@@ -1731,7 +1731,7 @@ msgstr "קובץ"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr "לוח סרטוט"
 
 #: ../gui/filehandling.py:1099
@@ -1749,7 +1749,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "פתיחה..."
+msgstr "פתיחה…"
 
 #: ../gui/filehandling.py:1427
 #, fuzzy
@@ -1761,7 +1761,7 @@ msgstr "פתח אחרונים"
 #, fuzzy
 msgctxt "File→Open Most Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "פתיחה..."
+msgstr "פתיחה…"
 
 #: ../gui/filehandling.py:1446
 msgctxt "File→Open Next/Prev Scrap: error message"
@@ -1782,7 +1782,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
 msgid "_Open"
-msgstr "פתיחה..."
+msgstr "פתיחה…"
 
 #: ../gui/filehandling.py:1487
 msgctxt "File→Revert: status message: canvas has no filename yet"
@@ -2161,12 +2161,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2178,8 +2178,8 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
-msgstr "פרטים..."
+msgid "Details…"
+msgstr "פרטים…"
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
@@ -2366,7 +2366,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2437,7 +2437,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:18+0000\n"
 "Last-Translator: Yaron Shahrabani <sh.yaron@gmail.com>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -20,29 +20,7 @@ msgstr ""
 "n % 10 == 0) ? 2 : 3));\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr "<big><b>{accel_label}</b></big>"
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr "{action_label} {action_desc} {accel_label}"
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "פעולה"
 
@@ -50,39 +28,39 @@ msgstr "פעולה"
 msgid "Key combination"
 msgstr "צירוף מקשים"
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr "עריכת מקש עבור '%s'"
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "פעולה:"
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "נתיב:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "מקש:"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr "להקיש על מקשים כדי לעדכן את המשימה הזאת"
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "פעולה לא ידוע"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr "<b>{accel}כבר נעשה בשימוש עבור '{action}'. המשימה הקיימת תוחלף.</b>"
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr "פתח את התיקיה \"{folder_basename}\"…"
@@ -90,214 +68,225 @@ msgstr "פתח את התיקיה \"{folder_basename}\"…"
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "אישור"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr "לא נמצאו גיבויים במטמון."
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr "אין אפשרויות גיבוי זמינות"
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr "פתח את תיקיית המטמון …"
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr "שחזור גיבוי נכשל"
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr "פתח את תיקיית הגיבוי…"
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr "הקובץ המשוחזר מ .ora {iso_datetime}"
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "שמור כברירת מחדל"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "רקע"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "תבנית"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "צבע"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "להוסיף צבע לתבניות"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr "לא היתה אפשרות לטעון אחד או יותר רקעים"
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr "שגיאה בטעינת רקעים"
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
-msgstr "הסר בבקשה את הקבצים שאינם ניתנים להעברה, או בדוק את התקנת libgdkpixbuf."
+msgstr ""
+"הסר בבקשה את הקבצים שאינם ניתנים להעברה, או בדוק את התקנת libgdkpixbuf."
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr "Gdk-Pixbuf לא יכול לטעון \"{filename}\" ודיווח על \"{error}\""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr "{filename}יש גודל אפסי (w={w}, h={h})"
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr "עורך הגדרות מברשת"
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr "אודות"
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "ניסיוני"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr "בסיסי"
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr "אטימות"
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr "טפיחות"
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "מריחה"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr "מהירות"
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr ""
+
+#: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr "מעקב"
 
-#: ../gui/brusheditor.py:359
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "מכחול"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr "צבע"
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "הגדרות אישיות"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr "לא נבחרה מברשת, השתמש ב \"הוסף חדש\" במקום."
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr "לא נבחרה מברשת!"
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "שנה את שם המברשת"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "מברשת עם השם הזה כבר קיימת!"
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr "לא נבחרה מברשת!"
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr "האם באמת למחק מברשת “{brush_name}” מהדיסק?"
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr "(מברשת ללא שם)"
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr "{brush_name} [שלא נשמר]"
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr "סמל מברשת"
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr "סמל מברשת (עריכה)"
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr "אין מברשת מסומנת"
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr "<b>%s</b><small>בחר מברשת תקפה קודם</small>"
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr "<b>%s</b><i>(הותאם)</i><small>השינויים עדיין לא נשמרו</small>"
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr "<b>%s</b>(עריכה)<small>צבע עם מברשת או צבע</small>"
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -336,142 +325,182 @@ msgstr "אוטומטי"
 msgid "Use the default icon"
 msgstr "השתמש באיקון ברירת מחדל"
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "שמור"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr "שמור את סמל התצוגה המקדימה, וסיים את העריכה"
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr "אבידות ומציאות"
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr "נמחק"
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr "מועדפים"
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr "דיו"
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr "קלאסי"
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr "סט #1"
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr "סט #2"
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr "סט #3"
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr "סט #4"
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr "סט #5"
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr "ניסיוני"
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "חדש"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr "מברשת לא ידוע"
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr "הוסף למועדפים"
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr "הסר ממועדפים"
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr "שכפל"
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr "עריכת הגדרות מברשת"
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
-msgstr "מחק"
+#: ../gui/brushselectionwindow.py:250
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
+msgstr "שינוי שם קבוצה"
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
-msgstr "האם באמת למחק מברשת מהדיסק?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, fuzzy, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
+msgstr "האם באמת למחק מברשת “{brush_name}” מהדיסק?"
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] "%d מברשת"
 msgstr[1] "%d מברשות"
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr "קבוצת \"{group_name}\""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr "שינוי שם קבוצה"
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr "לייצא Brushset מכווצות"
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr "מחק קבוצה"
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr "שינוי שם קבוצה"
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "קבוצה בשם זה כבר קיים!"
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr "באמת למחוק קבוצת \"{group_name}\"?"
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -481,58 +510,58 @@ msgstr ""
 "לא היתה אפשרות למחוק את קבוצת \"{group_name}\".\n"
 "אין אפשרות למחוק כמה קבוצות מיוחדות."
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr "לייצא מברשות"
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr "חבילת מברשות MyPaint (*.zip)"
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "קבוצה חדשה..."
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr "ייבוא מברשות..."
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr "קבל עוד מברשות ..."
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "ליצור קבוצה"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr "לחצן"
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr "לחצן"
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr "לחיצה על לחצן"
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr "הוסף עטיפה חדשה"
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr "הסר את הכריכה הנוכחית"
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr "ערוך כריכה עבור '%s'"
@@ -541,52 +570,80 @@ msgstr "ערוך כריכה עבור '%s'"
 msgid "Button press:"
 msgstr "לחיצה על לחצן:"
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr "לחץ על לחצני שינוי, ולחץ על לחצן מעל לטקסט זה כדי להגדיר כריכה חדשה."
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr "{button}לא יכול להיות מחויב ללא מפתחות שינוי (משמעותו קבועה, מצטער)"
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr "{button_combination}כבר קשורה לפעולה '{action_name}'"
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr "בחר צבע"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr "הגדר את הצבע המשמש לציור"
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+#, fuzzy
+msgid "Set the color Hue used for painting"
+msgstr "הגדר את הצבע המשמש לציור"
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "בחר צבע"
+
+#: ../gui/colorpicker.py:296
+#, fuzzy
+msgid "Set the color Chroma used for painting"
+msgstr "הגדר את הצבע המשמש לציור"
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+#, fuzzy
+msgid "Set the color Luma used for painting"
+msgstr "הגדר את הצבע המשמש לציור"
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr "פרטי צבע"
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr "צבע המברשת הנוכחי, ואת הצבע שהיה בשימוש לאחרונה לצביעה"
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr "מסכת טווח פעילה"
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr "הגבל את הצבעים שלך עבור מצבי רוח ספציפיים באמצעות מסכת סולם."
@@ -596,137 +653,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr "פעיל"
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr "עזרה…"
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -734,162 +791,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr "כותרת:"
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr "עמודות:"
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr "מספר העמודות"
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr "שם הצבע:"
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr "שם הצבע הנוכחי"
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -897,373 +946,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr "הוספת שורה"
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr "הוספת עמודה"
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr "כל הקבצים (*)"
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr "כל הקבצים (*)"
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr "בחר צבע מהמסך"
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr "G"
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr "B"
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr "H"
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr "C"
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr "Y"
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr "מחק"
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr "מקלדת"
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr "עכבר"
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr "עט"
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr "משטח מגע"
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr "מסך מגע"
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr "להתעלם"
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr "כל משימה"
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr "ניווט בלבד"
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr "זום"
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr "התקן"
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr "צירים"
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr "סוג"
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr "השתמש עבור..."
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr "גלול..."
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "שם"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr "החלף"
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr "שנה שם"
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr "מברשת קיימת"
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr "לייבא חבילת מברשות?"
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr "שחזור מברשת %d"
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr "בטל את %s"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "בטל"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "בצע שוב"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1273,324 +1319,696 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
-msgstr "שם שכבה"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
+msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "פתיחה..."
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "מסך-מלא"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
+#: ../gui/drawwindow.py:675
+#, fuzzy
+msgctxt "Quit confirm dialog: title"
+msgid "Really Quit?"
+msgstr "באמת להמשיך?"
+
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
 msgstr "יציאה"
 
-#: ../gui/drawwindow.py:740
-msgid "Really Quit?"
-msgstr ""
-
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr "אין אפשרות לטעון \"{file_basename}\"."
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr "איקון"
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr "ללא תיאור"
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
+#: ../gui/filehandling.py:126
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
+msgstr "טוען \"{file_basename}\"…"
+
+#: ../gui/filehandling.py:130
+#, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:134
+#, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:138
+#, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:145
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr "לא ניתן לייצא ל- \"{file_basename}\"."
+
+#: ../gui/filehandling.py:149
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr "שמירת \"{file_basename}\" נכשלה."
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr "אין אפשרות לטעון \"{file_basename}\"."
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "שמור כברירת מחדל"
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: ../gui/filehandling.py:221
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
+msgstr "טוען \"{file_basename}\"…"
+
+#: ../gui/filehandling.py:427
+msgctxt "save/load dialogs: filter patterns"
 msgid "All Recognized Formats"
 msgstr ""
 
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
+#: ../gui/filehandling.py:432
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "OpenRaster (*.ora)"
 msgstr "OpenRaster (*.ora)"
 
-#: ../gui/filehandling.py:95
+#: ../gui/filehandling.py:437
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "PNG (*.png)"
-msgstr ""
+msgstr "PNG שקוף (*.png)"
 
-#: ../gui/filehandling.py:96
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
 msgid "JPEG (*.jpg; *.jpeg)"
 msgstr ""
 
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
 msgid "By extension (prefer default format)"
 msgstr ""
 
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
+#: ../gui/filehandling.py:494
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
 msgstr "PNG שקוף (*.png)"
 
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:113
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
 msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr "שמור..."
+#: ../gui/filehandling.py:576
+#, fuzzy
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr "תמיכה"
 
-#: ../gui/filehandling.py:177
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "שמירה בשם…"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
 msgid "Format to save as:"
 msgstr ""
 
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr "לאשר"
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
+#: ../gui/filehandling.py:668
+#, fuzzy
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
 msgstr "באמת להמשיך?"
 
-#: ../gui/filehandling.py:234
-#, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
 msgstr ""
 
-#: ../gui/filehandling.py:282
-#, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
-msgstr "טוען \"{file_basename}\"…"
-
-#: ../gui/filehandling.py:296
-#, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
-msgstr "אין אפשרות לטעון \"{file_basename}\"."
-
-#: ../gui/filehandling.py:321
-#, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:734
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
 msgstr ""
 
-#: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
-msgstr "לא ניתן לייצא ל- \"{file_basename}\"."
-
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
-msgstr "שמירת \"{file_basename}\" נכשלה."
-
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr "פתח…"
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "קובץ"
+
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
+msgid "Open Scratchpad..."
+msgstr "לוח סרטוט"
+
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "שכבות"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
 msgstr "פתיחה..."
 
-#: ../gui/filehandling.py:552
-msgid "Open Scratchpad..."
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "פתח אחרונים"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "פתיחה..."
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "פתיחה..."
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+#, fuzzy
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr "שחזר"
+
+#: ../gui/fill.py:121
+#, fuzzy
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
-msgstr ""
+msgstr "מילוי"
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+#, fuzzy
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr "התאם לתצוגה"
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
-msgstr ""
+msgstr "קבוצת שכבות חדשה"
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr ""
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "מחק שכבה"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1598,130 +2016,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr "מופעל"
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr "אינץ'"
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr "סמ'"
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr "ממ'"
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr "ציור Freehand"
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr "חלק:"
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1730,35 +2160,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr "התעלם מהשגיאה"
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr "פרטים..."
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1782,45 +2212,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr "להזיז שכבה"
 
@@ -1828,155 +2262,224 @@ msgstr "להזיז שכבה"
 msgid "Move the current layer"
 msgstr "להזיז את השכבה הנוכחית"
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+#, fuzzy
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr "%s: עריכת מאפיינים"
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr "גלוי"
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "שכבה"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+#, fuzzy
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr "נעול"
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, fuzzy, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr "שם שכבה"
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "שכבות"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr "סדר שכבות ולהקצות אפקטים"
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr "שכבה"
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
-msgstr "מצב:"
-
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
-msgstr "מצב מיזוג: איך השכבה הנוכחית משלבת עם השכבות שמתחת."
-
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/linemode.py:37
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "שנה שם"
+
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr ""
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr ""
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr ""
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr ""
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 msgid "Stroke lead-in end"
 msgstr ""
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr ""
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr "קווים ועקומות"
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr "קווים מחוברים"
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr "אליפסות ועיגולים"
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
+#, fuzzy
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 "זכויות יוצרים (C) 2005-2015\n"
 "מרטין ריינולדס, וצוות הפיתוח MyPaint"
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1988,256 +2491,285 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr "תכנות"
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr "ניהול פרויקט"
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr "מברשות"
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr "תיעוד"
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr "תמיכה"
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr "קהילה"
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr "גודל:"
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr "אפשרויות הכלי"
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr "<b>{mode_name}</b>"
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr "אין אפשרויות זמינות"
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr "תקריב: %.01f%%"
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr "בחר צבע…"
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr "העדפות"
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr "הפריט הקודם"
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr "הפריט הבא"
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
+#, fuzzy
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr "מיקום:"
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr "מיקום:"
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr "אלפא:"
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+#, fuzzy
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr "מיקום:"
+
+#: ../gui/symmetry.py:477
+#, fuzzy
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr "מיקום:"
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2245,188 +2777,214 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr "<b>MyPaint</b>"
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
-msgstr "%s: עריכת מאפיינים"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
+msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr "פקודה לא ידועה"
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr "לא מוגדר (הפקודה לא החלה עדיין)"
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr "חיתוך שכבה"
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "שינוי שם קבוצה"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr "ריקון שכבה"
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr "הדבקת שכבה"
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "שכבות"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2435,13 +2993,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2451,7 +3009,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2459,13 +3017,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2473,7 +3031,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2481,7 +3039,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2492,7 +3050,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2500,7 +3058,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2510,7 +3073,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2521,285 +3084,400 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
-msgctxt "layer default names"
-msgid "Vector Layer"
-msgstr ""
-
 #: ../lib/layer/data.py:1153
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Vectors"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
+#: ../lib/layer/data.py:1158
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Vector Layer"
+msgstr "ריקון שכבה"
+
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Data Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr "פעולה לא ידוע"
+
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "שכבת צביעה חדשה"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "קבוצת שכבות חדשה"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+#, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "תצוגה"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+#, fuzzy
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr "להזיז שכבה"
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2809,7 +3487,28 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+#, fuzzy
+msgid "Rotational"
+msgstr "תיעוד"
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2818,52 +3517,84 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr "מחק"
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2885,17 +3616,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2924,113 +3653,89 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr "<ymin>"
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr "<ymax>"
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr "<xmin>"
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr "<xmax>"
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
 msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+#, fuzzy
+msgid "<big><b>No Brush Dynamics</b></big>"
+msgstr "<big><b>{accel_label}</b></big>"
 
 #: ../po/tmp/inktool.glade.h:1
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
@@ -3042,7 +3747,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3083,6 +3788,137 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+#, fuzzy
+msgid "Insert Point"
+msgstr "הוספת שורה"
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "שם"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr "מצב:"
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "אטימות"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr "הסר את הכריכה הנוכחית"
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3452,56 +4288,77 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+#, fuzzy
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr "מופעל"
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3509,12 +4366,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3523,7 +4380,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3534,28 +4391,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3617,1828 +4474,2069 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
-msgstr "שמירה"
+msgid "Import Layers…"
+msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
-msgstr "שמירה בשם…"
+msgid "Save"
+msgstr "שמירה"
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
-msgstr ""
+msgid "Save As…"
+msgstr "שמירה בשם…"
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "מחיקת תוכן השכבה"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+#, fuzzy
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr "אפשרויות הכלי"
+
+#: ../po/tmp/resources.xml.h:76
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
-msgstr ""
+msgstr "חיתוך שכבה"
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "קבוצת שכבות חדשה"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "קבוצת שכבות חדשה"
+
+#: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:71
+#: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Edit Layer in External App…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
-msgstr "שכבת צביעה חדשה"
-
-#: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:85
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
-msgstr "קבוצת שכבות חדשה"
-
-#: ../po/tmp/resources.xml.h:86
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:87
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:88
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:89
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
-msgstr "מחק שכבה"
+msgid "New Painting Layer"
+msgstr "שכבת צביעה חדשה"
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr "קבוצת שכבות חדשה"
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr "מחק שכבה"
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr "התאם לתצוגה"
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "התרחק"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+#, fuzzy
+msgid "Delete Point"
+msgstr "מחק קבוצה"
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "קובץ"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "יציאה"
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "עריכה"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "צבעים"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "שכבה"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr "לוח סרטוט"
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "חלון"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "מברשת"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "שנה מברשת…"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "שנה צבע…"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "שנה צבע (תת קבוצה)…"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr "קבל עוד מברשות…"
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "עזרה"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr "עזרה אונליין"
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "אודות MyPaint"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "ניפוי שגיאות"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "תצוגה"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "מסך מלא"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "ערוך העדפות"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr "עורך הגדרות מברשת"
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr "מסך שכבות"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr "הצג מסך שכבות"
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "פלטת צבעים"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr "הצג פנקס רשימות"
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr "תצוגת מסך מקדימה"
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "תצוגה מקדימה"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr "מסך אפשרויות כלי"
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr "הצג את מסך אפשרויות הכלי"
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr "מסך היסטוריית המברשת והצבע"
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr "מברשות וצבע שהשתמשת בהם לאחרונה"
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr "יד חופשית"
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr "יד חופשית"
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr "קווים ועקומות"
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr "קווים מחוברים"
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr "אליפסות ועיגולים"
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr "סימן בדיו"
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr "מיקום מחדש של השכבה"
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr "ערוך שכבה"
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "ערוך סימטריית ציור"
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "בחר צבע"
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "בחר צבע"
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "בחר צבע"
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr "בחר צבע"
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr "מילוי"
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""
+
+#~ msgctxt "Accelerator map editor: action column markup"
+#~ msgid ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+#~ msgstr ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+
+#~ msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
+#~ msgid "{action_label} {action_desc} {accel_label}"
+#~ msgstr "{action_label} {action_desc} {accel_label}"
+
+#~ msgctxt "brush list commands"
+#~ msgid "Really delete brush from disk?"
+#~ msgstr "האם באמת למחק מברשת מהדיסק?"
+
+#~ msgid "Pick a color from the screen"
+#~ msgstr "בחר צבע מהמסך"
+
+#~ msgid "Save..."
+#~ msgstr "שמור..."
+
+#~ msgid "Confirm"
+#~ msgstr "לאשר"
+
+#~ msgid ""
+#~ "Blending mode: how the current layer combines with the layers underneath "
+#~ "it."
+#~ msgstr "מצב מיזוג: איך השכבה הנוכחית משלבת עם השכבות שמתחת."
+
+#~ msgid "<ymin>"
+#~ msgstr "<ymin>"
+
+#~ msgid "<ymax>"
+#~ msgstr "<ymax>"
+
+#~ msgid "<xmin>"
+#~ msgstr "<xmin>"
+
+#~ msgid "<xmax>"
+#~ msgstr "<xmax>"

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-08-24 13:23+0000\n"
 "Last-Translator: leela <53352@protonmail.com>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/mypaint/mypaint/hi/"
@@ -19,27 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.9-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -47,39 +27,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -87,214 +67,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "रंग"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "मनपसंद"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -333,142 +323,177 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "सहेजें"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "नया"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -476,58 +501,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -536,51 +561,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -590,137 +639,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -728,162 +777,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -891,373 +932,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "नाम"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "पहले जैसा"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "दोहराएँ"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1267,324 +1305,679 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "खोलें..."
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "फूलस्क्रीन"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "बाहर जाएँ"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "बाहर जाएँ"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "खोलें..."
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "सहेजें"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr ""
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr ""
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "फ़ाइल"
+
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "परतें"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "खोलें..."
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "हाल ही का खोलें"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "खोलें..."
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "खोलें..."
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "अपारदर्शिता:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1592,130 +1985,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1724,35 +2129,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1776,45 +2181,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1822,153 +2231,218 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "परतें"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "परतें"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "अपारदर्शिता:"
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1980,256 +2454,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2237,188 +2736,213 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "परतें"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2427,13 +2951,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2443,7 +2967,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2451,13 +2975,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2465,7 +2989,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2473,7 +2997,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2484,7 +3008,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2492,7 +3016,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2502,7 +3031,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2513,285 +3042,394 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr ""
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2801,7 +3439,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2810,52 +3468,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2877,17 +3566,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2916,112 +3603,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3034,7 +3696,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3075,6 +3737,134 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "नाम"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "अपारदर्शिता:"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3444,56 +4234,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3501,12 +4311,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3515,7 +4325,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3526,28 +4336,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3609,1828 +4419,2019 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "ज़ूम आउट"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "फ़ाइल"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "मदद"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "डिबग"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
-msgstr ""
+msgstr "परतें"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/hi.po
+++ b/po/hi.po
@@ -513,17 +513,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1184,12 +1184,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1372,7 +1372,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Open dragged file confirm dialog: continue button"
 msgid "_Open"
-msgstr "खोलें..."
+msgstr "खोलें…"
 
 #: ../gui/drawwindow.py:486
 msgid "Set current color"
@@ -1406,7 +1406,7 @@ msgid "_Quit"
 msgstr "बाहर जाएँ"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1456,7 +1456,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1633,13 +1633,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "सहेजें"
 
@@ -1705,7 +1705,7 @@ msgstr "फ़ाइल"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -1723,7 +1723,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "खोलें..."
+msgstr "खोलें…"
 
 #: ../gui/filehandling.py:1427
 #, fuzzy
@@ -1735,7 +1735,7 @@ msgstr "हाल ही का खोलें"
 #, fuzzy
 msgctxt "File→Open Most Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "खोलें..."
+msgstr "खोलें…"
 
 #: ../gui/filehandling.py:1446
 msgctxt "File→Open Next/Prev Scrap: error message"
@@ -1756,7 +1756,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
 msgid "_Open"
-msgstr "खोलें..."
+msgstr "खोलें…"
 
 #: ../gui/filehandling.py:1487
 msgctxt "File→Revert: status message: canvas has no filename yet"
@@ -2130,12 +2130,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2147,7 +2147,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2333,7 +2333,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2403,7 +2403,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/hr.po
+++ b/po/hr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:18+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Croatian <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -16,31 +16,11 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<="
-"4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -48,39 +28,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -88,214 +68,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Boja"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Prilagodi"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -334,98 +324,133 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Spremi"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Novo"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
@@ -433,44 +458,44 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -478,58 +503,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -538,51 +563,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -592,137 +641,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -730,162 +779,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -893,373 +934,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Ime"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Poništi"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Ponovi"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1269,324 +1307,679 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Otvori..."
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Cijeli zaslon"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Izlaz"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Izlaz"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Otvori..."
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Spremi"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr ""
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr ""
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Datoteka"
+
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Otvori..."
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Otvori nedavno"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Otvori..."
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Otvori..."
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Prozirnost:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1594,130 +1987,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1726,35 +2131,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1778,45 +2183,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1824,153 +2233,217 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr ""
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr ""
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Prozirnost:"
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1982,256 +2455,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2239,188 +2737,212 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+msgid "Import Layers"
+msgstr ""
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2429,13 +2951,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2445,7 +2967,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2453,13 +2975,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2467,7 +2989,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2475,7 +2997,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2486,7 +3008,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2494,7 +3016,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2504,7 +3031,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2515,285 +3042,394 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr ""
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2803,7 +3439,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2812,52 +3468,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2879,17 +3566,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2918,112 +3603,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3036,7 +3696,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3077,6 +3737,134 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Ime"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Prozirnost:"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3446,56 +4234,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3503,12 +4311,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3517,7 +4325,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3528,28 +4336,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3611,1828 +4419,2018 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Umanji"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Datoteka"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Pomoć"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/hr.po
+++ b/po/hr.po
@@ -515,17 +515,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1186,12 +1186,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1374,7 +1374,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Open dragged file confirm dialog: continue button"
 msgid "_Open"
-msgstr "Otvori..."
+msgstr "Otvori…"
 
 #: ../gui/drawwindow.py:486
 msgid "Set current color"
@@ -1408,7 +1408,7 @@ msgid "_Quit"
 msgstr "Izlaz"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1458,7 +1458,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1636,13 +1636,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Spremi"
 
@@ -1708,7 +1708,7 @@ msgstr "Datoteka"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -1725,7 +1725,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Otvori..."
+msgstr "Otvori…"
 
 #: ../gui/filehandling.py:1427
 #, fuzzy
@@ -1737,7 +1737,7 @@ msgstr "Otvori nedavno"
 #, fuzzy
 msgctxt "File→Open Most Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Otvori..."
+msgstr "Otvori…"
 
 #: ../gui/filehandling.py:1446
 msgctxt "File→Open Next/Prev Scrap: error message"
@@ -1758,7 +1758,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
 msgid "_Open"
-msgstr "Otvori..."
+msgstr "Otvori…"
 
 #: ../gui/filehandling.py:1487
 msgctxt "File→Revert: status message: canvas has no filename yet"
@@ -2132,12 +2132,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2149,7 +2149,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2334,7 +2334,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2404,7 +2404,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/hu.po
+++ b/po/hu.po
@@ -519,18 +519,18 @@ msgstr "MyPaint ecsetcsomag (*.zip)"
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
-msgstr "Új csoport..."
+msgid "New Group…"
+msgstr "Új csoport…"
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
-msgstr "Ecsetek importálása..."
+msgid "Import Brushes…"
+msgstr "Ecsetek importálása…"
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
-msgstr "További ecsetek beszerzése..."
+msgid "Get More Brushes…"
+msgstr "További ecsetek beszerzése…"
 
 #: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
@@ -1203,13 +1203,13 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
-msgstr "Görgetés..."
+msgid "Scroll…"
+msgstr "Görgetés…"
 
 #. Name and preview column: will be indented
 #: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
@@ -1395,7 +1395,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Open dragged file confirm dialog: continue button"
 msgid "_Open"
-msgstr "Megnyitás..."
+msgstr "Megnyitás…"
 
 #: ../gui/drawwindow.py:486
 msgid "Set current color"
@@ -1430,8 +1430,8 @@ msgid "_Quit"
 msgstr "Kilépés"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
-msgstr "Ecsetcsomag importálása..."
+msgid "Import brush package…"
+msgstr "Ecsetcsomag importálása…"
 
 #: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
@@ -1480,8 +1480,8 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
-msgstr "Megnyitás..."
+msgid "Open With…"
+msgstr "Megnyitás…"
 
 #: ../gui/externalapp.py:123
 msgid "Icon"
@@ -1674,13 +1674,13 @@ msgstr "JPEG 90%-os minőség (*.jpg; *.jpeg)"
 
 #: ../gui/filehandling.py:576
 #, fuzzy
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr "Exportálás…"
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Mentés másként…"
 
@@ -1740,7 +1740,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open: confirm dialog: continue button"
 msgid "_Open…"
-msgstr "Megnyitás..."
+msgstr "Megnyitás…"
 
 #: ../gui/filehandling.py:1015
 #, fuzzy
@@ -1751,8 +1751,8 @@ msgstr "Legutóbbi fájlok megnyitása"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
-msgstr "Vázlattömb megnyitása..."
+msgid "Open Scratchpad…"
+msgstr "Vázlattömb megnyitása…"
 
 #: ../gui/filehandling.py:1099
 #, fuzzy
@@ -1769,7 +1769,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Megnyitás..."
+msgstr "Megnyitás…"
 
 #: ../gui/filehandling.py:1427
 #, fuzzy
@@ -1781,7 +1781,7 @@ msgstr "Legutóbbi megnyitása"
 #, fuzzy
 msgctxt "File→Open Most Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Megnyitás..."
+msgstr "Megnyitás…"
 
 #: ../gui/filehandling.py:1446
 #, fuzzy
@@ -1805,7 +1805,7 @@ msgstr "Előző vázlat betöltése"
 #, fuzzy
 msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
 msgid "_Open"
-msgstr "Megnyitás..."
+msgstr "Megnyitás…"
 
 #: ../gui/filehandling.py:1487
 msgctxt "File→Revert: status message: canvas has no filename yet"
@@ -2185,13 +2185,13 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
-msgstr "Jelentés..."
+msgid "Report…"
+msgstr "Jelentés…"
 
 #: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
@@ -2202,8 +2202,8 @@ msgid "Quit MyPaint"
 msgstr "Névjegy"
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
-msgstr "Részletek..."
+msgid "Details…"
+msgstr "Részletek…"
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
@@ -2391,8 +2391,8 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
-msgstr "Rétegek átrendezése a veremben..."
+msgid "Move layer in stack…"
+msgstr "Rétegek átrendezése a veremben…"
 
 #: ../gui/layerswindow.py:110
 msgid ""
@@ -2462,7 +2462,7 @@ msgid "Stroke trail-off beginning"
 msgstr "Ecsetvonás levezető részének kezdete"
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777
@@ -4509,7 +4509,7 @@ msgstr ""
 #: ../po/tmp/resources.xml.h:5
 msgctxt "Toolbar (short labels)"
 msgid "Open"
-msgstr "Megnyitás..."
+msgstr "Megnyitás…"
 
 #: ../po/tmp/resources.xml.h:6
 msgctxt "Toolbar (tooltips), Accel Editor (descriptions)"

--- a/po/hu.po
+++ b/po/hu.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MyPaint git\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:19+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Hungarian <https://hosted.weblate.org/projects/mypaint/"
@@ -18,27 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "Művelet"
 
@@ -46,39 +26,39 @@ msgstr "Művelet"
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr "„%s” hozzárendelésének szerkesztése"
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "Művelet:"
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "Elérési út:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "Kulcs:"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr "Nyomd meg a billentyűket a hozzárendelés beállításához"
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "Ismeretlen tevékenység"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr "Nyitott mappa “{folder_basename} 1”…"
@@ -86,217 +66,227 @@ msgstr "Nyitott mappa “{folder_basename} 1”…"
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "Oké"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "Mentés alapértelmezettként"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "Háttér"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "Minta"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Szín"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "Szín hozzáadása a mintákhoz"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr "Egy, vagy több hátteret nem lehetett betölteni"
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr "Hiba a hátterek betöltése közben"
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 "Távolítsd el a be nem tölthető fájlokat, vagy ellenőrízd a libgdkpixbuf "
 "telepítésedet."
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr "A Gdk-Pixbuf nem tudta betölteni a „{filename}” fájt, az ok „{error}”"
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr "Ecsetbeállítás szerkesztő"
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "Kísérleti"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr "Alap"
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr "Átlátszatlanság"
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr "Foltok"
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "Elkenés"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr "Sebesség"
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr ""
+
+#: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr "Követés"
 
-#: ../gui/brusheditor.py:359
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "Vonás"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr "Szín"
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Saját"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 "Nincsen kiválasztott ecset, használd inkább a „Hozzáadás újként” gombot ."
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr "Nem választottál ecsetet!"
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "Ecset átnevezése"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "Már létezik ilyen nevű ecset!"
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr "Nem választottál ecsetet!"
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr "(névtelen ecset)"
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr "Ecsetikon szerkesztése"
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr "Ecsetbeállítások"
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr "Nem választottál ecsetet"
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -335,142 +325,181 @@ msgstr ""
 msgid "Use the default icon"
 msgstr "Visszaállítás az alapértelmezett értékre"
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Mentés"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr "Megkerült"
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr "Törölt"
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr "Kedvencek"
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr "Tinta"
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr "Klasszikus"
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr "1.Készlet"
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr "2.Készlet"
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr "3.Készlet"
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr "4.Készlet"
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr "5.Készlet"
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr "Kísérleti"
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Új"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr "Ismeretlen ecset"
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr "Kedvencek"
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr "Minden szín eltávolítása"
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr "Aktív ecset beállításainak szerkesztése"
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
-msgstr "Törlés"
+#: ../gui/brushselectionwindow.py:250
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
+msgstr "Csoport átnevezése"
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
-msgstr "Valóban törli ezt az ecsetet?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
+msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr "Csoport átnevezése"
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr "Csoport törlése"
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr "Csoport átnevezése"
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "Már létezik ilyen nevű csoport!"
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -478,58 +507,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr "Ecsetek exportálása"
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr "MyPaint ecsetcsomag (*.zip)"
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "Új csoport..."
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr "Ecsetek importálása..."
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr "További ecsetek beszerzése..."
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "Csoport létrehozása"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr "Gombok"
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr "Gombok"
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr "Gomb"
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr "Új hozzárendelés"
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr "Jelenlegi hozzárendelés törlése"
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr "„%s” hozzárendelésének szerkesztése"
@@ -538,7 +567,7 @@ msgstr "„%s” hozzárendelésének szerkesztése"
 msgid "Button press:"
 msgstr "Megnyomott gomb:"
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
@@ -546,45 +575,73 @@ msgstr ""
 "Tarsd lenyomva a módosító billenytűket és e fölött a szöveg felett nyomd meg "
 "a gombot a hozzárendelés létrehozásához."
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr "Szín mintavétel"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr "Festéshez használt szín beállítása"
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+#, fuzzy
+msgid "Set the color Hue used for painting"
+msgstr "Festéshez használt szín beállítása"
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "Színmintavétel"
+
+#: ../gui/colorpicker.py:296
+#, fuzzy
+msgid "Set the color Chroma used for painting"
+msgstr "Festéshez használt szín beállítása"
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+#, fuzzy
+msgid "Set the color Luma used for painting"
+msgstr "Festéshez használt szín beállítása"
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr "Szín részletei"
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr "Az újonnan választott szín és a festéshez legutóbb használt szín"
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr "A színskála-maszk aktív"
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr "A paletta korlátozása különböző hangulatokra színskála-maszkka."
@@ -594,7 +651,7 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr "HCY Árnyalat és Chroma."
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
@@ -603,34 +660,34 @@ msgstr ""
 "Színskála-maszk szerkesztő. Kattints középre a forma kezeléséhez, vagy "
 "forgasd a maszkot a kör szélét használva."
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr "Atmoszferikus triád"
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr "Eltolt triád"
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr "Erősen a domináns szín felé súlyozva."
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr "Komplementer"
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
@@ -639,12 +696,12 @@ msgstr ""
 "Egymással kontrasztot alkotó ellentétek, amiket a középen lévő semlegesek "
 "egyensúlyoznak ki."
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr "Hangulat és kiemelés"
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
@@ -653,12 +710,12 @@ msgstr ""
 "Egy fő színskála egy komplementer kiemelőszínnel, ami változatosságot és "
 "hangsúlyozást biztosíthat."
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr "Osztott komplementer"
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
@@ -666,72 +723,72 @@ msgid ""
 msgstr ""
 "Két analóg szín és ezek egy komplementere, másodlagos színekkel közöttük."
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr "Új színskála-maszk sablonból"
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr "Színskála-maszk szerkesztő"
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr "Aktív"
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr "Súgó…"
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr "Maszk létrehozása sablonból."
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr "Maszk betöltése GIMP paletta fájlból."
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr "Maszk mentése GIMP paletta fájlba."
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr "Maszk törlése."
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr "Maszk mentése GIMP palettaként"
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr "Maszk betöltése GIMP paletta fájlból"
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr "Színskála-maszk maszk beállítása."
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr "HCY kerék"
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -739,162 +796,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr "HSV Árnyalat"
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr "HSV Telítettség"
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr "HSV Érték"
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr "HSV Telítettség és Érték"
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr "HSV Árnyalat és Érték"
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr "HSV Árnyalat és Telítettség"
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr "Kocka forgatása (más tengelyek mutatása)"
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr "HSV kocka"
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr "Egy HSV kocka, ami forgatáskor különböző síkmetszeteket mutat."
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr "Négyzet"
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr "Egy HSV kocka, ami forgatáskor különböző síkmetszeteket mutat."
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr "HSV háromszög"
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr "A standard GTK színválasztó"
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr "HSV kerék"
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr "Telítettség és Érték színmódosító."
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr "Paletta tulajdonságai"
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr "Paletta"
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr "Szín beállítása egy betölthető, szerkeszthető palettából."
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr "Névtelen réteg #%d"
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr "Palettaszerkesztő"
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr "Betöltés GIMP palettafájlból"
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr "Mentés GIMP paletta fájlba"
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr "Új üres hely hozzáadása"
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr "Jelenlegi szín eltávolítása"
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr "Minden szín eltávolítása"
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr "A paletta neve, vagy leírása"
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr "Oszlopok:"
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr "Oszlopok száma"
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr "Szín neve:"
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr "Jelenlegi szín neve"
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr "Üres palettahely"
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr "Paletta betöltése"
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr "Paletta mentése"
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -902,375 +951,374 @@ msgid ""
 "drag them to organize."
 msgstr "Színpaletta. Ejts ide színeket és rendezd át őket húzással."
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr "Üres palettacella (húzz ide egy színt)"
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "GIMP paletta fájl (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr "Minden fájl (*)"
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "GIMP paletta fájl (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr "Minden fájl (*)"
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr "Szín kijelölése a képernyőről"
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr "Komponens-csúszkák"
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr "A szín komponenseinek állítása."
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr "RGB Vörös"
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr "RGB Zöld"
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr "RGB kék"
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr "HSV Árnyalat"
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr "HSV Telítettség"
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr "HSV Érték"
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr "HSV Árnyalat"
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr "HCY Árnyalat és Chroma"
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr "Színváltó ablak (koncentrikus körök)."
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr "Radír"
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr "Mozgatás"
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr "Teljes képernyő"
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr "Nagyítás"
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr "Mozgatás"
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr "Eszköz"
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr "Görgetés..."
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Név"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr "Felülírod az ecsetet?"
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr "Csere"
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr "Átnevezés"
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr "Összes lecserélése"
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr "Az összes átnevezése"
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr "Importált ecset"
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr "Létező ecset"
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 "<b>A „%s” nevű ecset már létezik.</b>\n"
 "Ki szeretnéd cserélni, vagy az új ecset kapjon más nevet?"
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr "Felülírja az ecsetcsoportot?"
 
-#: ../gui/dialogs.py:190
-#, python-brace-format
+#: ../gui/dialogs.py:220
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
+"<b>A „%s” nevű ecset már létezik.</b>\n"
+"Ki szeretnéd cserélni, vagy az új ecset kapjon más nevet?"
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr "Importálod az ecsetcsomagot?"
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, fuzzy, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr "<b>Biztosan importálod a „%s” csomagot?</b>"
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr "%d. ecset visszaállítása"
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr "Mentés %d. ecsetként"
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr "%s visszavonása"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Visszavonás"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr "%s újra"
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Újra"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1280,324 +1328,711 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
-msgstr "Réteg neve"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
+msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr "MyPaint"
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Megnyitás..."
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr "Jelenlegi szín beállítása"
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr "Teljes képernyős mód elhagyása"
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr "Teljes képernyős mód elhagyása"
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr "Teljes képernyős mód"
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Teljes képernyő"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Kilépés"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+#, fuzzy
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr "Valóban ki szeretnél lépni?"
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Kilépés"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr "Ecsetcsomag importálása..."
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr "MyPaint ecsetcsomag (*.zip)"
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr "Megnyitás..."
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr "Minden felismert formátum"
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr "OpenRaster (*.ora)"
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr "PNG (*.png)"
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr "JPEG (*.jpg; *.jpeg)"
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr "Kiterjesztés szerint (lehetőleg az alapértelmezett formátum)"
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr "PNG háttérrel (*.png)"
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr "Átlátszó PNG (*.png)"
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr "Több átlátszó PNG (*.XXX.png)"
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr "JPEG 90%-os minőség (*.jpg; *.jpeg)"
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr "Mentés.."
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr "Mentési formátum:"
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr "Elfogadás"
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr "Biztosan folytatod?"
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr "Menté_s vázlatként"
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "Paletta mentése"
+
+#: ../gui/filehandling.py:168
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr "Exportálás fájlba"
+
+#: ../gui/filehandling.py:172
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr "Exportálás fájlba"
+
+#: ../gui/filehandling.py:176
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr "Legutóbbi fájlok megnyitása"
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
+msgstr "Minden felismert formátum"
+
+#: ../gui/filehandling.py:432
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:437
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:442
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
+msgstr "JPEG (*.jpg; *.jpeg)"
+
+#: ../gui/filehandling.py:490
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
+msgstr "Kiterjesztés szerint (lehetőleg az alapértelmezett formátum)"
+
+#: ../gui/filehandling.py:494
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:498
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr "PNG háttérrel (*.png)"
+
+#: ../gui/filehandling.py:502
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:506
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr "Átlátszó PNG (*.png)"
+
+#: ../gui/filehandling.py:510
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr "Több átlátszó PNG (*.XXX.png)"
+
+#: ../gui/filehandling.py:514
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr "Több átlátszó PNG (*.XXX.png)"
+
+#: ../gui/filehandling.py:518
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr "JPEG 90%-os minőség (*.jpg; *.jpeg)"
+
+#: ../gui/filehandling.py:576
+#, fuzzy
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr "Exportálás…"
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Mentés másként…"
+
+#: ../gui/filehandling.py:601
+#, fuzzy
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr "Mentési formátum:"
+
+#: ../gui/filehandling.py:668
+#, fuzzy
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr "Biztosan folytatod?"
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:705
+#, fuzzy
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr "Menté_s vázlatként"
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
 msgstr ""
 
-#: ../gui/filehandling.py:454
+#: ../gui/filehandling.py:734
 #, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
 msgstr "Megnyitás..."
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Legutóbbi fájlok megnyitása"
+
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr "Vázlattömb megnyitása..."
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Importált ecset"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Megnyitás..."
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Legutóbbi megnyitása"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Megnyitás..."
+
+#: ../gui/filehandling.py:1446
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
 msgstr "Még nincsen „%s”  nevű vázlat."
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1455
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr "Következő vázlat betöltése"
+
+#: ../gui/filehandling.py:1463
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr "Előző vázlat betöltése"
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Megnyitás..."
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+#, fuzzy
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr "Visszaállítás"
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+#, fuzzy
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
-msgstr ""
+msgstr "Töltse ki a területet színnel."
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+#, fuzzy
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr "Nézet forgatása"
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
-msgstr ""
+msgstr "Új csoport"
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Átlátszatlanság:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr "Visszaállítás"
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+#, fuzzy
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr "Visszaállítás az alapértelmezett értékre"
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "Réteg kiválasztása"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1605,130 +2040,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr "Keret szerkesztése"
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr "Dokumentum keret be-ki"
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr "Keret"
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr "px"
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr "Magasság:"
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr "Szélesség:"
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr "Felbontás:"
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr "Szín:"
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr "Keret színe"
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr "<b>Teljes képernyő</b>"
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr "Réteg átnevezése"
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr "A jelenlegi réteg pontos másolatának létrehozása"
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr "Vágás a dokumentum méretére"
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr "Keret vágása az összes réteg méretére"
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr "Réteg neve"
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr "Bekapcsolva"
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr "hüvelyk"
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr "cm"
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr "mm"
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr "Szabadkézi rajz"
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr "Nyomás:"
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr "A MyPaint programhibát észlelt"
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr "<big><b>A MyPaint programhibát észlelt.</b></big>"
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1737,35 +2184,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr "Jelentés..."
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr "Névjegy"
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr "Részletek..."
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr "Kivétel a kivétel elemzése közben."
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1789,45 +2236,50 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr "Bemeneti eszköz tesztelése"
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr "(nincsen nyomás)"
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr "Nyomás:"
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr "(nincsen dőlés)"
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr "Dőlés:"
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr "(nincsen eszköz)"
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
 msgstr "Eszköz:"
 
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+#, fuzzy
+msgid "Barrel Rotation:"
+msgstr "Forgatás"
+
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr "Réteg mozgatása"
 
@@ -1835,157 +2287,224 @@ msgstr "Réteg mozgatása"
 msgid "Move the current layer"
 msgstr "Jelenlegi réteg kiürítése"
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+#, fuzzy
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr "Paletta tulajdonságai"
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr "Látható"
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Rétegek"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+#, fuzzy
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr "Zárolt"
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, fuzzy, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr "Réteg neve"
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Rétegek"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr "Réteg átlátszatlanság: %d%%"
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr "Rétegek átrendezése a veremben..."
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr "Rétegek"
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
-msgstr "Mód:"
-
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
-msgstr "Keverési mód: hogyan hasson a jelenlegi réteg az alatta lévőkre."
-
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Átlátszatlanság:"
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
-"Réteg-átlátszatlanság: mennyi kerül felhasználásra a jelenlegi rétegből. A "
-"kisebb értékek átlátszóbbá teszik."
 
-#: ../gui/linemode.py:37
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
+msgstr ""
+
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "Nézet forgatása"
+
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr "Bemeneti nyomás"
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr "Vonás kezdeti nyomása vonal eszközöknél"
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr "Középső nyomás"
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr "Vonás közbeni nyomás vonal eszközöknél"
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr "Kilépési nyomás"
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr "Vonás kilépési nyomása vonal eszközöknél"
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr "Fej"
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 msgid "Stroke lead-in end"
 msgstr "Ecsetvonás bevezető részének vége"
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr "Farok"
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr "Ecsetvonás levezető részének kezdete"
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr "Egyenesek és görbék"
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr "Összekötött egyenesek"
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr "Ellipszisek és körök"
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
+#, fuzzy
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 "Copyright (C) 2005-2012\n"
 "Martin Renold és a MyPaint Fejlesztőcsapat"
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -2005,256 +2524,286 @@ msgstr ""
 "ALKALMAZHATÓSÁGRA való származtatott garanciát is beleértve. További "
 "részleteket a COPYING fájl tartalmaz."
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr "programozás"
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr "hordozhatóság"
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr "ecsetek"
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr "minták"
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr "eszközikonok"
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr "program ikonja"
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr "Paletta"
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr "Forgatás"
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr "Gergely Aradszki"
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr "Átlátszatlanabb:"
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr "eszközikonok"
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr "Fájl megnyitása a jelenlegi festmény helyett"
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr "Nagyítás: %.01f%%"
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr "Kattints egy vonásra a beállítások és réteg kiválasztásához…"
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr "Színmintavétel…"
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr "Beállítások"
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr "Előző elem"
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr "Alablakok be-ki"
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr "Vázlattömb"
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr "Színek keverése és vázlatok készítése külön vázlatlapokon"
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr "Előző elem"
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr "Következő elem"
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
 msgstr "(Nincsen megjeleníthető elem)"
 
-#: ../gui/symmetry.py:76
+#: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Place axis"
 msgstr ""
 
-#: ../gui/symmetry.py:80
+#: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Move axis"
 msgstr "Réteg mozgatása"
 
-#: ../gui/symmetry.py:84
+#: ../gui/symmetry.py:88
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr "Törlés"
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr "Szimmetriatengely mutatása"
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr "Szimmetriatengely mutatása."
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
+#, fuzzy
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr "Művelet:"
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr "Művelet:"
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
+msgstr "Szimmetriatengely"
+
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:446
+#, fuzzy
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr "Művelet:"
+
+#: ../gui/symmetry.py:477
+#, fuzzy
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr "Művelet:"
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr "Bekapcsolva"
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr "Fájlkezelés"
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr "Vázlatváltó"
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr "Visszavonás és Újra"
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr "Keverési módok"
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr "Vonalmód"
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr "Nézet (Fő)"
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr "Nézet (Alternatív/Másodlagos)"
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr "Nézet (Visszaállítás)"
 
@@ -2262,188 +2811,214 @@ msgstr "Nézet (Visszaállítás)"
 msgid "<b>MyPaint</b>"
 msgstr "<b>Mentés</b>"
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr "Nézet görgetése"
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr "Nézet nagyítása"
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr "Nézet forgatása"
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr "Nézet jobbra forgatása"
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr "Ismeretlen tevékenység"
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr "Réteg kiürítése"
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "Csoport átnevezése"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr "Réteg kiürítése"
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr "Réteg átnevezése"
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr "Réteg láthatóvá tétele"
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr "Rétegek összeolvasztása"
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr "Összefésülés lefelé"
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr "Réteg keverési módjának konvertálása"
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Importált ecset"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr "Réteg törlése"
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr "Réteg kiválasztása"
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr "Réteg kétszerezése"
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr "Réteg mozgatása"
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr "Réteg mozgatása"
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr "Rétegek átrendezése a veremben"
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr "Réteg átnevezése"
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr "Réteg láthatóvá tétele"
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr "Réteg elrejtése"
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr "Réteg zárolása"
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr "Réteg zárolásának feloldása"
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr "Réteg átlátszatlanság: %0.1f%%"
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr "Ismeretlen tevékenység"
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr "Keret szerkesztése"
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr "Keret szerkesztése"
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr "Keret szerkesztése"
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2452,13 +3027,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2468,7 +3043,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2476,13 +3051,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2490,7 +3065,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2498,7 +3073,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2509,7 +3084,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2517,7 +3092,13 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+#, fuzzy
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr "Importált ecset"
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2527,7 +3108,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2538,98 +3119,207 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+#, fuzzy
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr "Fájlkezelés"
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr "Rétegek"
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
+#, fuzzy
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr "Réteg kiválasztása"
+
+#: ../lib/layer/data.py:1158
+#, fuzzy
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr "Réteg kiválasztása"
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
-msgstr "Ismeretlen ecset"
+msgid "Bitmap"
+msgstr ""
 
-#: ../lib/layer/data.py:1169
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1244
 msgctxt "layer default names"
-msgid "Unknown Data Layer"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
 msgstr "Ugrás rétegre"
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "Festés"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "Új csoport"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+#, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "Nézet"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+#, fuzzy
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr "Réteg hozzáadása"
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+#, fuzzy
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr "Réteg törlése"
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr "Réteg zárolása"
+
+#: ../lib/layervis.py:697
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr "Réteg zárolásának feloldása"
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr "Normál"
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr "Csak a legfelső réteg, keverési módok nélkül."
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr "Szorzás"
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
@@ -2637,11 +3327,11 @@ msgstr ""
 "Hasonló ahhoz, mintha egy diavetítőbe több diát raknák egymás elé, és ezt "
 "vetítenénk."
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr "Kivetítés"
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
@@ -2649,11 +3339,11 @@ msgstr ""
 "Olyan, mint ha két vetitővel vetítenénk egyetlen vászonra. A „Szorzás” "
 "ellentéte."
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr "Átfedés"
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
@@ -2661,27 +3351,27 @@ msgstr ""
 "Háttér fedése a felső réteggel úgy, hogy a háttér csúcsfényei és árnyékai "
 "megmaradjanak. Az „Erős fény” ellentéte."
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr "Sötétítés"
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr "A felső réteg azon részeit használja, amik sötétebbek, mint a háttér."
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr "Világosítás"
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr "A felső réteg azon részeit használja, amik világosabb, mint a háttér."
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr "Fakítás"
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
@@ -2691,11 +3381,11 @@ msgstr ""
 "fényképészetben használt hasonló nevű eljáráshoz, amivel az árnyékokban lévő "
 "kontrasztot javították."
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr "Sötétítés"
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
@@ -2705,43 +3395,43 @@ msgstr ""
 "fényképészetben használt hasonló nevű eljáráshoz, amivel az túlságosan "
 "fényes részeket csökkentették."
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr "Erős fény"
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr "Olyan, mint ha a háttérre erős fénnyel világítanánk."
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr "Gyenge fény"
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr "Olyan, mint ha a háttérre szórt fénnyel világítanánk."
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr "Különbség"
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr "A két szín közül a sötétebbet kivonja a világosabból."
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr "Kivétel"
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr "Hasonló a Különbség módhoz, de kevésbé kontrasztos."
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr "Árnyalat"
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
@@ -2749,11 +3439,11 @@ msgstr ""
 "A felső réteg árnyalatát a háttér telítettségével és fényességével "
 "kombinálja."
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr "Telítettség"
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
@@ -2761,18 +3451,18 @@ msgstr ""
 "A felső réteg színeinek telítettségét használja a háttér árnyalataihoz és "
 "fényerejéhez."
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 "A felső réteg árnyalatait és fényességét használja a háttér fényerejéhez."
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr "Fényesség"
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
@@ -2780,62 +3470,73 @@ msgstr ""
 "A felső réteg fényességét használja a háttér árnyalataihoz és "
 "telítettségéhez."
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2845,7 +3546,30 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+#, fuzzy
+msgid "Vertical"
+msgstr "Tükrözés függőlegesen"
+
+#: ../lib/tiledsurface.py:49
+#, fuzzy
+msgid "Horizontal"
+msgstr "Tükrözés vízszintesen"
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+#, fuzzy
+msgid "Rotational"
+msgstr "Forgatás"
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2854,55 +3578,85 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr "Törlés"
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
-msgstr "%s másolata"
+msgid "Live update"
+msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
-msgstr ""
-"Az ecset összes beállításának visszaállítása a jelenlegi ecset mentett "
-"értékeire"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
+msgstr "Az utolsó ecsetvonás valós idejű frissítése"
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
-msgstr "Ecset átnevezése"
+msgid "Save these settings to the brush"
+msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
 msgid "Edit Icon"
@@ -2923,18 +3677,18 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
-msgstr ""
+msgid "Copy to New"
+msgstr "%s másolata"
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
-msgstr "Az utolsó ecsetvonás valós idejű frissítése"
+msgid "Copy these settings and the current brush's icon to a new brush"
+msgstr ""
+"Az ecset összes beállításának visszaállítása a jelenlegi ecset mentett "
+"értékeire"
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
-msgstr ""
+msgid "Rename this brush"
+msgstr "Ecset átnevezése"
 
 #: ../po/tmp/brusheditor.glade.h:13
 msgid "Brush Setting"
@@ -2962,112 +3716,89 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr "Beállítások ablak:"
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
-msgstr "Alapérték:"
+#: ../po/tmp/brusheditor.glade.h:22
+#, fuzzy
+msgid "Value:"
+msgstr "HSV Érték"
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr "<ymin>"
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr "<ymax>"
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr "Toll bemenet"
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr "<xmin>"
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr "<xmax>"
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr "Vissza a beállításokhoz"
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr "Beállítások mentése"
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+#, fuzzy
+msgid "Brush dynamics are not available for this setting."
+msgstr "Vissza a beállításokhoz"
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3080,7 +3811,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr "Nyomás:"
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3122,6 +3853,140 @@ msgstr "Csoport törlése"
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
 msgstr "Jelenlegi réteg törlése"
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+#, fuzzy
+msgid "Insert Point"
+msgstr "Csoport törlése"
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+#, fuzzy
+msgid "Cull Points"
+msgstr "Csoport törlése"
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Név"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr "Mód"
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Átlátszatlanság"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr "Keret vágása az aktív réteg méretére"
+
+#: ../po/tmp/layervis.glade.h:2
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr "Nézet jobbra forgatása"
+
+#: ../po/tmp/layervis.glade.h:3
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr "Nézet jobbra forgatása"
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
+msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
 msgctxt "footer: color picker button: tooltip"
@@ -3492,56 +4357,77 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+#, fuzzy
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr "Bekapcsolva"
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr "Nézet"
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3549,12 +4435,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr "Vörös, Zöld és Kék komponensek változtatása"
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3563,7 +4449,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3574,28 +4460,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr "<b>Teljes képernyő</b>"
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr "Szín"
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr "Képernyő (normál)"
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr "Kikapcsolva (nincsen nyomásérzékenység)"
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr "Ablak (nem ajánlott)"
@@ -3656,1624 +4542,1809 @@ msgid "Reload the file your current work was loaded from."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
+#, fuzzy
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Import Layers…"
+msgstr "Ecsetek importálása…"
+
+#: ../po/tmp/resources.xml.h:13
+msgctxt "Accel Editor (descriptions)"
+msgid "Import layers from one or more files."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save"
 msgstr "Mentés"
 
-#: ../po/tmp/resources.xml.h:13
+#: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file."
 msgstr "Mentés fájlba."
 
-#: ../po/tmp/resources.xml.h:14
+#: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As…"
 msgstr "Mentés másként…"
 
-#: ../po/tmp/resources.xml.h:15
+#: ../po/tmp/resources.xml.h:17
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file, assigning it a new name."
 msgstr "Mentés fájlba új néven."
 
-#: ../po/tmp/resources.xml.h:16
+#: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Export…"
 msgstr "Exportálás…"
 
-#: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:18
-msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
-msgstr "Mentés vázlatként"
-
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Save As Scrap"
+msgstr "Mentés vázlatként"
+
+#: ../po/tmp/resources.xml.h:21
+msgctxt "Accel Editor (descriptions)"
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:22
+msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Previous Scrap"
 msgstr "Előző vázlat betöltése"
 
-#: ../po/tmp/resources.xml.h:21
+#: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file before the current one."
 msgstr "Következő vázlatfájl betöltése a jelenlegi rajz helyett."
 
-#: ../po/tmp/resources.xml.h:22
+#: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Next Scrap"
 msgstr "Következő vázlat betöltése"
 
-#: ../po/tmp/resources.xml.h:23
+#: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file after the current one."
 msgstr "Következő vázlatfájl betöltése a jelenlegi rajz helyett."
 
-#: ../po/tmp/resources.xml.h:24
+#: ../po/tmp/resources.xml.h:26
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Recover File from an Automated Backup…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:25
+#: ../po/tmp/resources.xml.h:27
 msgctxt "Accel Editor (descriptions)"
 msgid "Try to save and resume interrupted unsaved work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:26
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr "Ecsetek"
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr "Ecsetek"
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr "Felülírja az ecsetcsoportot."
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr "Szín részletei"
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr "Színek"
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr "Mód"
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr "Mód"
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr "A jelenlegi réteg láthatósági állapota."
 
-#: ../po/tmp/resources.xml.h:35
+#: ../po/tmp/resources.xml.h:37
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Pressure"
+msgstr "Bemeneti nyomás"
+
+#: ../po/tmp/resources.xml.h:38
+msgctxt "Accel Editor (descriptions)"
+msgid "Send harder pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:39
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Pressure"
+msgstr "Bemeneti nyomás"
+
+#: ../po/tmp/resources.xml.h:40
+msgctxt "Accel Editor (descriptions)"
+msgid "Send softer pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:41
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Rotation"
+msgstr "Szín telítettségének növelése"
+
+#: ../po/tmp/resources.xml.h:42
+msgctxt "Accel Editor (descriptions)"
+msgid "Increase barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:43
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
+msgstr "Szín telítettségének csökkentése"
+
+#: ../po/tmp/resources.xml.h:44
+msgctxt "Accel Editor (descriptions)"
+msgid "Decrease barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:45
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Size"
 msgstr "Ecset sugarának növelése"
 
-#: ../po/tmp/resources.xml.h:36
+#: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush bigger."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:37
+#: ../po/tmp/resources.xml.h:47
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Size"
 msgstr "Ecset sugarának csökkentése"
 
-#: ../po/tmp/resources.xml.h:38
+#: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush smaller."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:39
+#: ../po/tmp/resources.xml.h:49
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Opacity"
 msgstr "Ecset átlátszatlanabbá tétele"
 
-#: ../po/tmp/resources.xml.h:40
+#: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush more opaque."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:41
+#: ../po/tmp/resources.xml.h:51
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Opacity"
 msgstr "Ecset álátszatlanságának csökkentése"
 
-#: ../po/tmp/resources.xml.h:42
+#: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush less opaque."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:43
+#: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Lighten Painting Color"
 msgstr "Utolsó festési pozíció"
 
-#: ../po/tmp/resources.xml.h:44
+#: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase the lightness of the current painting color."
 msgstr "Fájl megnyitása a jelenlegi festmény helyett."
 
-#: ../po/tmp/resources.xml.h:45
+#: ../po/tmp/resources.xml.h:55
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Darken Painting Color"
 msgstr "Utolsó festési pozíció"
 
-#: ../po/tmp/resources.xml.h:46
+#: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease the lightness of the current painting color."
 msgstr "Fájl megnyitása a jelenlegi festmény helyett."
 
-#: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
-msgstr "Árnyalat forgatása óramutató járásával ellentétesen"
-
-#: ../po/tmp/resources.xml.h:48
-msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
-msgstr "Szín árnyalatának forgatása óramutató járásával ellentétesen."
-
-#: ../po/tmp/resources.xml.h:49
+#: ../po/tmp/resources.xml.h:57
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Change Hue Clockwise"
 msgstr "Árnyalat változtatása (óramutató járásával megegyezően)"
 
-#: ../po/tmp/resources.xml.h:50
+#: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
 msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:51
+#: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr "Árnyalat forgatása óramutató járásával ellentétesen"
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr "Szín árnyalatának forgatása óramutató járásával ellentétesen."
+
+#: ../po/tmp/resources.xml.h:61
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Increase Saturation"
 msgstr "Szín telítettségének növelése"
 
-#: ../po/tmp/resources.xml.h:52
+#: ../po/tmp/resources.xml.h:62
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color more saturated (more colorful, purer)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:53
+#: ../po/tmp/resources.xml.h:63
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Decrease Saturation"
 msgstr "Szín telítettségének csökkentése"
 
-#: ../po/tmp/resources.xml.h:54
+#: ../po/tmp/resources.xml.h:64
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color less saturated (grayer)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:55
+#: ../po/tmp/resources.xml.h:65
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Reload Brush Settings"
 msgstr "Ecset részletes beállításai"
 
-#: ../po/tmp/resources.xml.h:56
+#: ../po/tmp/resources.xml.h:66
 msgctxt "Accel Editor (descriptions)"
 msgid "Restore all brush settings to the current brush’s saved values."
 msgstr ""
 "Az ecset összes beállításának visszaállítása a jelenlegi ecset mentett "
 "értékeire."
 
-#: ../po/tmp/resources.xml.h:57
+#: ../po/tmp/resources.xml.h:67
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Pick Stroke and Layer"
 msgstr "Vonás és Réteg kiválasztása"
 
-#: ../po/tmp/resources.xml.h:58
+#: ../po/tmp/resources.xml.h:68
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
-msgstr ""
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr "Kattints egy vonásra a beállítások és réteg kiválasztásához"
 
-#: ../po/tmp/resources.xml.h:59
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr "Ecset mentése legutóbb használtként"
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr "Ecset mentése legutóbb használtként."
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "Réteg kiürítése"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr "Jelenlegi réteg kiürítése."
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+#, fuzzy
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr "eszközikonok"
+
+#: ../po/tmp/resources.xml.h:76
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr "Réteg neve"
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr ""
+"A felső réteg színeinek telítettségét használja a háttér árnyalataihoz és "
+"fényerejéhez."
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "Új csoport"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "Új csoport"
+
+#: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr "Másolás vágólapra"
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr "Jelenlegi réteg másolása a vágólapra."
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr "Másolás vágólapra"
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr "Réteg lecserélése a vágólapon lévő tartalomra."
 
-#: ../po/tmp/resources.xml.h:71
+#: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Edit Layer in External App…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:72
+#: ../po/tmp/resources.xml.h:90
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
+msgid "Edit the active layer in an external application."
 msgstr "Réteg mozgatása: jelenlegi réteg áthelyezése a vásznon."
 
-#: ../po/tmp/resources.xml.h:73
+#: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Update Layer with External Edits"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:74
+#: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
 msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:75
+#: ../po/tmp/resources.xml.h:93
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer at Cursor"
 msgstr "Kurzor alatti réteg kiválasztása"
 
-#: ../po/tmp/resources.xml.h:76
+#: ../po/tmp/resources.xml.h:94
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr "Réteg kiválasztása ecsetvonásra kattintva."
 
-#: ../po/tmp/resources.xml.h:77
+#: ../po/tmp/resources.xml.h:95
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Above"
 msgstr "Ugrás rétegre"
 
-#: ../po/tmp/resources.xml.h:78
+#: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer up in the layer stack."
 msgstr "Egy réteggel feljebb mozgás."
 
-#: ../po/tmp/resources.xml.h:79
+#: ../po/tmp/resources.xml.h:97
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Below"
 msgstr "Ugrás rétegre"
 
-#: ../po/tmp/resources.xml.h:80
+#: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer down in the layer stack."
 msgstr "Egy réteggel lejjebb mozgás."
 
-#: ../po/tmp/resources.xml.h:81
+#: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer"
 msgstr "Festés"
 
-#: ../po/tmp/resources.xml.h:82
+#: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer above the current layer."
 msgstr "Új réteg hozzáadása a jelenlegi felett."
 
-#: ../po/tmp/resources.xml.h:83
+#: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer…"
 msgstr "Réteg kiválasztása…"
 
-#: ../po/tmp/resources.xml.h:84
+#: ../po/tmp/resources.xml.h:102
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer above the current layer, and begin editing it."
 msgstr "Új réteg hozzáadása a jelenlegi felett."
 
-#: ../po/tmp/resources.xml.h:85
+#: ../po/tmp/resources.xml.h:103
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group"
 msgstr "Új csoport"
 
-#: ../po/tmp/resources.xml.h:86
+#: ../po/tmp/resources.xml.h:104
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group above the current layer."
 msgstr "Új réteg hozzáadása a jelenlegi felett."
 
-#: ../po/tmp/resources.xml.h:87
+#: ../po/tmp/resources.xml.h:105
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:88
+#: ../po/tmp/resources.xml.h:106
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer below the current layer."
 msgstr "Új réteg hozzáadása a jelenlegi alatt."
 
-#: ../po/tmp/resources.xml.h:89
+#: ../po/tmp/resources.xml.h:107
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer Below…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:90
+#: ../po/tmp/resources.xml.h:108
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer below the current layer, and begin editing it."
 msgstr "Új réteg hozzáadása a jelenlegi alatt."
 
-#: ../po/tmp/resources.xml.h:91
+#: ../po/tmp/resources.xml.h:109
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:92
+#: ../po/tmp/resources.xml.h:110
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group below the current layer."
 msgstr "Új réteg hozzáadása a jelenlegi alatt."
 
-#: ../po/tmp/resources.xml.h:93
+#: ../po/tmp/resources.xml.h:111
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Layer Down"
 msgstr "Rétegek összeolvasztása"
 
-#: ../po/tmp/resources.xml.h:94
+#: ../po/tmp/resources.xml.h:112
 msgctxt "Accel Editor (descriptions)"
 msgid "Merge the current layer with the layer beneath it."
 msgstr "Réteg összefésülése az alatta lévővel."
 
-#: ../po/tmp/resources.xml.h:95
+#: ../po/tmp/resources.xml.h:113
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Visible Layers"
 msgstr "Rétegek összeolvasztása"
 
-#: ../po/tmp/resources.xml.h:96
+#: ../po/tmp/resources.xml.h:114
 msgctxt "Accel Editor (descriptions)"
 msgid "Consolidate all visible layers, and delete the originals."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:97
+#: ../po/tmp/resources.xml.h:115
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer from Visible"
 msgstr "Réteg láthatóvá tétele"
 
-#: ../po/tmp/resources.xml.h:98
+#: ../po/tmp/resources.xml.h:116
 msgctxt "Accel Editor (descriptions)"
 msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:99
+#: ../po/tmp/resources.xml.h:117
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Delete Layer"
 msgstr "Réteg kiválasztása"
 
-#: ../po/tmp/resources.xml.h:100
+#: ../po/tmp/resources.xml.h:118
 msgctxt "Accel Editor (descriptions)"
 msgid "Remove the current layer from the layer stack."
 msgstr "Jelenlegi réteg egy szinttel feljebb mozgatása a rétegek között."
 
-#: ../po/tmp/resources.xml.h:101
+#: ../po/tmp/resources.xml.h:119
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Convert to Normal Painting Layer"
 msgstr "Konvertálás normál módba"
 
-#: ../po/tmp/resources.xml.h:102
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr "Átlátszatlanabbá tétel"
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr "Átlátszatlanság csökkentése"
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr "Réteg átnevezése"
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr "Jelenlegi réteg egy szinttel feljebb mozgatása a rétegek között."
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr "Réteg betöltése"
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr "Jelenlegi réteg egy szinttel lejjebb mozgatása a rétegek között."
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr "Réteg kétszerezése"
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr "A jelenlegi réteg pontos másolatának létrehozása."
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
+#, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
-msgstr "Réteg átnevezése…"
+msgid "Layer Properties…"
+msgstr "Paletta tulajdonságai"
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
-msgstr "Add meg a jelenlegi réteg új nevét."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr "Zárolt"
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 "A jelenlegi réteg zárolási állapota: a zárolt rétegekre nem lehet rajzolni."
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr "Réteg láthatóvá tétele"
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr "A jelenlegi réteg láthatósági állapota."
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr "Háttér választása"
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr "A jelenlegi réteg láthatósági állapota."
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr "Jelenlegi réteg egy szinttel feljebb mozgatása a rétegek között."
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr "Visszaállítás és középre igazítás"
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 "Nagyítás, forgatás és tükrözés visszaállítása és a dokumentum középre "
 "igazítása."
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr "Nézet forgatása"
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr "Visszaállítás"
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr "Visszaállítás"
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr "Forgatás"
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr "Nagyítás"
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr "Nagyítás növelése."
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Kicsinyítés"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr "Nagyítás csökkentése."
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
+#, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
-msgstr "Forgatás balra"
+msgid "Pan Left"
+msgstr "Nézet"
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
-msgstr "Nézet forgatás óramutató járásával ellenkezően."
+msgid "Move your view of the canvas to the left."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr "Erős fény"
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr "Nézet"
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr "Forgatás jobbra"
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr "Nézet forgatás óramutató járásával megegyezően."
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr "Forgatás balra"
+
+#: ../po/tmp/resources.xml.h:167
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr "Nézet forgatás óramutató járásával ellenkezően."
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr "Tükrözés vízszintesen"
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr "A kép bal és jobb oldalának felcserélése."
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr "Tükrözés függőlegesen"
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr "Kép fejjel lefelé tükrözése."
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr "Réteg szóló módban"
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr "Jelenlegi réteg törlése."
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr "Szimmetrikus festés"
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr "Keret bekapcsolva"
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr "Dokumentum keret be-ki."
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr "Ecset bemeneti értékeinek kiírása a konzolra"
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr "Renderelés megjelenítése"
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr "Renderelési frissításek mutatása debuggolási céllal."
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr "GTK Double Buffering kikapcsolása"
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+#, fuzzy
+msgid "Delete Point"
+msgstr "Csoport törlése"
+
+#: ../po/tmp/resources.xml.h:187
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr "Jelenlegi réteg törlése"
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr "Vonalmód"
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr "Normál festés"
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr "Törlés a jelenlegi ecsettel."
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Fájl"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "Kilépés"
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "Szerkesztés"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr "Jelenlegi eszköz"
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "Szín"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr "Szín módosítása"
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr "Színtörténet"
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr "Szín részletei"
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr "Szín részletei ablak szöveges mezővel."
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr "Következő palettaszín"
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr "Következő szín a palettán."
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr "Előző palettaszín"
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr "Előző szín a palettán."
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr "Szín hozzáadása a palettához"
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "Rétegek"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr "Átlátszatlanság"
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr "Ugrás rétegre"
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr "Réteg szóló módban"
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr "Paletta tulajdonságai"
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr "Vázlattömb"
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr "Új vázlattömb"
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr "Vázlattömb megnyitása…"
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr "Vázlattömb mentése most"
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr "Vázlattömb visszaállítása…"
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr "Vázlattömb visszaállítása"
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr "Vázlattömb mentése alapértelmezettként"
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr "Az alapértelmezett vázlattömb törlése"
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr "Az alapértelmezett vázlattömb törlése."
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr "Háttér másolása a Vázlattömbbe"
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "Szín ablak"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "Ecset"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr "Gyorsbillentyűk"
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr "Gyorsbillentyűk"
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "Ecsetváltás…"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "Szín változtatása…"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "Szín változtatása („wash”)…"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr "További ecsetek beszerzése…"
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr "Ecsetek importálása…"
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr "Valóban törli ezt az ecsetet."
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Súgó"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "Névjegy"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Debug"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr "Memóriaszivárgási info kiírása a konzolba (Lassú!)"
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr "Szemétgyűjtő futtatása"
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr "Python Profiling elindítása/leállítása (cProfile)"
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "Nézet"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr "Visszajelzés"
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr "Nézet állítása"
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
+#, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr "Felugró menü"
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "Teljes képernyő"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "Beállítások"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr "Bemeneti eszközök tesztelése"
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr "Háttér"
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr "Ecsetbeállítás szerkesztő"
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr "Aktív ecset beállításainak szerkesztése."
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr "Ecsetlista szerkesztő"
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr "Ecsetikon szerkesztése."
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr "Réteg neve"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr "HCY kerék"
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "Szín hozzáadása a palettához"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr "HSV kerék"
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr "Telítettség és Érték színmódosító."
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr "HSV háromszög"
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr "HSV kocka"
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr "Egy HSV kocka, ami forgatáskor különböző síkmetszeteket mutat."
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr "Négyzet"
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr "Egy HSV kocka, ami forgatáskor különböző síkmetszeteket mutat."
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr "Komponens-csúszkák"
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr "A szín komponenseinek állítása."
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr "Vázlattömb"
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr "Új vázlattömb"
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "Előző elem"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr "Színtörténet"
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr "Legutóbb használt színek"
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr "Nagyítási mérték"
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr "Utolsó festési pozíció"
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr "Szabadkézi"
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr "Szabadkézi"
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 "Szabadkézi rajz: szabad rajzolás és festés, geometrikus korlátozások nélkül."
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr "Szabadkézi"
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 "Szabadkézi rajz: szabad rajzolás és festés, geometrikus korlátozások nélkül."
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr "Nézet"
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr "Mozgatás"
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr "Nézet"
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr "Nézet forgatása"
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr "Forgatás"
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr "Nézet forgatása"
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr "Nézet nagyítása"
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr "Nagyítás"
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr "Nézet nagyítása"
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr "Egyenesek és görbék"
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr "Egyenesek"
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
@@ -5281,27 +6352,27 @@ msgstr ""
 "Ctrl: szög korlátozása.\n"
 "Shift: görbe hozzáadása a legutóbbi vonalhoz."
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr "Egyenesek és görbék"
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr "Egyenes vonal."
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr "Összekötött egyenesek"
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr "Összekötött egyenesek"
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
@@ -5309,102 +6380,102 @@ msgstr ""
 "Ctrl: szög korlátozása.\n"
 "Shift: görbe hozzáadása a legutóbbi vonalhoz."
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr "Összekötött egyenesek"
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr "Ellipszisek és körök"
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr "Ellipszis"
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr "Ellipszisek és körök."
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr "Ellipszisek és körök"
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr "Tinta"
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr "Ugrás rétegre"
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr "Rétegek"
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr "Réteg mozgatása: jelenlegi réteg áthelyezése a vásznon."
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr "Ugrás rétegre"
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr "Réteg mozgatása: jelenlegi réteg áthelyezése a vásznon."
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr "Keret szerkesztése"
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr "Keret"
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
@@ -5412,12 +6483,12 @@ msgstr ""
 "Keret szerkesztése: dokumentum véges méretre korlátozása. Exportálásnál ezt "
 "a keretet használjuk."
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr "Keret szerkesztése"
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
@@ -5425,80 +6496,202 @@ msgstr ""
 "Keret szerkesztése: dokumentum véges méretre korlátozása. Exportálásnál ezt "
 "a keretet használjuk."
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr "Szimmetriatengely"
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr "Színmintavétel"
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr "Színmintavétel"
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "Szín mintavétel"
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "Szín mintavétel"
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "Szín mintavétel"
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr "Színmintavétel"
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr "Töltse ki a területet színnel."
+
+#~ msgctxt "brush list context menu"
+#~ msgid "Delete"
+#~ msgstr "Törlés"
+
+#~ msgctxt "brush list commands"
+#~ msgid "Really delete brush from disk?"
+#~ msgstr "Valóban törli ezt az ecsetet?"
+
+#~ msgid "HSV Triangle"
+#~ msgstr "HSV háromszög"
+
+#~ msgid "The standard GTK color selector"
+#~ msgstr "A standard GTK színválasztó"
+
+#~ msgid "Pick a color from the screen"
+#~ msgstr "Szín kijelölése a képernyőről"
+
+#~ msgid "Save..."
+#~ msgstr "Mentés.."
+
+#~ msgid "Confirm"
+#~ msgstr "Elfogadás"
+
+#~ msgid "Open..."
+#~ msgstr "Megnyitás..."
+
+#~ msgid "Mode:"
+#~ msgstr "Mód:"
+
+#~ msgid ""
+#~ "Blending mode: how the current layer combines with the layers underneath "
+#~ "it."
+#~ msgstr "Keverési mód: hogyan hasson a jelenlegi réteg az alatta lévőkre."
+
+#~ msgid ""
+#~ "Layer opacity: how much of the current layer to use. Smaller values make "
+#~ "it more transparent."
+#~ msgstr ""
+#~ "Réteg-átlátszatlanság: mennyi kerül felhasználásra a jelenlegi rétegből. "
+#~ "A kisebb értékek átlátszóbbá teszik."
+
+#~ msgctxt "layer default names"
+#~ msgid "Unknown Bitmap Layer"
+#~ msgstr "Ismeretlen ecset"
+
+#~ msgid "Setting name:"
+#~ msgstr "Beállítások ablak:"
+
+#~ msgid "Base value:"
+#~ msgstr "Alapérték:"
+
+#~ msgid "<ymin>"
+#~ msgstr "<ymin>"
+
+#~ msgid "<ymax>"
+#~ msgstr "<ymax>"
+
+#~ msgid "<xmin>"
+#~ msgstr "<xmin>"
+
+#~ msgid "<xmax>"
+#~ msgstr "<xmax>"
+
+#~ msgid "Edit Setting"
+#~ msgstr "Beállítások mentése"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Trim Layer to Frame"
+#~ msgstr "Réteg neve"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Rename Layer…"
+#~ msgstr "Réteg átnevezése…"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Enter a new name for the current layer."
+#~ msgstr "Add meg a jelenlegi réteg új nevét."
+
+#~ msgctxt "Menu→Edit (labels)"
+#~ msgid "Current Tool"
+#~ msgstr "Jelenlegi eszköz"
+
+#~ msgctxt "Menu→Color (labels), Accel Editor (labels)"
+#~ msgid "HSV Triangle"
+#~ msgstr "HSV háromszög"
 
 #~ msgid ""
 #~ "\"%s\" has an alpha channel. Background images with transparency are not "
@@ -5698,9 +6891,6 @@ msgstr "Töltse ki a területet színnel."
 #~ "beállításokról (átlátszóság, keménység, stb.) és a bemenetekről (nyomás, "
 #~ "sebesség, stb.)\n"
 
-#~ msgid "Open Recent files"
-#~ msgstr "Legutóbbi fájlok megnyitása"
-
 #~ msgid "This will discard %d second of unsaved painting."
 #~ msgid_plural "This will discard %d seconds of unsaved painting."
 #~ msgstr[0] "%d másodperc mentetlen festés fog elveszni."
@@ -5708,9 +6898,6 @@ msgstr "Töltse ki a területet színnel."
 
 #~ msgid "Crop to Current Layer"
 #~ msgstr "Vágás a jelenlegi réteg méretére"
-
-#~ msgid "Crop frame to the currently active layer"
-#~ msgstr "Keret vágása az aktív réteg méretére"
 
 #~ msgid ""
 #~ "While the frame is enabled, it \n"
@@ -5818,9 +7005,6 @@ msgstr "Töltse ki a területet színnel."
 #~ msgid "Brush Blend Mode"
 #~ msgstr "Ecset keverési módja"
 
-#~ msgid "Add Layer"
-#~ msgstr "Réteg hozzáadása"
-
 #~ msgid "Move Layer on Canvas"
 #~ msgstr "Réteg mozgatása a vásznon"
 
@@ -5858,9 +7042,6 @@ msgstr "Töltse ki a területet színnel."
 #~ msgctxt "Menu|File|"
 #~ msgid "Save"
 #~ msgstr "Mentés"
-
-#~ msgid "Export to a file"
-#~ msgstr "Exportálás fájlba"
 
 #~ msgid ""
 #~ "Saves to a new scrap file. If the drawing is currently saved as a scrap, "

--- a/po/hy.po
+++ b/po/hy.po
@@ -513,17 +513,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1184,12 +1184,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1405,7 +1405,7 @@ msgid "_Quit"
 msgstr "Ավարտել"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1455,7 +1455,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1632,13 +1632,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Պահել"
 
@@ -1704,7 +1704,7 @@ msgstr "Ֆայլ"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -2124,12 +2124,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2141,7 +2141,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2326,7 +2326,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2396,7 +2396,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/hy.po
+++ b/po/hy.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:18+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Armenian <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -19,27 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -47,39 +27,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -87,214 +67,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr ""
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -333,142 +323,177 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Պահել"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Նորը"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -476,58 +501,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -536,51 +561,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -590,137 +639,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -728,162 +777,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -891,373 +932,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Անվանում"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Ետարկել"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Կրկնել"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1267,324 +1305,673 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr ""
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Ավարտել"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Ավարտել"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
+msgstr ""
+
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
+msgstr ""
+
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Պահել"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
 #, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr ""
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Ֆայլ"
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1427
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1432
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr ""
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1592,130 +1979,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1724,35 +2123,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1776,45 +2175,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1822,153 +2225,217 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr ""
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr ""
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr ""
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1980,256 +2447,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2237,188 +2729,212 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+msgid "Import Layers"
+msgstr ""
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2427,13 +2943,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2443,7 +2959,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2451,13 +2967,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2465,7 +2981,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2473,7 +2989,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2484,7 +3000,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2492,7 +3008,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2502,7 +3023,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2513,285 +3034,394 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr ""
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2801,7 +3431,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2810,52 +3460,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2877,17 +3558,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2916,112 +3595,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3034,7 +3688,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3075,6 +3729,133 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Անվանում"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3444,56 +4225,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3501,12 +4302,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3515,7 +4316,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3526,28 +4327,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3609,1828 +4410,2018 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Ֆայլ"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -528,17 +528,17 @@ msgstr "Paket kuas MyPaint (*.zip)"
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
-msgstr "Kelompok Baru..."
+msgid "New Group…"
+msgstr "Kelompok Baru…"
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
-msgstr "Impor Kuas..."
+msgid "Import Brushes…"
+msgstr "Impor Kuas…"
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr "Dapatkan Beberapa Kuas…"
 
 #: ../gui/brushselectionwindow.py:554
@@ -1216,13 +1216,13 @@ msgstr "Jenis"
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
-msgstr "Gunakan untuk..."
+msgid "Use for…"
+msgstr "Gunakan untuk…"
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
-msgstr "Gulir..."
+msgid "Scroll…"
+msgstr "Gulir…"
 
 #. Name and preview column: will be indented
 #: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
@@ -1408,7 +1408,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Open dragged file confirm dialog: continue button"
 msgid "_Open"
-msgstr "Buka..."
+msgstr "Buka…"
 
 #: ../gui/drawwindow.py:486
 msgid "Set current color"
@@ -1443,8 +1443,8 @@ msgid "_Quit"
 msgstr "Keluar"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
-msgstr "Impor paket kuas..."
+msgid "Import brush package…"
+msgstr "Impor paket kuas…"
 
 #: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
@@ -1493,8 +1493,8 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
-msgstr "Buka..."
+msgid "Open With…"
+msgstr "Buka…"
 
 #: ../gui/externalapp.py:123
 msgid "Icon"
@@ -1562,13 +1562,13 @@ msgstr "Simpan Pengaturan"
 #, fuzzy
 msgctxt "Document I/O: fail dialog title"
 msgid "Export failed"
-msgstr "Ekspor palet..."
+msgstr "Ekspor palet…"
 
 #: ../gui/filehandling.py:172
 #, fuzzy
 msgctxt "Document I/O: fail dialog title"
 msgid "Import Layers failed"
-msgstr "Ekspor palet..."
+msgstr "Ekspor palet…"
 
 #: ../gui/filehandling.py:176
 #, fuzzy
@@ -1686,13 +1686,13 @@ msgstr "JPEG kualitas 90% (*.jpg; *.jpeg)"
 
 #: ../gui/filehandling.py:576
 #, fuzzy
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr "Ekspor…"
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Simpan Sebagai…"
 
@@ -1763,8 +1763,8 @@ msgstr "Buka Berkas Terdahulu"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
-msgstr "Buka Scratchpad..."
+msgid "Open Scratchpad…"
+msgstr "Buka Scratchpad…"
 
 #: ../gui/filehandling.py:1099
 #, fuzzy
@@ -1781,7 +1781,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Buka..."
+msgstr "Buka…"
 
 #: ../gui/filehandling.py:1427
 #, fuzzy
@@ -1793,7 +1793,7 @@ msgstr "Buka yg Terdahulu"
 #, fuzzy
 msgctxt "File→Open Most Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Buka..."
+msgstr "Buka…"
 
 #: ../gui/filehandling.py:1446
 #, fuzzy
@@ -1817,7 +1817,7 @@ msgstr "Buka Scrap Terdahulu"
 #, fuzzy
 msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
 msgid "_Open"
-msgstr "Buka..."
+msgstr "Buka…"
 
 #: ../gui/filehandling.py:1487
 msgctxt "File→Revert: status message: canvas has no filename yet"
@@ -2203,13 +2203,13 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
-msgstr "Laporkan..."
+msgid "Report…"
+msgstr "Laporkan…"
 
 #: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
@@ -2220,8 +2220,8 @@ msgid "Quit MyPaint"
 msgstr "Tentang MyPaint"
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
-msgstr "Detil..."
+msgid "Details…"
+msgstr "Detil…"
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
@@ -2409,7 +2409,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2480,7 +2480,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777
@@ -4504,7 +4504,7 @@ msgstr "Buka…"
 #: ../po/tmp/resources.xml.h:5
 msgctxt "Toolbar (short labels)"
 msgid "Open"
-msgstr "Buka..."
+msgstr "Buka…"
 
 #: ../po/tmp/resources.xml.h:6
 msgctxt "Toolbar (tooltips), Accel Editor (descriptions)"

--- a/po/id.po
+++ b/po/id.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.8\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:19+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/mypaint/"
@@ -16,29 +16,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr "<big><b>{accel_label}</b></big>"
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr "{action_label} {action_desc} {accel_label}"
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "Aksi"
 
@@ -46,41 +24,41 @@ msgstr "Aksi"
 msgid "Key combination"
 msgstr "Kombinasi tombol"
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr "Mengedit Tombol untuk '%s'"
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "Aksi:"
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "Jalur:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "Tombol:"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr "Tekan tombol untuk memperbaharui tugas ini"
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "Aksi tidak diketahui"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
-"<b>{accel} telah digunakan '{action}'. Tugas yang tersedia akan "
-"digantikan.</b>"
+"<b>{accel} telah digunakan '{action}'. Tugas yang tersedia akan digantikan.</"
+"b>"
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr "Buka Folder “{folder_basename}”…"
@@ -88,195 +66,205 @@ msgstr "Buka Folder “{folder_basename}”…"
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "OK"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr "Tidak ditemukan cadangan di dalam cache."
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr "Cadangan Tidak Tersedia"
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr "Buka Folder Cache…"
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr "Pemulihan Cadangan Gagal"
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr "Buka Folder Cadangan…"
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr "File dipulihkan dari {iso_datetime}.ora"
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "Simpan sebagai Default"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "Latar"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "Pola"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Warna"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "Tambahkan warna pada Pola"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr "Satu atau beberapa latar tidak dapat diambil"
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr "Kesalahan saat mengambil latar"
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 "Singkirkan file yang tidak terambil, atau periksa pemasangan libgdkpixbuf."
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 "Gdk-Pixbuf tidak dapat mengambil \"{filename}\", dan melaporkan \"{error}\""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr "{filename} memiliki ukuran kosong (w={w}, h={h})"
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr "Pengaturan Kuas"
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr "Tentang"
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "Percobaan"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr "Dasar"
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr "Kegelapan"
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr "Goresan"
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "smudge"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr "Kecepatan"
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr ""
+
+#: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr "Pelacak"
 
-#: ../gui/brusheditor.py:359
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "Coretan"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr "Warna"
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr ""
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr "Tiada kuas yang dipilih, harap gunakan \"Tambah Baru\"."
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr "Tiada kuas yg dipilih!"
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "Ganti nama Kuas"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "Kuas dengan nama ini sudah ada sebelumnya!"
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr "Tiada kuas yg dipilih!"
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr "Yakin akan menghapus kuas “{brush_name}” dari disk?"
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr "(Kuas tak bernama)"
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr "Ikon Kuas"
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr "Ikon Kuas (mengedit)"
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr "Tiada kuas yg dipilih"
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -285,7 +273,7 @@ msgstr ""
 "<b>%s</b>\n"
 "<small>Pilih kuas yg benar dulu</small>"
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
@@ -294,7 +282,7 @@ msgstr ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Perubahan belum tersimpan</small>"
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
@@ -303,7 +291,7 @@ msgstr ""
 "<b>%s</b> (editing)\n"
 "<small>Lukis dengan sembarang kuas dan warna</small>"
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -344,141 +332,181 @@ msgstr "Otomatis"
 msgid "Use the default icon"
 msgstr "Gunakan ikon default"
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Simpan"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr "Simpan tampilan ikon, dan akhiri mengedit"
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr "Hilang dan Ditemukan"
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr "Terhapus"
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr "Favorit"
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr "Tinta"
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr "Klasik"
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr "Set#1"
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr "Set#2"
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr "Set#3"
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr "Set#4"
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr "Set#5"
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr "Eksperimen"
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Baru"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr "Kuas tak diketahui"
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr "Tambahkan ke Favorit"
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr "Hapus dari favorit"
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr "Klon"
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr "Pengaturan kuas"
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
-msgstr "Hapus"
+#: ../gui/brushselectionwindow.py:250
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
+msgstr "Ganti Nama Kelompok"
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
-msgstr "Yakin akan menghapus kuas ini?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, fuzzy, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
+msgstr "Yakin akan menghapus kuas “{brush_name}” dari disk?"
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] "%d kuas"
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr "Kelompok “{group_name}”"
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr "Ganti Nama Kelompok"
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr "Ekspor Paket Kuas"
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr "Hapus Kelompok"
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr "Ganti Nama Kelompok"
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "Kelompok dengan nama ini sudah ada sebelumnya!"
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr "Yakin akan menghapus kelompok “{group_name}”?"
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -488,58 +516,58 @@ msgstr ""
 "Tidak mampu menghapus kelompok “{group_name}”.\n"
 "Beberapa kelompok khusus tak dapat dihapus.."
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr "Ekspor Kuas"
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr "Paket kuas MyPaint (*.zip)"
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "Kelompok Baru..."
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr "Impor Kuas..."
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr "Dapatkan Beberapa Kuas…"
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "Buat Kelompok"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr "Tombol"
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr "Tmbl"
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr "Tekan tombol"
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr "Tambah ikatan baru"
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr "Hapus ikatan saat ini"
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr "Mengedit untuk ikatan '%s'"
@@ -548,7 +576,7 @@ msgstr "Mengedit untuk ikatan '%s'"
 msgid "Button press:"
 msgstr "Tekan tombol:"
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
@@ -556,7 +584,7 @@ msgstr ""
 "Tekan tahan tombol pengubah, dan tekan tombol diatas teks ini untuk ikatan "
 "baru."
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
@@ -564,40 +592,68 @@ msgstr ""
 "{button} tak mampu mengikat tanpa tombol pengubah (maaf, artinya telah "
 "ditetapkan)"
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr "{button_combination} telah terikat pada aksi '{action_name}'"
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr "Pungut Warna"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr "Set warna yg akan digunakan untuk melukis"
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+#, fuzzy
+msgid "Set the color Hue used for painting"
+msgstr "Set warna yg akan digunakan untuk melukis"
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "Pungut warna"
+
+#: ../gui/colorpicker.py:296
+#, fuzzy
+msgid "Set the color Chroma used for painting"
+msgstr "Set warna yg akan digunakan untuk melukis"
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+#, fuzzy
+msgid "Set the color Luma used for painting"
+msgstr "Set warna yg akan digunakan untuk melukis"
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr "Detil warna"
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr "Warna saat ini, dan warna yg sesaat lalu digunakan untuk melukis"
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr "Topeng Gamut Aktif"
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr "Batasi paletmu untuk mood yg spesifik menggunakan topeng gamut."
@@ -607,7 +663,7 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr "HCY hue dan chroma."
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
@@ -616,12 +672,12 @@ msgstr ""
 "Pengaturan topeng gamut. Klik di tengah untuk membuat atau memanipulasi "
 "bentuk, atau memutar topeng menggunakan ujung lingkaran."
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
@@ -630,22 +686,22 @@ msgstr ""
 "Mood dan subjektif, didefinisikan oleh satu dominan primer dan dua primer yg "
 "tidak terlalu intens."
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr "Diberatkan lebih kepada kekuatan warna dominan."
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr "Komplementer"
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
@@ -654,96 +710,96 @@ msgstr ""
 "Berlainan kontras, dengan diantaranya diimbangi pusat netral dalam roda "
 "warna."
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr "Mood dan Aksen"
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr "Split complementary"
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr "Topeng Gamut Baru dari Templat"
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr "Pengaturan Topeng Gamut"
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr "Aktif"
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr "Bantuan…"
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr "Buat topeng dari templat."
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr "Ambil topeng dari file palet GIMP."
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr "Simpan topeng ke file palet GIMP."
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr "Hapus topeng."
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr "Buka bantuan online untuk dialog ini di web browser."
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr "Simpan Topeng sebagai Palet GIMP"
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr "Ambil Topeng dari Palet GIMP"
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr "Set topeng gamut."
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr "Roda HCY"
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -753,162 +809,154 @@ msgstr ""
 "adalah equiluminant."
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr "HSV Saturasi"
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr "Nilai HSV"
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr "Saturasi dan Nilai HSV"
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr "Square"
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr "Segitiga Warna"
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr "Pemilih warna MyPaint"
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr "Ubah Saturasi dan Nilai."
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr "Palet Gimp (*.gpl)"
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr "Palet Gimp (*.gpl)"
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr "Palet Gimp (*.gpl)"
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr "Simpan sebagai Standar"
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr "Buka Berkas Terdahulu"
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr "Buka Berkas Terdahulu"
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr "Warna sekarang vs terakhir dipakai"
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr "Palet Gimp (*.gpl)"
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr "Simpan palet di"
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr "Simpan Pengaturan"
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -916,375 +964,374 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr "Palet Gimp (*.gpl)"
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "Simpan sebagai Standar"
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr "Berkas"
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "Simpan sebagai Standar"
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr "Berkas"
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr "Nilai dasar"
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr "Putaran"
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr "Nilai dasar"
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr "penghapus"
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr "Geser"
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr "Penuhi Layar"
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr "Perbesaran"
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr "Geser"
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr "Perangkat"
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr "Axis"
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr "Jenis"
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr "Gunakan untuk..."
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr "Gulir..."
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Nama"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr "Tulias ulang kuas?"
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr "Ganti"
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr "Ganti nama"
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr "Ganti semua"
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr "Ganti nama semua"
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr "Kuas hasil impor"
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr "Kuas yang ada"
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 "<b>Nama kuas `%s' telah ada.</b>\n"
 "Mau menggantinya, atau beri nama baru?"
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr "Tulis ulang kelompok kuas?"
 
-#: ../gui/dialogs.py:190
-#, python-brace-format
+#: ../gui/dialogs.py:220
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
+"<b>Nama kuas `%s' telah ada.</b>\n"
+"Mau menggantinya, atau beri nama baru?"
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr "Impor paket kuas?"
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, fuzzy, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr "<b>Akan mengimpor paket`%s'?</b>"
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr "Pilih Kuas %d"
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr "Simpan sbg Kuas %d"
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr "Batalkan %s"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr ""
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr ""
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1294,267 +1341,527 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
-msgstr "Lapisan"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
+msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr "Tentang MyPaint"
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Buka..."
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr "Pilihan warna sekarang"
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr "Penuhi Layar"
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr "Penuhi Layar"
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr "Penuhi Layar"
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Penuhi Layar"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Keluar"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+#, fuzzy
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr "Benar mau keluar?"
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Keluar"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr "Impor paket kuas..."
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr "paket kuas MyPaint (*.zip)"
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr "Buka..."
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
+#: ../gui/filehandling.py:126
+#, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:130
+#, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:134
+#, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:138
+#, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:145
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr "Gagal menyimpan “{file_basename}”."
+
+#: ../gui/filehandling.py:149
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr "Gagal menyimpan “{file_basename}”."
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "Simpan Pengaturan"
+
+#: ../gui/filehandling.py:168
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr "Ekspor palet..."
+
+#: ../gui/filehandling.py:172
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr "Ekspor palet..."
+
+#: ../gui/filehandling.py:176
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr "Buka Berkas Terdahulu"
+
+#: ../gui/filehandling.py:183
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr "Ekspor ke “{file_basename}” berhasil."
+
+#: ../gui/filehandling.py:187
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr "Simpan “{file_basename}” berhasil."
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+
+#: ../gui/filehandling.py:221
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
+msgstr "Gagal menyimpan “{file_basename}”."
+
+#: ../gui/filehandling.py:427
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "All Recognized Formats"
 msgstr "Semua Format yg dikenal"
 
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
+#: ../gui/filehandling.py:432
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "OpenRaster (*.ora)"
 msgstr "Openraster (*.ora)"
 
-#: ../gui/filehandling.py:95
+#: ../gui/filehandling.py:437
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "PNG (*.png)"
 msgstr "PNG (*.png)"
 
-#: ../gui/filehandling.py:96
+#: ../gui/filehandling.py:442
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "JPEG (*.jpg; *.jpeg)"
 msgstr "JPEG (*.jpg; *.jpeg)"
 
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
+#: ../gui/filehandling.py:490
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "By extension (prefer default format)"
 msgstr "Ekstensi (pilih format standar)"
 
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
+#: ../gui/filehandling.py:494
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr "Openraster (*.ora)"
+
+#: ../gui/filehandling.py:498
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
 msgstr "PNG dengan latar solid (*.png)"
 
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
+#: ../gui/filehandling.py:502
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:506
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
 msgstr "PNG transparan (*.png)"
 
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
+#: ../gui/filehandling.py:510
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
 msgstr "Beberapa PNG transparen (*.xxx.png)"
 
-#: ../gui/filehandling.py:113
+#: ../gui/filehandling.py:514
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr "Beberapa PNG transparen (*.xxx.png)"
+
+#: ../gui/filehandling.py:518
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr "JPEG kualitas 90% (*.jpg; *.jpeg)"
 
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr "Simpan..."
+#: ../gui/filehandling.py:576
+#, fuzzy
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr "Ekspor…"
 
-#: ../gui/filehandling.py:177
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Simpan Sebagai…"
+
+#: ../gui/filehandling.py:601
+#, fuzzy
+msgctxt "save dialogs: formats and options: (label)"
 msgid "Format to save as:"
 msgstr "Format untuk menyimpan:"
 
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr "Konfirmasi"
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
+#: ../gui/filehandling.py:668
+#, fuzzy
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
 msgstr "Lanjutkan?"
 
-#: ../gui/filehandling.py:234
-#, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
-msgstr "Akan mengabaikan {abbreviated_time} menit lukisan yang tak tersimpan"
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
+#: ../gui/filehandling.py:705
+#, fuzzy
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
 msgstr "_Simpan sebagai Scrap"
 
-#: ../gui/filehandling.py:282
-#, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
 msgstr ""
 
-#: ../gui/filehandling.py:296
-#, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+#: ../gui/filehandling.py:734
+#, fuzzy, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr "Akan mengabaikan {abbreviated_time} menit lukisan yang tak tersimpan"
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
 msgstr ""
 
-#: ../gui/filehandling.py:321
-#, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
 msgstr ""
 
-#: ../gui/filehandling.py:422
-#, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
-msgstr ""
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr "Buka…"
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
-msgstr ""
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Buka Berkas Terdahulu"
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
-msgstr "Gagal menyimpan “{file_basename}”."
-
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
-msgstr "Ekspor ke “{file_basename}” berhasil."
-
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
-msgstr "Simpan “{file_basename}” berhasil."
-
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Buka..."
-
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr "Buka Scratchpad..."
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Kuas hasil impor"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Buka..."
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Buka yg Terdahulu"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Buka..."
+
+#: ../gui/filehandling.py:1446
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
 msgstr "Tiada berkas scrap dengan nama \"%s\" saat ini."
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1455
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr "Simpan Scrap Selanjutnya"
+
+#: ../gui/filehandling.py:1463
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr "Buka Scrap Terdahulu"
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Buka..."
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+#, fuzzy
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr "Kembali"
+
+#: ../gui/fill.py:121
+#, fuzzy
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr "Tumpahkan Isi"
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+#, fuzzy
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr "Isi area dengan warna"
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+#, fuzzy
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr "Toleransi:"
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+#, fuzzy
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
@@ -1562,58 +1869,188 @@ msgstr ""
 "Seberapa banyak warna yang diperbolehkan berbeda dari awal\n"
 "sebelum Tumpahkan Isi akan menolak untuk mengisinya"
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+#, fuzzy
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr "Sumber:"
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
-msgstr "Manakah layer yg nampak yg harus diisi"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
+msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+#, fuzzy
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr "Muatkan Pada Layar"
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
-msgstr ""
+msgstr "Grup Lapisan Baru"
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Kejelasan:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr "Set Ulang"
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+#, fuzzy
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr "Set ulang ke nilai standar"
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "Pilih lapisan oleh cursor"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1621,130 +2058,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr "Alihkan Bingkai Dokumen"
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr "Aktif"
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr "Tinggi:"
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr "Lebar:"
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr "Putaran:"
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr "Warna:"
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr "Ganti hue warna"
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr "<b>Penuhi Layar</b>"
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr "Hapus"
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr "Buka Berkas Terdahulu"
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr "Potong sesuai batas dokumen"
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr "Lapisan"
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr "Aktif"
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr "Tekanan:"
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr "Bug terdeteksi"
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr "<big><b>Kesalahan pemrograman terdeteksi.</b></big>"
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1753,35 +2202,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr "Laporkan..."
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr "Tentang MyPaint"
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr "Detil..."
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr "Pengcualian ketika menganalisa pengecualian."
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1805,45 +2254,50 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr "Tes Perangkat Input"
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr "(tiada tekanan)"
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr "Tekanan:"
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr "(tiada kemiringan)"
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr "Kemiringan:"
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr "(tiada perangkat)"
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
 msgstr "Perangkat:"
 
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+#, fuzzy
+msgid "Barrel Rotation:"
+msgstr "Putaran"
+
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr "Hapus"
 
@@ -1851,155 +2305,224 @@ msgstr "Hapus"
 msgid "Move the current layer"
 msgstr "Buka Berkas Terdahulu"
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+#, fuzzy
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr "Palet Gimp (*.gpl)"
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
-msgid "Locked"
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Lapisan"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+#, fuzzy
+msgctxt "Layers dockable: description parts: layer locked flag"
+msgid "Locked"
+msgstr "Lapisan"
+
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, fuzzy, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr "Lapisan"
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Lapisan"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr "Lapisan"
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
-msgstr "Modus:"
-
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Kejelasan:"
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/linemode.py:37
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "Putar"
+
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr "Tekanan Input"
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr "Tekanan Input"
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr "Tekanan"
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr ""
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 msgid "Stroke lead-in end"
 msgstr "Waktu menahan coretan"
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr ""
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
+#, fuzzy
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 "Hak Cipta (C) 2005-2010\n"
 "Martin Renold dan Tim Pengembangan MyPaint"
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -2018,256 +2541,285 @@ msgstr ""
 "Perangkat lunak is diedarkan dengan harapan akan berguna, tapi TANPA JAMINAN "
 "APAPUN. Lihat berkas COPYING untuk lebih detilnya."
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr "pemrograman"
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr "portabilitas"
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr "kuas"
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr "pola"
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr "icon desktop"
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr "icon desktop"
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr "Putaran"
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr "icon desktop"
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr "Pungut warna…"
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr "Preferensi"
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr "Ukuran Preview"
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr "Alih Sub-jendela"
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr "Ukuran Preview"
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Place axis"
+msgstr ""
+
+#: ../gui/symmetry.py:84
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Move axis"
 msgstr "Hapus"
 
-#: ../gui/symmetry.py:84
+#: ../gui/symmetry.py:88
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr "Hapus"
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
+#, fuzzy
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr "Tiada aksi:"
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr "Tiada aksi:"
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+#, fuzzy
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr "Tiada aksi:"
+
+#: ../gui/symmetry.py:477
+#, fuzzy
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr "Tiada aksi:"
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr "Aktif"
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr "Tekanan"
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2275,188 +2827,214 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr "<b>Menyimpan</b>"
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr "Perbesaran"
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr "Putar"
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr "Putar Berlawanan Jam"
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr "Tiada aksi"
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr "Tumpahkan Isi"
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr "Kosongkan"
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "Ganti Nama Kelompok"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr "Kosongkan"
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr "Hapus"
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr "Penampakan lapisan"
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr "Lapisan"
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr "Gabung kebawah"
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr "Kosongkan"
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Kuas hasil impor"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr "Hapus"
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr "Pilih lapisan oleh cursor"
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr "Tempel lapisan"
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr "Hapus"
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr "Hapus"
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr "Hapus"
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr "Hapus"
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr "Penampakan lapisan"
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr "Penampakan lapisan"
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr "Lapisan"
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr "Tiada aksi"
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr "Aktif"
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2465,13 +3043,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2481,7 +3059,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2491,13 +3069,13 @@ msgstr ""
 "Gagal menyimpan: “{filename}1”: {err}2\n"
 "Apa masih ada sisa ruang di media penyimpanan?"
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2505,7 +3083,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2513,7 +3091,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2524,7 +3102,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2532,7 +3110,13 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+#, fuzzy
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr "Kuas hasil impor"
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2542,7 +3126,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2553,285 +3137,404 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr "Lapisan"
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
+#, fuzzy
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr "Pilih lapisan oleh cursor"
+
+#: ../lib/layer/data.py:1158
+#, fuzzy
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr "Pilih lapisan oleh cursor"
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1244
 msgctxt "layer default names"
-msgid "Unknown Data Layer"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
 msgstr "Lapisan"
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "Lapisan Lukis Baru"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "Grup Lapisan Baru"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+#, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "Pandangan"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+#, fuzzy
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr "Lapisan"
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+#, fuzzy
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr "Hapus"
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr "Lapisan"
+
+#: ../lib/layervis.py:697
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr "Lapisan"
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr "Penuhi Layar"
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr "Pergelap"
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr "Lebih terang"
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr "Tinggi"
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr "Preferensi"
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr "Putaran"
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2841,7 +3544,30 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+#, fuzzy
+msgid "Vertical"
+msgstr "Cermin Vertikal"
+
+#: ../lib/tiledsurface.py:49
+#, fuzzy
+msgid "Horizontal"
+msgstr "Cermin Horizontal"
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+#, fuzzy
+msgid "Rotational"
+msgstr "Putaran"
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2850,53 +3576,85 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr "Terhapus"
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
-msgstr ""
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
+msgstr "Aplikasikan langsung pada coretan terakhir"
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
-msgstr "Ganti nama Kuas"
+msgid "Save these settings to the brush"
+msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
 msgid "Edit Icon"
@@ -2917,18 +3675,16 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
-msgstr "Aplikasikan langsung pada coretan terakhir"
+msgid "Copy these settings and the current brush's icon to a new brush"
+msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
-msgstr ""
+msgid "Rename this brush"
+msgstr "Ganti nama Kuas"
 
 #: ../po/tmp/brusheditor.glade.h:13
 msgid "Brush Setting"
@@ -2956,113 +3712,91 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr "Pengaturan Kuas:"
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
-msgstr "Nilai dasar:"
+#: ../po/tmp/brusheditor.glade.h:22
+#, fuzzy
+msgid "Value:"
+msgstr "Nilai HSV"
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr "<ymin>"
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr "<ymax>"
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr "Input Pinsil"
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr "<xmin>"
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr "<xmax>"
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr "Pengaturan Kuas"
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr "Simpan Pengaturan"
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
 msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+#, fuzzy
+msgid "Brush dynamics are not available for this setting."
+msgstr "Pengaturan Kuas"
+
+#: ../po/tmp/brusheditor.glade.h:43
+#, fuzzy
+msgid "<big><b>No Brush Dynamics</b></big>"
+msgstr "<big><b>{accel_label}</b></big>"
 
 #: ../po/tmp/inktool.glade.h:1
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
@@ -3074,7 +3808,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr "Tekanan:"
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3116,6 +3850,140 @@ msgstr "Hapus grup"
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
 msgstr "Buka Berkas Terdahulu"
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+#, fuzzy
+msgid "Insert Point"
+msgstr "Hapus grup"
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+#, fuzzy
+msgid "Cull Points"
+msgstr "Hapus grup"
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Nama"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr "Modus"
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Kegelapan"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr "Putar Berlawanan Jam"
+
+#: ../po/tmp/layervis.glade.h:3
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr "Putar Berlawanan Jam"
+
+#: ../po/tmp/layervis.glade.h:4
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr "Manakah layer yg nampak yg harus diisi"
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
+msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
 msgctxt "footer: color picker button: tooltip"
@@ -3484,56 +4352,77 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+#, fuzzy
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr "Aktif"
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr "Pandangan"
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3541,12 +4430,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr "Ubah komponen Merah, Hijau dan Biru"
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3555,7 +4444,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3566,28 +4455,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr "Warna"
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr "Layar (normal)"
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr "Tak aktif (tiada sensitivitas tekanan)"
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr "Jendela (tak direkomendasi)"
@@ -3648,1832 +4537,2121 @@ msgid "Reload the file your current work was loaded from."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
+#, fuzzy
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Import Layers…"
+msgstr "Impor paket kuas…"
+
+#: ../po/tmp/resources.xml.h:13
+msgctxt "Accel Editor (descriptions)"
+msgid "Import layers from one or more files."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save"
 msgstr "Simpan"
 
-#: ../po/tmp/resources.xml.h:13
+#: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file."
 msgstr "Simpan sebagai Standar."
 
-#: ../po/tmp/resources.xml.h:14
+#: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As…"
 msgstr "Simpan Sebagai…"
 
-#: ../po/tmp/resources.xml.h:15
+#: ../po/tmp/resources.xml.h:17
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:16
+#: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Export…"
 msgstr "Ekspor…"
 
-#: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:18
-msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
-msgstr "Simpan Sebagai Scrap"
-
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
-msgstr "Buka Scrap Terdahulu"
+msgid "Save As Scrap"
+msgstr "Simpan Sebagai Scrap"
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
-msgstr "Simpan Scrap Selanjutnya"
+msgid "Open Previous Scrap"
+msgstr "Buka Scrap Terdahulu"
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Open Next Scrap"
+msgstr "Simpan Scrap Selanjutnya"
+
+#: ../po/tmp/resources.xml.h:25
+msgctxt "Accel Editor (descriptions)"
+msgid "Load the scrap file after the current one."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Recover File from an Automated Backup…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:25
+#: ../po/tmp/resources.xml.h:27
 msgctxt "Accel Editor (descriptions)"
 msgid "Try to save and resume interrupted unsaved work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:26
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr "Tombol Kuas"
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr "Tombol Kuas"
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr "Tulis ulang kelompok kuas."
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr "Nilai warna"
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr "Warna"
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr "Modus"
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr "Modus"
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
+#: ../po/tmp/resources.xml.h:37
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Pressure"
+msgstr "Tekanan Input"
+
+#: ../po/tmp/resources.xml.h:38
+msgctxt "Accel Editor (descriptions)"
+msgid "Send harder pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:39
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Pressure"
+msgstr "Tekanan Input"
+
+#: ../po/tmp/resources.xml.h:40
+msgctxt "Accel Editor (descriptions)"
+msgid "Send softer pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:41
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Rotation"
+msgstr "Putaran"
+
+#: ../po/tmp/resources.xml.h:42
+msgctxt "Accel Editor (descriptions)"
+msgid "Increase barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:43
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
+msgstr "Putaran"
+
+#: ../po/tmp/resources.xml.h:44
+msgctxt "Accel Editor (descriptions)"
+msgid "Decrease barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:45
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Size"
 msgstr "Tambah Kejelasan Lapisan"
 
-#: ../po/tmp/resources.xml.h:36
+#: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush bigger."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:37
+#: ../po/tmp/resources.xml.h:47
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Size"
 msgstr "Kurangi Kejelasan Lapisan"
 
-#: ../po/tmp/resources.xml.h:38
+#: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush smaller."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:39
+#: ../po/tmp/resources.xml.h:49
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Opacity"
 msgstr "Tambah Kejelasan Lapisan"
 
-#: ../po/tmp/resources.xml.h:40
+#: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush more opaque."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:41
+#: ../po/tmp/resources.xml.h:51
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Opacity"
 msgstr "Kurangi Kejelasan Lapisan"
 
-#: ../po/tmp/resources.xml.h:42
+#: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush less opaque."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:43
+#: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Lighten Painting Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:44
+#: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase the lightness of the current painting color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:45
+#: ../po/tmp/resources.xml.h:55
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Darken Painting Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:46
+#: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
-msgstr "Putar Berlawanan Jam"
-
-#: ../po/tmp/resources.xml.h:48
-msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
-msgstr "Putar Berlawanan Jam."
-
-#: ../po/tmp/resources.xml.h:49
+#: ../po/tmp/resources.xml.h:57
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Change Hue Clockwise"
 msgstr "Ganti nilai warna (HSV)"
 
-#: ../po/tmp/resources.xml.h:50
+#: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
 msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:51
+#: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr "Putar Berlawanan Jam"
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr "Putar Berlawanan Jam."
+
+#: ../po/tmp/resources.xml.h:61
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Increase Saturation"
 msgstr "Putaran"
 
-#: ../po/tmp/resources.xml.h:52
+#: ../po/tmp/resources.xml.h:62
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color more saturated (more colorful, purer)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:53
+#: ../po/tmp/resources.xml.h:63
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Decrease Saturation"
 msgstr "Putaran"
 
-#: ../po/tmp/resources.xml.h:54
+#: ../po/tmp/resources.xml.h:64
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color less saturated (grayer)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:55
+#: ../po/tmp/resources.xml.h:65
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Reload Brush Settings"
 msgstr "Pengaturan Kuas"
 
-#: ../po/tmp/resources.xml.h:56
+#: ../po/tmp/resources.xml.h:66
 msgctxt "Accel Editor (descriptions)"
 msgid "Restore all brush settings to the current brush’s saved values."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:57
+#: ../po/tmp/resources.xml.h:67
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Pick Stroke and Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:58
+#: ../po/tmp/resources.xml.h:68
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:59
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr "Simpan yg terakhir tadi terpakai"
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr "Simpan yg terakhir tadi terpakai."
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "Bersihkan Lapisan"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr "Buka Berkas Terdahulu."
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+#, fuzzy
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr "icon desktop"
+
+#: ../po/tmp/resources.xml.h:76
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr "Lapisan"
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "Grup Lapisan Baru"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "Grup Lapisan Baru"
+
+#: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr "Salin ke Clipboard"
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr "Salin ke Clipboard"
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:71
+#: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Edit Layer in External App…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr "Pilih lapisan oleh cursor"
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr "Lapisan"
-
-#: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
-msgstr "Lapisan"
-
-#: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
-msgstr "Lapisan Lukis Baru"
-
-#: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
-msgstr "Buka Berkas Terdahulu."
-
-#: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
-msgstr "Pilih lapisan oleh cursor…"
-
-#: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:85
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
-msgstr "Grup Lapisan Baru"
-
-#: ../po/tmp/resources.xml.h:86
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
-msgstr "Buka Berkas Terdahulu."
-
-#: ../po/tmp/resources.xml.h:87
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:88
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
-msgstr "Buka Berkas Terdahulu."
-
-#: ../po/tmp/resources.xml.h:89
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
-msgstr "Buka Berkas Terdahulu."
+msgid "Commit changes saved from the external app (normally automatic)."
+msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
-msgstr "Lapisan"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
+msgstr "Pilih lapisan oleh cursor"
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr "Lapisan"
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
-msgstr "Penampakan lapisan"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
+msgstr "Lapisan"
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
-msgstr "Hapus Lapisan"
+msgid "New Painting Layer"
+msgstr "Lapisan Lukis Baru"
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr "Buka Berkas Terdahulu."
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer…"
+msgstr "Pilih lapisan oleh cursor…"
+
+#: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr "Grup Lapisan Baru"
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr "Buka Berkas Terdahulu."
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr "Buka Berkas Terdahulu."
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr "Buka Berkas Terdahulu."
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr "Lapisan"
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr "Lapisan"
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr "Penampakan lapisan"
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr "Hapus Lapisan"
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr "Buka Berkas Terdahulu."
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Convert to Normal Painting Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:102
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr "Tambah Kejelasan Lapisan"
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr "Kurangi Kejelasan Lapisan"
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr "Hapus"
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr "Lapisan"
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr "Tempel lapisan"
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr "Buka Berkas Terdahulu."
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
+#, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
-msgstr "Hapus…"
+msgid "Layer Properties…"
+msgstr "Palet Gimp (*.gpl)"
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
-msgstr "Buka Berkas Terdahulu."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr "Lapisan"
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr "Penampakan lapisan"
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr "Latar"
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr "Nyalakan lapisan sebagai topeng."
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr "Buka Berkas Terdahulu."
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr "Set Ulang dan Tengahkan"
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr "Muatkan Pada Layar"
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr "Set Ulang"
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr "Set Ulang"
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr "Putaran"
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr "Perbesaran"
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr "Tambah Kejelasan Lapisan."
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Perkecil"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr "Kurangi Kejelasan Lapisan."
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
+#, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
-msgstr "Putar Berlawanan Jarum Jam"
+msgid "Pan Left"
+msgstr "Pandangan"
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
-msgstr "Putar Berlawanan Jam."
+msgid "Move your view of the canvas to the left."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr "Tinggi"
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr "Pandangan"
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr "Putar Searah Jarum Jam"
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr "Putar Berlawanan Jam."
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr "Putar Berlawanan Jarum Jam"
+
+#: ../po/tmp/resources.xml.h:167
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr "Putar Berlawanan Jam."
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr "Cermin Horizontal"
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr "Cermin Vertikal"
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr "Lapisan sendiri"
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr "Buka Berkas Terdahulu."
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr "Aktif"
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr "Alihkan Bingkai Dokumen."
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr "Cetak Nilai Input Kuas pada Konsol"
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr "Gambarkan Prosesnya"
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr "Matikan GTK Double Rendering"
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+#, fuzzy
+msgid "Delete Point"
+msgstr "Hapus grup"
+
+#: ../po/tmp/resources.xml.h:187
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr "Buka Berkas Terdahulu"
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr "Pilihan warna sekarang"
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Berkas"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "Keluar"
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "Sunting"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr "Pilihan warna sekarang"
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "Warna"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr "Pilihan warna sekarang"
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr "Warna yg terpakai"
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr "Detil"
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr "Ukuran Preview"
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr "Ukuran Preview"
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr "Tambahkan warna pada Pola"
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "Lapisan"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr "Kejelasan"
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr "Lapisan"
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr "Lapisan Sendiri"
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr "Papan goresan"
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr "Simpan Scrap Selanjutnya"
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr "Simpan Scrap Selanjutnya…"
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr "Simpan palet di"
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr "Simpan Sebagai…"
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr "Simpan Scrap Selanjutnya"
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr "Simpan sebagai Standar"
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr "Simpan sebagai Standar"
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr "Latar"
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "Jendela"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "Kuas"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr "Tombol pintas"
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr "Tombol pintas"
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "Ubah Kuas…"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "Ganti hue warna…"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "Ganti hue warna…"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr "Impor paket kuas…"
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr "Benar akan menghapus kuas ini."
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Bantuan"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "Tentang MyPaint"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Debug"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr "Cetak Informasi Kebocoran Memori ke Konsol (Lambat!)"
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr "Jalankan Garbage Collector Sekarang"
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr "Mulai/Hentikan Profiling Python (cProfile)"
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "Lihat"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr "Pilihan warna sekarang"
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
+#, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr "PopUp Menu"
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "Penuhi Layar"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "Preferensi"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr "Tes perangkat input"
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr "Latar"
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr "Pengaturan Kuas"
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr "Pengaturan Kuas."
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr "Editor Kuas"
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr "Lapisan"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "Tambahkan warna pada Pola"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr "Ubah Saturasi dan Nilai."
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr "Nilai dasar"
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr "Square"
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr "Simpan Scrap Selanjutnya"
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr "Simpan sebagai Standar"
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "Ukuran Preview"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr "Warna yg terpakai"
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr "Warna yg baru dipakai"
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr "Pandangan"
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr "Geser"
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr "Pandangan"
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr "Putar"
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr "Putar"
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr "Putar"
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr "Perbesaran"
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr "Perbesaran"
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr "Perbesaran"
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr "Tinta"
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr "Lapisan"
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr "Lapisan"
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr "Lapisan"
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr "Ganti hue warna"
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr "Pungut warna"
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr "Pungut warna"
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "Pungut Warna"
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "Pungut Warna"
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "Pungut Warna"
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr "Pungut warna"
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr "Isi area dengan warna."
+
+#~ msgctxt "Accelerator map editor: action column markup"
+#~ msgid ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+#~ msgstr ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+
+#~ msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
+#~ msgid "{action_label} {action_desc} {accel_label}"
+#~ msgstr "{action_label} {action_desc} {accel_label}"
+
+#~ msgctxt "brush list context menu"
+#~ msgid "Delete"
+#~ msgstr "Hapus"
+
+#~ msgctxt "brush list commands"
+#~ msgid "Really delete brush from disk?"
+#~ msgstr "Yakin akan menghapus kuas ini?"
+
+#~ msgid "HSV Triangle"
+#~ msgstr "Segitiga Warna"
+
+#~ msgid "The standard GTK color selector"
+#~ msgstr "Pemilih warna MyPaint"
+
+#~ msgid "Save..."
+#~ msgstr "Simpan..."
+
+#~ msgid "Confirm"
+#~ msgstr "Konfirmasi"
+
+#~ msgid "Open..."
+#~ msgstr "Buka..."
+
+#~ msgid "Mode:"
+#~ msgstr "Modus:"
+
+#~ msgid "Setting name:"
+#~ msgstr "Pengaturan Kuas:"
+
+#~ msgid "Base value:"
+#~ msgstr "Nilai dasar:"
+
+#~ msgid "<ymin>"
+#~ msgstr "<ymin>"
+
+#~ msgid "<ymax>"
+#~ msgstr "<ymax>"
+
+#~ msgid "<xmin>"
+#~ msgstr "<xmin>"
+
+#~ msgid "<xmax>"
+#~ msgstr "<xmax>"
+
+#~ msgid "Edit Setting"
+#~ msgstr "Simpan Pengaturan"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Trim Layer to Frame"
+#~ msgstr "Lapisan"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Rename Layer…"
+#~ msgstr "Hapus…"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Enter a new name for the current layer."
+#~ msgstr "Buka Berkas Terdahulu."
+
+#~ msgctxt "Menu→Edit (labels)"
+#~ msgid "Current Tool"
+#~ msgstr "Pilihan warna sekarang"
 
 #~ msgid "Add As New"
 #~ msgstr "Tambah Jadi Baru"
@@ -5575,9 +6753,6 @@ msgstr "Isi area dengan warna."
 #~ "(tekanan, kecepatan, dll.) tersdia sebagai tooltips. Cukup arahkan mouse "
 #~ "diatas label untuk melihatnya. \n"
 
-#~ msgid "Open Recent files"
-#~ msgstr "Buka Berkas Terdahulu"
-
 #~ msgid "This will discard %d second of unsaved painting."
 #~ msgid_plural "This will discard %d seconds of unsaved painting."
 #~ msgstr[0] "Akan mengabaikan %d detik lukisan yang tak tersimpan."
@@ -5654,10 +6829,6 @@ msgstr "Isi area dengan warna."
 #~ msgstr "Simpan Pengaturan"
 
 #, fuzzy
-#~ msgid "Add Layer"
-#~ msgstr "Lapisan"
-
-#, fuzzy
 #~ msgid "Change Layer Visibility"
 #~ msgstr "Penampakan lapisan"
 
@@ -5686,10 +6857,6 @@ msgstr "Isi area dengan warna."
 #~ msgctxt "Menu|File|"
 #~ msgid "Save"
 #~ msgstr "Simpan"
-
-#, fuzzy
-#~ msgid "Export to a file"
-#~ msgstr "Ekspor palet..."
 
 #, fuzzy
 #~ msgctxt "Menu|Brush|"

--- a/po/is.po
+++ b/po/is.po
@@ -527,18 +527,18 @@ msgstr "MyPaint penslapakki (*.zip)"
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
-msgstr "Nýr hópur..."
+msgid "New Group…"
+msgstr "Nýr hópur…"
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
-msgstr "Flytja inn pensla..."
+msgid "Import Brushes…"
+msgstr "Flytja inn pensla…"
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
-msgstr "Ná í fleiri pensla..."
+msgid "Get More Brushes…"
+msgstr "Ná í fleiri pensla…"
 
 #: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
@@ -1220,13 +1220,13 @@ msgstr "Tegund"
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
-msgstr "Nota fyrir..."
+msgid "Use for…"
+msgstr "Nota fyrir…"
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
-msgstr "Skruna..."
+msgid "Scroll…"
+msgstr "Skruna…"
 
 #. Name and preview column: will be indented
 #: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
@@ -1449,8 +1449,8 @@ msgid "_Quit"
 msgstr "Hætta"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
-msgstr "Flytja inn penslapakka..."
+msgid "Import brush package…"
+msgstr "Flytja inn penslapakka…"
 
 #: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
@@ -1505,8 +1505,8 @@ msgstr ""
 "“{type_name}” ({content_type})?"
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
-msgstr "Opna með..."
+msgid "Open With…"
+msgstr "Opna með…"
 
 #: ../gui/externalapp.py:123
 msgid "Icon"
@@ -1696,13 +1696,13 @@ msgstr "JPEG 90% gæði (*.jpg; *.jpeg)"
 
 #: ../gui/filehandling.py:576
 #, fuzzy
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr "Flytja út…"
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Vista sem…"
 
@@ -1773,8 +1773,8 @@ msgstr "Opna"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
-msgstr "Opna krassblað..."
+msgid "Open Scratchpad…"
+msgstr "Opna krassblað…"
 
 #: ../gui/filehandling.py:1099
 #, fuzzy
@@ -2230,13 +2230,13 @@ msgstr ""
 "annar er þegar búinn að tilkynna þetta."
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
-msgstr "Leita í villuskrá..."
+msgid "Search Tracker…"
+msgstr "Leita í villuskrá…"
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
-msgstr "Skýrsla..."
+msgid "Report…"
+msgstr "Skýrsla…"
 
 #: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
@@ -2247,8 +2247,8 @@ msgid "Quit MyPaint"
 msgstr "Hætta í MyPaint"
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
-msgstr "Nánar..."
+msgid "Details…"
+msgstr "Nánar…"
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
@@ -2437,8 +2437,8 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
-msgstr "Flytja lag í stafla..."
+msgid "Move layer in stack…"
+msgstr "Flytja lag í stafla…"
 
 #: ../gui/layerswindow.py:110
 msgid ""
@@ -2508,8 +2508,8 @@ msgid "Stroke trail-off beginning"
 msgstr "Endi við lok stroklínu"
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
-msgstr "Breytileiki þrýstings..."
+msgid "Pressure variation…"
+msgstr "Breytileiki þrýstings…"
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
@@ -3686,7 +3686,7 @@ msgstr "Eyða þessum pensli af diski"
 #, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid "_Recover & Save…"
-msgstr "Endu_rheimta og vista..."
+msgstr "Endu_rheimta og vista…"
 
 #: ../po/tmp/autorecover.glade.h:12
 #, fuzzy

--- a/po/is.po
+++ b/po/is.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Icelandic (MyPaint)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-23 17:31+0200\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:19+0000\n"
 "Last-Translator: Sveinn í Felli <sv1@fellsnet.is>\n"
 "Language-Team: Icelandic <https://hosted.weblate.org/projects/mypaint/"
@@ -15,29 +15,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n % 10 != 1 || n % 100 == 11;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr "<big><b>{accel_label}</b></big>"
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr "{action_label} {action_desc} {accel_label}"
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "Aðgerð"
 
@@ -45,32 +23,32 @@ msgstr "Aðgerð"
 msgid "Key combination"
 msgstr "Lyklasamsetning"
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr "Breyta lykli fyrir '%s'"
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "Aðgerð:"
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "Slóð:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "Lykill:"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr "Ýttu á lykla til að uppfæra þessa úthlutun/bindingu"
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "Óþekkt aðgerð"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
@@ -79,7 +57,7 @@ msgstr ""
 "<b>{accel} er þegar í notkun fyrir '{action}'. Fyrirliggjandi úthlutun "
 "verður skipt út.</b>"
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr "Opna möppuna “{folder_basename}”…"
@@ -87,194 +65,204 @@ msgstr "Opna möppuna “{folder_basename}”…"
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "Í lagi"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr "Engin öryggisafrit fundust í skyndiminninu."
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr "Engin öryggisafrit tiltæk"
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr "Opna skyndiminnismöppuna…"
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr "Endurheimting öryggisafrits mistókst"
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr "Opna öryggisafritamöppuna…"
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr "Endurheimti skrá úr {iso_datetime}.ora"
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "Vista sem sjálfgefið"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "Bakgrunnur"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "Mynstur"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Litur"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "Bæta lit í mynstur"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr "Ekki var hægt að hlaða inn einum eða fleiri bakgrunnum"
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr "Villa við hleðslu bakgrunna"
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 "Fjarlægðu óhlaðanlegu skrárnar, eða athugaðu libgdkpixbuf uppsetninguna."
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr "Gdk-Pixbuf gat ekki hlaðið \"{filename}\", og tilkynnti um \"{error}\""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr "{filename} er með núll-stærð (w={w}, h={h})"
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr "Stillingaritill fyrir pensla"
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr "Um"
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "Á tilraunastigi"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr "Einfalt"
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr "Ógegnsæi"
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr "Blettir"
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "Káma"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr "Hraði"
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr ""
+
+#: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr "Fylgni"
 
-#: ../gui/brusheditor.py:359
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "Pensilstroka"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr "Litur"
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Sérsniðið"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr "Enginn pensill valinn, notaðu \"Bæta við sem nýju\" í staðinn."
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr "Enginn pensill valinn!"
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "Endurnefna pensil"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "Pensill með þessu nafni er þegar til!"
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr "Enginn pensill valinn!"
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr "Í alvörunni eyða penslinum “{brush_name}” af diski?"
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr "(nafnlaus pensill)"
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr "{brush_name} [óvistað]"
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr "Táknmynd pensils"
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr "Táknmynd pensils (ritill)"
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr "Enginn pensill valinn"
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -283,7 +271,7 @@ msgstr ""
 "<b>%s</b>\n"
 "<small>Veldu fyrst gildan pensil</small>"
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
@@ -292,7 +280,7 @@ msgstr ""
 "<b>%s</b> <i>(breytt)</i>\n"
 "<small>Breytingarnar eru ekki ennþá vistaðar</small>"
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
@@ -301,7 +289,7 @@ msgstr ""
 "<b>%s</b> (editing)\n"
 "<small>Málaðu með einhverjum pensli eða lit</small>"
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -342,142 +330,182 @@ msgstr "Sjálfvirkt"
 msgid "Use the default icon"
 msgstr "Nota sjálfgefna táknmynd"
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Vista"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr "Vista þessa forskoðunartáknmynd og ljúka breytingum"
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr "Tapað & fundið"
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr "Eytt"
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr "Eftirlæti"
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr "Blek"
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr "Hefðbundið"
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr "Sett#1"
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr "Sett#2"
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr "Sett#3"
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr "Sett#4"
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr "Sett#5"
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr "Á tilraunastigi"
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Nýtt"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr "Óþekktur pensill"
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr "Bæta við Eftirlæti"
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr "Fjarlægja úr Eftirlæti"
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr "Klóna"
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr "Breyta pensilstillingum"
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
-msgstr "Eyða"
+#: ../gui/brushselectionwindow.py:250
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
+msgstr "Endurnefna hóp"
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
-msgstr "Í alvörunni eyða pensli af diski?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, fuzzy, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
+msgstr "Í alvörunni eyða penslinum “{brush_name}” af diski?"
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] "%d pensill"
 msgstr[1] "%d penslar"
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr "Hópur “{group_name}”"
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr "Endurnefna hóp"
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr "Flytja út sem ZIP-þjappað penslasett"
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr "Eyða hóp"
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr "Fjarlægja hóp"
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "Hópur með þessu nafni er þegar til!"
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr "Viltu virkilega eyða hópnum “{group_name}”?"
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -487,58 +515,58 @@ msgstr ""
 "Gat ekki eytt hópnum “{group_name}”.\n"
 "Sumum sérhópum er ekki hægt að eyða."
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr "Flytja út pensla"
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr "MyPaint penslapakki (*.zip)"
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "Nýr hópur..."
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr "Flytja inn pensla..."
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr "Ná í fleiri pensla..."
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "Búa til hóp"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr "Hnappur"
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr "Hnp"
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr "Ýtt á hnapp"
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr "Bæta við nýrri lyklabindingu"
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr "Fjarlægja núverandi lyklabindingu"
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr "Breyta lyklabindingu fyrir '%s'"
@@ -547,7 +575,7 @@ msgstr "Breyta lyklabindingu fyrir '%s'"
 msgid "Button press:"
 msgstr "Ýtt á hnapp:"
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
@@ -555,7 +583,7 @@ msgstr ""
 "Haltu niðri breytilyklum og ýttu á hnappinn fyrir ofan þennan texta til að "
 "setja nýja lyklabindingu."
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
@@ -563,41 +591,69 @@ msgstr ""
 "{button} er ekki hægt að binda án breytilykils (þýðing hans er föst, því "
 "miður)"
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr "{button_combination} er þegar bundið aðgerðinni '{action_name}'"
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr "Veldu lit"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr "Veldu lit til að mála með"
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+#, fuzzy
+msgid "Set the color Hue used for painting"
+msgstr "Veldu lit til að mála með"
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "Veldu lit"
+
+#: ../gui/colorpicker.py:296
+#, fuzzy
+msgid "Set the color Chroma used for painting"
+msgstr "Veldu lit til að mála með"
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+#, fuzzy
+msgid "Set the color Luma used for painting"
+msgstr "Veldu lit til að mála með"
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr "Nánar um lit"
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 "Núverandi litur pensils, og liturinn sem síðast var notaður til að mála með"
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr "Litrófsmaski virkur"
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -608,7 +664,7 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr "HCY litblær og litgildi."
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
@@ -617,12 +673,12 @@ msgstr ""
 "Ritill fyrir litrófsmaska. Smelltu í miðjuna til að útbúa eða vinna með "
 "form, eða snúðu maskanum með jöðrum hringsins."
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr "Loftslagsþrenning"
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
@@ -631,22 +687,22 @@ msgstr ""
 "Blæbrigðafullt og túlkunarháð, skilgreint með einum aðalfrumlit og tveimur "
 "oðrum frumlitum með minna vægi."
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr "Hliðruð þrenning"
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr "Vægi meira í áttina að megnasta litnum."
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr "Gagnstæður litur"
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
@@ -655,96 +711,96 @@ msgstr ""
 "Árekstrar milli andstæðna í ákveðnu jafnvægi frá hlutlausum millilitum af "
 "litahringnum."
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr "Hughrif og áherslur"
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr "Skipta upp gagnstæðum litum"
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr "Nýr litrófsmaski út frá sniðmáti"
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr "Ritill fyrir litrófsmaska"
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr "Virkt"
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr "Hjálp…"
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr "Búa til maska út frá sniðmáti."
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr "Hlaða maska inn úr GIMP-litaspjaldskrá."
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr "Vista maska í GIMP-litaspjaldskrá."
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr "Þurrka út maskann."
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr "Opnar hjálparsíðu á netinu í vafra fyrir þennan samskiptaglugga."
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr "Vista maska sem GIMP-litaspjaldskrá"
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr "Hlaða maska inn úr GIMP-litaspjaldi"
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr "Setja litrófsmaska."
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr "HCY-litahringur"
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -754,162 +810,154 @@ msgstr ""
 "jafn bjartar."
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr "HSV litblær (H)"
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr "HSV litmettun (S)"
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr "HSV gildi (V)"
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr "HSV litmettun og gildi (SV)"
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr "HSV litblær og gildi (HV)"
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr "HSV litblær og litmettun (HS)"
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr "Snúa teningi (sýna mismunandi ása)"
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr "HSV-teningur"
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr "HSV-kubbur sem hægt er að snúa til að skoða mismunandi sniðfleti."
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr "HSV-ferningur"
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr "HSV-ferningur sem hægt er að snúa til að skoða mismunandi litblæ."
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr "HSV-þríhyrningur"
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr "Staðlaði GTK-litaveljarinn"
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr "HSV-litahringur"
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr "Breytir litmettun og gildi (SV)."
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr "Eiginleikar litaspjalds"
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr "Litaspjald"
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr "Velja litinn af hlaðanlegu, breytanlegu litaspjaldi."
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr "Ónefnt litaspjald"
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr "Litaspjaldsritill"
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr "Hlaða inn úr GIMP-litaspjaldskrá"
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr "Vista í GIMP-litaspjaldskrá"
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr "Bæta við nýrri auðri litaprufu"
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr "Fjarlægja núverandi litaprufu"
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr "Fjarlægja allar litaprufur"
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr "Titill:"
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr "Nafn eða lýsing á þessu litaspjaldi"
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr "Dálkar:"
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr "Fjöldi dálka"
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr "Heiti litar:"
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr "Núverandi heiti litarins"
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr "Tómt hólf á litaspjaldi"
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr "Hlaða inn litaspjaldi"
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr "Vista litaspjald"
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -920,379 +968,376 @@ msgstr ""
 "Slepptu litum hingað,\n"
 "dragðu þá til að raða."
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr "Tómt hólf á litaspjaldi (dragðu lit hingað)"
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr "Bæta við tómu hólfi"
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr "Setja inn röð"
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr "Setja inn dálk"
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr "Fylla bil (RGB)"
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr "Fylla bil (HCY)"
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr "Fylla bil (HSV)"
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "GIMP litaspjald (*gpl)"
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr "Allar skrár (*)"
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "GIMP litaspjald (*gpl)"
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr "Allar skrár (*)"
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr "Plokkaðu lit af skjánum"
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr "R"
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr "G"
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr "B"
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr "H"
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr "C"
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr "Y"
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr "Sleðar fyrir litþætti"
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr "Breyta stökum þáttum litarins."
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr "RGB Rautt"
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr "RGB Grænt"
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr "RGB Blátt"
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr "HSV litblær (H)"
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr "HSV litmettun (S)"
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr "HSV gildi (V)"
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr "HCY litblær (H)"
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr "HCY litgildi (C)"
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr "HCY ljómi (Y')"
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr "Vökvalegið"
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr "Skiptu um lit með spjaldi sem dregið hefur liti frá næstu litum."
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr "Sammiðja hringir"
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr "Skiptu um lit með hjálp sammiðja HSV-hringja."
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr "Krosslitamark"
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr "Skiptu um lit með HSV-litstiglum þvert á litgeislahring."
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr "Bendill"
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr "Strokleður"
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr "Lyklaborð"
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr "Mús"
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr "Penni"
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr "Snertiplatti"
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr "Snertiskjár"
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr "Hunsa"
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr "Eitthvað verk"
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr "Ekki-málunarverk"
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr "Einungis flakk"
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr "Aðdráttur"
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr "Hliðra"
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr "Tæki"
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr "Ásar"
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr "Tegund"
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr "Nota fyrir..."
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr "Skruna..."
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Heiti"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr "Skrifa yfir pensil?"
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr "Skipta út"
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr "Endurnefna"
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr "Skipta öllu út"
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr "Endurnefna allt"
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr "Innfluttur pensill"
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr "Fyrirliggjandi pensill"
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 "<b>Pensill með heitinu `%s' er þegar til.</b>\n"
 "Viltu skipta honum út, eða ætti að endurnefna nýja pensilinn?"
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr "Skrifa yfir pensilhóp?"
 
-#: ../gui/dialogs.py:190
-#, python-brace-format
+#: ../gui/dialogs.py:220
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 "<b>Hópur með heitinu `{groupname}' er þegar til.</b>\n"
 "Viltu skipta honum út, eða ætti að endurnefna nýja hópinn?\n"
 "Ef þú skiptir honum út, gætu penslarnir verið færðir í hóp með heitinu "
 "`{deleted_groupname}'."
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr "Flytja inn penslapakka?"
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, fuzzy, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr "<b>Ertu viss um að þú viljir flytja inn pakkann `%s'?</b>"
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr "Hlaða inn pensilstillingum úr flýtilyklahólfi %d"
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr "Geyma pensilstillingar í flýtilyklahólfi %d"
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr "Endurheimta pensil %d"
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr "Vista í pensil %d"
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr "Afturkalla '%s'"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Afturkalla"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr "Endurtaka '%s'"
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Endurtaka"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr "{button_combination} er {resultant_action}"
@@ -1302,90 +1347,127 @@ msgstr "{button_combination} er {resultant_action}"
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ";  "
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr "Þegar {modifiers} er haldið niðri:  {button_actions}."
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
-msgstr "Heiti lags"
-
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
-#, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
-"<b>{name}</b>\n"
-"{description}"
+
+#: ../gui/document.py:909
+#, python-brace-format
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
+msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr "%s - MyPaint"
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr "MyPaint"
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Opna"
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr "Stilla núverandi lit"
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr "Yfirgefa skjáfylliham"
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr "Yfirgefa skjáfylli"
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr "Fara í skjáfylliham"
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Skjáfylli"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Hætta"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+#, fuzzy
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr "Hætta í alvöru?"
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Hætta"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr "Flytja inn penslapakka..."
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr "MyPaint penslapakki (*.zip)"
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr "Ræsti {app_name} til að breyta laginu “{layer_name}”"
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr "Villa: mistókst að ræsa {app_name} til að breyta laginu “{layer_name}”"
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
@@ -1393,12 +1475,18 @@ msgstr ""
 "Hætt við breytingar. Þú getur áfram breytt “{layer_name}” með því að fara í "
 "valmyndina 'Lög'."
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr "Uppfærði lagið “{layer_name}” með utanaðkomandi breytingum"
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr "Gat ekki hlaðið inn “{file_basename}”."
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
@@ -1407,7 +1495,7 @@ msgstr ""
 "MyPaint þarf að vinna með skrá af tegundinni “{type_name}” ({content_type}). "
 "Hvaða forrit ætti að nota við það?"
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
@@ -1416,161 +1504,374 @@ msgstr ""
 "Hvaða forrit ætti MyPaint að nota við vinnslu skráa af tegundinni "
 "“{type_name}” ({content_type})?"
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr "Opna með..."
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr "Táknmynd"
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr "engin lýsing"
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
+#: ../gui/filehandling.py:126
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
+msgstr "Hleð inn “{file_basename}”…"
+
+#: ../gui/filehandling.py:130
+#, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:134
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
+msgstr "Vista “{file_basename}”…"
+
+#: ../gui/filehandling.py:138
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
+msgstr "Flyt út í “{file_basename}”…"
+
+#: ../gui/filehandling.py:145
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr "Mistókst að flytja út í “{file_basename}”."
+
+#: ../gui/filehandling.py:149
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr "Mistókst að vista “{file_basename}”."
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr "Gat ekki hlaðið inn “{file_basename}”."
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "Vista litaspjald"
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr "Það tókst að flytja út í “{file_basename}”."
+
+#: ../gui/filehandling.py:187
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr "Það tókst að vista “{file_basename}”."
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr "Hlóð inn “{file_basename}”."
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
+msgstr "Hlóð inn “{file_basename}”."
+
+#: ../gui/filehandling.py:427
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "All Recognized Formats"
 msgstr "Öll þekkt skráasnið"
 
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
+#: ../gui/filehandling.py:432
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "OpenRaster (*.ora)"
 msgstr "OpenRaster (*.ora)"
 
-#: ../gui/filehandling.py:95
+#: ../gui/filehandling.py:437
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "PNG (*.png)"
 msgstr "PNG (*.png)"
 
-#: ../gui/filehandling.py:96
+#: ../gui/filehandling.py:442
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "JPEG (*.jpg; *.jpeg)"
 msgstr "JPEG (*.jpg; *.jpeg)"
 
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
+#: ../gui/filehandling.py:490
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "By extension (prefer default format)"
 msgstr "Eftir skráarendingu (velja helst sjálfgefið snið)"
 
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
+#: ../gui/filehandling.py:494
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:498
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
 msgstr "PNG með heillitum bakgrunni (*.png)"
 
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
+#: ../gui/filehandling.py:502
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:506
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
 msgstr "PNG með gegnsæi (*.png)"
 
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
+#: ../gui/filehandling.py:510
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
 msgstr "PNG myndaröð með gegnsæi (*.XXX.png)"
 
-#: ../gui/filehandling.py:113
+#: ../gui/filehandling.py:514
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr "PNG myndaröð með gegnsæi (*.XXX.png)"
+
+#: ../gui/filehandling.py:518
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr "JPEG 90% gæði (*.jpg; *.jpeg)"
 
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr "Vista..."
+#: ../gui/filehandling.py:576
+#, fuzzy
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr "Flytja út…"
 
-#: ../gui/filehandling.py:177
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Vista sem…"
+
+#: ../gui/filehandling.py:601
+#, fuzzy
+msgctxt "save dialogs: formats and options: (label)"
 msgid "Format to save as:"
 msgstr "Snið til að vista sem:"
 
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr "Staðfesta"
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
+#: ../gui/filehandling.py:668
+#, fuzzy
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
 msgstr "Viltu halda áfram?"
 
-#: ../gui/filehandling.py:234
-#, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
-msgstr "Þetta mun henda {abbreviated_time} af óvistuðum breytingum"
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
+#: ../gui/filehandling.py:705
+#, fuzzy
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
 msgstr "Vista _sem úrklippu"
 
-#: ../gui/filehandling.py:282
-#, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
-msgstr "Hleð inn “{file_basename}”…"
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
 
-#: ../gui/filehandling.py:296
-#, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
-msgstr "Gat ekki hlaðið inn “{file_basename}”."
+#: ../gui/filehandling.py:734
+#, fuzzy, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr "Þetta mun henda {abbreviated_time} af óvistuðum breytingum"
 
-#: ../gui/filehandling.py:321
-#, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
-msgstr "Hlóð inn “{file_basename}”."
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
 
-#: ../gui/filehandling.py:422
-#, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
-msgstr "Flyt út í “{file_basename}”…"
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
 
-#: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
-msgstr "Vista “{file_basename}”…"
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
-msgstr "Mistókst að flytja út í “{file_basename}”."
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr "Opna…"
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
-msgstr "Mistókst að vista “{file_basename}”."
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Opna"
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
-msgstr "Það tókst að flytja út í “{file_basename}”."
-
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
-msgstr "Það tókst að vista “{file_basename}”."
-
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Opna..."
-
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr "Opna krassblað..."
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Innfluttur pensill"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Opna"
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Opna nýjasta"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Opna"
+
+#: ../gui/filehandling.py:1446
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
 msgstr "Það eru engar úrklippuskrár með heitinu \"%s\" ennþá."
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1455
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr "Opna næstu úrklippu"
+
+#: ../gui/filehandling.py:1463
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr "Opna fyrri úrklippu"
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Opna"
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+#, fuzzy
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr "Endurlesa"
+
+#: ../gui/fill.py:121
+#, fuzzy
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr "Flæðifylla"
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+#, fuzzy
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr "Fylla svæði með lit"
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+#, fuzzy
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr "Þolmörk:"
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+#, fuzzy
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
@@ -1578,19 +1879,36 @@ msgstr ""
 "Hve mikið litir mynddíla mega vera ólíkir upphafsgildi\n"
 "áður en flæðifylling neitar að fylla þá"
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+#, fuzzy
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr "Uppruni:"
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
-msgstr "Hvaða sýnilegu lög eigi að fylla"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
+msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+#, fuzzy
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr "Sameinað sýni"
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+#, fuzzy
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
@@ -1600,19 +1918,50 @@ msgstr ""
 "nota tímabundna sameiningu allra sýnilegra\n"
 "laga undir núverandi lagi"
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+#, fuzzy
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr "Laga að sýn"
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+#, fuzzy
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr "Áfangastaður:"
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+#, fuzzy
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr "Hvert frálagið ætti að fara"
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr "Nýtt lag (einu sinni)"
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+#, fuzzy
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
@@ -1620,21 +1969,108 @@ msgstr ""
 "Búa til nýtt lag með útkomu fyllingarinnar.\n"
 "Slökkt er á þessu sjálfkrafa eftir notkun."
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Ógegnsæi:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr "Núllstilla"
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+#, fuzzy
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr "Núllstilla valkosti á sjálfgefin gildi"
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "Velja lag"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr "<b>{brush_name}</b>"
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1644,130 +2080,142 @@ msgstr ""
 "<b>{brush_name}</b>\n"
 "{brush_desc}"
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr "Breyta ramma"
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr "Aðlaga ramma skjalsins"
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr "Stærð ramma"
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr "px"
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr "Hæð:"
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr "Breidd:"
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr "Upplausn:"
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr "PÁT"
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr "Punktar á þumlung (í rauninni mynddílar á hverja tommu)"
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr "Litur:"
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr "Litur ramma"
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr "<b>Stærðir ramma</b>"
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr "<b>Þéttleiki mynddíla</b>"
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr "Set ramma að lagi"
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr "Set ramma að ytri mörkum núverandi lags"
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr "Set ramma að skjali"
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr "Set ramma að samsettum mörkum allra laga"
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr "Utanskera lag að ramma"
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr "Skera af þá hluta núverandi lags sem liggja utan rammans"
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr "Virkt"
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr "{width:g}×{height:g} {units}"
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr "tommur"
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr "sm"
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr "mm"
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr "Fríhendisteikning"
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr "Mála fríhendis pensilstrokur"
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr "Mýking:"
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr "Þrýstingur:"
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr "Villa fannst"
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr "<big><b>Forritunarvilla fannst.</b></big>"
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1781,35 +2229,35 @@ msgstr ""
 "Endilega segðu samt forriturunum frá þessu í verkskráningarkerfinu ef enginn "
 "annar er þegar búinn að tilkynna þetta."
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr "Leita í villuskrá..."
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr "Skýrsla..."
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr "Hunsa villu"
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr "Hætta í MyPaint"
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr "Nánar..."
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr "Undantekning fannst við greiningu á undantekningunni."
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1833,45 +2281,50 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr "Blek"
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr "Teikna og síðan laga til mjúkar línur"
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr "Prófun á inntakstæki"
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr "(enginn þrýstingur)"
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr "Þrýstingur:"
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr "(enginn halli)"
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr "Halli:"
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr "(ekkert tæki)"
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
 msgstr "Tæki:"
 
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+#, fuzzy
+msgid "Barrel Rotation:"
+msgstr "Núllstilla snúning"
+
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr "Flytja lag"
 
@@ -1879,158 +2332,226 @@ msgstr "Flytja lag"
 msgid "Move the current layer"
 msgstr "Flytja núverandi lag"
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
-msgstr "{default_name} á {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
+msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
-msgstr "Gerð"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
+msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+#, fuzzy
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr "Eiginleikar"
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr "Sýnilegt"
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Lag"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+#, fuzzy
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr "Læst"
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+#, fuzzy
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ", "
+
+#: ../gui/layers.py:990
+#, fuzzy, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr "Bæta við {layer_default_name}"
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Lög"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr "Raða upp lögum og úthluta sjónhverfingum"
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr "Ógegnsæi lags: %d%%"
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr "Flytja lag í stafla..."
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr "Færa lag í stafla (slepping inn í venjulegt lag mun útbúa nýjan hóp)"
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr "Lag"
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
-msgstr "Hamur:"
+#: ../gui/layervis.py:53
+#, fuzzy, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
+msgstr "<b>{brush_name}</b>"
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
-"Blöndunarhamur: hvernig núverandi lag samtvinnast lögunum fyrir neðan það."
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Ógegnsæi:"
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "Snúa sýn"
 
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-"Ógegnsæi lags: hve mikið núverandi lag eigi að nota. Minni gildi gera lagið "
-"gegnsærra."
-
-#: ../gui/linemode.py:37
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr "Upphafsþrýstingur"
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr "Upphafsþrýstingur stroklínu fyrir línuverkfæri"
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr "Þrýstingur um miðbik"
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr "Þrýstingur miðrar stroklínu fyrir línuverkfæri"
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr "Lokaþrýstingur"
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr "Lokaþrýstingur stroklínu fyrir línuverkfæri"
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr "Haus"
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 msgid "Stroke lead-in end"
 msgstr "Endi í upphafi stroklínu"
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr "Skott"
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr "Endi við lok stroklínu"
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr "Breytileiki þrýstings..."
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr "Línur og ferlar"
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr "Almennur hamur línu/ferils"
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr "Teikna beinar línur; Shift bætir við boglínum, Ctrl skilyrðir horn"
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr "Tengdar línur"
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
-msgstr "Teikna samhangandi línur; Shift bætir við boglínum, Ctrl skilyrðir horn"
+msgstr ""
+"Teikna samhangandi línur; Shift bætir við boglínum, Ctrl skilyrðir horn"
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr "Sporbaugar og hringir"
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr "Teikna sporöskjur; Shift snýr, Ctrl skilyrðir hlutfall/horn"
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
+#, fuzzy
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 "Höfundarréttur (C) 2005-2015\n"
 "Martin Renold og MyPaint þróunarteymið"
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -2050,256 +2571,286 @@ msgstr ""
 "ÁBYRGÐAR; einnig án óbeinnar SÖLUÁBYRGÐAR eða HÆFNI TIL NOKKURS HLUTAR. Sjá "
 "nánari upplýsingar í COPYING-skránni."
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr "forritun"
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr "samhæfni milli kerfa"
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr "verkefnastjórn"
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr "penslar"
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr "mynstur"
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr "verkfæratáknmyndir"
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr "skjáborðstáknmynd"
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr "litaspjöld"
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr "skjölun"
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr "aðstoð"
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr "útbreiðsla"
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr "samfélag"
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ", "
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr "Sveinn í Felli, sv1@fellsnet.is"
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr "Stærð:"
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr "Ógegnsæi:"
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr "Skerping:"
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr "Styrkaukning:"
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr "Valkostir verkfæra"
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr "Sértækar stillingar fyrir núverandi verkfæri"
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr "<b>{mode_name}</b>"
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr "<i>Engir valkostir tiltækir</i>"
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr "Aðdráttur: %.01f%%"
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr "Veldu stillingar pensilstroku, lit hennar og lag…"
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr "Veldu lit…"
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr "Kjörstillingar"
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr "Forskoðun"
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr "Birtir forskoðun á öllum myndfleti teikningarinnar"
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr "Birta útlínur sýnar"
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr "Krassblað"
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr "Blandaðu litum og gerðu skissur á aðskildum úrklippusíðum"
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr "Fyrra atriði"
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr "Næsta atriði"
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
 msgstr "(ekkert til að sýna)"
 
-#: ../gui/symmetry.py:76
+#: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Place axis"
 msgstr "Staðsetja ás"
 
-#: ../gui/symmetry.py:80
+#: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Move axis"
 msgstr "Færa ás"
 
-#: ../gui/symmetry.py:84
+#: ../gui/symmetry.py:88
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr "Fjarlægja ás"
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr "Breyta samhverfuás"
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr "Breyta samhverfuás myndar."
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
+#, fuzzy
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr "Staðsetning:"
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr "Staðsetning:"
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr "Ekkert"
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr "%d px"
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr "Alfa gegnsæisrás:"
 
-#: ../gui/symmetry.py:352
+#: ../gui/symmetry.py:376
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
+msgstr "Samhverfa"
+
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+#, fuzzy
 msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+msgid "X axis Position"
 msgstr "Staðsetning áss"
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:477
+#, fuzzy
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr "Staðsetning áss"
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr "Virkt"
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr "Meðhöndlun skráa"
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr "Skiptir milli úrklippa"
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr "Afturkalla og endurtaka"
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr "Blöndunarhamir"
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr "Línuhamir"
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr "Sýn (aðal)"
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr "Sýn (vara/auka)"
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr "Sýn (endurstilli)"
 
@@ -2307,190 +2858,216 @@ msgstr "Sýn (endurstilli)"
 msgid "<b>MyPaint</b>"
 msgstr "<b>MyPaint</b>"
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr "Skruna sýn"
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr "Dragðu til sýn á myndflöt"
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr "Aðdráttur sýnar"
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr "Renna að myndfleti"
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr "Snúa sýn"
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr "Snúðu sýn á myndflöt"
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, fuzzy, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr "%s: loka flipa"
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
-msgstr "%s: breyta eigindum"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
+msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr "Óþekkt skipun"
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr "Óskilgreint (skipun ekki ræst ennþá)"
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr "{seconds:.01f}sek málað með {brush_name}"
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr "Flæðifylla"
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr "Utanskera lag"
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "Endurnefna hóp"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr "Hreinsa lag"
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr "Líma lag"
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr "Nýtt lag úr sýnilegu"
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr "Sameina sýnileg lög"
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr "Sameina niður"
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr "Samræma lagaham"
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Innfluttur pensill"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr "Bæta við {layer_default_name}"
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr "Fjarlægja lag"
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr "Velja lag"
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr "Tvöfalda lag"
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr "Flytja lag upp"
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr "Flytja lag niður"
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr "Færa lag í stafla"
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr "Endurnefna lag"
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr "Gera lagið sýnilegt"
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr "Gera lagið ósýnilegt"
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr "Læsa lagi"
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr "Aflæsa lagi"
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr "Stilla ógegnsæi lags: %0.1f%%"
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr "Óþekktur hamur"
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr "Stilla ham lagsins: %s"
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr "Virkja ramma"
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr "Gera ramma óvirkan"
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr "Uppfæra ramma"
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr "Breyta lagi með öðru forriti"
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr "Villa við hleðslu “{basename}”."
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 "Atvikaskrárnar (annálarnir) gætu verið með nákvæmari upplýsingar um þessa "
 "villu."
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr "héðan í frá"
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr "síðan"
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2503,13 +3080,13 @@ msgstr ""
 "Lokaðu forritinu og bíddu í {cache_update_interval}sek áður en þú reynir "
 "aftur."
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr "Ófullgert öryggisafrit uppfært {last_modified_time} {ago}"
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2519,11 +3096,11 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 "Öryggisafrit uppfært {last_modified_time} {ago}\n"
-"Stærð: {autosave.width}×{autosave.height} mynddílar, Lög: "
-"{autosave.num_layers}\n"
+"Stærð: {autosave.width}×{autosave.height} mynddílar, Lög: {autosave."
+"num_layers}\n"
 "Inniheldur {unsaved_time} af óvistaðri vinnu."
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2533,13 +3110,13 @@ msgstr ""
 "Gat ekki skrifað “{filename}”: {err}\n"
 "Er nægilegt laust pláss eftir á tækinu?"
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr "Gat ekki skrifað “{filename}”: {err}"
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2549,7 +3126,7 @@ msgstr ""
 "{error_loading_common}\n"
 "Skráin er ekki til."
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2559,7 +3136,7 @@ msgstr ""
 "{error_loading_common}\n"
 "Þú ert ekki með nægar heimildir til að opna þessa skrá."
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2575,7 +3152,7 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2585,7 +3162,13 @@ msgstr ""
 "{error_loading_common}\n"
 "Óþekkt skráarending: “{ext}”"
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+#, fuzzy
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr "Innfluttur pensill"
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2599,7 +3182,7 @@ msgstr ""
 "Prófaðu að vista í staðinn á PNG-sniði, sérstaklega ef tölvan þín er ekki "
 "með mikið vinnsluminni. PNG vistun í MyPaint er öflugri."
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2615,98 +3198,207 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/helpers.py:402
-#, python-brace-format
+#: ../lib/floodfill.py:131
+#, fuzzy
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr "Fylling"
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr "{days}d{hours}klst"
 
-#: ../lib/helpers.py:404
-#, python-brace-format
+#: ../lib/helpers.py:537
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr "{hours}klst{minutes}mín"
 
-#: ../lib/helpers.py:406
-#, python-brace-format
+#: ../lib/helpers.py:539
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr "{minutes}mín{seconds}sek"
 
-#: ../lib/helpers.py:408
-#, python-brace-format
+#: ../lib/helpers.py:541
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr "{seconds}sek"
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr "Lag"
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr "%(name)s %(number)d"
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr "^(.*?)\\s*(\\d+)$"
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
+#, fuzzy
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr "Vigralag"
+
+#: ../lib/layer/data.py:1158
+#, fuzzy
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr "Vigralag"
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
-msgstr "Óþekkt bitamyndalag"
+msgid "Bitmap"
+msgstr ""
 
-#: ../lib/layer/data.py:1169
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1244
 msgctxt "layer default names"
-msgid "Unknown Data Layer"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
 msgstr "Óþekkt gagnalag"
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "Nýtt málunarlag"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr "Hópur"
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "Nýr hópur laga"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr "Frátökutákn"
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr "Rót"
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ", "
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+#, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "Skoðun"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+#, fuzzy
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr "Lagið er sýnilegt"
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+#, fuzzy
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr "Fjarlægja lag"
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr "Læsa lagi"
+
+#: ../lib/layervis.py:697
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr "Aflæsa lagi"
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr "Gegnumstreymi"
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr "Efni hópsins er beitt beint á bakgrunn hópsins"
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr "Venjulegt"
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr "Einungis efsta lagið, án blöndunar lita."
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr "Margfalda"
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
@@ -2714,11 +3406,11 @@ msgstr ""
 "Svipað og að setja tvær skyggnur inn í myndvarpa og skoða sameinaða útkomu "
 "beggja."
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr "Skjár"
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
@@ -2726,135 +3418,135 @@ msgstr ""
 "Eins og að varpa tveimur skyggnum á skerm í einu. Þetta er andstæðan við "
 "'Margfalda'."
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr "Yfirprentun"
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr "Dekkja"
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr "Efsta lagið er notað þar sem það er dekkra en bakgrunnurinn."
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr "Lýsa"
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr "Efsta lagið er notað þar sem það er ljósara en bakgrunnurinn."
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr "Upplita"
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr "Brenna"
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr "Hart ljós"
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr "Líkt og skarpt kastljós skíni á bakgrunninn."
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr "Mjúkt ljós"
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr "Líkt og dreift kastljós skíni á bakgrunninn."
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr "Mismunur"
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr "Útilokun"
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr "Litblær"
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr "Litmettun"
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr "Birtustig"
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr "Samlagning"
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr "Þessu lagi og bakgrunni þess er einfaldlega blandað saman."
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr "Útkoma á"
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
@@ -2862,11 +3554,11 @@ msgstr ""
 "Sýnir bakgrunninn einungis þar sem þetta lag hylur hann. Allt annað er "
 "hunsað."
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr "Útkoma af"
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
@@ -2874,27 +3566,38 @@ msgstr ""
 "Sýnir bakgrunninn einungis þar sem þetta lag hylur hann ekki. Allt annað er "
 "hunsað."
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr "Uppruni ofaná"
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr "Útkoma ofaná"
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, fuzzy, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr "%(name)s %(number)d"
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
@@ -2903,7 +3606,7 @@ msgstr ""
 "Tókst ekki að útbúa nauðsynlegt innra atriði. Hugsanlega er kerfið þitt ekki "
 "með nægt minni til að framkvæma þessa aðgerð."
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2917,7 +3620,30 @@ msgstr ""
 "Ástæða: {err}\n"
 "Úttaksmappa: “{dirname}”."
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+#, fuzzy
+msgid "Vertical"
+msgstr "Spegla lóðrétt"
+
+#: ../lib/tiledsurface.py:49
+#, fuzzy
+msgid "Horizontal"
+msgstr "Spegla lárétt"
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+#, fuzzy
+msgid "Rotational"
+msgstr "Núllstilla snúning"
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr "PNG-lestur brást: %s"
@@ -2926,57 +3652,93 @@ msgstr "PNG-lestur brást: %s"
 msgid "Recover interrupted work?"
 msgstr "Endurheimta gögn sem urðu fyrir truflun?"
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
-msgstr "Endu_rheimta og vista..."
+msgid "_Look for backups at startup"
+msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr "Eyða"
+
+#: ../po/tmp/autorecover.glade.h:9
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr "Eyða þessum pensli af diski"
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr "Endu_rheimta og vista..."
+
+#: ../po/tmp/autorecover.glade.h:12
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr "Vista þetta öryggisafrit á disk, halda síðan áfram að vinna með það."
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
-msgstr "_Hunsa í bili"
+msgid "Decide _Later"
+msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 "Byrja að vinna með nýjan myndflöt. Haldið verður upp á þessi öryggisafrit."
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
+#, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 "MyPaint hrundi með óvistuð gögn, en náði að gera öryggisafrit. Þú getur "
 "endurheimt skrá núna, eða geymt það þangað til þú ræsir MyPaint aftur."
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr "Smámynd"
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr "Lýsing"
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
-msgstr "Afrita í nýtt"
+msgid "Live update"
+msgstr "Síuppfærsla"
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
-"Afrita þessar stillingar og táknmynd núverandi pensils yfir í nýjan pensil"
+"Uppfærir í rauntíma síðustu stroku á myndfletinum með stillingum þessa glugga"
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
-msgstr "Endurnefna þennan pensil"
+msgid "Save these settings to the brush"
+msgstr "Vista þessar stillingar í pensilinn"
 
 #: ../po/tmp/brusheditor.glade.h:5
 msgid "Edit Icon"
@@ -2999,19 +3761,17 @@ msgid "Delete this brush from the disk"
 msgstr "Eyða þessum pensli af diski"
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
-msgstr "Síuppfærsla"
+msgid "Copy to New"
+msgstr "Afrita í nýtt"
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
-"Uppfærir í rauntíma síðustu stroku á myndfletinum með stillingum þessa glugga"
+"Afrita þessar stillingar og táknmynd núverandi pensils yfir í nýjan pensil"
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
-msgstr "Vista þessar stillingar í pensilinn"
+msgid "Rename this brush"
+msgstr "Endurnefna þennan pensil"
 
 #: ../po/tmp/brusheditor.glade.h:13
 msgid "Brush Setting"
@@ -3039,12 +3799,7 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr "Athugasemdir:"
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr "Heiti stillingar:"
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
@@ -3052,102 +3807,84 @@ msgstr ""
 "neðan ganga út frá þessu."
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
-msgstr "Ggrunngildi:"
+#: ../po/tmp/brusheditor.glade.h:22
+#, fuzzy
+msgid "Value:"
+msgstr "HSV gildi (V)"
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr "Núllstilla grunngildið á sjálfgefið gildi"
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr "<ylágm>"
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr "<yhám>"
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr "Frálag"
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr "Ílag"
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr "Breytir hámarksgildi"
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr "Breytir lágmarksgildi"
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr "<xlágm>"
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr "<xhám>"
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr "Pensilhreyfingar"
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr "Breyta stillingu"
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr "{vísbending}"
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
 msgstr "{dname}:"
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+#, fuzzy
+msgid "<big><b>No Brush Dynamics</b></big>"
+msgstr "<big><b>{accel_label}</b></big>"
 
 #: ../po/tmp/inktool.glade.h:1
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
@@ -3159,7 +3896,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr "Þrýstingur:"
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3204,6 +3941,141 @@ msgstr "Eyða punkti"
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
 msgstr "Eyða þeim punkti sem núna er valinn"
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+#, fuzzy
+msgid "Insert Point"
+msgstr "Setja inn röð"
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+#, fuzzy
+msgid "Cull Points"
+msgstr "Eyða punkti"
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Heiti"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr "Hamur"
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Ógegnsæi"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr "Samsetningarhamur núverandi lags."
+
+#: ../po/tmp/layervis.glade.h:2
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr "Snúðu sýn á myndflöt"
+
+#: ../po/tmp/layervis.glade.h:3
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr "Snúðu sýn á myndflöt"
+
+#: ../po/tmp/layervis.glade.h:4
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr "Hvaða sýnilegu lög eigi að fylla"
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
+msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
 msgctxt "footer: color picker button: tooltip"
@@ -3581,31 +4453,52 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr "Fela bendil á meðan málað er"
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+#, fuzzy
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr "Virkt"
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr "Skoðun"
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr "Frumlitir eru:"
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr "Staðlað stafrænt Rautt/Grænt/Blátt"
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
@@ -3613,7 +4506,7 @@ msgstr ""
 "Rautt/Grænt/Blátt frumlitir &apos;tölvuskjás&apos;, raðað jafnt í hringnum. "
 "Grænt er gagnstætt blárauðu."
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
@@ -3622,12 +4515,12 @@ msgstr ""
 "Rautt/Grænt/Blátt frumlitir 'tölvuskjás', raðað jafnt í hringnum. Grænt er "
 "gagnstætt blárauðu."
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr "Hefðbundið Rautt/Gult/Blátt listmálarans"
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
@@ -3637,7 +4530,7 @@ msgstr ""
 "öld, nálgað með hreinum skjálitum röðuðum jafnt í hringnum. Grænt er "
 "gagnstætt rauðu."
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3648,12 +4541,12 @@ msgstr ""
 "öld, nálgað með hreinum skjálitum röðuðum jafnt í hringnum. Grænt er "
 "gagnstætt rauðu."
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr "Gagnstæð pör Rautt-Grænt og Blátt-Gult"
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3668,7 +4561,7 @@ msgstr ""
 "litalíkön. Hér notum við hreinan rauðan fyrir skjá, hreinan gulan o.s.frv. "
 "fyrir frumlitina fjóra."
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3684,28 +4577,28 @@ msgstr ""
 "rauðan fyrir skjá, hreinan gulan o.s.frv. fyrir frumlitina fjóra."
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr "<b>Litahringur</b>"
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr "Litur"
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr "Skjár (venjulegt)"
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr "Óvirkt (engin þrýstinæmi)"
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr "Gluggi (ekki mælt með því)"
@@ -3766,248 +4659,305 @@ msgid "Reload the file your current work was loaded from."
 msgstr "Endurhlaða skrána sem þú varst að vinna með af diski."
 
 #: ../po/tmp/resources.xml.h:12
+#, fuzzy
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Import Layers…"
+msgstr "Flytja inn pensla…"
+
+#: ../po/tmp/resources.xml.h:13
+msgctxt "Accel Editor (descriptions)"
+msgid "Import layers from one or more files."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save"
 msgstr "Vista"
 
-#: ../po/tmp/resources.xml.h:13
+#: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file."
 msgstr "Vista vinnuna þína í skrá."
 
-#: ../po/tmp/resources.xml.h:14
+#: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As…"
 msgstr "Vista sem…"
 
-#: ../po/tmp/resources.xml.h:15
+#: ../po/tmp/resources.xml.h:17
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file, assigning it a new name."
 msgstr "Vista verkið þitt í skrá með nýju heiti."
 
-#: ../po/tmp/resources.xml.h:16
+#: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Export…"
 msgstr "Flytja út…"
 
-#: ../po/tmp/resources.xml.h:17
+#: ../po/tmp/resources.xml.h:19
 msgid "Export your work to a file, but keep working on the same file."
 msgstr "Vista verkið þitt í skrá, en halda áfram að vinna í sömu skránni."
 
-#: ../po/tmp/resources.xml.h:18
+#: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As Scrap"
 msgstr "Vista sem úrklippu"
 
-#: ../po/tmp/resources.xml.h:19
+#: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
 msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 "Vista í nýja úrklippuskrá, eða vista sem nýja útgáfu ef úrklippa er þegar "
 "fyrirliggjandi."
 
-#: ../po/tmp/resources.xml.h:20
+#: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Previous Scrap"
 msgstr "Opna fyrri úrklippu"
 
-#: ../po/tmp/resources.xml.h:21
+#: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file before the current one."
 msgstr "Hlaða inn næstu úrklippuskrá á undan núverandi."
 
-#: ../po/tmp/resources.xml.h:22
+#: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Next Scrap"
 msgstr "Opna næstu úrklippu"
 
-#: ../po/tmp/resources.xml.h:23
+#: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file after the current one."
 msgstr "Hlaða inn næstu úrklippuskrá á eftir núverandi."
 
-#: ../po/tmp/resources.xml.h:24
+#: ../po/tmp/resources.xml.h:26
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Recover File from an Automated Backup…"
 msgstr "Endurheimta úr skrá úr sjálfvirku öryggisafriti…"
 
-#: ../po/tmp/resources.xml.h:25
+#: ../po/tmp/resources.xml.h:27
 msgctxt "Accel Editor (descriptions)"
 msgid "Try to save and resume interrupted unsaved work."
 msgstr ""
 "Reyna að vista og endurheimta óvistuð gögn sem hafa orðið fyrir truflun."
 
-#: ../po/tmp/resources.xml.h:26
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr "Penslahópar"
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr "Penslar"
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr "Listi yfir hópa pensla."
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr "Litablandarar"
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr "Litir"
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr "Tiltækir litablandarar."
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr "Hamur"
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr "Hamur"
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr "Samsetningarhamur núverandi lags."
 
-#: ../po/tmp/resources.xml.h:35
+#: ../po/tmp/resources.xml.h:37
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Pressure"
+msgstr "Upphafsþrýstingur"
+
+#: ../po/tmp/resources.xml.h:38
+msgctxt "Accel Editor (descriptions)"
+msgid "Send harder pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:39
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Pressure"
+msgstr "Upphafsþrýstingur"
+
+#: ../po/tmp/resources.xml.h:40
+msgctxt "Accel Editor (descriptions)"
+msgid "Send softer pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:41
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Rotation"
+msgstr "Auka litmettun"
+
+#: ../po/tmp/resources.xml.h:42
+msgctxt "Accel Editor (descriptions)"
+msgid "Increase barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:43
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
+msgstr "Minnka litmettun"
+
+#: ../po/tmp/resources.xml.h:44
+msgctxt "Accel Editor (descriptions)"
+msgid "Decrease barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:45
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Size"
 msgstr "Stækka pensil"
 
-#: ../po/tmp/resources.xml.h:36
+#: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush bigger."
 msgstr "Gera vinnupensilinn stærri."
 
-#: ../po/tmp/resources.xml.h:37
+#: ../po/tmp/resources.xml.h:47
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Size"
 msgstr "Minnka pensil"
 
-#: ../po/tmp/resources.xml.h:38
+#: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush smaller."
 msgstr "Gera vinnupensilinn minni."
 
-#: ../po/tmp/resources.xml.h:39
+#: ../po/tmp/resources.xml.h:49
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Opacity"
 msgstr "Auka ógegnsæi pensils"
 
-#: ../po/tmp/resources.xml.h:40
+#: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush more opaque."
 msgstr "Gera vinnupensilinn ógegnsærri."
 
-#: ../po/tmp/resources.xml.h:41
+#: ../po/tmp/resources.xml.h:51
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Opacity"
 msgstr "Minnka ógegnsæi pensils"
 
-#: ../po/tmp/resources.xml.h:42
+#: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush less opaque."
 msgstr "Gera vinnupensilinn minna ógegnsæjan."
 
-#: ../po/tmp/resources.xml.h:43
+#: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Lighten Painting Color"
 msgstr "Lýsa málunarlit"
 
-#: ../po/tmp/resources.xml.h:44
+#: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase the lightness of the current painting color."
 msgstr "Auka ljósleika (lightness) núverandi litar."
 
-#: ../po/tmp/resources.xml.h:45
+#: ../po/tmp/resources.xml.h:55
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Darken Painting Color"
 msgstr "Dekkja málunarlit"
 
-#: ../po/tmp/resources.xml.h:46
+#: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease the lightness of the current painting color."
 msgstr "Minnka ljósleika (lightness) núverandi litar."
 
-#: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
-msgstr "Breyta litblæ rangsælis"
-
-#: ../po/tmp/resources.xml.h:48
-msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
-msgstr "Snúa litblæ litarins í myndinni rangsælis í litahringnum."
-
-#: ../po/tmp/resources.xml.h:49
+#: ../po/tmp/resources.xml.h:57
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Change Hue Clockwise"
 msgstr "Breyta litblæ réttsælis"
 
-#: ../po/tmp/resources.xml.h:50
+#: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
 msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr "Snúa litblæ litarins í myndinni réttsælis í litahringnum."
 
-#: ../po/tmp/resources.xml.h:51
+#: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr "Breyta litblæ rangsælis"
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr "Snúa litblæ litarins í myndinni rangsælis í litahringnum."
+
+#: ../po/tmp/resources.xml.h:61
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Increase Saturation"
 msgstr "Auka litmettun"
 
-#: ../po/tmp/resources.xml.h:52
+#: ../po/tmp/resources.xml.h:62
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color more saturated (more colorful, purer)."
 msgstr "Gera málunarlitinn meira litmettaðan (litskærri, hreinni)."
 
-#: ../po/tmp/resources.xml.h:53
+#: ../po/tmp/resources.xml.h:63
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Decrease Saturation"
 msgstr "Minnka litmettun"
 
-#: ../po/tmp/resources.xml.h:54
+#: ../po/tmp/resources.xml.h:64
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color less saturated (grayer)."
 msgstr "Gera málunarlitinn minna litmettaðan (grárri)."
 
-#: ../po/tmp/resources.xml.h:55
+#: ../po/tmp/resources.xml.h:65
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Reload Brush Settings"
 msgstr "Endurhlaða pensilstillingar"
 
-#: ../po/tmp/resources.xml.h:56
+#: ../po/tmp/resources.xml.h:66
 msgctxt "Accel Editor (descriptions)"
 msgid "Restore all brush settings to the current brush’s saved values."
 msgstr "Endurheimta allar stillingar pensils úr vistuðum gildum pensilsins."
 
-#: ../po/tmp/resources.xml.h:57
+#: ../po/tmp/resources.xml.h:67
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Pick Stroke and Layer"
 msgstr "Velja stroku og lag"
 
-#: ../po/tmp/resources.xml.h:58
+#: ../po/tmp/resources.xml.h:68
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
 msgstr "Veldu pensilstroku af myndfletinum: endurheimtir pensil, lit og lag."
 
-#: ../po/tmp/resources.xml.h:59
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr "Flýtilyklar fyrir pensla endurheimta lit"
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
@@ -4016,215 +4966,266 @@ msgstr ""
 "Víxla af/á hvort endurheimting pensils með flýtilykli endurheimtir líka "
 "vistaða litinn."
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr "Vista pensil á nýjasta flýtilykilinn"
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr "Vista stillingar pensils á síðast notaðan flýtilykil."
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "Hreinsa lag"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr "Hreinsa allt efni af núverandi lagi."
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+#, fuzzy
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr "Valkostir verkfæra"
+
+#: ../po/tmp/resources.xml.h:76
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr "Utanskera lag að ramma"
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr "Þurrka út þá hluta núverandi lags sem liggja utan rammans."
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr "Þurrka út þá hluta núverandi lags sem liggja utan rammans."
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "Nýr hópur laga fyrir neðan"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "Nýr hópur laga fyrir neðan"
+
+#: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr "Afrita lag á klippispjald"
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr "Afrita efni núverandi lags á klippispjaldið."
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr "Líma lag af klippispjaldi"
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr "Skiptir út efni núverandi lags fyrir innihald klippispjaldsins."
 
-#: ../po/tmp/resources.xml.h:71
+#: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Edit Layer in External App…"
 msgstr "Breyta lagi með öðru forriti…"
 
-#: ../po/tmp/resources.xml.h:72
+#: ../po/tmp/resources.xml.h:90
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
+msgid "Edit the active layer in an external application."
 msgstr "Byrja að vinna með núverandi lag í utanaðkomandi forriti."
 
-#: ../po/tmp/resources.xml.h:73
+#: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Update Layer with External Edits"
 msgstr "Uppfæra lag með utanaðkomandi breytingum"
 
-#: ../po/tmp/resources.xml.h:74
+#: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
 msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 "Samlaga breytingar vistaðar úr utanaðkomandi forriti (venjulega sjálfvirkt)."
 
-#: ../po/tmp/resources.xml.h:75
+#: ../po/tmp/resources.xml.h:93
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer at Cursor"
 msgstr "Fara á lag við bendil"
 
-#: ../po/tmp/resources.xml.h:76
+#: ../po/tmp/resources.xml.h:94
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr "Veldu lag með því að plokka atriði á laginu."
 
-#: ../po/tmp/resources.xml.h:77
+#: ../po/tmp/resources.xml.h:95
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Above"
 msgstr "Fara á lagið fyrir ofan"
 
-#: ../po/tmp/resources.xml.h:78
+#: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer up in the layer stack."
 msgstr "Fara upp um eitt lag í lagastaflanum."
 
-#: ../po/tmp/resources.xml.h:79
+#: ../po/tmp/resources.xml.h:97
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Below"
 msgstr "Fara á lagið fyrir neðan"
 
-#: ../po/tmp/resources.xml.h:80
+#: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer down in the layer stack."
 msgstr "Fara niður um eitt lag í lagastaflanum."
 
-#: ../po/tmp/resources.xml.h:81
+#: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer"
 msgstr "Nýtt málunarlag"
 
-#: ../po/tmp/resources.xml.h:82
+#: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer above the current layer."
 msgstr "Bæta við nýju lagi fyrir ofan núverandi lag."
 
-#: ../po/tmp/resources.xml.h:83
+#: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer…"
 msgstr "Nýtt vigralag…"
 
-#: ../po/tmp/resources.xml.h:84
+#: ../po/tmp/resources.xml.h:102
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer above the current layer, and begin editing it."
 msgstr ""
 "Bæta við nýju vigralagi fyrir ofan núverandi lag, og byrja að vinna með það."
 
-#: ../po/tmp/resources.xml.h:85
+#: ../po/tmp/resources.xml.h:103
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group"
 msgstr "Nýr hópur laga"
 
-#: ../po/tmp/resources.xml.h:86
+#: ../po/tmp/resources.xml.h:104
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group above the current layer."
 msgstr "Bæta við nýjum lagahóp fyrir ofan núverandi lag."
 
-#: ../po/tmp/resources.xml.h:87
+#: ../po/tmp/resources.xml.h:105
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer Below"
 msgstr "Nýtt málunarlag fyrir neðan"
 
-#: ../po/tmp/resources.xml.h:88
+#: ../po/tmp/resources.xml.h:106
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer below the current layer."
 msgstr "Bæta við nýju lagi fyrir neðan núverandi lag."
 
-#: ../po/tmp/resources.xml.h:89
+#: ../po/tmp/resources.xml.h:107
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer Below…"
 msgstr "Nýtt vigralag fyrir neðan…"
 
-#: ../po/tmp/resources.xml.h:90
+#: ../po/tmp/resources.xml.h:108
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer below the current layer, and begin editing it."
 msgstr ""
 "Bæta við nýju vigralagi fyrir neðan núverandi lag, og byrja að vinna með það."
 
-#: ../po/tmp/resources.xml.h:91
+#: ../po/tmp/resources.xml.h:109
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group Below"
 msgstr "Nýr hópur laga fyrir neðan"
 
-#: ../po/tmp/resources.xml.h:92
+#: ../po/tmp/resources.xml.h:110
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group below the current layer."
 msgstr "Bæta við nýjum lagahóp fyrir neðan núverandi lag."
 
-#: ../po/tmp/resources.xml.h:93
+#: ../po/tmp/resources.xml.h:111
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Layer Down"
 msgstr "Sameina lag niður"
 
-#: ../po/tmp/resources.xml.h:94
+#: ../po/tmp/resources.xml.h:112
 msgctxt "Accel Editor (descriptions)"
 msgid "Merge the current layer with the layer beneath it."
 msgstr "Sameina þetta lag við  lagið fyrir neðan það."
 
-#: ../po/tmp/resources.xml.h:95
+#: ../po/tmp/resources.xml.h:113
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Visible Layers"
 msgstr "Sameina sýnileg lög"
 
-#: ../po/tmp/resources.xml.h:96
+#: ../po/tmp/resources.xml.h:114
 msgctxt "Accel Editor (descriptions)"
 msgid "Consolidate all visible layers, and delete the originals."
 msgstr "Sameina öll sýnileg lög í eitt, og eyða upprunalegu lögunum."
 
-#: ../po/tmp/resources.xml.h:97
+#: ../po/tmp/resources.xml.h:115
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer from Visible"
 msgstr "Nýtt lag úr sýnilegu"
 
-#: ../po/tmp/resources.xml.h:98
+#: ../po/tmp/resources.xml.h:116
 msgctxt "Accel Editor (descriptions)"
 msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
 msgstr "Eins og 'Sameina sýnileg lög', en eyðir ekki upprunalegu lögunum."
 
-#: ../po/tmp/resources.xml.h:99
+#: ../po/tmp/resources.xml.h:117
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Delete Layer"
 msgstr "Eyða lagi"
 
-#: ../po/tmp/resources.xml.h:100
+#: ../po/tmp/resources.xml.h:118
 msgctxt "Accel Editor (descriptions)"
 msgid "Remove the current layer from the layer stack."
 msgstr "Fjarlægja núverandi lag úr lagastaflanum."
 
-#: ../po/tmp/resources.xml.h:101
+#: ../po/tmp/resources.xml.h:119
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Convert to Normal Painting Layer"
 msgstr "Umbreyta í venjulegt málunarlag"
 
-#: ../po/tmp/resources.xml.h:102
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
@@ -4233,571 +5234,660 @@ msgstr ""
 "Umbreyta núverandi lagi eða hóp í málunarlag í 'Venjulegt'-ham, halda þannig "
 "í áferð þess."
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr "Auka ógegnsæi lags"
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr "Gera lagið minna gegnsætt."
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr "Minnka ógegnsæi lags"
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr "Gera lagið meira gegnsætt."
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr "Lyfta lagi"
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr "Hækka núverandi lag um eitt þrep í lagastaflanum."
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr "Lækka lag"
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr "Lækka núverandi lag um eitt þrep í lagastaflanum."
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr "Tvöfalda lag"
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr "Búa til nákvæmt klón af núverandi lag."
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
+#, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
-msgstr "Endurnefna lag…"
+msgid "Layer Properties…"
+msgstr "Eiginleikar"
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
-msgstr "Settu inn nýtt heiti á núverandi lag."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr "Lagið er læst"
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 "Víxla af/á hvort núverandi lag er læst. Ekki er hægt að breyta læstum lögum."
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr "Lagið er sýnilegt"
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr "Víxla af/á sýnileika núverandi lags."
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr "Birta bakgrunn"
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr "Víxla sýnileika bakgrunnslags af/á."
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr "Fjarlægja núverandi lag úr lagastaflanum."
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr "Núllstilla og miðja sýn"
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr "Núllstilla aðdrátt, snúning og speglun og endurmiðja skjalið."
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr "Laga að sýn"
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 "Skipta á milli aðlagaðrar sýnar og sértækrar vinnustaðsetningar/aðdráttar."
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr "Núllstilla"
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr "Núllstilla aðdrátt"
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr "Endurstilla aðdrátt sýnar á sjálfgefið gildi."
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr "Núllstilla snúning"
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr "Endurstilla snúning sýnar á 0°"
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr "Núllstilla speglun"
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
-msgstr "Slökkva á speglun sýnarinnar."
+msgid "Reset the view's mirroring."
+msgstr "Núllstilla speglun"
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr "Renna að"
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr "Auka aðdrátt að myndinni."
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Renna frá"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr "Minnka aðdrátt að myndinni."
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
+#, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
-msgstr "Snúa rangsælis"
+msgid "Pan Left"
+msgstr "Hliðra sýn"
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
-msgstr "Snúa sýninni rangsælis."
+msgid "Move your view of the canvas to the left."
+msgstr "Snúa sýn: halla sýn þinni á myndflötinn."
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr "Hart ljós"
+
+#: ../po/tmp/resources.xml.h:159
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr "Hliðra sýn: færa sýn þína á myndflötinn lárétt eða lóðrétt."
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr "Snúa sýn: halla sýn þinni á myndflötinn."
+
+#: ../po/tmp/resources.xml.h:162
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr "Hliðra sýn"
+
+#: ../po/tmp/resources.xml.h:163
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr "Snúa sýn: halla sýn þinni á myndflötinn."
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr "Snúa réttsælis"
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr "Snúa sýninni réttsælis."
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr "Snúa rangsælis"
+
+#: ../po/tmp/resources.xml.h:167
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr "Snúa sýninni rangsælis."
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr "Spegla lárétt"
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr "Fletta sýninni frá vinstri til hægri."
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr "Spegla lóðrétt"
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr "Fletta sýninni á hvolf."
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr "Einangrað lag"
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr "Víxla af/á hvort einungis núverandi lag er birt."
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr "Samhverf málun virk"
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr "Spegla pensilstrokum um samhverfuásinn"
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr "Rammi virkur"
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr "Víxla sýnileika ramma utan um skjalið."
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr "Birta inntaksgildi pensils á stjórnskjá (console/terminal)"
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 "Birtir innri inntaksgildi pensilvélarinnar á stjórnskjá (console/terminal)."
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr "Myndgera útkomu"
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr "Birta myndgerðaruppfærslur á skjánum, fyrir villuleit."
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr "Engin tvöföld biðvistun"
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr "Slökkva á tvöfaldri biðvistun GTK, sem venjulega er virk."
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+#, fuzzy
+msgid "Delete Point"
+msgstr "Eyða punkti"
+
+#: ../po/tmp/resources.xml.h:187
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr "Eyða þeim punkti sem núna er valinn"
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr "Málunarhamur"
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr "Málunarhamur: Venjulegur"
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr "Beita lit á venjulegan máta við málun."
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr "Málunarhamur: Útstrokun"
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr "Stroka út með fyrirliggjandi pensli."
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr "Málunarhamur: Læsa gegnsæi"
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr "Málun með penslinum breytir ekki gegnsæi lagsins."
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr "Málunarhamur: Litþrykkja"
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 "Setur lit á núverandi lag án þess að hafa áhrif á birtustig þess eða gegnsæi."
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Skrá"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "Hætta"
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr "Loka aðalglugga og hætta í forritinu."
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "Breyta"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr "Núverandi verkfæri"
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "Litur"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr "Stilla lit"
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr "Sprettgluggi með ferli litar"
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr "Láta tímalínu nýlegra lita spretta upp við bendil."
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr "Nákvæmur litavalgluggi"
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr "Birtir nákvæman litavalglugga með textainnslætti."
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr "Næsti litur á litaspjaldi"
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr "Setja málunarlit á næsta lit í litaspjaldinu."
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr "Fyrri litur af litaspjaldi"
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr "Setja málunarlit á fyrri lit í litaspjaldinu."
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr "Bæta lit á litaspjald"
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr "Bæta núverandi málunarlit á litaspjaldið."
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "Lag"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr "Ógegnsæi"
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr "Fara á lag"
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr "Nýtt lag fyrir neðan"
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr "Eiginleikar"
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr "Krassblað"
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr "Nýtt krassblað"
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr "Hlaða inn sjálfgefnu krassblaði sem nýjum myndfleti krassblaðs."
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr "Opna krassblað…"
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr "Hlaða myndaskrá af diski inn á krassblaðið."
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr "Vista krassblað"
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr "Vista krassblað í fyrirliggjandi skrá sína á diski."
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr "Flytja krassblað út sem…"
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr "Flytja krassblaðið út á disk, með því skráarheiti sem þér hentar best."
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr "Endurlesa krassblað"
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr "Endurlesa krassblað í síðast vistuðu stöðu."
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr "Vista krassblað sem sjálfgefið"
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr "Vista krassblaðið sem sjálfgefið fyrir 'Nýtt krassblað'."
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr "Hreinsa sjálfgefið krassblað"
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr "Hreinsa sjálfgefið krassblað yfir í auðan myndflöt."
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr "Afrita aðalbakgrunn á krassblað"
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr "Afrita bakgrunnsmyndina úr vinnuskjalinu yfir í krassblaðið."
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "Gluggi"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "Pensill"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr "Flýtilyklar"
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr "Hjálp með flýtilykla fyrir pensla"
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr "Birta útskýringu á því hvernig flýtilyklar virka."
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "Skipta um pensil…"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr "Láta pensilveljara spretta upp við bendil."
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "Breyta lit…"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 "Láta litaveljara spretta upp við bendil, með alla litamöguleika upptalda."
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "Breyta lit (hraðvirkt úrval)…"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
@@ -4806,208 +5896,211 @@ msgstr ""
 "Láta litaveljara spretta upp við bendil, með einungis eins-smells "
 "litamöguleika upptalda."
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr "Ná í fleiri pensla…"
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr "Sækja penslapakka af MyPaint wiki-vefnum."
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr "Flytja inn pensla…"
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr "Hlaða penslapakka inn af diski."
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Hjálp"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr "Hjálp á netinu"
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr "Fara í wiki-hjálparskjöl MyPaint."
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "Um hugbúnaðinn"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr "Sýna notkunarleyfi MyPaint, útgáfunúmer og framlög."
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Aflúsa"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr "Skrifa minnisleka á stjórnskjá (hægvirkt!)"
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr "Aflúsa minnisleka."
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr "Keyra ruslsöfnun (garbage collector) núna"
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr "Laust minni notað undir Python hluti sem ekki er lengur í notkun."
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr "Ræsa/stöðva ástandsskoðun…"
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr "Ræsa/stöðva Python ástandsskoðun (cProfile)"
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr "Líkja eftir hruni…"
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr "Valda Python-undantekningu, til að prófa hrungluggann."
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "Sýn"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr "Svörun"
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr "Aðlaga sýn"
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
+#, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr "Sprettvalmynd"
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr "Sýna aðalvalmyndina sem sprettglugga."
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "Skjáfylli"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr "Víxla á milli heilskjáshams og glugga."
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "Breyta kjörstillingum"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr "Sýsla með víðværar stillingar MyPaint."
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr "Prófa inntakstæki"
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr "Birtir glugga sem grípur öll merki sem inntakstækin þín senda."
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr "Val á bakgrunni"
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr "Breyta pappírsáferð á bakgrunni."
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr "Stillingaritill fyrir pensla"
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr "Breyta stillingum fyrir virkan pensil."
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr "Ritill fyrir táknmyndir pensla"
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr "Breyta táknmyndum pensla."
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr "Lagaspjald"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
-"Víxla af/á hliðarspjaldi fyrir lög (raða upp lögum, úthluta sjónhverfingum)."
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr "Birta lagaspjald"
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr "Birta hliðarspjald fyrir lög (raða upp lögum, úthluta sjónhverfingum)."
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr "HCY-litahringur"
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
@@ -5016,42 +6109,32 @@ msgstr ""
 "Tengjanlegt hólklaga litblær/litgildi/ljómi litaspjald. Hringlaga sneiðarnar "
 "eru jafn bjartar."
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "Litaspjald"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr "Tengjanlegt litaspjald."
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr "HSV-litahringur"
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr "Tengjanlegur blandari sem breytir litmettun og gildi (SV)."
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr "HSV-þríhyrningur"
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr "Tengjanlegt litaspjald: gamli GTK-litaþríhyrningurinn."
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr "HSV-teningur"
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
@@ -5060,472 +6143,469 @@ msgstr ""
 "Tengjanlegt litaspjald: HSV-kubbur sem hægt er að snúa til að skoða "
 "mismunandi sniðfleti."
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr "HSV-ferningur"
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
-msgstr ""
-"Tengjanlegt litaspjald: HSV-ferningur sem hægt er að snúa til að skoða "
-"mismunandi litblæ."
+msgid "Dockable color selector: HSV square with Hue ring."
+msgstr "Tengjanlegt litaspjald með sammiðja HSV-hringjum."
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr "Sleðar fyrir litþætti"
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr "Tengjanlegt litaspjald sem sýnir einstaka þætti litarins."
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr "Vökvalegið"
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr "Tengjanlegt litaspjald sem dregið hefur liti frá næstu litum."
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr "Sammiðja hringir"
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr "Tengjanlegt litaspjald með sammiðja HSV-hringjum."
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr "Krosslitamark"
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr "Tengjanlegt litaspjald með HSV-litstiglum þvert á litgeislahring."
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr "Krassblaðsspjald"
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
-msgstr "Víxla af/á krassblaðaspjaldi (blanda litum og gera skissur)."
+msgid "Dockable Panel for mixing colors and testing brushes."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr "Birta krassblaðsspjald"
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr "Birta krassblaðaspjald (blanda litum og gera skissur)."
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr "Birta forskoðunarspjald"
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
-msgstr "Víxla af/á forskoðunarspjaldi (yfirsýn á allan myndflötinn)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "Forskoðun"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr "Birta forskoðunarspjald (yfirsýn á allan myndflötinn)."
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr "Spjald fyrir valkosti verkfæra"
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
-msgstr "Víxla af/á verkfæraspjaldi (valkostir fyrir virkt verkfæri)."
+msgid "Dockable panel for adjusting the options with the activated tool."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr "Birta spjald fyrir valkosti verkfæra"
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr "Birta verkfæraspjald (valkostir fyrir virkt verkfæri)."
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr "Ferilsspjald fyrir pensla og liti"
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
-msgstr "Víxla af/á ferilspjaldi (nýlega notaðir penslar og litir)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr "Nýlegir penslar og litir"
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr "Birta ferilspjaldið (nýlega notaðir penslar og litir)."
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr "Fela stýringar í skjáfylliham"
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr "Víxla af/á hvort notandaviðmót sé falið í skjáfylliham."
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr "Sýna aðdráttarstig"
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr "Víxla af/á svörun fyrir aðdrátt."
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr "Sýna síðustu staðsetningu við málun"
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr "Víxla af/á birtingu á hvar síðasta pensilstroka endaði."
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr "Birtingarsía"
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr "Birta liti á venjulegan hátt"
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr "Litasía: birta liti óbreytta."
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr "Birta liti sem grátóna"
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr "Litasía:  einungis sýna birtustig (HCY/YCbCr ljómi)"
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr "Birta liti sem viðsnúna"
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr "Litasía: snúa við litum. Svart er hvítt og rautt er blágrænt."
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr "Birta liti þannig að hermt sé eftir rauðri litblindu"
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr "Sía liti til að herma eftir deuteranopia, algengri gerð litblindu."
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr "Birta liti þannig að hermt sé eftir grænni litblindu"
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr "Sía liti til að herma eftir protanopia, algengri gerð litblindu."
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr "Birta liti þannig að hermt sé eftir blárri litblindu"
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr "Sía liti til að herma eftir tritanopia, fágætri gerð litblindu."
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr "Fríhendis"
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr "Fríhendis"
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr "Fríhendis: teiknaðu og málaðu frjálst, án rúmfræðilegra takmarkana."
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr "Fríhendis"
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr "Teiknaðu og málaðu frjálst, án rúmfræðilegra takmarkana."
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr "Hliðra sýn"
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr "Hliðra"
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr "Hliðra sýn: færa sýn þína á myndflötinn lárétt eða lóðrétt."
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr "Hliðra sýn"
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr "Færa gagnvirkt sýn þína á myndflötinn lárétt eða lóðrétt."
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr "Snúa sýn"
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr "Snúa"
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr "Snúa sýn: halla sýn þinni á myndflötinn."
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr "Snúa sýn"
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr "Snúa gagnvirkt sýn þinni á myndflötinn."
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr "Aðdráttur sýnar"
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr "Aðdráttur"
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr "Aðdráttur sýnar: renna að eða frá myndfletinum."
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr "Aðdráttur sýnar"
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr "Renna gagnvirkt að eða frá myndfletinum."
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr "Línur og ferlar"
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr "Línur"
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr "Línur og ferlar: teikna beinar eða sveigðar línur."
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr "Línur og ferlar"
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr "Teikna beinar eða sveigðar línur."
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr "Tengdar línur"
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr "Teng.línur"
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr "Tengdar línur: teikna samtengdar beinar eða sveigðar línur."
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr "Tengdar línur"
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr "Teikna samtengdar beinar eða sveigðar línur."
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr "Sporbaugar og hringir"
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr "Sporbaugur"
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr "Sporbaugar og hringir: teikna hringlaga form."
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr "Sporbaugar og hringir"
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr "Teikna hringi og sporbauga."
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr "Blek"
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr "Blek"
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr "Blek: teikna stýrðar mjúkar línur."
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr "Blek"
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr "Teikna stýrðar mjúkar línur."
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr "Staðsetja lag"
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr "Staða lags"
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr "Staðsetja lag: færa núverandi lag á myndfletinum."
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr "Endurstaðsetja lag"
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr "Færa gagnvirkt núverandi lag á myndfletinum."
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr "Breyta ramma"
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr "Rammi"
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
@@ -5533,90 +6613,296 @@ msgstr ""
 "Breyta ramma: skilgreina ramma í kringum skjalið til að gefa því endanlega "
 "stærð."
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr "Breyta ramma"
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 "Skilgreina ramma gagnvirkt í kringum skjalið til að gefa því endanlega stærð."
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Breyta samhverfu myndar"
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr "Samhverfa"
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 "Breyta samhverfu myndar: breyta ásnum sem notaður er við samhverfa málun."
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Breyta samhverfu myndar"
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr "Breyta ásnum sem notaður er við samhverfa málun."
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr "Litaplokkari"
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr "Veldu lit"
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr "Litaplokkari: stilltu málunarlit eftir mynddílum á skjánum."
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "Veldu lit"
+
+#: ../po/tmp/resources.xml.h:401
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr "Stilltu málunarlit eftir mynddílum á skjánum."
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "Veldu lit"
+
+#: ../po/tmp/resources.xml.h:403
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr "Stilltu málunarlit eftir mynddílum á skjánum."
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "Veldu lit"
+
+#: ../po/tmp/resources.xml.h:405
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr "Stilltu málunarlit eftir mynddílum á skjánum."
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr "Veldu lit"
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr "Stilltu málunarlit eftir mynddílum á skjánum."
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr "Flæðifylla"
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr "Fylling"
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr "Flæðifylling: fylla svæði með lit."
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr "Flæðifylla"
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr "Fylla svæði með lit."
+
+#~ msgctxt "Accelerator map editor: action column markup"
+#~ msgid ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+#~ msgstr ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+
+#~ msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
+#~ msgid "{action_label} {action_desc} {accel_label}"
+#~ msgstr "{action_label} {action_desc} {accel_label}"
+
+#~ msgctxt "brush list context menu"
+#~ msgid "Delete"
+#~ msgstr "Eyða"
+
+#~ msgctxt "brush list commands"
+#~ msgid "Really delete brush from disk?"
+#~ msgstr "Í alvörunni eyða pensli af diski?"
+
+#~ msgid "HSV Triangle"
+#~ msgstr "HSV-þríhyrningur"
+
+#~ msgid "The standard GTK color selector"
+#~ msgstr "Staðlaði GTK-litaveljarinn"
+
+#~ msgid "Pick a color from the screen"
+#~ msgstr "Plokkaðu lit af skjánum"
+
+#~ msgid "Layer Name"
+#~ msgstr "Heiti lags"
+
+#~ msgid ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+#~ msgstr ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+
+#~ msgid "Save..."
+#~ msgstr "Vista..."
+
+#~ msgid "Confirm"
+#~ msgstr "Staðfesta"
+
+#~ msgid "Open..."
+#~ msgstr "Opna..."
+
+#~ msgid "{default_name} at {path}"
+#~ msgstr "{default_name} á {path}"
+
+#~ msgid "Type"
+#~ msgstr "Gerð"
+
+#~ msgid "Mode:"
+#~ msgstr "Hamur:"
+
+#~ msgid ""
+#~ "Blending mode: how the current layer combines with the layers underneath "
+#~ "it."
+#~ msgstr ""
+#~ "Blöndunarhamur: hvernig núverandi lag samtvinnast lögunum fyrir neðan það."
+
+#~ msgid ""
+#~ "Layer opacity: how much of the current layer to use. Smaller values make "
+#~ "it more transparent."
+#~ msgstr ""
+#~ "Ógegnsæi lags: hve mikið núverandi lag eigi að nota. Minni gildi gera "
+#~ "lagið gegnsærra."
+
+#~ msgid "%s: edit properties"
+#~ msgstr "%s: breyta eigindum"
+
+#~ msgctxt "layer unique names: match regex (leave untranslated if unsure)"
+#~ msgid "^(.*?)\\s*(\\d+)$"
+#~ msgstr "^(.*?)\\s*(\\d+)$"
+
+#~ msgctxt "layer default names"
+#~ msgid "Unknown Bitmap Layer"
+#~ msgstr "Óþekkt bitamyndalag"
+
+#~ msgctxt "Autosave Recovery dialog|"
+#~ msgid "_Ignore for Now"
+#~ msgstr "_Hunsa í bili"
+
+#~ msgid "Setting name:"
+#~ msgstr "Heiti stillingar:"
+
+#~ msgid "Base value:"
+#~ msgstr "Ggrunngildi:"
+
+#~ msgid "Reset the base value to its default"
+#~ msgstr "Núllstilla grunngildið á sjálfgefið gildi"
+
+#~ msgid "<ymin>"
+#~ msgstr "<ylágm>"
+
+#~ msgid "<ymax>"
+#~ msgstr "<yhám>"
+
+#~ msgid "<xmin>"
+#~ msgstr "<xlágm>"
+
+#~ msgid "<xmax>"
+#~ msgstr "<xhám>"
+
+#~ msgid "Edit Setting"
+#~ msgstr "Breyta stillingu"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Trim Layer to Frame"
+#~ msgstr "Utanskera lag að ramma"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Rename Layer…"
+#~ msgstr "Endurnefna lag…"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Enter a new name for the current layer."
+#~ msgstr "Settu inn nýtt heiti á núverandi lag."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Turn off mirroring of the view."
+#~ msgstr "Slökkva á speglun sýnarinnar."
+
+#~ msgctxt "Menu→Edit (labels)"
+#~ msgid "Current Tool"
+#~ msgstr "Núverandi verkfæri"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+#~ msgstr ""
+#~ "Víxla af/á hliðarspjaldi fyrir lög (raða upp lögum, úthluta "
+#~ "sjónhverfingum)."
+
+#~ msgctxt "Menu→Color (labels), Accel Editor (labels)"
+#~ msgid "HSV Triangle"
+#~ msgstr "HSV-þríhyrningur"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Dockable color selector: the old GTK color triangle."
+#~ msgstr "Tengjanlegt litaspjald: gamli GTK-litaþríhyrningurinn."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid ""
+#~ "Dockable color selector: HSV square which can be rotated to show "
+#~ "different hues."
+#~ msgstr ""
+#~ "Tengjanlegt litaspjald: HSV-ferningur sem hægt er að snúa til að skoða "
+#~ "mismunandi litblæ."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+#~ msgstr "Víxla af/á krassblaðaspjaldi (blanda litum og gera skissur)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+#~ msgstr "Víxla af/á forskoðunarspjaldi (yfirsýn á allan myndflötinn)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+#~ msgstr "Víxla af/á verkfæraspjaldi (valkostir fyrir virkt verkfæri)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the History panel (recently used brushes and colors)."
+#~ msgstr "Víxla af/á ferilspjaldi (nýlega notaðir penslar og litir)."

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.7.1-git\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-06 22:10+0000\n"
 "Last-Translator: albanobattistella <albano_battistella@hotmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -22,29 +22,7 @@ msgstr ""
 "X-Poedit-Country: ITALY\n"
 "X-Poedit-SourceCharset: utf-8\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr "<big><b>{accel_label}</b></big>"
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr "{action_label} {action_desc} {accel_label}"
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "Azione"
 
@@ -52,32 +30,32 @@ msgstr "Azione"
 msgid "Key combination"
 msgstr "Combinazione di tasti"
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr "Modifica Tasto per '%s'"
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "Azione:"
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "Percorso:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "Tasto:"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr "Premi i tasti per aggiornare questa combinazione"
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "Azione Sconosciuta"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
@@ -86,7 +64,7 @@ msgstr ""
 "<b>{accel} è già in uso per '{action}'. La combinazione esistente sarà "
 "sostituita.</b>"
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr "Apri Cartella “{folder_basename}”…"
@@ -94,196 +72,206 @@ msgstr "Apri Cartella “{folder_basename}”…"
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "OK"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr "Nessun backup trovato nella cache."
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr "Nessun Backup Disponibile"
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr "Apri la Cartella Cache…"
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr "Recupero Backup Fallito"
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr "Apri la Cartella dei Backup…"
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr "Recupero file da {iso_datetime}.ora"
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "Salva come Predefinito"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "Sfondo"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "Motivo"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Colore"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "Aggiungi colore ai Motivi"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr "Uno o più sfondi non possono essere caricati"
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr "Errore nel caricamento degli sfondi"
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 "Per favore rimuovi i file non caricabili oppure controlla la tua "
 "installazione di libgdkpixbuf."
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr "Gdk-Pixbuf non riesce a caricare \"{filename}\", e riporta \"{error}\""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr "{filename} ha dimensione zero (w={w}, h={h})"
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr "Modifica Impostazioni Pennello"
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr "Informazioni"
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "Sperimentale"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr "Di base"
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr "Opacità"
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr "Pennellate"
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "Sfuma"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr "Velocità"
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr ""
+
+#: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr "Tracciamento"
 
-#: ../gui/brusheditor.py:359
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "Tratto"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr "Colore"
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Personalizzato"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 "Non hai selezionato alcun pennello, per favore usa \"Aggiungi Come Nuovo\"."
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr "Nessun pennello selezionato!"
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "Rinomina Pennello"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "Un pennello con lo stesso nome esiste già!"
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr "Nessun pennello selezionato!"
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr "Vuoi veramente eliminare “{brush_name}” dal disco?"
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr "(Pennello senza nome)"
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr "{brush_name} [non salvato]"
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr "Icona Pennello"
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr "Icona Pennello (impostazioni)"
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr "Nessun pennello selezionato"
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -292,7 +280,7 @@ msgstr ""
 "<b>%s</b>\n"
 "<small>Prima selezione un pennello valido</small>"
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
@@ -301,7 +289,7 @@ msgstr ""
 "<b>%s</b> <i>(modificato)</i>\n"
 "<small>Modifiche non ancora salvate</small>"
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
@@ -310,7 +298,7 @@ msgstr ""
 "<b>%s</b> (impostazioni)\n"
 "<small>Dipingi con qualsiasi pennello o colore</small>"
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -351,142 +339,182 @@ msgstr "Automatico"
 msgid "Use the default icon"
 msgstr "Usa l'icona predefinita"
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Salva"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr "Salva questa anteprima icona e termina modifica"
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr "Oggetti smarriti"
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr "Eliminati"
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr "Preferiti"
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr "Inchiostro"
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr "Classico"
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr "Gruppo#1"
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr "Gruppo#2"
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr "Gruppo#3"
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr "Gruppo#4"
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr "Gruppo#5"
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr "Sperimentale"
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Nuovo"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr "Pennello Sconosciuto"
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr "Aggiungi a Preferiti"
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr "Rimuovi da Preferiti"
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr "Clona"
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr "Modifica Impostazioni Pennello"
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
-msgstr "Elimina"
+#: ../gui/brushselectionwindow.py:250
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
+msgstr "Rinomina Gruppo"
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
-msgstr "Vuoi veramente eliminare questo pennello dal disco?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, fuzzy, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
+msgstr "Vuoi veramente eliminare “{brush_name}” dal disco?"
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] "%d pennello"
 msgstr[1] "%d pennelli"
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr "Gruppo “{group_name}”"
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr "Rinomina Gruppo"
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr "Esporta come Set di Pennelli Zippato"
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr "Elimina Gruppo"
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr "Rinomina Gruppo"
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "Un gruppo con questo nome esiste già!"
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr "Vuoi veramente eliminare il gruppo “{group_name}”?"
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -496,58 +524,58 @@ msgstr ""
 "Non riesco ad eliminare in gruppo “{group_name}”.\n"
 "Alcuni gruppi speciali non possono essere eliminati."
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr "Esporta Pennelli"
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr "MyPaint pacchetto pennelli (*.zip)"
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "Nuovo Gruppo..."
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr "Importa Pennelli..."
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr "Ottieni Altri Pennelli..."
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "Crea Gruppo"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr "Tasto"
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr "Tasto"
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr "Premi il tasto"
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr "Aggiungi una nuova associazione"
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr "Rimuovi l'associazione corrente"
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr "Modifica associazione per '%s'"
@@ -556,7 +584,7 @@ msgstr "Modifica associazione per '%s'"
 msgid "Button press:"
 msgstr "Premi il tasto:"
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
@@ -564,7 +592,7 @@ msgstr ""
 "Tieni premuto il tasto modificatore e premi il pulsante del mouse sopra "
 "questo testo per impostare una nuova associazione."
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
@@ -572,40 +600,68 @@ msgstr ""
 "{button} non può essere associato senza un tasto modificatore (spiacente, la "
 "sua funzione è prestabilita)"
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr "{button_combination} è già associato con l'azione '{action_name}'"
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr "Preleva Colore"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr "Imposta il colore usato per dipingere"
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+#, fuzzy
+msgid "Set the color Hue used for painting"
+msgstr "Imposta il colore usato per dipingere"
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "Preleva Col."
+
+#: ../gui/colorpicker.py:296
+#, fuzzy
+msgid "Set the color Chroma used for painting"
+msgstr "Imposta il colore usato per dipingere"
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+#, fuzzy
+msgid "Set the color Luma used for painting"
+msgstr "Imposta il colore usato per dipingere"
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr "Dettagli colore"
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr "Colore appena scelto e il colore usato più recentemente per dipingere"
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr "Maschera Gamut Attiva"
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -617,7 +673,7 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr "HCY tinta e croma."
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
@@ -626,12 +682,12 @@ msgstr ""
 "Editor di maschera gamut. Clicca nel centro per creare o manipolare le forme "
 "oppure ruota la maschera usando il bordo del disco."
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr "Triade Atmosferica"
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
@@ -640,22 +696,22 @@ msgstr ""
 "Cupa e soggettiva, definita da un primario dominante e due primari meno "
 "intensi."
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr "Triade Spostata"
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr "Sbilanciata fortemente  verso il colore dominante."
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr "Complementare"
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
@@ -664,12 +720,12 @@ msgstr ""
 "Opposti contrastanti, bilanciati avendo il centro neutrali interposti fra di "
 "loro nel cerchio colori."
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr "Atmosfera e Risalto"
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
@@ -678,12 +734,12 @@ msgstr ""
 "Una gamma di colori principale, con un accento complementare per variazione "
 "e sottolineature."
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr "Complementare scisso"
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
@@ -692,72 +748,72 @@ msgstr ""
 "Due colori analoghi e un complemento ad essi, senza colori secondari tra "
 "loro."
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr "Nuova Maschera Gamut da Modello"
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr "Impostazioni Maschera Gamut"
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr "Attivo"
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr "Aiuto…"
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr "Crea maschera da modello."
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr "Carica maschera da una tavolozza GIMP."
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr "Salva la maschera su una tavolozza GIMP."
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr "Elimina la maschera."
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr "Apri l'aiuto online per questa finestra sul browser web."
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr "Salva Maschera come Tavolozza GIMP"
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr "Carica Maschera da una Tavolozza GIMP"
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr "Imposta maschera gamut."
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr "Cerchio HCY"
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -767,163 +823,155 @@ msgstr ""
 "sezioni circolari sono equiluminanti."
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr "Colore HSV"
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr "Saturazione HSV"
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr "Tinta HSV"
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr "Saturazione e Tinta HSV"
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr "Tonalità e Intensità HSV"
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr "Tonalità e Saturazione HSV"
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr "Ruota cubo (mostra assi diversi)"
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr "Cubo HSV"
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 "Un cubo HSV che può essere ruotato per mostrare diverse sezioni planari."
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr "Quadrato HSV"
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr "Un quadrato HSV che può essere ruotato per mostrare diverse tonalità."
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr "Triangolo HSV"
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr "Selettore colore GTK standard"
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr "Cerchio HSV"
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr "Modificatore Saturazione e Tinta."
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr "Proprietà tavolozza"
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr "Tavolozza"
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr "Imposta il colore da una tavolozza caricabile ed editabile."
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr "Tavolozza senza titolo"
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr "Impostazioni Tavolozza"
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr "Carica da un file Tavolozza GIMP"
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr "Salva come file Tavolozza GIMP"
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr "Aggiungi un nuovo campione vuoto"
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr "Rimuovi il campione corrente"
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr "Rimuovi tutti i campioni"
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr "Titolo:"
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr "Nome o descrizione per questa tavolozza"
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr "Colonne:"
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr "Numero di colonne"
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr "Nome Colore:"
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr "Nome del colore in uso"
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr "Spazio tavolozza vuoto"
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr "Carica tavolozza"
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr "Salva tavolozza"
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -934,379 +982,376 @@ msgstr ""
 "Metti qui i colori ,\n"
 "organizzali trascinandoli."
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr "Spazio tavolozza vuoto (trascina un colore qui)"
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr "Aggiungi uno Spazio Vuoto"
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr "Inserisci Riga"
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr "Inserisci Colonna"
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr "Riempi Intervallo (RGB)"
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr "Riempi Intervallo (HCY)"
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr "Riempi Intervallo (HSV)"
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "File tavolozza GIMP (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr "Tutti i File (*)"
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "File tavolozza GIMP (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr "Tutti i File (*)"
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr "Preleva un colore dallo schermo"
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr "R"
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr "G"
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr "B"
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr "H"
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr "C"
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr "Y"
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr "Cursori Componente"
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr "Regola i componenti individuali del colore."
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr "RGB Rosso"
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr "RGB Verde"
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr "RGB Blu"
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr "HSV Colore"
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr "HSV Saturazione"
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr "HSV Tinta"
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr "HCY Colore"
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr "HCY Croma"
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr "HCY Luminanza (Y')"
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr "Liquido di Lavaggio"
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr "Modifica il colore usando uno pseudo-lavaggio dei colori adiacenti."
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr "Anelli Concentrici"
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr "Modifica il colore usando gli anelli concentrici HSV."
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr "Tavolozza a Croce"
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr "Modifica colore con scale HSV su una tavolozza colore radiale."
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr "Cursore/disco"
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr "Gomma"
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr "Tastiera"
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr "Mouse"
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr "Penna"
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr "Touchpad"
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr "Touchscreen"
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr "Ignora"
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr "Qualsiasi funzione"
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr "funzioni non di pittura"
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr "Solo navigazione"
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr "Zoom"
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr "Panoramica"
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr "Dispositivo"
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr "Assi"
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr "Tipo"
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr "Usa per..."
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr "Scorri..."
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Nome"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr "Sovrascrivere il Pennello?"
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr "Sostituisci"
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr "Rinomina"
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr "Sostituisci tutto"
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr "Rinomina tutti"
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr "Pennello Importato"
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr "Pennello Esistente"
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 "<b>Un pennello chiamato `%s' esiste già.</b>\n"
 "Vuoi sostituirlo, oppure il nuovo pennello deve essere rinominato?"
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr "Sovrascrivere il gruppo pennelli?"
 
-#: ../gui/dialogs.py:190
-#, python-brace-format
+#: ../gui/dialogs.py:220
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 "<b>Un gruppo chiamato `{groupname}' esiste già.</b>\n"
 "Vuoi sostituire il gruppo vecchio o vuoi rinominare quello nuovo?\n"
 "Se lo sostituisci, i pennelli possono essere spostati nel gruppo chiamato "
 "`{deleted_groupname}''."
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr "Importare pacchetto pennelli?"
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, fuzzy, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr "<b>Vuoi veramente importare il pacchetto `%s'?</b>"
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr "Carica le impostazioni pennello dallo spazio scorciatoia %d"
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr "Salva impostazioni pennello nello spazio scorciatoia %d"
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr "Ripristina Pennello %d"
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr "Salva sul Pennello %d"
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr "Annulla %s"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Annulla"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr "Ripeti %s"
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Ripeti"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr "{button_combination} è {resultant_action}"
@@ -1316,112 +1361,155 @@ msgstr "{button_combination} è {resultant_action}"
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ";  "
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr "Con {modifiers} premuto:  {button_actions}."
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
-msgstr "Nome Livello"
-
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
-#, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
-"<b>{name}</b>\n"
-"{description}"
+
+#: ../gui/document.py:909
+#, python-brace-format
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
+msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, fuzzy, python-format
 msgid "%s - MyPaint"
 msgstr "%s - MyPaint"
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 #, fuzzy
 msgid "MyPaint"
 msgstr "MyPaint"
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Apri"
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr "Imposta il colore corrente"
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr "Esci dalla Modalità Schermo Pieno"
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr "Esci dalla Modalità Schermo Pieno"
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr "Entra in Modalità Schermo Pieno"
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Schermo Pieno"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Esci"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+#, fuzzy
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr "Vuoi Veramente Chiudere il Programma?"
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Esci"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr "Importa pacchetto pennelli..."
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr "MyPaint pacchetto pennelli (*.zip)"
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr "Inviata {app_name} al livello modifica “{layer_name}”"
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr "Errore: fallito invio {app_name} al livello modifica “{layer_name}”"
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 "Modifica annullata. Puoi ancora modificare “{layer_name}” dal menù Livelli."
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr "Livello aggiornato “{layer_name}” con modifiche esterne"
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr "Non riesco a caricare “{file_basename}”."
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
-"MyPaint necessita di modificare un file del tipo “{type_name}” "
-"({content_type}). Quale applicazione deve usare?"
+"MyPaint necessita di modificare un file del tipo "
+"“{type_name}” ({content_type}). Quale applicazione deve usare?"
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
@@ -1430,163 +1518,379 @@ msgstr ""
 "Quali applicazione deve usare MyPaint per modificare i file del tipo "
 "“{type_name}” ({content_type})?"
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr "Apri Con..."
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr "Icona"
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr "nessuna descrizione"
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
+#: ../gui/filehandling.py:126
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
+msgstr "Sto caricando “{file_basename}”…"
+
+#: ../gui/filehandling.py:130
+#, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:134
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
+msgstr "Sto salvando “{file_basename}”…"
+
+#: ../gui/filehandling.py:138
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
+msgstr "Sto esportando su “{file_basename}”…"
+
+#: ../gui/filehandling.py:145
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr "Fallito il salvataggio su “{file_basename}”."
+
+#: ../gui/filehandling.py:149
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr "Fallito nel salvare “{file_basename}”."
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr "Non riesco a caricare “{file_basename}”."
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "Salva tavolozza"
+
+#: ../gui/filehandling.py:168
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr "Esporta su file"
+
+#: ../gui/filehandling.py:172
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr "Esporta su file"
+
+#: ../gui/filehandling.py:176
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr "Apri File Recenti"
+
+#: ../gui/filehandling.py:183
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr "Esportato “{file_basename}” con successo."
+
+#: ../gui/filehandling.py:187
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr "Salvato “{file_basename}” con successo."
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr "Ho caricato “{file_basename}”."
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
+msgstr "Ho caricato “{file_basename}”."
+
+#: ../gui/filehandling.py:427
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "All Recognized Formats"
 msgstr "Tutti i Formati Conosciuti"
 
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
+#: ../gui/filehandling.py:432
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "OpenRaster (*.ora)"
 msgstr "OpenRaster (*.ora)"
 
-#: ../gui/filehandling.py:95
+#: ../gui/filehandling.py:437
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "PNG (*.png)"
 msgstr "PNG (*.png)"
 
-#: ../gui/filehandling.py:96
+#: ../gui/filehandling.py:442
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "JPEG (*.jpg; *.jpeg)"
 msgstr "JPEG (*.jpg; *.jpeg)"
 
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
+#: ../gui/filehandling.py:490
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "By extension (prefer default format)"
 msgstr "Per estensione (altrimenti usa quella predefinita )"
 
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
+#: ../gui/filehandling.py:494
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:498
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
 msgstr "PNG opaco con sfondo (*.png)"
 
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
+#: ../gui/filehandling.py:502
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:506
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
 msgstr "PNG con trasparenza (*.png)"
 
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
+#: ../gui/filehandling.py:510
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
 msgstr "PNG multipli con trasparenza (*.XXX.png)"
 
-#: ../gui/filehandling.py:113
+#: ../gui/filehandling.py:514
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr "PNG multipli con trasparenza (*.XXX.png)"
+
+#: ../gui/filehandling.py:518
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr "JPEG qualità 90% (*.jpg; *.jpeg)"
 
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr "Salva..."
+#: ../gui/filehandling.py:576
+#, fuzzy
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr "Esporta…"
 
-#: ../gui/filehandling.py:177
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Salva Come…"
+
+#: ../gui/filehandling.py:601
+#, fuzzy
+msgctxt "save dialogs: formats and options: (label)"
 msgid "Format to save as:"
 msgstr "Formato di salvataggio:"
 
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr "Conferma"
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
+#: ../gui/filehandling.py:668
+#, fuzzy
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
 msgstr "Vuoi veramente continuare?"
 
-#: ../gui/filehandling.py:234
-#, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+#, fuzzy
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr "_Salva come Schizzo"
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, fuzzy, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
 msgstr ""
 "Questa azione porterà alla perdita di {abbreviated_time} di lavoro non "
 "salvate"
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr "_Salva come Schizzo"
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
 
-#: ../gui/filehandling.py:282
-#, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
-msgstr "Sto caricando “{file_basename}”…"
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
 
-#: ../gui/filehandling.py:296
-#, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
-msgstr "Non riesco a caricare “{file_basename}”."
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
 
-#: ../gui/filehandling.py:321
-#, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
-msgstr "Ho caricato “{file_basename}”."
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr "Apri…"
 
-#: ../gui/filehandling.py:422
-#, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
-msgstr "Sto esportando su “{file_basename}”…"
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Apri File Recenti"
 
-#: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
-msgstr "Sto salvando “{file_basename}”…"
-
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
-msgstr "Fallito il salvataggio su “{file_basename}”."
-
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
-msgstr "Fallito nel salvare “{file_basename}”."
-
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
-msgstr "Esportato “{file_basename}” con successo."
-
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
-msgstr "Salvato “{file_basename}” con successo."
-
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Apri..."
-
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr "Apri Blocco Schizzi..."
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Pennello Importato"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Apri"
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Apri Più Recente"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Apri"
+
+#: ../gui/filehandling.py:1446
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
 msgstr "Non esiste ancora uno schizzo chiamato \"%s\"."
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1455
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr "Apri Schizzo Successivo"
+
+#: ../gui/filehandling.py:1463
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr "Apri Schizzo Precedente"
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Apri"
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+#, fuzzy
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr "Ripristina"
+
+#: ../gui/fill.py:121
+#, fuzzy
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr "Riempimento"
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+#, fuzzy
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr "riempi aree con il colore"
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+#, fuzzy
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr "Tolleranza:"
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+#, fuzzy
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
@@ -1594,19 +1898,36 @@ msgstr ""
 "Quanto i colori dei pixel possono variare da quelli di partenza\n"
 "prima che il Riempimento rifiuti di riempirli"
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+#, fuzzy
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr "Sorgente:"
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
-msgstr "Quali livelli visibili devono essere riempiti"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
+msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+#, fuzzy
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr "Campione Unito"
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+#, fuzzy
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
@@ -1616,19 +1937,50 @@ msgstr ""
 "unione temporanea di tutti i livelli visibili\n"
 "sotto il livello corrente"
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+#, fuzzy
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr "Adatta alla Vista"
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+#, fuzzy
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr "Destinazione:"
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+#, fuzzy
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr "Dove devono andare i dati in uscita"
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr "Nuovo Livello (una volta)"
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+#, fuzzy
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
@@ -1636,21 +1988,108 @@ msgstr ""
 "Crea un nuovo livello con il risultato del riempimento.\n"
 "Si spegne automaticamente dopo l'uso."
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Opacità:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr "Reimpostare"
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+#, fuzzy
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr "Reimposta le opzioni ai valori predefiniti"
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "Seleziona Livello"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr "<b>{brush_name}</b>"
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1660,130 +2099,142 @@ msgstr ""
 "<b>{brush_name}</b>\n"
 "{brush_desc}"
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr "Modifica Inquadratura"
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr "Regola l'inquadratura del documento"
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr "Dimensioni Inquadratura"
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr "px"
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr "Altezza:"
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr "Larghezza:"
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr "Risoluzione:"
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr "DPI"
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr "Punti Per Pollice (in realtà Pixel Per Pollice)"
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr "Colore:"
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr "Colore Cornice Inquadratura"
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr "<b>Dimensioni schermo</b>"
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr "<b>Densità pixel</b>"
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr "Adatta Inquadratura al Livello"
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr "Adatta l'inquadratura alle dimensioni del livello corrente"
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr "Adatta Inquadratura al Documento"
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr "Adatta inquadratura alla dimensione combinata di tutti i livelli"
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr "Taglia Livello all'Inquadratura"
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr "Ritaglia le parti del livello corrente  che sono fuori inquadratura"
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr "Abilitata"
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr "{width:g}×{height:g} {units}"
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr "pollici"
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr "cm"
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr "mm"
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr "Disegno a Mano Libera"
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr "Dipingi pennellate a forma libera"
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr "Liscio:"
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr "Pressione:"
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr "È stato rilevato un errore"
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr "<big><b>È stato rilevato un errore di programmazione.</b></big>"
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1797,35 +2248,35 @@ msgstr ""
 "Per favore comunicalo agli sviluppatori usando l' issue tracker se "
 "nessun'altro ha già riportato questo problema."
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr "Tracciatore Ricerca..."
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr "Rapporto..."
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr "Ignora Errore"
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr "Termina MyPaint"
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr "Dettagli..."
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr "Si è verificata un'eccezione analizzando un'eccezione."
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1868,45 +2319,50 @@ msgstr ""
 "            #### Traceback\n"
 "        "
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr "Inchiostrazione"
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr "Disegna e poi regola la morbidezza delle linee"
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr "Test del Dispositivo di Ingresso"
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr "(nessuna pressione)"
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr "Pressione:"
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr "(nessuna inclinazione)"
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr "Inclinazione:"
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr "(nessun dispositivo)"
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
 msgstr "Dispositivo:"
 
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+#, fuzzy
+msgid "Barrel Rotation:"
+msgstr "Reimposta Rotazione"
+
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr "Sposta Livello"
 
@@ -1914,165 +2370,232 @@ msgstr "Sposta Livello"
 msgid "Move the current layer"
 msgstr "Muovi il livello corrente"
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
-msgstr "{default_name} su {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
+msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
-msgstr "Tipo"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
+msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+#, fuzzy
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr "Proprietà"
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr "Visibile"
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Livello"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+#, fuzzy
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr "Bloccato"
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+#, fuzzy
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ", "
+
+#: ../gui/layers.py:990
+#, fuzzy, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr "Aggiungi {layer_default_name}"
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Livelli"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr "Organizza livelli e assegna effetti"
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr "Opacità Livello: %d%%"
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr "Sposta il livello nella pila..."
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 "Muovi i livelli nella pila (lasciandolo cadere su un livello normale creerà "
 "un nuovo gruppo)"
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr "Livello"
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
-msgstr "Modalità:"
+#: ../gui/layervis.py:53
+#, fuzzy, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
+msgstr "<b>{brush_name}</b>"
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
-"Modalità fusione: come il livello corrente si combina con quello sottostante."
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Opacità:"
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "Rotazione Visuale"
 
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-"Opacità livello: quanto del livello corrente usare. Valori più piccoli lo "
-"rendono più trasparente."
-
-#: ../gui/linemode.py:37
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr "Pressione In Entrata"
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr "pressione in entrata del tratto per lo strumento linea"
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr "Pressione Punto Intermedio"
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr "Pressione di metà tratto per lo strumento linea"
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr "Pressione in Uscita"
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr "Pressione tratto in uscita per lo strumento linea"
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr "Testa"
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 msgid "Stroke lead-in end"
 msgstr "Termine del tratto di avvio"
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr "Coda"
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr "Inizio del tratto finale"
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr "Variazione pressione..."
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr "Linee e Curve"
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr "Modo generico linea/curva"
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 "Disegna linee dritte; il Tasto Shift aggiunge curve, il tasto Ctrl limita "
 "l'angolo"
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr "Linee Connesse"
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 "Disegna sequenze di linee; il Tasto Shift aggiunge curve, il tasto Ctrl "
 "limita l'angolo"
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr "Ellissi e Cerchi"
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 "Disegna ellissi; il Tasto Shift ruota, il tasto Ctrl limita rapporto/angolo"
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
+#, fuzzy
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 "Copyright (C) 2005-2015\n"
 "Martin Renold e il Team di Sviluppo MyPaint"
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -2091,258 +2614,288 @@ msgstr ""
 "Questo programma è distribuito nella speranza che possa essere utile, ma "
 "SENZA ALCUNA GARANZIA. Leggi il file COPYING per maggiori dettagli."
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr "programmazione"
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr "portabilità"
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr "gestione progetto"
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr "pennelli"
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr "motivi"
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr "strumenti icone"
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr "icona scrivania"
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr "tavolozze"
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr "documentazione"
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr "supporto"
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr "divulgazione"
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr "comunità"
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ", "
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 "Traduzione italiana a cura di\n"
 "Lamberto Tedaldi (Officine Pixel)"
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr "Dimensione:"
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr "Opacità:"
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr "Netto:"
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr "Guadagno:"
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr "Opzioni Strumenti"
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr "Impostazioni specializzate per lo strumento in uso"
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr "<b>{mode_name}</b>"
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr "<i>Nessuna opzione disponibile</i>"
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr "Zoom: %.01f%%"
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr "Preleva impostazioni, traccia, colore e livello della pennellata…"
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr "Preleva colore…"
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr "Preferenze"
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr "Anteprima"
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr "Mostra anteprima dell'intera area di disegno"
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr "Mostra Mirino"
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr "Blocco Schizzi"
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr "Miscela colori e fai schizzi su pagine diverse"
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr "Elemento precedente"
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr "Elemento successivo"
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
 msgstr "(Niente da mostrare)"
 
-#: ../gui/symmetry.py:76
+#: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Place axis"
 msgstr "Posiziona assi"
 
-#: ../gui/symmetry.py:80
+#: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Move axis"
 msgstr "Sposta assi"
 
-#: ../gui/symmetry.py:84
+#: ../gui/symmetry.py:88
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr "Rimuovi assi"
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr "Modifica Asse di Simmetria"
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr "Regola l'asse di simmetria di pittura."
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
+#, fuzzy
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr "Posizione:"
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr "Posizione:"
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr "Nessuna"
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr "%d px"
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr "Alfa:"
 
-#: ../gui/symmetry.py:352
+#: ../gui/symmetry.py:376
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
+msgstr "Simmetria"
+
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+#, fuzzy
 msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+msgid "X axis Position"
 msgstr "Posizione Assi"
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:477
+#, fuzzy
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr "Posizione Assi"
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr "Abilitata"
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr "Gestione File"
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr "Commutatore schizzi"
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr "Annulla e Ripeti"
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr "Modalità Fusione"
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr "Modalità Linea"
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr "Visuale (Principale)"
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr "Visuale (Alternativa/Secondaria)"
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr "Visuale (Ripristino)"
 
@@ -2350,188 +2903,214 @@ msgstr "Visuale (Ripristino)"
 msgid "<b>MyPaint</b>"
 msgstr "<b>MyPaint</b>"
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr "Scorrimento Visuale"
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr "Trascina la vista superficie"
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr "Zoom Visuale"
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr "Zooma la vista superficie"
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr "Rotazione Visuale"
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr "Ruota la vista superficie"
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, fuzzy, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr "%s: chiudi tab"
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
-msgstr "%s: modifica proprietà"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
+msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr "Comando Sconosciuto"
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr "Non definito (comando non ancora partito)"
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr "{seconds:.01f}s di pittura con {brush_name}"
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr "Riempimento"
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr "Ritaglia Livello"
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "Rinomina Gruppo"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr "Pulisci Livello"
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr "Incolla Livello"
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr "Nuovo Livello da Visibili"
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr "Fondi Livelli Visibili"
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr "Fondi in Basso"
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr "Modo Livello Normalizza"
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Pennello Importato"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr "Aggiungi {layer_default_name}"
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr "Rimuovi Livello"
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr "Seleziona Livello"
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr "Duplica Livello"
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr "Sposta Livello Su"
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr "Sposta Livello Giù"
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr "Riordina Livello nella Pila"
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr "Rinomina Livello"
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr "Rendi Visibile il livello"
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr "Rendi Invisibile il Livello"
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr "Blocca Livello"
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr "Sblocca Livello"
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr "Imposta Opacità Livello: %0.1f%%"
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr "Modo Sconosciuto"
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr "Imposta Modalità Livello: %s"
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr "Abilita Inquadratura"
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr "Disabilita Inquadratura"
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr "Aggiorna Inquadratura"
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr "Modifica Livello Esternamente"
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr "Errore caricando “{basename}”."
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr "I log potrebbero contenere più dettagli riguardo questo errore."
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr "da ora"
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr "fa"
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2543,13 +3122,13 @@ msgstr ""
 "Stai usando più di una istanza di MyPaint?\n"
 "Chiudi il programma e attendi {cache_update_interval}s prima di riprovare."
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr "Backup incompleto aggiornato {last_modified_time} {ago}"
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2559,11 +3138,11 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 "Backup aggiornato {last_modified_time} {ago}\n"
-"Dimensione: {autosave.width}×{autosave.height} pixel, Livelli: "
-"{autosave.num_layers}\n"
+"Dimensione: {autosave.width}×{autosave.height} pixel, Livelli: {autosave."
+"num_layers}\n"
 "Contiene {unsaved_time} di lavoro non salvato."
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2573,13 +3152,13 @@ msgstr ""
 "Non riesco a salvare “{filename}”: {err}\n"
 "Hai abbastanza spazio libero sul dispositivo?"
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr "Non riesco a scrivere “{filename}”: {err}"
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2589,7 +3168,7 @@ msgstr ""
 "{error_loading_common}\n"
 "Il file non esiste."
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2599,7 +3178,7 @@ msgstr ""
 "{error_loading_common}\n"
 "Non hai i permessi necessari per aprire il file."
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2615,7 +3194,7 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2625,7 +3204,13 @@ msgstr ""
 "{error_loading_common}\n"
 "Estensione formato file sconosciuta: “{ext}”"
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+#, fuzzy
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr "Pennello Importato"
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2639,7 +3224,7 @@ msgstr ""
 "Prova a salvare in formato PNG se la tua macchina non dispone di un bel po' "
 "di memoria. Il salvataggio in formato PNG di MyPaint è più efficiente."
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2655,98 +3240,207 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/helpers.py:402
-#, python-brace-format
+#: ../lib/floodfill.py:131
+#, fuzzy
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr "Riempire"
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr "{days}d{hours}h"
 
-#: ../lib/helpers.py:404
-#, python-brace-format
+#: ../lib/helpers.py:537
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr "{hours}h{minutes}m"
 
-#: ../lib/helpers.py:406
-#, python-brace-format
+#: ../lib/helpers.py:539
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr "{minutes}m{seconds}s"
 
-#: ../lib/helpers.py:408
-#, python-brace-format
+#: ../lib/helpers.py:541
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr "{seconds}s"
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr "Livello"
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr "%(name)s %(number)d"
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr "^(.*?)\\s*(\\d+)$"
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
+#, fuzzy
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr "Livello Vettoriale"
+
+#: ../lib/layer/data.py:1158
+#, fuzzy
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr "Livello Vettoriale"
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
-msgstr "Livello Bitmap Sconosciuto"
+msgid "Bitmap"
+msgstr ""
 
-#: ../lib/layer/data.py:1169
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1244
 msgctxt "layer default names"
-msgid "Unknown Data Layer"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
 msgstr "Livello Dati Sconosciuto"
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "Nuovo Livello di Pittura"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr "Gruppo"
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "Nuovo Gruppo Livelli"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr "Segnaposto"
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr "Radice"
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ", "
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+#, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "Visualizza"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+#, fuzzy
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr "Aggiungi Livello"
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+#, fuzzy
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr "Rimuovi Livello"
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr "Blocca Livello"
+
+#: ../lib/layervis.py:697
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr "Sblocca Livello"
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr "Passante"
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr "Il contenuto del gruppo si applica direttamente allo sfondo del gruppo"
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr "Normale"
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr "Solo il livello superiore senza colori di fusione."
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr "Moltiplica"
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
@@ -2754,11 +3448,11 @@ msgstr ""
 "Simile al caricare più diapositive in un unico slot del proiettore per "
 "vederne il risultato combinato."
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr "Schermo"
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
@@ -2766,11 +3460,11 @@ msgstr ""
 "Come proiettare contemporaneamente due diapositive su uno schermo  da due "
 "proiettori diversi. Questo è l'inverso di 'Moltiplica'."
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr "Sovrapposto"
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
@@ -2778,27 +3472,27 @@ msgstr ""
 "Sovrappone allo sfondo il livello superiore preservando luci e ombre dello "
 "sfondo stesso. Questo è il contrario di 'Luce Forte'."
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr "Più Scuro"
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr "Il livello superiore è utilizzato solo dove è più scuro dello sfondo."
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr "Più Chiaro"
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr "Il livello superiore è utilizzato solo dove è più chiaro dello sfondo."
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr "Scherma"
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
@@ -2808,11 +3502,11 @@ msgstr ""
 "all'omonima tecnica fotografica usata in camera oscura che viene utilizzato "
 "per migliorare il contrasto nelle ombre."
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr "Brucia"
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
@@ -2822,43 +3516,43 @@ msgstr ""
 "all'omonima tecnica fotografica usata in camera oscura che viene utilizzato "
 "per ridurre i colpi di luce troppo luminosi."
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr "Luce Forte"
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr "Simile alla proiezione di un faretto intenso sullo sfondo."
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr "Luce Debole"
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr "Come illuminare lo sfondo con un faretto diffusore."
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr "Differenza"
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr "Sottrae il colore più scuro da quello più chiaro dei due."
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr "Esclusione"
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr "Simile a 'differenza' ma con minor contrasto."
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr "Tinta"
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
@@ -2866,11 +3560,11 @@ msgstr ""
 "Combina la tinta del livello superiore con la saturazione e luminosità dello "
 "sfondo."
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr "Saturazione"
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
@@ -2878,7 +3572,7 @@ msgstr ""
 "Applica la saturazione del livello superiore alla tinta e luminosità dello "
 "sfondo."
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
@@ -2886,11 +3580,11 @@ msgstr ""
 "Applica la tinta e la saturazione del livello superiore alla luminosità "
 "dello sfondo."
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr "Luminosità"
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
@@ -2898,30 +3592,30 @@ msgstr ""
 "Applica la luminosità del livello superiore alla tinta e saturazione dello "
 "sfondo."
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr "Più"
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr "Questo livello e il suo sfondo sono semplicemente sommati insieme."
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr "Destinazione Interno"
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 "Usa lo sfondo solo dove questo livello lo copre. Tutto il resto è ignorato."
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr "Destinazione Esterno"
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
@@ -2929,11 +3623,11 @@ msgstr ""
 "Usa lo sfondo solo dove questo livello non lo copre. Tutto il resto è "
 "ignorato."
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr "Sorgente In Cima"
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
@@ -2941,11 +3635,11 @@ msgstr ""
 "I dati sorgente che si sovrappongono a dati destinazione rimpiazzano quelli "
 "di destinazione. I dati destinazione sono mantenuti altrove."
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr "Destinazione In Cima"
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
@@ -2953,7 +3647,18 @@ msgstr ""
 "I dati destinazione che si sovrappongono a dati sorgente rimpiazzano quelli "
 "di sorgente. I dati sorgente sono mantenuti altrove."
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, fuzzy, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr "%(name)s %(number)d"
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
@@ -2962,7 +3667,7 @@ msgstr ""
 "Non riesco a costruire un oggetto interno vitale. Il tuo sistema non ha "
 "abbastanza memoria per eseguire questa operazione."
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2976,7 +3681,30 @@ msgstr ""
 "Motivo: {err}\n"
 "Cartella destinazione: “{dirname}”."
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+#, fuzzy
+msgid "Vertical"
+msgstr "Rifletti Verticale"
+
+#: ../lib/tiledsurface.py:49
+#, fuzzy
+msgid "Horizontal"
+msgstr "Rifletti Orizzontale"
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+#, fuzzy
+msgid "Rotational"
+msgstr "Reimposta Rotazione"
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr "Lettura PNG fallita: %s"
@@ -2985,56 +3713,94 @@ msgstr "Lettura PNG fallita: %s"
 msgid "Recover interrupted work?"
 msgstr "Recupero lavoro interrotto?"
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
-msgstr "_Recupera e Salva..."
+msgid "_Look for backups at startup"
+msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr "Elimina"
+
+#: ../po/tmp/autorecover.glade.h:9
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr "Elimina questo pennello dal disco"
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr "_Recupera e Salva..."
+
+#: ../po/tmp/autorecover.glade.h:12
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr "Salva questo backup su disco poi continua a lavorare su esso."
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
-msgstr "_Ignora per Ora"
+msgid "Decide _Later"
+msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 "Inizia a lavorare su una nuova area di lavoro. Questo backup verrà mantenuto."
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
+#, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 "MyPaint si è bloccato con del lavoro non salvato ma ha fatto un backup. Puoi "
 "recuperare il file ora oppure lascialo dove sta fino al prossimo avvio."
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr "Miniatura"
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr "Descrizione"
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
-msgstr "Copia a Nuovo"
+msgid "Live update"
+msgstr "Aggiornamento in tempo reale"
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
-msgstr "Copia queste impostazioni e l'icona corrente in un nuovo pennello"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
+msgstr ""
+"Aggiorna l'ultimo tratto sulla superficie di lavoro con le impostazioni di "
+"questa finestra, in tempo reale"
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
-msgstr "Rinomina questo pennello"
+msgid "Save these settings to the brush"
+msgstr "Salva queste impostazioni nel pennello"
 
 #: ../po/tmp/brusheditor.glade.h:5
 msgid "Edit Icon"
@@ -3057,20 +3823,16 @@ msgid "Delete this brush from the disk"
 msgstr "Elimina questo pennello dal disco"
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
-msgstr "Aggiornamento in tempo reale"
+msgid "Copy to New"
+msgstr "Copia a Nuovo"
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
-msgstr ""
-"Aggiorna l'ultimo tratto sulla superficie di lavoro con le impostazioni di "
-"questa finestra, in tempo reale"
+msgid "Copy these settings and the current brush's icon to a new brush"
+msgstr "Copia queste impostazioni e l'icona corrente in un nuovo pennello"
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
-msgstr "Salva queste impostazioni nel pennello"
+msgid "Rename this brush"
+msgstr "Rinomina questo pennello"
 
 #: ../po/tmp/brusheditor.glade.h:13
 msgid "Brush Setting"
@@ -3098,12 +3860,7 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr "Note:"
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr "Nome impostazione:"
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
@@ -3111,19 +3868,16 @@ msgstr ""
 "pennello sottostanti agiranno su questo."
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
-msgstr "Valore base:"
+#: ../po/tmp/brusheditor.glade.h:22
+#, fuzzy
+msgid "Value:"
+msgstr "Tinta HSV"
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr "Reimposta il valore di base al suo valore predefinito"
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr "Reimposta questo ingresso per non avere effetto sull'impostazione"
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
@@ -3131,11 +3885,7 @@ msgstr ""
 "Valore minimo per l'asse in uscita.\n"
 "Questo può essere impostato usando il cursore principale per {dname}."
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr "<ymin>"
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
@@ -3143,27 +3893,23 @@ msgstr ""
 "Valore massimo per l'asse in uscita.\n"
 "Questo può essere impostato usando il cursore principale per {dname}."
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr "<ymax>"
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr "Uscita"
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr "Ingresso dati"
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr "Regola il valore massimo"
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr "Regola il valore minimo"
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
@@ -3171,11 +3917,7 @@ msgstr ""
 "Valore minimo per l'asse in ingresso.\n"
 "Usa la scala a comparsa per regolarlo."
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr "<xmin>"
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
@@ -3183,38 +3925,36 @@ msgstr ""
 "Valore massimo per l'asse in ingresso.\n"
 "Usa la scala a comparsa per regolarlo."
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr "<xmax>"
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr "Variazione del valore base dall'ingresso stilo e altri criteri"
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr "Dinamiche Pennello"
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr "Dettagli base per questa impostazione"
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr "Modifica Impostazione"
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr "Regola questa mappatura ingresso nel dettaglio"
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr "{tooltip}"
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
 msgstr "{dname}:"
+
+#: ../po/tmp/brusheditor.glade.h:42
+#, fuzzy
+msgid "Brush dynamics are not available for this setting."
+msgstr "Dettagli base per questa impostazione"
+
+#: ../po/tmp/brusheditor.glade.h:43
+#, fuzzy
+msgid "<big><b>No Brush Dynamics</b></big>"
+msgstr "<big><b>{accel_label}</b></big>"
 
 #: ../po/tmp/inktool.glade.h:1
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
@@ -3226,7 +3966,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr "Pressione:"
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3271,6 +4011,141 @@ msgstr "Elimina Punto"
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
 msgstr "Elimina il punto selezionato"
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+#, fuzzy
+msgid "Insert Point"
+msgstr "Inserisci Riga"
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+#, fuzzy
+msgid "Cull Points"
+msgstr "Elimina Punto"
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Nome"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr "Modalità"
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Opacità"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr "Ritaglia inquadratura al livello attualmente attivo"
+
+#: ../po/tmp/layervis.glade.h:2
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr "Ruota la vista superficie"
+
+#: ../po/tmp/layervis.glade.h:3
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr "Ruota la vista superficie"
+
+#: ../po/tmp/layervis.glade.h:4
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr "Quali livelli visibili devono essere riempiti"
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
+msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
 msgctxt "footer: color picker button: tooltip"
@@ -3681,13 +4556,34 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr "Nascondi il cursore durante panoramica"
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+#, fuzzy
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr "Abilitata"
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr "Visualizza"
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
@@ -3696,18 +4592,18 @@ msgstr ""
 "La serie di colori da mostrare come colori primari sul cerchio colori.\n"
 "Diverse tradizioni hanno diverse armonie di colori."
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr "Primari sono:"
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr "Rosso/Verde/Blu standard digitale"
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
@@ -3715,7 +4611,7 @@ msgstr ""
 "Il rosso, verde a blu primari del &apos;monitor del computer&apos; "
 "uniformemente disposti intorno al cerchio. Il verde è di fronte al magenta."
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
@@ -3724,12 +4620,12 @@ msgstr ""
 "Il rosso, verde a blu primari del 'monitor del computer' uniformemente "
 "disposti intorno al cerchio. Il verde è di fronte al magenta."
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr "Rosso/Giallo/Blu tradizionali dell'artisa"
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
@@ -3739,7 +4635,7 @@ msgstr ""
 "artisti sin dal diciottesimo secolo approssimato con i colori del monitor "
 "uniformemente disposti attorno al cerchio. Il verde è all'opposto del rosso."
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3750,12 +4646,12 @@ msgstr ""
 "artisti sin dal diciottesimo secolo approssimato con i colori del monitor "
 "uniformemente disposti attorno al cerchio. Il verde è all'opposto del rosso."
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr "Rosso-Verde e Blu-Giallo coppie complementari"
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3770,7 +4666,7 @@ msgstr ""
 "presentano un modello simile. Qui usiamo rosso giallo verde e blu puri come "
 "i quattro colori primari."
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3787,28 +4683,28 @@ msgstr ""
 "colori primari."
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr "<b>Cerchio Colori</b>"
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr "Colore"
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr "Schermo (normale)"
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr "Disabilitata (nessuna sensibilità alla pressione)"
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr "Finestra(non raccomandato)"
@@ -3869,252 +4765,309 @@ msgid "Reload the file your current work was loaded from."
 msgstr "Ricarica il file da cui il tuo lavoro corrente è stato caricato."
 
 #: ../po/tmp/resources.xml.h:12
+#, fuzzy
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Import Layers…"
+msgstr "Importa Pennelli…"
+
+#: ../po/tmp/resources.xml.h:13
+msgctxt "Accel Editor (descriptions)"
+msgid "Import layers from one or more files."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save"
 msgstr "Salva"
 
-#: ../po/tmp/resources.xml.h:13
+#: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file."
 msgstr "Salva il lavoro su file."
 
-#: ../po/tmp/resources.xml.h:14
+#: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As…"
 msgstr "Salva Come…"
 
-#: ../po/tmp/resources.xml.h:15
+#: ../po/tmp/resources.xml.h:17
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file, assigning it a new name."
 msgstr "Salva il lavoro su un file assegnandogli un nuovo nome."
 
-#: ../po/tmp/resources.xml.h:16
+#: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Export…"
 msgstr "Esporta…"
 
-#: ../po/tmp/resources.xml.h:17
+#: ../po/tmp/resources.xml.h:19
 msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 "Esporta il tuo lavoro su un file ma continua a lavorare sullo stesso file."
 
-#: ../po/tmp/resources.xml.h:18
+#: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As Scrap"
 msgstr "Salva come Schizzo"
 
-#: ../po/tmp/resources.xml.h:19
+#: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
 msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 "Salva su un nuovo file schizzo oppure salva una nuova revisione se è già uno "
 "schizzo."
 
-#: ../po/tmp/resources.xml.h:20
+#: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Previous Scrap"
 msgstr "Apri Schizzo Precedente"
 
-#: ../po/tmp/resources.xml.h:21
+#: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file before the current one."
 msgstr "Carica lo schizzo precedente a quello corrente."
 
-#: ../po/tmp/resources.xml.h:22
+#: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Next Scrap"
 msgstr "Apri Schizzo Successivo"
 
-#: ../po/tmp/resources.xml.h:23
+#: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file after the current one."
 msgstr "Carica lo schizzo successivo a quello corrente."
 
-#: ../po/tmp/resources.xml.h:24
+#: ../po/tmp/resources.xml.h:26
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Recover File from an Automated Backup…"
 msgstr "Recupera File da un Backup Automatico…"
 
-#: ../po/tmp/resources.xml.h:25
+#: ../po/tmp/resources.xml.h:27
 msgctxt "Accel Editor (descriptions)"
 msgid "Try to save and resume interrupted unsaved work."
 msgstr "Prova a salvare e recuperare un lavoro non salvato."
 
-#: ../po/tmp/resources.xml.h:26
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr "Gruppi Pennello"
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr "Pennelli"
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr "Lista gruppi pennello."
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr "Regolatori Colore"
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr "Colori"
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr "Regolatori colore disponibili."
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr "Modalità"
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr "Modalità"
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr "Modalità di composizione del livello corrente."
 
-#: ../po/tmp/resources.xml.h:35
+#: ../po/tmp/resources.xml.h:37
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Pressure"
+msgstr "Pressione In Entrata"
+
+#: ../po/tmp/resources.xml.h:38
+msgctxt "Accel Editor (descriptions)"
+msgid "Send harder pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:39
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Pressure"
+msgstr "Pressione In Entrata"
+
+#: ../po/tmp/resources.xml.h:40
+msgctxt "Accel Editor (descriptions)"
+msgid "Send softer pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:41
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Rotation"
+msgstr "Aumenta Saturazione"
+
+#: ../po/tmp/resources.xml.h:42
+msgctxt "Accel Editor (descriptions)"
+msgid "Increase barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:43
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
+msgstr "Diminuisci Saturazione"
+
+#: ../po/tmp/resources.xml.h:44
+msgctxt "Accel Editor (descriptions)"
+msgid "Decrease barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:45
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Size"
 msgstr "Aumenta Dimensione Pennello"
 
-#: ../po/tmp/resources.xml.h:36
+#: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush bigger."
 msgstr "Rende il pennello in uso più grande."
 
-#: ../po/tmp/resources.xml.h:37
+#: ../po/tmp/resources.xml.h:47
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Size"
 msgstr "Riduci Dimensione Pennello"
 
-#: ../po/tmp/resources.xml.h:38
+#: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush smaller."
 msgstr "Rende il pennello in uso più piccolo."
 
-#: ../po/tmp/resources.xml.h:39
+#: ../po/tmp/resources.xml.h:49
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Opacity"
 msgstr "Aumenta Opacità Pennello"
 
-#: ../po/tmp/resources.xml.h:40
+#: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush more opaque."
 msgstr "Rende il pennello in uso più opaco."
 
-#: ../po/tmp/resources.xml.h:41
+#: ../po/tmp/resources.xml.h:51
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Opacity"
 msgstr "Riduci Opacità Pennello"
 
-#: ../po/tmp/resources.xml.h:42
+#: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush less opaque."
 msgstr "Rende il pennello in uso meno opaco."
 
-#: ../po/tmp/resources.xml.h:43
+#: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Lighten Painting Color"
 msgstr "Schiarisci Colore di Pittura"
 
-#: ../po/tmp/resources.xml.h:44
+#: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase the lightness of the current painting color."
 msgstr "Aumenta la luminosità del colore di pittura in uso."
 
-#: ../po/tmp/resources.xml.h:45
+#: ../po/tmp/resources.xml.h:55
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Darken Painting Color"
 msgstr "Scurisci Colore di Pittura"
 
-#: ../po/tmp/resources.xml.h:46
+#: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease the lightness of the current painting color."
 msgstr "Diminuisce la luminosità del colore di pittura in uso."
 
-#: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
-msgstr "Cambia Tonalità in Senso Antiorario"
-
-#: ../po/tmp/resources.xml.h:48
-msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
-msgstr "Ruota la tonalità di colore in senso antiorario sul cerchio colori."
-
-#: ../po/tmp/resources.xml.h:49
+#: ../po/tmp/resources.xml.h:57
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Change Hue Clockwise"
 msgstr "Cambia Tonalità in Senso Orario"
 
-#: ../po/tmp/resources.xml.h:50
+#: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
 msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr "Ruota il colore di pittura in senso orario sul cerchio colori."
 
-#: ../po/tmp/resources.xml.h:51
+#: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr "Cambia Tonalità in Senso Antiorario"
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr "Ruota la tonalità di colore in senso antiorario sul cerchio colori."
+
+#: ../po/tmp/resources.xml.h:61
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Increase Saturation"
 msgstr "Aumenta Saturazione"
 
-#: ../po/tmp/resources.xml.h:52
+#: ../po/tmp/resources.xml.h:62
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color more saturated (more colorful, purer)."
 msgstr "Rendi il colore di pittura più saturo (più colorato, puro)."
 
-#: ../po/tmp/resources.xml.h:53
+#: ../po/tmp/resources.xml.h:63
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Decrease Saturation"
 msgstr "Diminuisci Saturazione"
 
-#: ../po/tmp/resources.xml.h:54
+#: ../po/tmp/resources.xml.h:64
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color less saturated (grayer)."
 msgstr "Rendi il colore di pittura meno saturo (ingrigito)."
 
-#: ../po/tmp/resources.xml.h:55
+#: ../po/tmp/resources.xml.h:65
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Reload Brush Settings"
 msgstr "Ricarica Impostazioni Pennello"
 
-#: ../po/tmp/resources.xml.h:56
+#: ../po/tmp/resources.xml.h:66
 msgctxt "Accel Editor (descriptions)"
 msgid "Restore all brush settings to the current brush’s saved values."
 msgstr ""
 "Ripristina tutte le impostazioni del pennello ai valori salvati del pennello "
 "corrente."
 
-#: ../po/tmp/resources.xml.h:57
+#: ../po/tmp/resources.xml.h:67
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Pick Stroke and Layer"
 msgstr "Preleva Tratto e Livello"
 
-#: ../po/tmp/resources.xml.h:58
+#: ../po/tmp/resources.xml.h:68
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
 msgstr ""
 "Preleva una pennellata dall'area di lavoro: reimposta pennello, colore e "
 "livello."
 
-#: ../po/tmp/resources.xml.h:59
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr "Tasto Scorciatoia Ripristino Colore Pennello"
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
@@ -4123,221 +5076,273 @@ msgstr ""
 "Commuta se il ripristino del pennello da un tasto scorciatoia ripristina "
 "anche il colore salvato."
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr "Salva Pennello sulla Scorciatoia Più Recente"
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 "Salva le impostazioni del pennello sulla scorciatoia da tastiera usata "
 "recentemente."
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "Pulisci Livello"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr "Elimina il contenuto del livello corrente."
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Trim Layer to Frame"
-msgstr "Ritaglia Livello all'Inquadratura"
+#: ../po/tmp/resources.xml.h:75
+#, fuzzy
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr "Opzioni Strumenti"
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:76
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Trim Layer to Frame"
+msgstr "Taglia Livello all'Inquadratura"
+
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 "Cancella le parti del livello corrente che stanno fuori dall'inquadratura."
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr ""
+"Cancella le parti del livello corrente che stanno fuori dall'inquadratura."
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "Nuovo Gruppo Livelli Sotto"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "Nuovo Gruppo Livelli Sotto"
+
+#: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr "Copia Livello negli Appunti"
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr "Copia il contenuto del livello in uso negli appunti."
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr "Incolla Livello dagli Appunti"
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr "Rimpiazza il livello in uso con il contenuto degli appunti."
 
-#: ../po/tmp/resources.xml.h:71
+#: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Edit Layer in External App…"
 msgstr "Modifica Livello in Applicazione Esterna…"
 
-#: ../po/tmp/resources.xml.h:72
+#: ../po/tmp/resources.xml.h:90
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
+msgid "Edit the active layer in an external application."
 msgstr "Inizia modifica del livello in uso con un applicazione esterna."
 
-#: ../po/tmp/resources.xml.h:73
+#: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Update Layer with External Edits"
 msgstr "Aggiorna Livello con Programmi Esterni"
 
-#: ../po/tmp/resources.xml.h:74
+#: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
 msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 "Conferma le modifiche salvate dall'applicazione esterna (normalmente "
 "automatico)."
 
-#: ../po/tmp/resources.xml.h:75
+#: ../po/tmp/resources.xml.h:93
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer at Cursor"
 msgstr "Seleziona Livello sotto il Cursore"
 
-#: ../po/tmp/resources.xml.h:76
+#: ../po/tmp/resources.xml.h:94
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr "Seleziona un livello cliccando un oggetto che si trova su di esso."
 
-#: ../po/tmp/resources.xml.h:77
+#: ../po/tmp/resources.xml.h:95
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Above"
 msgstr "Vai al Livello Superiore"
 
-#: ../po/tmp/resources.xml.h:78
+#: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer up in the layer stack."
 msgstr "Vai su di un livello nella pila dei livelli."
 
-#: ../po/tmp/resources.xml.h:79
+#: ../po/tmp/resources.xml.h:97
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Below"
 msgstr "Vai al Livello Inferiore"
 
-#: ../po/tmp/resources.xml.h:80
+#: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer down in the layer stack."
 msgstr "Vai giù di un livello nella pila dei livelli."
 
-#: ../po/tmp/resources.xml.h:81
+#: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer"
 msgstr "Nuovo Livello di Pittura"
 
-#: ../po/tmp/resources.xml.h:82
+#: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer above the current layer."
 msgstr "Aggiungi un nuovo livello per la pittura sopra al livello corrente."
 
-#: ../po/tmp/resources.xml.h:83
+#: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer…"
 msgstr "Nuovo Livello Vettoriale…"
 
-#: ../po/tmp/resources.xml.h:84
+#: ../po/tmp/resources.xml.h:102
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer above the current layer, and begin editing it."
 msgstr ""
 "Aggiungi un nuovo livello vettoriale sopra al livello corrente e inizia a "
 "modificarlo."
 
-#: ../po/tmp/resources.xml.h:85
+#: ../po/tmp/resources.xml.h:103
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group"
 msgstr "Nuovo Gruppo Livelli"
 
-#: ../po/tmp/resources.xml.h:86
+#: ../po/tmp/resources.xml.h:104
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group above the current layer."
 msgstr "Aggiungi un nuovo gruppo di livelli sopra al livello in uso."
 
-#: ../po/tmp/resources.xml.h:87
+#: ../po/tmp/resources.xml.h:105
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer Below"
 msgstr "Nuovo Livello Pittura Sotto"
 
-#: ../po/tmp/resources.xml.h:88
+#: ../po/tmp/resources.xml.h:106
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer below the current layer."
 msgstr "Aggiungi un nuovo livello per la pittura sotto al livello corrente."
 
-#: ../po/tmp/resources.xml.h:89
+#: ../po/tmp/resources.xml.h:107
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer Below…"
 msgstr "Nuovo Livello Vettoriale Sotto…"
 
-#: ../po/tmp/resources.xml.h:90
+#: ../po/tmp/resources.xml.h:108
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer below the current layer, and begin editing it."
 msgstr ""
 "Aggiungi un nuovo livello vettoriale sotto al livello corrente e inizia a "
 "modificarlo."
 
-#: ../po/tmp/resources.xml.h:91
+#: ../po/tmp/resources.xml.h:109
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group Below"
 msgstr "Nuovo Gruppo Livelli Sotto"
 
-#: ../po/tmp/resources.xml.h:92
+#: ../po/tmp/resources.xml.h:110
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group below the current layer."
 msgstr "Aggiungi un nuovo gruppo di livelli sotto al livello in uso."
 
-#: ../po/tmp/resources.xml.h:93
+#: ../po/tmp/resources.xml.h:111
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Layer Down"
 msgstr "Fondi Livelli in Basso"
 
-#: ../po/tmp/resources.xml.h:94
+#: ../po/tmp/resources.xml.h:112
 msgctxt "Accel Editor (descriptions)"
 msgid "Merge the current layer with the layer beneath it."
 msgstr "Unisci il livello in uso con quello sottostante."
 
-#: ../po/tmp/resources.xml.h:95
+#: ../po/tmp/resources.xml.h:113
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Visible Layers"
 msgstr "Fondi Livelli Visibili"
 
-#: ../po/tmp/resources.xml.h:96
+#: ../po/tmp/resources.xml.h:114
 msgctxt "Accel Editor (descriptions)"
 msgid "Consolidate all visible layers, and delete the originals."
 msgstr "Consolida tutti i livelli visibili e cancella gli originali."
 
-#: ../po/tmp/resources.xml.h:97
+#: ../po/tmp/resources.xml.h:115
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer from Visible"
 msgstr "Nuovo Livello da Visibili"
 
-#: ../po/tmp/resources.xml.h:98
+#: ../po/tmp/resources.xml.h:116
 msgctxt "Accel Editor (descriptions)"
 msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
 msgstr "Come 'Fondi Livelli Visibili' ma non cancella gli originali."
 
-#: ../po/tmp/resources.xml.h:99
+#: ../po/tmp/resources.xml.h:117
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Delete Layer"
 msgstr "Elimina Livello"
 
-#: ../po/tmp/resources.xml.h:100
+#: ../po/tmp/resources.xml.h:118
 msgctxt "Accel Editor (descriptions)"
 msgid "Remove the current layer from the layer stack."
 msgstr "Elimina il livello in uso dalla pila dei livelli."
 
-#: ../po/tmp/resources.xml.h:101
+#: ../po/tmp/resources.xml.h:119
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Convert to Normal Painting Layer"
 msgstr "Converti in Normale Livello di Pittura"
 
-#: ../po/tmp/resources.xml.h:102
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
@@ -4346,72 +5351,74 @@ msgstr ""
 "Converte il livello corrente o il gruppo in un livello pittura modalità "
 "'Normale' preservando il suo aspetto."
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr "Aumenta Opacità Livello"
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr "Rendi il livello meno trasparente."
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr "Riduci Opacità Livello"
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr "Rendi il livello più trasparente."
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr "Alza Livello"
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr "Alza il livello corrente di una posizione nella pila dei livelli."
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr "Abbassa Livello"
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr "Abbassa il livello corrente di una posizione nella pila dei livelli."
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr "Duplica Livello"
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr "Crea una copia esatta del livello corrente."
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
+#, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
-msgstr "Rinomina Livello…"
+msgid "Layer Properties…"
+msgstr "Proprietà"
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
-msgstr "Scrivi un nuovo nome per il livello corrente."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr "Livello Bloccato"
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
@@ -4419,246 +5426,340 @@ msgstr ""
 "Commuta lo stato di blocco del livello in uso. I livelli bloccati non "
 "possono essere modificati."
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr "Livello Visibile"
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr "Commuta lo stato di visibilità del livello in uso."
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr "Mostra Sfondo"
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr "Commuta la visibilità del livello di sfondo."
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr "Elimina il livello in uso dalla pila dei livelli."
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr "Azzera e Centra la Vista"
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr "Reimposta Zoom, Rotazione, Riflessione e centra il documento."
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr "Adatta alla Vista"
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 "Commuta tra una vista d'insieme e la tua posizione di lavoro e livello di "
 "zoom."
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr "Reimposta"
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr "Reimposta Zoom"
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr "Ripristina la vista al livello di zoom predefinito."
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr "Reimposta Rotazione"
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr "Ripristina la rotazione della vista a 0°"
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr "Ripristina Specularità"
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
-msgstr "Spegni specularità della vista."
+msgid "Reset the view's mirroring."
+msgstr "Ripristina Specularità"
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr "Zoom Avanti"
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr "Aumenta l'ingrandimento."
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Zoom Indietro"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr "Diminuisce l'ingrandimento."
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
+#, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
-msgstr "Ruota in Senso Antiorario"
+msgid "Pan Left"
+msgstr "Vista Panoramica"
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
-msgstr "Ruota la vista del documento in senso antiorario."
+msgid "Move your view of the canvas to the left."
+msgstr "Ruota Vista: inclina il punto di visione dell'area di lavoro."
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr "Luce Forte"
+
+#: ../po/tmp/resources.xml.h:159
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+"Panoramica Vista: muovi la vista dell'area di lavoro orizzontalmente o "
+"verticalmente."
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr "Ruota Vista: inclina il punto di visione dell'area di lavoro."
+
+#: ../po/tmp/resources.xml.h:162
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr "Vista Panoramica"
+
+#: ../po/tmp/resources.xml.h:163
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr "Ruota Vista: inclina il punto di visione dell'area di lavoro."
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr "Ruota in Senso Orario"
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr "Ruota la vista del documento in senso orario."
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr "Ruota in Senso Antiorario"
+
+#: ../po/tmp/resources.xml.h:167
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr "Ruota la vista del documento in senso antiorario."
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr "Rifletti Orizzontale"
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr "Riflette la visuale da sinistra a destra."
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr "Rifletti Verticale"
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr "Capovolge la visuale a testa in giù."
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr "Solo Livello Corrente"
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr "Commuta la visione del solo livello in uso."
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr "Pittura Simmetrica Attivata"
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr "Specularità delle pennellate lungo l'asse di simmetria"
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr "Inquadratura Abilitata"
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr "Commuta visibilità dell'inquadratura del documento."
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr "Stampa i Valori di Ingresso del Pennello sulla Console"
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 "Mostra l'ingresso generato internamente dal motore del pennello sulla "
 "console."
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr "Visualizza Resa"
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr "Mostra aggiornamenti resa sullo schermo per il debug."
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr "Disabilita Double Buffering"
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr "Disabilita il double buffering GTK, normalmente è abilitato."
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+#, fuzzy
+msgid "Delete Point"
+msgstr "Elimina Punto"
+
+#: ../po/tmp/resources.xml.h:187
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr "Elimina il punto selezionato"
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr "Modalità Pittura"
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr "Modalità Pittura: Normale"
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr "Applica il colore normalmente quando si dipinge."
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr "Modo Pittura: Gomma"
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ".Cancella usando il pennello corrente."
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr "Modo Pittura: Alfa Bloccato"
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr "Utilizzando il pennello non verrà cambiata l'opacità del livello."
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr "Modo Pittura: Colora"
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
@@ -4666,256 +5767,252 @@ msgstr ""
 "Applica il colore al livello corrente senza compromettere la sua opacità e "
 "luminosità."
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "File"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "Esci"
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr "Chiudi la finestra principale ed esci dall'applicazione."
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "Modifica"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr "Strumento in Uso"
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "Colore"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr "Regola Colore"
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr "Popup Storia Colore"
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 "Apri una linea temporale dei colori usati recentemente sotto il cursore."
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr "Finestra Dettagli Colore"
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr "Mostra finestra dettagli colore con immissione testo."
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr "Colore Successivo sulla Tavolozza"
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr "Imposta il colore di pittura al colore successivo nella tavolozza."
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr "Colore Precedente sulla Tavolozza"
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr "Imposta il colore di pittura al colore precedente nella tavolozza."
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr "Aggiungi Colore alla Tavolozza"
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr "Aggiungi il colore della pittura corrente alla tavolozza."
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "Livello"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr "Opacità"
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr "Vai al Livello"
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr "Nuovo Livello Sotto"
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr "Proprietà"
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr "Blocco Schizzi"
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr "Nuovo Blocco Schizzi"
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 "Apri il blocco schizzi predefinito come una nuova superficie blocco schizzi."
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr "Apri Blocco Schizzi…"
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr "Carica un immagine da disco al blocco schizzi."
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr "Salva Blocco Schizzi"
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr "Salva un blocco schizzi sul suo file esistente su disco."
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr "Esporta Blocco Schizzi Come…"
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr "Esporta il blocco schizzi su disco con un nome a scelta."
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr "Ripristina Blocco Schizzi"
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr "Ripristina il blocco schizzi all'ultimo stato salvato."
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr "Salva Blocco Schizzi come Predefinito"
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr "Salva il blocco schizzi come predefinito per \"Nuovo Blocco Schizzi\"."
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr "Elimina Blocco Schizzi Predefinito"
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
-msgstr "Cancella il blocco schizzi predefinito come superficie di lavoro vuota."
+msgstr ""
+"Cancella il blocco schizzi predefinito come superficie di lavoro vuota."
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr "Copia Sfondo Principale sul Blocco Schizzi"
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr "Copia l'immagine di sfondo del documento in uso sul Blocco Schizzi."
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "Finestra"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "Pennello"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr "Scorciatoie da Tastiera"
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr "Aiuto Scorciatoie da Tastiera Pennelli"
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr "Mostra una spiegazione su come funzionano le scorciatoie da tastiera."
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "Cambia Pennello…"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr "Fai comparire un selettore pennello sotto al cursore."
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "Cambia Colore…"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr "Fai comparire la lista dei selettori colore sotto al cursore."
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "Cambia Colore (sottoinsieme veloce)…"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
@@ -4924,214 +6021,217 @@ msgstr ""
 "Fai comparire un selettore colore sotto al mouse che comprenda solo i colori "
 "cliccabili direttamente."
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr "Ottieni Altri Pennelli…"
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr "Scarica pacchetti pennelli dal wiki di MyPaint."
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr "Importa Pennelli…"
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr "Carica un pacchetto pennelli da disco."
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Aiuto"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr "Aiuto Online"
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr "Vai al wiki della documentazione di MyPaint."
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "Informazioni su MyPaint"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr "Mostra la licenza MyPaint, il numero di versione e i crediti."
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Debug"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr "Stampa Informazioni su Memory Leak nella Console (Lento!)"
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr "Attiva debug memory leaks."
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr "Eseguire Garbage Collector Adesso"
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 "Libera la memoria utilizzata per gli oggetti Python che non sono più in uso."
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr "Avvia/Ferma Profilazione…"
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr "Avvia/Ferma Python Profiling (cProfile)"
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr "Simula un Blocco…"
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
-msgstr "Solleva un'eccezione Python, per testare la finestra di dialogo blocco."
+msgstr ""
+"Solleva un'eccezione Python, per testare la finestra di dialogo blocco."
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "Vista"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr "Retroazione"
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr "Regola Visuale"
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
+#, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr "Menù a Comparsa"
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr "Mostra il menù principale come finestra a comparsa."
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "Schermo Pieno"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr "Commuta tra schermo pieno e modalità finestra."
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "Modifica Preferenze"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr "Modifica le impostazioni globali di MyPaint."
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr "Prova Periferiche di Ingresso"
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 "Mostra la finestra di dialogo che cattura tutti gli eventi che i tuoi "
 "dispositivi di immissione mandano."
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr "Selettore Sfondo"
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr "Cambia la trama della carta di sfondo."
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr "Modificatore Impostazioni Pennello"
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr "Modifica le impostazioni del pennello attivo."
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr "Modificatore Icona Pennello"
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr "Modifica Icona Pennello."
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr "Pannello Livelli"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
-"Attiva/disattiva il pannello di alloggio dei Livelli  (organizza livelli "
-"oppure assegna modalità)."
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr "Mostra Pannello Livelli"
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 "Mostra il pannello di alloggio Livelli (organizza livelli oppure assegna "
 "modalità)."
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr "Cerchio HCY"
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
@@ -5140,42 +6240,32 @@ msgstr ""
 "Selettore colore cilindrico hue/chroma/luma agganciabile. Le sezioni "
 "circolari sono equi-illuminanti."
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "Tavolozza Colore"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr "Tavolozza selettore colore agganciabile."
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr "Cerchio HSV"
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr "Modificatore saturazione e tinta agganciabile."
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr "Triangolo HSV"
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr "Selettore colore agganciabile: il vecchio triangolo colore GTK."
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr "Cubo HSV"
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
@@ -5184,501 +6274,493 @@ msgstr ""
 "Selettore colore agganciabile: il cubo HSV che può essere ruotato per "
 "mostrare diverse sezioni planari."
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr "Quadrato HSV"
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
-msgstr ""
-"Selettore colore agganciabile: il cubo HSV che può essere ruotato per "
-"mostrare diverse tinte."
+msgid "Dockable color selector: HSV square with Hue ring."
+msgstr "Selettore di colore agganciabile con anelli HSV concentrici."
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr "Cursori Componente"
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 "Selettore colore agganciabile che mostra la componenti individuali del "
 "colore."
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr "Lavaggio con Liquido"
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 "Selettore colore agganciabile che mostra la versione slavata dei colori "
 "adiacenti."
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr "Anelli Concentrici"
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr "Selettore di colore agganciabile con anelli HSV concentrici."
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr "Tavolozza a Croce"
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 "Selettore colori agganciabile con scale HSV su una tavolozza colore radiale."
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr "Pannello Blocco Schizzi"
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
-"Attiva/disattiva il pannello di alloggio del Blocco Schizzi (miscela colori "
-"e disegna schizzi)."
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr "Mostra Pannello Blocco Schizzi"
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 "Mostra il pannello di alloggio del Blocco Schizzi (miscela colori e disegna "
 "schizzi)."
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr "Pannello Anteprima"
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
-"Attiva/disattiva il pannello di alloggio dell'anteprima (visione d'insieme "
-"di tutta l'area di lavoro)."
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "Anteprima"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 "Mostra il pannello di alloggio dell'anteprima (visione d'insieme di tutta "
 "l'area di lavoro)."
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr "Pannello Opzioni Strumento"
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
-"Attiva/disattiva il pannello di alloggio delle Opzioni Strumenti (Opzioni "
-"per lo strumento in uso)."
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr "Mostra il Pannello Opzioni Strumento"
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 "Mostra il pannello di alloggio delle Opzioni Strumenti (Opzioni per lo "
 "strumento in uso)."
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr "Pannello Storia Pennello e Colore"
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
-"Attiva/disattiva il pannello della Storia (colori e pennelli usati "
-"recentemente)."
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr "Pennelli e Colori Recenti"
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
-msgstr "Mostra il pannello della Storia (colori e pennelli usati recentemente)."
+msgstr ""
+"Mostra il pannello della Storia (colori e pennelli usati recentemente)."
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr "Nascondi Controlli quando a Schermo Pieno"
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 "Commuta la scomparsa automatica dell'interfaccia utente quando a schermo "
 "pieno."
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr "Mostra Livello di Zoom"
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr "Attiva/disattiva la retroazione del livello di zoom."
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr "Mostra Ultima Posizione di Pittura"
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
-msgstr "Commuta la retroazione che mostra dove l'ultima pennellata è terminata."
+msgstr ""
+"Commuta la retroazione che mostra dove l'ultima pennellata è terminata."
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr "Filtro Schermo"
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr "Mostra Colori Normalmente"
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr "Filtro colori: mostra colori inalterati."
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr "Mostra Colori in Scala di Grigio"
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr "Filtro Colori: mostra solo luminosità (HCY/YCbCr Luma)"
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr "Mostra Colori Invertiti"
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr "Filtri colori: video negativo. Il nero è bianco a il rosso è ciano."
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr "Mostra Colori con Insensibilità al Rosso Simulata"
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 "Filtro colori per simulare la deuteranopia, una comune forma di daltonismo."
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr "Mostra Colori con Insensibilità al Verde Simulata"
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 "Filtra i colori per simulare la protanopia, una comune forma di daltonismo."
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr "Mostra Colori con Insensibilità al Blu Simulata"
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
-msgstr "Filtra colori per simulare la tritanopia, una rara forma di daltonismo."
+msgstr ""
+"Filtra colori per simulare la tritanopia, una rara forma di daltonismo."
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr "Mano Libera"
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr "Mano Libera"
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 "Disegno a mano libera: disegna e dipingi liberamente senza costrizioni "
 "geometriche."
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr "Mano Libera"
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr "Disegna e dipingi liberamente senza costrizioni geometriche."
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr "Vista Panoramica"
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr "Panoramica"
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 "Panoramica Vista: muovi la vista dell'area di lavoro orizzontalmente o "
 "verticalmente."
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr "Vista Panoramica"
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 "Muovi interattivamente la vista dell'area di lavoro orizzontalmente o "
 "verticalmente."
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr "Ruota Vista"
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr "Ruota"
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr "Ruota Vista: inclina il punto di visione dell'area di lavoro."
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr "Ruota Vista"
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr "Ruota interattivamente il punto di visione dell'area di lavoro."
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr "Zoom Vista"
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr "Zoom"
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr "Zoom Vista: Zoom avanti o indietro dell'area di lavoro."
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr "Zoom Vista"
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr "Imposta interattivamente il livello di zoom dell'area di lavoro."
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr "Linee e Curve"
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr "Linee"
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr "Linee e Curve: disegna linee dritte o curve."
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr "Linee e Curve"
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr "Disegna linee dritte o curve."
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr "Linee Connesse"
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr "Linee Connesse"
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr "Linee Connesse: disegna una sequenza di linee dritte o curve."
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr "Linee Connesse"
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr "Disegna sequenze di linee dritte o curve."
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr "Ellissi e Cerchi"
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr "Ellisse"
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr "Ellissi e Cerchi: disegna forme rotonde."
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr "Ellissi e Cerchi"
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr "Disegna cerchi ed ellissi."
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr "Inchiostrazione"
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr "Inchiostro"
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr "Inchiostrazione: disegna linee morbide in maniera controllata."
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr "Inchiostrazione"
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr "Disegna linee morbide in modo controllato."
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr "Riposizione Livello"
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr "Pos. Livello."
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr "Riposiziona Livello: muovi il livello corrente sull'area di lavoro."
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr "Riposiziona Livello"
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr "Sposta interattivamente il livello un uso sull'area di lavoro."
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr "Modifica Inquadratura"
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr "Inquadratura"
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
@@ -5686,12 +6768,12 @@ msgstr ""
 "Modifica Inquadratura: definisci un quadro attorno al documento per dargli "
 "una dimensione definita."
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr "Modifica Inquadratura"
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
@@ -5699,81 +6781,296 @@ msgstr ""
 "Definisci interattivamente un quadro attorno al documento per dargli una "
 "dimensione definita."
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Modifica Simmetria Pittura"
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr "Simmetria"
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 "Modifica Simmetria Pittura: regola l'asse usato per la pittura simmetrica."
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Modifica Simmetria Pittura"
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr "Regolazione interattiva dell'asse usato per la pittura simmetrica."
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr "Preleva Colore"
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr "Preleva Col."
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr "Preleva Colore: imposta il colore di pittura dai pixel dello schermo."
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "Preleva Colore"
+
+#: ../po/tmp/resources.xml.h:401
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr "Imposta il colore di pittura dai pixel dello schermo."
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "Preleva Colore"
+
+#: ../po/tmp/resources.xml.h:403
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr "Imposta il colore di pittura dai pixel dello schermo."
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "Preleva Colore"
+
+#: ../po/tmp/resources.xml.h:405
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr "Imposta il colore di pittura dai pixel dello schermo."
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr "Preleva Colore"
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr "Imposta il colore di pittura dai pixel dello schermo."
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr "Riempimento"
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr "Riempire"
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr "Riempimento: riempie un area con il colore."
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr "Riempimento"
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr "Riempi area con colore."
+
+#~ msgctxt "Accelerator map editor: action column markup"
+#~ msgid ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+#~ msgstr ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+
+#~ msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
+#~ msgid "{action_label} {action_desc} {accel_label}"
+#~ msgstr "{action_label} {action_desc} {accel_label}"
+
+#~ msgctxt "brush list context menu"
+#~ msgid "Delete"
+#~ msgstr "Elimina"
+
+#~ msgctxt "brush list commands"
+#~ msgid "Really delete brush from disk?"
+#~ msgstr "Vuoi veramente eliminare questo pennello dal disco?"
+
+#~ msgid "HSV Triangle"
+#~ msgstr "Triangolo HSV"
+
+#~ msgid "The standard GTK color selector"
+#~ msgstr "Selettore colore GTK standard"
+
+#~ msgid "Pick a color from the screen"
+#~ msgstr "Preleva un colore dallo schermo"
+
+#~ msgid "Layer Name"
+#~ msgstr "Nome Livello"
+
+#~ msgid ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+#~ msgstr ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+
+#~ msgid "Save..."
+#~ msgstr "Salva..."
+
+#~ msgid "Confirm"
+#~ msgstr "Conferma"
+
+#~ msgid "Open..."
+#~ msgstr "Apri..."
+
+#~ msgid "{default_name} at {path}"
+#~ msgstr "{default_name} su {path}"
+
+#~ msgid "Type"
+#~ msgstr "Tipo"
+
+#~ msgid "Mode:"
+#~ msgstr "Modalità:"
+
+#~ msgid ""
+#~ "Blending mode: how the current layer combines with the layers underneath "
+#~ "it."
+#~ msgstr ""
+#~ "Modalità fusione: come il livello corrente si combina con quello "
+#~ "sottostante."
+
+#~ msgid ""
+#~ "Layer opacity: how much of the current layer to use. Smaller values make "
+#~ "it more transparent."
+#~ msgstr ""
+#~ "Opacità livello: quanto del livello corrente usare. Valori più piccoli lo "
+#~ "rendono più trasparente."
+
+#~ msgid "%s: edit properties"
+#~ msgstr "%s: modifica proprietà"
+
+#~ msgctxt "layer unique names: match regex (leave untranslated if unsure)"
+#~ msgid "^(.*?)\\s*(\\d+)$"
+#~ msgstr "^(.*?)\\s*(\\d+)$"
+
+#~ msgctxt "layer default names"
+#~ msgid "Unknown Bitmap Layer"
+#~ msgstr "Livello Bitmap Sconosciuto"
+
+#~ msgctxt "Autosave Recovery dialog|"
+#~ msgid "_Ignore for Now"
+#~ msgstr "_Ignora per Ora"
+
+#~ msgid "Setting name:"
+#~ msgstr "Nome impostazione:"
+
+#~ msgid "Base value:"
+#~ msgstr "Valore base:"
+
+#~ msgid "Reset the base value to its default"
+#~ msgstr "Reimposta il valore di base al suo valore predefinito"
+
+#~ msgid "<ymin>"
+#~ msgstr "<ymin>"
+
+#~ msgid "<ymax>"
+#~ msgstr "<ymax>"
+
+#~ msgid "<xmin>"
+#~ msgstr "<xmin>"
+
+#~ msgid "<xmax>"
+#~ msgstr "<xmax>"
+
+#~ msgid "Edit Setting"
+#~ msgstr "Modifica Impostazione"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Trim Layer to Frame"
+#~ msgstr "Ritaglia Livello all'Inquadratura"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Rename Layer…"
+#~ msgstr "Rinomina Livello…"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Enter a new name for the current layer."
+#~ msgstr "Scrivi un nuovo nome per il livello corrente."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Turn off mirroring of the view."
+#~ msgstr "Spegni specularità della vista."
+
+#~ msgctxt "Menu→Edit (labels)"
+#~ msgid "Current Tool"
+#~ msgstr "Strumento in Uso"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+#~ msgstr ""
+#~ "Attiva/disattiva il pannello di alloggio dei Livelli  (organizza livelli "
+#~ "oppure assegna modalità)."
+
+#~ msgctxt "Menu→Color (labels), Accel Editor (labels)"
+#~ msgid "HSV Triangle"
+#~ msgstr "Triangolo HSV"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Dockable color selector: the old GTK color triangle."
+#~ msgstr "Selettore colore agganciabile: il vecchio triangolo colore GTK."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid ""
+#~ "Dockable color selector: HSV square which can be rotated to show "
+#~ "different hues."
+#~ msgstr ""
+#~ "Selettore colore agganciabile: il cubo HSV che può essere ruotato per "
+#~ "mostrare diverse tinte."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+#~ msgstr ""
+#~ "Attiva/disattiva il pannello di alloggio del Blocco Schizzi (miscela "
+#~ "colori e disegna schizzi)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+#~ msgstr ""
+#~ "Attiva/disattiva il pannello di alloggio dell'anteprima (visione "
+#~ "d'insieme di tutta l'area di lavoro)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+#~ msgstr ""
+#~ "Attiva/disattiva il pannello di alloggio delle Opzioni Strumenti (Opzioni "
+#~ "per lo strumento in uso)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the History panel (recently used brushes and colors)."
+#~ msgstr ""
+#~ "Attiva/disattiva il pannello della Storia (colori e pennelli usati "
+#~ "recentemente)."
 
 #~ msgid ""
 #~ "\"%s\" has an alpha channel. Background images with transparency are not "
@@ -5977,9 +7274,6 @@ msgstr "Riempi area con colore."
 #~ "C'è un tutorial, disponibile sulla homepage di MyPaint, che spiega alcune "
 #~ "delle caratteristiche del programma difficili da scoprire da soli.\n"
 
-#~ msgid "Open Recent files"
-#~ msgstr "Apri File Recenti"
-
 #~ msgid "This will discard %d second of unsaved painting."
 #~ msgid_plural "This will discard %d seconds of unsaved painting."
 #~ msgstr[0] ""
@@ -5989,9 +7283,6 @@ msgstr "Riempi area con colore."
 
 #~ msgid "Crop to Current Layer"
 #~ msgstr "Ritaglia al Livello Corrente"
-
-#~ msgid "Crop frame to the currently active layer"
-#~ msgstr "Ritaglia inquadratura al livello attualmente attivo"
 
 #~ msgid ""
 #~ "While the frame is enabled, it \n"
@@ -6096,9 +7387,6 @@ msgstr "Riempi area con colore."
 #~ msgid "Brush Blend Mode"
 #~ msgstr "Modalità Fusione Pennello"
 
-#~ msgid "Add Layer"
-#~ msgstr "Aggiungi Livello"
-
 #~ msgid "Move Layer on Canvas"
 #~ msgstr "Muovi il Livello sull'Area di Lavoro"
 
@@ -6136,9 +7424,6 @@ msgstr "Riempi area con colore."
 #~ msgctxt "Menu|File|"
 #~ msgid "Save"
 #~ msgstr "Salva"
-
-#~ msgid "Export to a file"
-#~ msgstr "Esporta su file"
 
 #~ msgid ""
 #~ "Saves to a new scrap file. If the drawing is currently saved as a scrap, "

--- a/po/it.po
+++ b/po/it.po
@@ -536,18 +536,18 @@ msgstr "MyPaint pacchetto pennelli (*.zip)"
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
-msgstr "Nuovo Gruppo..."
+msgid "New Group…"
+msgstr "Nuovo Gruppo…"
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
-msgstr "Importa Pennelli..."
+msgid "Import Brushes…"
+msgstr "Importa Pennelli…"
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
-msgstr "Ottieni Altri Pennelli..."
+msgid "Get More Brushes…"
+msgstr "Ottieni Altri Pennelli…"
 
 #: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
@@ -1234,13 +1234,13 @@ msgstr "Tipo"
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
-msgstr "Usa per..."
+msgid "Use for…"
+msgstr "Usa per…"
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
-msgstr "Scorri..."
+msgid "Scroll…"
+msgstr "Scorri…"
 
 #. Name and preview column: will be indented
 #: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
@@ -1464,8 +1464,8 @@ msgid "_Quit"
 msgstr "Esci"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
-msgstr "Importa pacchetto pennelli..."
+msgid "Import brush package…"
+msgstr "Importa pacchetto pennelli…"
 
 #: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
@@ -1519,8 +1519,8 @@ msgstr ""
 "“{type_name}” ({content_type})?"
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
-msgstr "Apri Con..."
+msgid "Open With…"
+msgstr "Apri Con…"
 
 #: ../gui/externalapp.py:123
 msgid "Icon"
@@ -1713,13 +1713,13 @@ msgstr "JPEG qualità 90% (*.jpg; *.jpeg)"
 
 #: ../gui/filehandling.py:576
 #, fuzzy
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr "Esporta…"
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Salva Come…"
 
@@ -1792,8 +1792,8 @@ msgstr "Apri File Recenti"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
-msgstr "Apri Blocco Schizzi..."
+msgid "Open Scratchpad…"
+msgstr "Apri Blocco Schizzi…"
 
 #: ../gui/filehandling.py:1099
 #, fuzzy
@@ -2249,13 +2249,13 @@ msgstr ""
 "nessun'altro ha già riportato questo problema."
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
-msgstr "Tracciatore Ricerca..."
+msgid "Search Tracker…"
+msgstr "Tracciatore Ricerca…"
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
-msgstr "Rapporto..."
+msgid "Report…"
+msgstr "Rapporto…"
 
 #: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
@@ -2266,8 +2266,8 @@ msgid "Quit MyPaint"
 msgstr "Termina MyPaint"
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
-msgstr "Dettagli..."
+msgid "Details…"
+msgstr "Dettagli…"
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
@@ -2475,8 +2475,8 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
-msgstr "Sposta il livello nella pila..."
+msgid "Move layer in stack…"
+msgstr "Sposta il livello nella pila…"
 
 #: ../gui/layerswindow.py:110
 msgid ""
@@ -2548,8 +2548,8 @@ msgid "Stroke trail-off beginning"
 msgstr "Inizio del tratto finale"
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
-msgstr "Variazione pressione..."
+msgid "Pressure variation…"
+msgstr "Variazione pressione…"
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
@@ -3747,7 +3747,7 @@ msgstr "Elimina questo pennello dal disco"
 #, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid "_Recover & Save…"
-msgstr "_Recupera e Salva..."
+msgstr "_Recupera e Salva…"
 
 #: ../po/tmp/autorecover.glade.h:12
 #, fuzzy

--- a/po/ja.po
+++ b/po/ja.po
@@ -10,11 +10,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MyPaint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-04 18:33+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2016-03-06 14:24+0000\n"
 "Last-Translator: tou omiya <tokyogeometry@gmail.com>\n"
-"Language-Team: Japanese "
-"<https://hosted.weblate.org/projects/mypaint/mypaint/ja/>\n"
+"Language-Team: Japanese <https://hosted.weblate.org/projects/mypaint/mypaint/"
+"ja/>\n"
 "Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -25,29 +25,7 @@ msgstr ""
 "X-Poedit-Country: JAPAN\n"
 "X-Poedit-SourceCharset: utf-8\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr "<big><b>{accel_label}</b></big>"
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr "{action_label} {action_desc} {accel_label}"
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "アクション"
 
@@ -55,39 +33,41 @@ msgstr "アクション"
 msgid "Key combination"
 msgstr "キーの組み合わせ"
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr "'%s'にキーを割り当てる"
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "アクション:"
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "パス:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "キー:"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr "この機能に割り当てるキーを押してください"
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "不明なアクション"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
-msgstr "<b>{accel} は '{action}' に割り当てられています。既存の割り当てを変更します。</b>"
+msgstr ""
+"<b>{accel} は '{action}' に割り当てられています。既存の割り当てを変更します。"
+"</b>"
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr "フォルダ \"{folder_basename}\" を開く…"
@@ -95,198 +75,208 @@ msgstr "フォルダ \"{folder_basename}\" を開く…"
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "OK"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr "バックアップがキャッシュ内に見つかりませんでした。"
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr "利用可能なバックアップなし"
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr "キャッシュフォルダを開く…"
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr "バックアップの復帰に失敗しました"
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr "バックアップ用フォルダを開く…"
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr "{iso_datetime}.ora からファイルを復帰しました"
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "デフォルトとして保存"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "背景"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "パターン"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "色"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "色をパターンに追加"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr "1 つ以上の背景を読込むことができませんでした"
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr "背景読み込み時にエラーが発生しました"
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
-msgstr "読み込み不能なファイルを削除するか、libgdkpixbuf が正しくインストールされているか確認してください。"
+msgstr ""
+"読み込み不能なファイルを削除するか、libgdkpixbuf が正しくインストールされてい"
+"るか確認してください。"
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
-msgstr "Gdk-Pixbuf が \"{filename}\" の読み込みに失敗し、エラー \"{error}\" を出力しました"
+msgstr ""
+"Gdk-Pixbuf が \"{filename}\" の読み込みに失敗し、エラー \"{error}\" を出力し"
+"ました"
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr "ファイル{filename}は面積がありません(幅：{w}, 高さ:{h})"
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr "ブラシ設定エディター"
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr "このブラシについて"
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "実験的"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr "基本"
 
-#: ../gui/brusheditor.py:300
-#: ../brushsettings-gen.h:4
-#: ../po/tmp/resources.xml.h:183
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr "不透明度"
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr "ブラシ描点"
 
-#: ../gui/brusheditor.py:323
-#: ../brushsettings-gen.h:33
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "混色"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr "スピード"
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr ""
+
+#: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr "描線の修正"
 
-#: ../gui/brusheditor.py:359
-#: ../brushsettings-gen.h:57
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "ストローク"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr "色"
 
-#: ../gui/brusheditor.py:385
-#: ../brushsettings-gen.h:61
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "カスタム"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
-msgstr "ブラシが選択されていません。「新規ブラシとして追加」を利用してください。"
+msgstr ""
+"ブラシが選択されていません。「新規ブラシとして追加」を利用してください。"
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr "ブラシが選択されていません！"
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "ブラシ名の変更"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "既に同名のブラシが存在します！"
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr "ブラシが選択されていません！"
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr "ブラシ「{brush_name}」を本当にディスクから削除しますか？"
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr "(名称未設定ブラシ)"
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr "{brush_name} [未保存]"
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr "ブラシアイコン"
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr "ブラシアイコン (編集中)"
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr "ブラシが選択されていません"
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -295,7 +285,7 @@ msgstr ""
 "<b>%s</b>\n"
 "<small>まずは有効なブラシを選んでください</small>"
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
@@ -304,7 +294,7 @@ msgstr ""
 "<b>%s</b> <i>(変更済み)</i>\n"
 "<small>変更内容はまだ保存されていません</small>"
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
@@ -313,7 +303,7 @@ msgstr ""
 "<b>%s</b> (editing)\n"
 "<small>ワークスペースからお好みのブラシや色を選べます</small>"
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -354,141 +344,181 @@ msgstr "自動"
 msgid "Use the default icon"
 msgstr "デフォルトのアイコンを使用"
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "保存"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr "このプレビューアイコンを保存して編集を終了"
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr "ロスト&ファウンド"
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr "削除済み"
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr "お気に入り"
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr "ペン入れ"
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr "クラシック"
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr "セット#1"
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr "セット#2"
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr "セット#3"
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr "セット#4"
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr "セット#5"
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr "実験的"
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "新規"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr "不明なブラシ"
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr "お気に入りに追加"
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr "お気に入りから削除"
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr "クローン"
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr "ブラシ設定を編集"
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
-msgstr "削除"
+#: ../gui/brushselectionwindow.py:250
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
+msgstr "グループ名の変更"
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
-msgstr "ブラシを本当にディスクから削除しますか？"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, fuzzy, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
+msgstr "ブラシ「{brush_name}」を本当にディスクから削除しますか？"
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] "%d 個のブラシ"
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr "グループ “{group_name}”"
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr "グループ名の変更"
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr "ブラシパックのエクスポート"
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr "グループを削除"
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr "グループ名を変更"
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "同名のグループが既に存在します！"
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr "グループ “{group_name}” を本当に削除しますか？"
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -498,58 +528,58 @@ msgstr ""
 "グループ “{group_name}” を削除できませんでした。\n"
 "一部の特別なグループは削除できません。"
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr "ブラシをエクスポート"
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr "MyPaint ブラシパッケージ (*.zip)"
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "新しいグループ..."
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr "ブラシをインポート..."
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr "追加のブラシを入手..."
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "グループを作成"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr "ボタン"
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr "ボタン"
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr "ボタン"
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr "機能の割り当てを追加"
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr "機能の割り当てを削除"
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr "'%s'への割り当てを編集"
@@ -558,52 +588,85 @@ msgstr "'%s'への割り当てを編集"
 msgid "Button press:"
 msgstr "ボタン割り当て："
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
-msgstr "修飾キーを押したまま、機能に割り当てたいボタンをこの文章の上で押すことで割り当てを設定します。"
+msgstr ""
+"修飾キーを押したまま、機能に割り当てたいボタンをこの文章の上で押すことで割り"
+"当てを設定します。"
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
-msgstr "{button}は修飾キー無しに割り当てることはできません。 (申し訳ありませんが、固定機能という事です)"
+msgstr ""
+"{button}は修飾キー無しに割り当てることはできません。 (申し訳ありませんが、固"
+"定機能という事です)"
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
-msgstr "{button_combination} は既にアクション '{action_name}' に割り当てられています"
+msgstr ""
+"{button_combination} は既にアクション '{action_name}' に割り当てられています"
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr "色を採取"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr "描画色を取得します"
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+#, fuzzy
+msgid "Set the color Hue used for painting"
+msgstr "描画色を取得します"
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "色を採取"
+
+#: ../gui/colorpicker.py:296
+#, fuzzy
+msgid "Set the color Chroma used for painting"
+msgstr "描画色を取得します"
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+#, fuzzy
+msgid "Set the color Luma used for painting"
+msgstr "描画色を取得します"
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr "色の詳細"
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr "現在の描画色、そして先ほど描画に使った色です"
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr "色域マスク有効"
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr "色域マスクを用いてパレットを特定の色調に限定します。"
@@ -613,300 +676,304 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr "HCY 色空間での色相と彩度。"
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
-msgstr "色域マスクエディター。中央部分をクリックすると、色域マスクを作成したり、範囲を調整できます。円の端をクリックするとマスクを回転できます。"
+msgstr ""
+"色域マスクエディター。中央部分をクリックすると、色域マスクを作成したり、範囲"
+"を調整できます。円の端をクリックするとマスクを回転できます。"
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr "雰囲気の三色配色"
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
-msgstr "一つの支配色とそれより少し褪せた二つの主要色で構成される、暗い雰囲気で主観色的な配色です。"
+msgstr ""
+"一つの支配色とそれより少し褪せた二つの主要色で構成される、暗い雰囲気で主観色"
+"的な配色です。"
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr "偏移した三色配色"
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr "支配色を通常より重視して強めた配色です。"
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr "補色配色"
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
-msgstr "頂点が補色の位置で対極に離れますが、中間色がカラーホイールの中央と一致するため、非常に安定した配色です。"
+msgstr ""
+"頂点が補色の位置で対極に離れますが、中間色がカラーホイールの中央と一致するた"
+"め、非常に安定した配色です。"
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr "雰囲気とアクセントの配色"
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
-msgstr "ある色に偏った大きな領域と、それに対して補色となる、アクセントとしての小さな色の領域で構成された配色です。"
+msgstr ""
+"ある色に偏った大きな領域と、それに対して補色となる、アクセントとしての小さな"
+"色の領域で構成された配色です。"
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr "分裂補色配色"
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
-msgstr "ある色と、それに対して補色となる色から左右の類似色相に分裂させた二色からなる配色です。三色配色と異なり二次色は存在しません。"
+msgstr ""
+"ある色と、それに対して補色となる色から左右の類似色相に分裂させた二色からなる"
+"配色です。三色配色と異なり二次色は存在しません。"
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr "テンプレートから新しい色域マスクを作成"
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr "色域マスクエディター"
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr "有効"
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr "ヘルプ…"
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr "テンプレートからマスクを作成します。"
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr "GIMP パレットファイルからマスクを読み込みます。"
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr "マスクを GIMP パレットファイルに保存します。"
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr "マスクを消去します。"
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr "Web ブラウザでこのダイアログについてのオンラインヘルプを開きます。"
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr "マスクを GIMP 用パレットとして保存"
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr "マスクを GIMP 用パレットから読み込む"
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr "色域マスクを設定します。"
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr "HCY ホイール"
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
 "are equiluminant."
-msgstr "色相/彩度/輝度により円筒を模した色空間を使い、色を選択します。表示される円はその断面で、中は同一の輝度となります。"
+msgstr ""
+"色相/彩度/輝度により円筒を模した色空間を使い、色を選択します。表示される円は"
+"その断面で、中は同一の輝度となります。"
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr "HSV 色相"
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr "HSV 彩度"
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr "HSV 明度"
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr "HSV 彩度と明度"
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr "HSV 色相と明度"
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr "HSV 色相と彩度"
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr "回転 (違う軸にする)"
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr "HSV 色立方体"
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr "HSV色立方体を回転させて、それぞれの面の色空間を表示できます。"
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr "HSV 正方形"
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr "HSV正方形では、カラーホイールを回転させて異なる色相を選択できます。"
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr "HSV 三角形"
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr "GTK 標準カラーセレクタ"
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr "HSV ホイール"
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr "彩度と明度によって色を変更します。"
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr "パレットのプロパティ"
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr "パレット"
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr "読み込みと編集が可能なパレットから、色を選択できます。"
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr "無題のパレット"
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr "パレットエディター"
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr "GIMP パレットファイルから読み込む"
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr "GIMP パレットファイルに保存"
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr "新しい空のスウォッチを追加"
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr "現在のスウォッチを削除"
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr "すべてのスウォッチを削除"
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr "タイトル:"
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr "このパレットの名前または説明"
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr "列:"
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr "列の数"
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr "色名:"
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr "現在の色の名前"
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr "空のパレットスロット"
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr "パレットを読み込む"
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr "パレットを保存"
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -916,379 +983,380 @@ msgstr ""
 "パレット (カラースウォッチ) です。\n"
 "ドラッグ&ドロップで色の配置を編集できます。"
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr "空のパレットスロット (色をここにドラッグしてください)"
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr "空のスロットを追加"
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr "行を挿入"
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr "列を挿入"
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr "間を埋める (RGB)"
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr "間を埋める (HCY)"
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr "間を埋める (HSV)"
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "GIMP パレットファイル (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr "すべてのファイル (*)"
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "GIMP パレットファイル (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr "すべてのファイル (*)"
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr "スクリーンから色を採取"
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr "R"
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr "G"
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr "B"
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr "H"
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr "C"
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr "Y"
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr "色成分スライダ"
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr "色の各成分を調整します。"
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr "RGB 赤"
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr "RGB 緑"
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr "RGB 青"
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr "HSV 色相"
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr "HSV 彩度"
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr "HSV 明度"
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr "HCY 色相"
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr "HCY 彩度"
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr "HCY 輝度 (Y')"
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr "リキッドウォッシュ"
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
-msgstr "現在の描画色と色相環の近傍色を、水彩のウォッシュ技法のように混ぜた中から選択します。"
+msgstr ""
+"現在の描画色と色相環の近傍色を、水彩のウォッシュ技法のように混ぜた中から選択"
+"します。"
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr "同心環"
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr "外周から色相・彩度・明度の順に並んだ同心環で色を選択します。"
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr "十字とボウル"
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
-msgstr "放射状の色のお椀 (ボウル) と、その上を横断する HSV ランプから色を選択します。"
+msgstr ""
+"放射状の色のお椀 (ボウル) と、その上を横断する HSV ランプから色を選択します。"
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr "レンズカーソル (デジタイザー)"
 
-#: ../gui/device.py:50
-#: ../brushsettings-gen.h:36
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr "消しゴム"
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr "キーボード"
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr "マウス"
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr "ペン"
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr "タッチパッド"
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr "タッチスクリーン"
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr "無視"
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr "全用途"
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr "描画以外"
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr "ナビゲーションのみ"
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr "拡大・縮小"
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr "表示領域の移動"
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr "デバイス"
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr "軸数"
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr "種類"
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr "用途は..."
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr "スクロール機能は..."
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "名前"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr "ブラシを上書きしますか？"
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr "置換"
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr "名前の変更"
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr "すべて置換"
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr "すべての名前を変更"
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr "インポートされたブラシ"
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr "既存のブラシ"
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 "<b>「%s」という名前のブラシは既に存在します。</b>\n"
 "置き換えますか？新しいブラシの名前を変更しますか？"
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr "ブラシグループを上書きしますか？"
 
-#: ../gui/dialogs.py:190
-#, python-brace-format
+#: ../gui/dialogs.py:220
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 "<b>「{groupname}」という名前のグループは既に存在します。</b>\n"
-"既存のグループを置き換えますか？それとも、新しいグループの名前を変更しますか？\n"
-"もし置き換えると、元のグループのブラシは「{deleted_groupname}」というグループに移されます。"
+"既存のグループを置き換えますか？それとも、新しいグループの名前を変更します"
+"か？\n"
+"もし置き換えると、元のグループのブラシは「{deleted_groupname}」というグループ"
+"に移されます。"
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr "ブラシパッケージをインポートしますか？"
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, fuzzy, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr "<b>本当にパッケージ「%s」をインポートしますか？</b>"
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr "ブラシ設定をショートカットスロット %d から読み込みます"
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr "ブラシ設定をショートカットスロット %d へ保存します"
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr "ブラシ %d を復元"
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr "ブラシ %d を保存"
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr "「%s」を元に戻す"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "元に戻す"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr "「%s」をやり直す"
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "やり直す"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr "{button_combination}で{resultant_action}"
@@ -1298,291 +1366,571 @@ msgstr "{button_combination}で{resultant_action}"
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ";  "
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr "{modifiers} を押しているとき: {button_actions}。"
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
-msgstr "レイヤー名"
-
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
-#, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
-"<b>{name}</b>\n"
-"{description}"
+
+#: ../gui/document.py:909
+#, python-brace-format
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
+msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr "%s - MyPaint"
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr "MyPaint"
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "開く"
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr "現在の色"
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr "フルスクリーン モード解除"
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr "フルスクリーンを解除"
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr "フルスクリーンモード"
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "フルスクリーン"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "終了"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+#, fuzzy
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr "終了しますか？"
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "終了"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr "ブラシパッケージのインポート..."
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr "MyPaint ブラシパッケージ (*.zip)"
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr "レイヤー「{layer_name}」を編集するために {app_name} を起動しました"
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
-msgstr "レイヤー「{layer_name}」を編集するための {app_name} の起動に失敗しました"
+msgstr ""
+"レイヤー「{layer_name}」を編集するための {app_name} の起動に失敗しました"
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
-msgstr "編集をキャンセルしました。レイヤーメニューから引き続き「{layer_name}」を編集できます。"
+msgstr ""
+"編集をキャンセルしました。レイヤーメニューから引き続き「{layer_name}」を編集"
+"できます。"
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr "他のアプリケーションで編集したレイヤー \"{layer_name}\" を更新しました"
 
-#: ../gui/externalapp.py:46
-#, python-brace-format
-msgid ""
-"MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
-"application should it use?"
-msgstr ""
-"このレイヤの外部編集には、ファイル形式 \"{type_name}\" ({content_type}) "
-"を編集できるアプリケーションが必要です。どのアプリケーションを使いますか？"
-
-#: ../gui/externalapp.py:50
-#, python-brace-format
-msgid ""
-"What application should MyPaint use for editing files of type "
-"“{type_name}” ({content_type})?"
-msgstr ""
-"MyPaintでファイル形式 \"{type_name}\" ({content_type}) を編集するのに、どのアプリケーションを使用しますか？"
-
-#: ../gui/externalapp.py:56
-msgid "Open With..."
-msgstr "他のアプリケーションで編集..."
-
-#: ../gui/externalapp.py:107
-msgid "Icon"
-msgstr "アイコン"
-
-#: ../gui/externalapp.py:150
-msgid "no description"
-msgstr "説明なし"
-
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr "利用可能なすべてのフォーマット"
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr "OpenRaster (*.ora)"
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr "PNG (*.png)"
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr "JPEG (*.jpg; *.jpeg)"
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr "拡張子で判断 (デフォルト形式を優先)"
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr "PNG 背景固定 (*.png)"
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr "透過 PNG (*.png)"
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr "透過あり連番 PNG (*.XXX.png)"
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr "JPEG (90%の品質) (*.jpg; *.jpeg)"
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr "保存..."
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr "保存形式:"
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr "了解"
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr "続行してもよろしいですか？"
-
-#: ../gui/filehandling.py:234
-#, python-brace-format, python-brace-format
-#, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
-msgstr "未保存の {abbreviated_time} 間の描画は、破棄されます"
-
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr "スクラップとして保存(_S)"
-
-#: ../gui/filehandling.py:282
-#, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
-msgstr "“{file_basename}” を読み込み中…"
-
-#: ../gui/filehandling.py:296
+#: ../gui/externalapp.py:48
 #, python-brace-format
 msgctxt "file handling: open failed (statusbar)"
 msgid "Could not load “{file_basename}”."
 msgstr "“{file_basename}” を読み込めませんでした。"
 
-#: ../gui/filehandling.py:321
+#: ../gui/externalapp.py:61
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
-msgstr "“{file_basename}” を読み込みました。"
+msgid ""
+"MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
+"application should it use?"
+msgstr ""
+"このレイヤの外部編集には、ファイル形式 \"{type_name}\" ({content_type}) を編"
+"集できるアプリケーションが必要です。どのアプリケーションを使いますか？"
 
-#: ../gui/filehandling.py:422
+#: ../gui/externalapp.py:65
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
-msgstr "“{file_basename}” にエクスポート中です…"
+msgid ""
+"What application should MyPaint use for editing files of type "
+"“{type_name}” ({content_type})?"
+msgstr ""
+"MyPaintでファイル形式 \"{type_name}\" ({content_type}) を編集するのに、どのア"
+"プリケーションを使用しますか？"
 
-#: ../gui/filehandling.py:427
+#: ../gui/externalapp.py:71
+msgid "Open With..."
+msgstr "他のアプリケーションで編集..."
+
+#: ../gui/externalapp.py:123
+msgid "Icon"
+msgstr "アイコン"
+
+#: ../gui/externalapp.py:166
+msgid "no description"
+msgstr "説明なし"
+
+#: ../gui/filehandling.py:126
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
+msgstr "“{file_basename}” を読み込み中…"
+
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:134
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr "“{file_basename}” を保存中です…"
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:138
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
+msgstr "“{file_basename}” にエクスポート中です…"
+
+#: ../gui/filehandling.py:145
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
 msgstr "“{file_basename}” へのエクスポートに失敗しました。"
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:149
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
 msgstr "“{file_basename}” の保存に失敗しました。"
 
-#: ../gui/filehandling.py:476
+#: ../gui/filehandling.py:153
 #, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr "“{file_basename}” を読み込めませんでした。"
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "パレットを保存"
+
+#: ../gui/filehandling.py:168
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr "ファイルにエクスポートする"
+
+#: ../gui/filehandling.py:172
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr "ファイルにエクスポートする"
+
+#: ../gui/filehandling.py:176
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr "最近開いたファイル"
+
+#: ../gui/filehandling.py:183
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
 msgstr "“{file_basename}” へのエクスポートに成功しました。"
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:187
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
 msgstr "“{file_basename}” の保存に成功しました。"
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "開く..."
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:195
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr "“{file_basename}” を読み込みました。"
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+
+#: ../gui/filehandling.py:221
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
+msgstr "“{file_basename}” を読み込みました。"
+
+#: ../gui/filehandling.py:427
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
+msgstr "利用可能なすべてのフォーマット"
+
+#: ../gui/filehandling.py:432
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:437
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:442
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
+msgstr "JPEG (*.jpg; *.jpeg)"
+
+#: ../gui/filehandling.py:490
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
+msgstr "拡張子で判断 (デフォルト形式を優先)"
+
+#: ../gui/filehandling.py:494
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:498
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr "PNG 背景固定 (*.png)"
+
+#: ../gui/filehandling.py:502
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:506
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr "透過 PNG (*.png)"
+
+#: ../gui/filehandling.py:510
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr "透過あり連番 PNG (*.XXX.png)"
+
+#: ../gui/filehandling.py:514
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr "透過あり連番 PNG (*.XXX.png)"
+
+#: ../gui/filehandling.py:518
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr "JPEG (90%の品質) (*.jpg; *.jpeg)"
+
+#: ../gui/filehandling.py:576
+#, fuzzy
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr "エクスポート…"
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "名前を付けて保存…"
+
+#: ../gui/filehandling.py:601
+#, fuzzy
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr "保存形式:"
+
+#: ../gui/filehandling.py:668
+#, fuzzy
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr "続行してもよろしいですか？"
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+#, fuzzy
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr "スクラップとして保存(_S)"
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, fuzzy, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr "未保存の {abbreviated_time} 間の描画は、破棄されます"
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr "開く…"
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "最近開いたファイル"
+
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr "作業パレットを開く..."
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "インポートされたブラシ"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "開く"
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "最後に編集した画像を開く"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "開く"
+
+#: ../gui/filehandling.py:1446
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
 msgstr "まだ「%s」という名前のスクラップ・ファイルはありません。"
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1455
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr "次のスクラップを開く"
+
+#: ../gui/filehandling.py:1463
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr "前のスクラップを開く"
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "開く"
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+#, fuzzy
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr "復元"
+
+#: ../gui/fill.py:121
+#, fuzzy
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr "塗りつぶし"
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+#, fuzzy
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr "連続した領域を指定した色で塗りつぶす"
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+#, fuzzy
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr "許容範囲:"
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+#, fuzzy
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
-msgstr "塗りつぶす時に、対象となるピクセルと同じ色とみなされる許容範囲の値を設定します"
+msgstr ""
+"塗りつぶす時に、対象となるピクセルと同じ色とみなされる許容範囲の値を設定しま"
+"す"
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+#, fuzzy
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr "参照元:"
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
-msgstr "塗りつぶし範囲を決める参照元を指定します"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
+msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+#, fuzzy
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr "統合した内容を参照"
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+#, fuzzy
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
@@ -1592,19 +1940,50 @@ msgstr ""
 "すべてのレイヤーを統合した画像を一時的に作成し、\n"
 "それを使用して判定します"
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+#, fuzzy
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr "ビューに合わせる"
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+#, fuzzy
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr "対象:"
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+#, fuzzy
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr "塗りつぶした結果がどこに出力されるかを変更できます"
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr "新規レイヤ生成 (一回だけ)"
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+#, fuzzy
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
@@ -1612,21 +1991,108 @@ msgstr ""
 "塗りつぶし結果の画像で新規レイヤを作成します。\n"
 "使った後は自動でチェックが外されます。"
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "不透明度:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr "リセット"
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+#, fuzzy
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr "オプションを初期設定に戻す"
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "レイヤーの選択"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr "<b>{brush_name}</b>"
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1636,130 +2102,142 @@ msgstr ""
 "<b>{brush_name}</b>\n"
 "{brush_desc}"
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr "フレームを調整"
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr "画像フレームを調整"
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr "フレームサイズ"
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr "px"
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr "高さ:"
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr "幅:"
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr "解像度:"
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr "DPI"
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr "インチあたりドット数 (ここでは、インチあたりピクセル数)"
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr "色:"
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr "フレームの色"
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr "<b>フレームの寸法</b>"
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr "<b>ピクセル密度</b>"
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr "フレームをレイヤーに合わせる"
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr "フレームを現在のレイヤーのサイズに合わせる"
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr "フレームをドキュメントに合わせる"
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr "全レイヤーが収まるようにフレームを調整"
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr "レイヤーをフレームサイズで切り抜く"
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr "現在のレイヤーからフレームの外に出た部分を切り取ります"
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr "有効"
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr "{width:g}×{height:g} {units}"
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr "インチ"
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr "センチメートル"
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr "ミリメートル"
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr "フリーハンド描画"
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr "自由な形状のブラシストロークを描画"
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr "手ブレ補正:"
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr "筆圧:"
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr "バグが検出されました"
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr "<big><b>プログラミングエラーが検出されました</b></big>"
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1767,38 +2245,40 @@ msgid ""
 "Please tell the developers about this using the issue tracker if no-one else "
 "has reported it yet."
 msgstr ""
-"このエラーを無視して作業を続ける事も可能ですが、今すぐ画像を保存したほうがいいと思われます。\n"
-"まだ誰も開発者にこのエラーを報告していなければ、「イシュー・トラッカー」(問題を追跡する仕組みです) を使って知らせてくださると幸いです。"
+"このエラーを無視して作業を続ける事も可能ですが、今すぐ画像を保存したほうがい"
+"いと思われます。\n"
+"まだ誰も開発者にこのエラーを報告していなければ、「イシュー・トラッカー」(問題"
+"を追跡する仕組みです) を使って知らせてくださると幸いです。"
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr "トラッカーを検索..."
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr "エラーを報告..."
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr "エラーを無視"
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr "MyPaint を終了"
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr "詳細..."
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr "例外解析中の例外です。"
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1845,45 +2325,50 @@ msgstr ""
 "            #### Traceback\n"
 "        "
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr "ペン入れ"
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr "なめらかな線を引く・微調整する"
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr "入力デバイスのテスト"
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr "(筆圧なし)"
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr "筆圧:"
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr "(傾きなし)"
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr "傾き:"
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr "(デバイスなし)"
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
 msgstr "デバイス:"
 
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+#, fuzzy
+msgid "Barrel Rotation:"
+msgstr "回転をリセット"
+
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr "レイヤーを移動"
 
@@ -1891,155 +2376,226 @@ msgstr "レイヤーを移動"
 msgid "Move the current layer"
 msgstr "現在のレイヤーを移動"
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
-msgstr "{path}の{default_name}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
+msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
-msgstr "種類"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
+msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+#, fuzzy
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr "プロパティ"
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr "表示"
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "レイヤー"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+#, fuzzy
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr "ロック"
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+#, fuzzy
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ", "
+
+#: ../gui/layers.py:990
+#, fuzzy, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr "{layer_default_name} を追加"
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "レイヤー"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr "レイヤーを管理したり、様々な効果を指定できます"
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr "レイヤー不透明度: %d%%"
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr "レイヤーの並び替え..."
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
-msgstr "レイヤーの並び替え (通常のレイヤーにドロップすると新しいグループを作ります)"
+msgstr ""
+"レイヤーの並び替え (通常のレイヤーにドロップすると新しいグループを作ります)"
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr "レイヤー"
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
-msgstr "モード:"
+#: ../gui/layervis.py:53
+#, fuzzy, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
+msgstr "<b>{brush_name}</b>"
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
-msgstr "合成モード: 現在のレイヤーを下のレイヤーとどのように合成するかを指定します。"
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
+msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "不透明度:"
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "表示領域を回転"
 
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr "レイヤー不透明度: 現在のレイヤーを合成する割合です。値が小さいほど透明になります。"
-
-#: ../gui/linemode.py:37
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr "始点の筆圧"
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr "直線・曲線ツールの始点の筆圧"
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr "中央部分での筆圧"
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr "直線・曲線ツールの中央の筆圧"
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr "終端の筆圧"
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr "直線・曲線ツールの終点の筆圧"
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr "入り"
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 msgid "Stroke lead-in end"
 msgstr "「入り」の残留期間"
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr "抜き"
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr "「抜き」の開始点"
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr "筆圧の変動グラフ..."
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr "直線と曲線"
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr "通常の直線や曲線を描画します"
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr "直線を引きます。Shift で曲線を追加。Ctrl で角度を制限"
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr "連結線"
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr "連続した複数の線を引きます。Shift で曲線を追加。Ctrl で角度を制限"
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr "円"
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr "円を描きます。Shift で回転、Ctrl で比率と角度を制限"
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
+#, fuzzy
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 "Copyright (C) 2005-2015\n"
 "Martin Renold ならびに MyPaint 開発チーム"
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -2050,261 +2606,295 @@ msgid ""
 "This program is distributed in the hope that it will be useful, but WITHOUT "
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
-"このプログラムはフリーソフトウェアです。Free Software Foundation が公表した GNU General Public "
-"License (ライセンスのいずれか 2 つのバージョン、または任意でそれ以降のバージョン) 下で再配布または変更することができます。\n"
+"このプログラムはフリーソフトウェアです。Free Software Foundation が公表した "
+"GNU General Public License (ライセンスのいずれか 2 つのバージョン、または任意"
+"でそれ以降のバージョン) 下で再配布または変更することができます。\n"
 "\n"
-"このプログラムはユーザーの役に立つ事を願い配布されていますが、一切の保証はありません。詳細については、 COPYING ファイルを参照してください。"
+"このプログラムはユーザーの役に立つ事を願い配布されていますが、一切の保証はあ"
+"りません。詳細については、 COPYING ファイルを参照してください。"
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr "プログラミング"
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr "移植性"
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr "プロジェクトマネージメント"
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr "ブラシ"
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr "パターン"
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr "ツールアイコン"
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr "デスクトップアイコン"
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr "パレット"
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr "ドキュメンテーション"
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr "サポート"
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr "広報"
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr "コミュニティ"
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ", "
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr "翻訳者"
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr "サイズ:"
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr "不透明度:"
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr "シャープ:"
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr "筆圧ゲイン:"
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr "ツールオプション"
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr "現在使用中のツール特有の設定"
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr "<b>{mode_name}</b>"
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr "<i>利用可能なオプションなし</i>"
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr "ズーム: %.01f%%"
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
-msgstr "ブラシストロークの設定、ストロークの色、そして描画されているレイヤーを取り込みます…"
+msgstr ""
+"ブラシストロークの設定、ストロークの色、そして描画されているレイヤーを取り込"
+"みます…"
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr "色を採取…"
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr "設定"
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr "プレビュー"
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr "描画エリア全体のプレビューを表示"
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr "メイン画面を示す枠を表示"
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr "作業パレット"
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr "色を混ぜたりスケッチを描いたりするスクラップ帳です"
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr "前"
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr "次"
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
 msgstr "(表示するものはありません)"
 
-#: ../gui/symmetry.py:76
+#: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Place axis"
 msgstr "対称軸を設置"
 
-#: ../gui/symmetry.py:80
+#: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Move axis"
 msgstr "対称軸を移動"
 
-#: ../gui/symmetry.py:84
+#: ../gui/symmetry.py:88
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr "対称軸を削除"
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr "対称軸を編集"
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr "対称描画の中心軸を調整します。"
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
+#, fuzzy
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr "位置:"
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr "位置:"
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr "なし"
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr "%d px"
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr "アルファ:"
 
-#: ../gui/symmetry.py:352
+#: ../gui/symmetry.py:376
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
+msgstr "対称"
+
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+#, fuzzy
 msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+msgid "X axis Position"
 msgstr "中心軸の位置"
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:477
+#, fuzzy
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr "中心軸の位置"
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr "有効"
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr "ファイルの処理"
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr "スクラップ切り替え"
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr "元に戻す/やり直す"
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr "合成モード"
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr "直線/曲線モード"
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr "表示操作 (メイン)"
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr "表示操作 (補助的)"
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr "表示操作 (リセット関連)"
 
@@ -2312,188 +2902,214 @@ msgstr "表示操作 (リセット関連)"
 msgid "<b>MyPaint</b>"
 msgstr "<b>MyPaint</b>"
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr "表示領域をスクロール"
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr "表示領域をドラッグして移動"
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr "表示領域を拡大・縮小"
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr "キャンバスの表示領域を拡大・縮小"
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr "表示領域を回転"
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr "キャンバスの表示領域を回転"
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, fuzzy, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr "%s: タブを閉じる"
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
-msgstr "%s: プロパティを編集"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
+msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr "不明なコマンド"
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr "未定義 (コマンドはまだ開始されていません)"
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr "{brush_name} を使った {seconds:.01f} 秒間の描画"
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr "塗りつぶし"
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr "レイヤーを切り取る"
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "グループ名の変更"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr "レイヤーの消去"
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr "レイヤーを貼り付け"
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr "可視部分で新規レイヤーを作成"
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr "可視レイヤーを統合"
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr "下のレイヤーと統合"
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr "標準モードの描画レイヤーに変換"
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "インポートされたブラシ"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr "{layer_default_name} を追加"
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr "レイヤーの削除"
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr "レイヤーの選択"
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr "レイヤーの複製"
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr "レイヤーを上に移動"
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr "レイヤーを下に移動"
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr "レイヤーの並び替え"
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr "レイヤーの名前を変更"
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr "レイヤーを表示する"
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr "レイヤーを非表示にする"
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr "レイヤーを保護"
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr "レイヤーの保護を解除"
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr "レイヤーの不透明度を設定: %0.1f%%"
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr "不明なモード"
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr "レイヤーの合成モードを %s にする"
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr "フレームを使用"
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr "フレームを使用しない"
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr "フレームを更新"
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr "レイヤーを他のアプリケーションで編集"
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr "\"{basename}\" を読み込み中のエラーです。"
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr "このエラーについての詳細がログに出力されている場合があります。"
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr "後"
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr "前"
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2505,13 +3121,13 @@ msgstr ""
 "MyPaint を複数起動していますか？\n"
 "MyPaint を終了し、{cache_update_interval} 秒後にやり直してください。"
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr "未完了のバックアップ ： {last_modified_time} {ago}に更新"
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2521,10 +3137,11 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 "{last_modified_time} {ago}のバックアップの更新\n"
-"サイズ: {autosave.width}×{autosave.height} ピクセル, レイヤ数: {autosave.num_layers}\n"
+"サイズ: {autosave.width}×{autosave.height} ピクセル, レイヤ数: {autosave."
+"num_layers}\n"
 "未保存の {unsaved_time}回の描画を含みます。"
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2534,13 +3151,13 @@ msgstr ""
 "“{filename}”を保存することができませんでした  : {err}\n"
 "十分なディスクの空き容量が残されていますか？"
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr "“{filename}”を書き込めませんでした : {err}"
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2550,7 +3167,7 @@ msgstr ""
 "{error_loading_common}\n"
 "ファイルが存在しません。"
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2560,7 +3177,7 @@ msgstr ""
 "{error_loading_common}\n"
 "ファイルの読み込み権限がありません。"
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2576,8 +3193,8 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/document.py:1313
-#, python-brace-format, python-brace-format, python-brace-format
+#: ../lib/document.py:1534
+#, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
 "{error_loading_common}\n"
@@ -2586,7 +3203,13 @@ msgstr ""
 "{error_loading_common}\n"
 "不明な拡張子です: \"{ext}\""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+#, fuzzy
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr "インポートされたブラシ"
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2597,10 +3220,11 @@ msgid ""
 msgstr ""
 "JPEG 形式で保存できません: {original_msg}\n"
 "\n"
-"お使いの PC が十分なメモリを搭載していない場合、PNG 形式への保存を試してください。MyPaint は JPEG 形式よりも PNG "
-"形式への保存時に、高効率に処理を実行します。"
+"お使いの PC が十分なメモリを搭載していない場合、PNG 形式への保存を試してくだ"
+"さい。MyPaint は JPEG 形式よりも PNG 形式への保存時に、高効率に処理を実行しま"
+"す。"
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2616,286 +3240,431 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/helpers.py:402
-#, python-brace-format
+#: ../lib/floodfill.py:131
+#, fuzzy
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr "塗りつぶし"
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr "{days} 日 {hours} 時間"
 
-#: ../lib/helpers.py:404
-#, python-brace-format
+#: ../lib/helpers.py:537
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr "{hours} 時間 {minutes} 分"
 
-#: ../lib/helpers.py:406
-#, python-brace-format
+#: ../lib/helpers.py:539
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr "{minutes} 分 {seconds} 秒"
 
-#: ../lib/helpers.py:408
-#, python-brace-format
+#: ../lib/helpers.py:541
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr "{seconds} 秒"
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr "レイヤー"
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr "%(name)s %(number)d"
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr "^(.*?)\\s*(\\d+)$"
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
+#, fuzzy
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr "ベクターレイヤー"
+
+#: ../lib/layer/data.py:1158
+#, fuzzy
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr "ベクターレイヤー"
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
-msgstr "不明なビットマップレイヤー"
+msgid "Bitmap"
+msgstr ""
 
-#: ../lib/layer/data.py:1169
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1244
 msgctxt "layer default names"
-msgid "Unknown Data Layer"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
 msgstr "不明なデータレイヤー"
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "新しい描画レイヤー"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr "グループ"
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "新しいレイヤーグループ"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr "プレースホルダ"
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr "ルートレイヤー"
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ", "
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+#, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "表示"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+#, fuzzy
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr "レイヤーの追加"
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+#, fuzzy
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr "レイヤーの削除"
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr "レイヤーを保護"
+
+#: ../lib/layervis.py:697
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr "レイヤーの保護を解除"
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr "通過"
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
-msgstr "レイヤグループの内容とモードがグループ内で終わらず、外のレイヤーまで通過して直接適用されます"
+msgstr ""
+"レイヤグループの内容とモードがグループ内で終わらず、外のレイヤーまで通過して"
+"直接適用されます"
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr "標準"
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr "色を混ぜることなく、最前面のレイヤーの内容のみを表示します。"
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr "乗算"
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr "プロジェクターで、2 枚のスライドを重ねあわせるのに似ています。"
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr "スクリーン"
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
-msgstr "2 台のプロジェクターの出力を同じスクリーン上に重ねあわせるのに似ています。 「乗算」と逆の合成方法です。"
+msgstr ""
+"2 台のプロジェクターの出力を同じスクリーン上に重ねあわせるのに似ています。 "
+"「乗算」と逆の合成方法です。"
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr "オーバーレイ"
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
-msgstr "背面のハイライトと影を保持しつつ、色を重ね合わせます。これは「ハードライト」の逆です。"
+msgstr ""
+"背面のハイライトと影を保持しつつ、色を重ね合わせます。これは「ハードライト」"
+"の逆です。"
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr "暗くする"
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr "背面より暗い部分だけを使って色を上書きします。"
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr "明るくする"
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr "背面より明るい部分だけを使って色を上書きします。"
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr "覆い焼き"
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
-"最前面のレイヤーの色を使って、背面のレイヤーの内容を明るくします。シャドウ部のコントラストを高めるための、同名の写真現像技術に似た効果を得られます。"
+"最前面のレイヤーの色を使って、背面のレイヤーの内容を明るくします。シャドウ部"
+"のコントラストを高めるための、同名の写真現像技術に似た効果を得られます。"
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr "焼き込み"
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
-msgstr "最前面のレイヤーの色を使って、背面のレイヤーの内容を暗くします。ハイライト部の白飛びを抑えるための、同名の写真現像技術に似た効果を得られます。"
+msgstr ""
+"最前面のレイヤーの色を使って、背面のレイヤーの内容を暗くします。ハイライト部"
+"の白飛びを抑えるための、同名の写真現像技術に似た効果を得られます。"
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr "ハードライト"
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr "背面側の上に強く輝くスポットライトを当てるのに似ています。"
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr "ソフトライト"
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr "背面側に柔らかい分散光のスポットライトを当てるのに似ています。"
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr "差分"
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr "二つのレイヤの色のうち、明るい方の色から暗い方の色を減算します。"
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr "除外"
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr "「差分」モードに似ていますが、より低コントラストです。"
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr "色相"
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
-msgstr "上のレイヤからは色相を、下のレイヤからは彩度と輝度を取り出して合成します。"
+msgstr ""
+"上のレイヤからは色相を、下のレイヤからは彩度と輝度を取り出して合成します。"
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr "彩度"
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
-msgstr "上のレイヤからは彩度を、下のレイヤからは色相と輝度を取り出して合成します。"
+msgstr ""
+"上のレイヤからは彩度を、下のレイヤからは色相と輝度を取り出して合成します。"
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
-msgstr "上のレイヤから色相と彩度を取り出し、下のレイヤからは輝度を取り出して合成します。"
+msgstr ""
+"上のレイヤから色相と彩度を取り出し、下のレイヤからは輝度を取り出して合成しま"
+"す。"
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr "輝度"
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
-msgstr "上のレイヤからは輝度を取り出し、下のレイヤからは色相と彩度を取り出して合成します。"
+msgstr ""
+"上のレイヤからは輝度を取り出し、下のレイヤからは色相と彩度を取り出して合成し"
+"ます。"
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr "加算"
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr "上のレイヤと下のレイヤを単純に加算します。"
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr "不透明部分で背面を透過"
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
-msgstr "このレイヤの不透明部分の下にある背面だけを使い、他のすべては無視して透明化します。"
+msgstr ""
+"このレイヤの不透明部分の下にある背面だけを使い、他のすべては無視して透明化し"
+"ます。"
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr "透明部分で背面を透過"
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
-msgstr "このレイヤの透明部分の下にある背面だけを使い、他の全ては無視して透明化します。"
+msgstr ""
+"このレイヤの透明部分の下にある背面だけを使い、他の全ては無視して透明化しま"
+"す。"
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr "背面レイヤーの不透明部分に上書き"
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
-msgstr "このレイヤと背面レイヤーとの不透明部分が重なっている部分だけを上書きします。背面レイヤーのその他の部分はそのまま表示されます。"
+msgstr ""
+"このレイヤと背面レイヤーとの不透明部分が重なっている部分だけを上書きします。"
+"背面レイヤーのその他の部分はそのまま表示されます。"
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr "不透明部分に背面レイヤーで上書き"
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
-msgstr "このレイヤと背面レイヤーの不透明部分が重なっている場所だけを、背面レイヤーまで透過します。このレイヤのその他の部分はそのまま表示されます。"
+msgstr ""
+"このレイヤと背面レイヤーの不透明部分が重なっている場所だけを、背面レイヤーま"
+"で透過します。このレイヤのその他の部分はそのまま表示されます。"
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, fuzzy, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr "%(name)s %(number)d"
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
-msgstr "重要な内部オブジェクトを生成出来ませんでした。この作業を実行するにはシステムのメモリーが不足しているかもしれません。"
+msgstr ""
+"重要な内部オブジェクトを生成出来ませんでした。この作業を実行するにはシステム"
+"のメモリーが不足しているかもしれません。"
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2909,7 +3678,30 @@ msgstr ""
 "原因: {err}\n"
 "出力先のフォルダー: “{dirname}”."
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+#, fuzzy
+msgid "Vertical"
+msgstr "上下反転"
+
+#: ../lib/tiledsurface.py:49
+#, fuzzy
+msgid "Horizontal"
+msgstr "左右反転"
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+#, fuzzy
+msgid "Rotational"
+msgstr "回転をリセット"
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr "PNGファイルの読み込みに失敗: %s"
@@ -2918,55 +3710,96 @@ msgstr "PNGファイルの読み込みに失敗: %s"
 msgid "Recover interrupted work?"
 msgstr "中断した作業を再開しますか？"
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
-msgstr "バックアップから保存(_R)..."
+msgid "_Look for backups at startup"
+msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
-msgid "Save this backup to disk, then continue working on it."
-msgstr "バックアップされていたファイルを復活させてディスクに保存し、作業を続けます。"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+#, fuzzy
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
-msgstr "今は無視する(_I)"
+msgid "_Delete…"
+msgstr "削除"
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:9
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr "このブラシをディスクから削除"
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr "バックアップから保存(_R)..."
+
+#: ../po/tmp/autorecover.glade.h:12
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Recover button|"
+msgid "Save this backup to disk, then continue working on it."
+msgstr ""
+"バックアップされていたファイルを復活させてディスクに保存し、作業を続けます。"
+
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
+msgctxt "Autosave Recovery dialog|"
+msgid "Decide _Later"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
-msgstr "新しいキャンバスで作業を始めます。これらのバックアップは別の場所で保持されます。"
+msgstr ""
+"新しいキャンバスで作業を始めます。これらのバックアップは別の場所で保持されま"
+"す。"
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
+#, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
-"作業を保存しないうちに MyPaint が異常終了しました。しかし、その時のバックアップは存在します。バックアップからファイルを復活させるか、"
-"MyPaint を再起動するまで放置することができます。"
+"作業を保存しないうちに MyPaint が異常終了しました。しかし、その時のバックアッ"
+"プは存在します。バックアップからファイルを復活させるか、MyPaint を再起動する"
+"まで放置することができます。"
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr "サムネイル"
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr "説明"
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
-msgstr "コピーを新規作成"
+msgid "Live update"
+msgstr "すぐに反映"
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
-msgstr "これらの設定値とブラシのアイコンを新規ブラシとして複製"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
+msgstr ""
+"直近のキャンバスへのストロークの描画を、新しい設定値でリアルタイムに更新する"
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
-msgstr "このブラシの名前を変更"
+msgid "Save these settings to the brush"
+msgstr "これらの設定をブラシに保存"
 
 #: ../po/tmp/brusheditor.glade.h:5
 msgid "Edit Icon"
@@ -2976,7 +3809,8 @@ msgstr "アイコンを編集"
 msgid ""
 "Edit this brush's icon in a separate window (you will be able to use any "
 "brush to draw it)"
-msgstr "別ウィンドウでこのブラシのアイコンを編集 (編集にはすべてのブラシが使えます)"
+msgstr ""
+"別ウィンドウでこのブラシのアイコンを編集 (編集にはすべてのブラシが使えます)"
 
 #: ../po/tmp/brusheditor.glade.h:7
 msgid "Delete"
@@ -2987,18 +3821,16 @@ msgid "Delete this brush from the disk"
 msgstr "このブラシをディスクから削除"
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
-msgstr "すぐに反映"
+msgid "Copy to New"
+msgstr "コピーを新規作成"
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
-msgstr "直近のキャンバスへのストロークの描画を、新しい設定値でリアルタイムに更新する"
+msgid "Copy these settings and the current brush's icon to a new brush"
+msgstr "これらの設定値とブラシのアイコンを新規ブラシとして複製"
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
-msgstr "これらの設定をブラシに保存"
+msgid "Rename this brush"
+msgstr "このブラシの名前を変更"
 
 #: ../po/tmp/brusheditor.glade.h:13
 msgid "Brush Setting"
@@ -3026,30 +3858,23 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr "詳細:"
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr "設定名:"
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
-msgstr "この設定における基本値です。以下のブラシダイナミクスはこの値に基づきます。"
+msgstr ""
+"この設定における基本値です。以下のブラシダイナミクスはこの値に基づきます。"
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
-msgstr "基本となる値:"
+#: ../po/tmp/brusheditor.glade.h:22
+#, fuzzy
+msgid "Value:"
+msgstr "HSV 明度"
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr "基本値をデフォルトに戻します"
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr "この入力を、基本値に影響を与えない値に戻します"
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
@@ -3057,11 +3882,7 @@ msgstr ""
 "この出力軸の最小値です.\n"
 "これはメインスライダー {dname} を使って設定できます。"
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr "<ymin>"
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
@@ -3069,27 +3890,23 @@ msgstr ""
 "この出力軸の最大値です。\n"
 "これはメインスライダー {dname} を使って設定できます。"
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr "<ymax>"
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr "出力"
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr "入力"
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr "最大値を変更"
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr "最小値を変更"
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
@@ -3097,11 +3914,7 @@ msgstr ""
 "この入力軸の最小値です。\n"
 "変更するには、横のアイコンをクリックして出るポップアップスケールを使います。"
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr "<xmin>"
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
@@ -3109,38 +3922,36 @@ msgstr ""
 "この入力軸の最大値です。\n"
 "変更するには、横のアイコンをクリックして出るポップアップスケールを使います。"
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr "<xmax>"
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr "スタイラスの入力や動きなどによる基本値の変動"
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr "ブラシダイナミクス"
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr "この設定の基本となる値の詳細です"
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr "設定を編集"
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr "この入力のマッピングを詳細に編集"
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr "{tooltip}"
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
 msgstr "{dname}:"
+
+#: ../po/tmp/brusheditor.glade.h:42
+#, fuzzy
+msgid "Brush dynamics are not available for this setting."
+msgstr "この設定の基本となる値の詳細です"
+
+#: ../po/tmp/brusheditor.glade.h:43
+#, fuzzy
+msgid "<big><b>No Brush Dynamics</b></big>"
+msgstr "<big><b>{accel_label}</b></big>"
 
 #: ../po/tmp/inktool.glade.h:1
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
@@ -3152,7 +3963,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr "太さ:"
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3197,6 +4008,141 @@ msgstr "制御点を削除"
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
 msgstr "現在選択している制御点を削除します"
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+#, fuzzy
+msgid "Insert Point"
+msgstr "行を挿入"
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+#, fuzzy
+msgid "Cull Points"
+msgstr "制御点を削除"
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "名前"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr "モード"
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "不透明度"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr "現在のレイヤーの合成モードです。"
+
+#: ../po/tmp/layervis.glade.h:2
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr "キャンバスの表示領域を回転"
+
+#: ../po/tmp/layervis.glade.h:3
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr "キャンバスの表示領域を回転"
+
+#: ../po/tmp/layervis.glade.h:4
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr "塗りつぶし範囲を決める参照元を指定します"
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
+msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
 msgctxt "footer: color picker button: tooltip"
@@ -3245,7 +4191,6 @@ msgid "PNG solid with background (*.png)"
 msgstr "背景つき不透明 PNG (*.png)"
 
 #: ../po/tmp/preferenceswindow.glade.h:4
-#, no-c-format, no-c-format
 #, no-c-format
 msgctxt "Prefs Dialog|Saving|Save Formats and Locations|Default|"
 msgid "JPEG 90% quality (*.jpg; *.jpeg)"
@@ -3326,7 +4271,6 @@ msgstr "<b>グローバル筆圧マッピング</b>"
 
 #. Tab label in preferences dialog
 #: ../po/tmp/preferenceswindow.glade.h:27
-#: ../brushsettings-gen.h:53
 msgctxt "Prefs Dialog|"
 msgid "Pressure"
 msgstr "筆圧"
@@ -3336,7 +4280,9 @@ msgctxt "Prefs Dialog|Devices|"
 msgid ""
 "Here you can restrict pointing devices to specific tasks on the canvas, or "
 "have them ignored completely if they glitch your drawing."
-msgstr "ここでは特定のデバイスに対してのキャンバス上の振る舞いを制限したり、あるいは使用において問題がある場合、完全に無視させることができます。"
+msgstr ""
+"ここでは特定のデバイスに対してのキャンバス上の振る舞いを制限したり、あるいは"
+"使用において問題がある場合、完全に無視させることができます。"
 
 #: ../po/tmp/preferenceswindow.glade.h:29
 msgctxt "Prefs Dialog|Button|"
@@ -3418,12 +4364,15 @@ msgid ""
 "monitors. If you know your display is radically different from this, use the "
 "\"no automatic conversions or tagging\" setting instead."
 msgstr ""
-"<i>広色域</i>の情報を含む画像は、MyPaint に読み込まれた時に sRGB に変換されます。 MyPaint "
-"が保存する時には、他のプログラムが正しく処理できるようにヒントが付加されます。\n"
+"<i>広色域</i>の情報を含む画像は、MyPaint に読み込まれた時に sRGB に変換されま"
+"す。 MyPaint が保存する時には、他のプログラムが正しく処理できるようにヒントが"
+"付加されます。\n"
 "\n"
-"これは、使用されているディスプレイが、Web 標準であり、控えめに考えてもほとんどの PC モニターが使用していると考えられる「sRGB "
-"色空間」かそれに近い色空間でキャリブレーションされていることを前提としています。もし sRGB "
-"と大幅に異なるディスプレイを使っている場合は、「自動変換やタグ付けをしない」 設定を使ってください."
+"これは、使用されているディスプレイが、Web 標準であり、控えめに考えてもほとん"
+"どの PC モニターが使用していると考えられる「sRGB 色空間」かそれに近い色空間で"
+"キャリブレーションされていることを前提としています。もし sRGB と大幅に異なる"
+"ディスプレイを使っている場合は、「自動変換やタグ付けをしない」 設定を使ってく"
+"ださい."
 
 #: ../po/tmp/preferenceswindow.glade.h:47
 msgctxt "Prefs Dialog|Load & Save|Color Management|"
@@ -3439,8 +4388,10 @@ msgid ""
 "This is MyPaint's old behaviour, and can be used as a stopgap for non-sRGB "
 "working."
 msgstr ""
-"読み込み時に色空間の変換をせず、保存時にもカラーマネジメント情報を付加しません。\n"
-"これは MyPaint の古い挙動と同一で、非 sRGB 環境での作業に場当たり的に対応するのに使えます。"
+"読み込み時に色空間の変換をせず、保存時にもカラーマネジメント情報を付加しませ"
+"ん。\n"
+"これは MyPaint の古い挙動と同一で、非 sRGB 環境での作業に場当たり的に対応する"
+"のに使えます。"
 
 #: ../po/tmp/preferenceswindow.glade.h:51
 msgctxt "Prefs Dialog|Load & Save|"
@@ -3466,8 +4417,9 @@ msgid ""
 "the program crashes, you'll have a chance to restore what you were working "
 "on."
 msgstr ""
-"作品を MyPaint "
-"のディスクキャッシュ領域に、非同期で自動的に増分バックアップします。もしプログラムが異常終了した場合、その時行っていた作業を復活させるチャンスがあります。"
+"作品を MyPaint のディスクキャッシュ領域に、非同期で自動的に増分バックアップし"
+"ます。もしプログラムが異常終了した場合、その時行っていた作業を復活させるチャ"
+"ンスがあります。"
 
 #: ../po/tmp/preferenceswindow.glade.h:56
 msgctxt "Prefs Dialog|Load & Save|Automated Backups|interval label"
@@ -3519,7 +4471,9 @@ msgctxt "Prefs Dialog|View|Interface|Dark theme variant|checkbox tooltip"
 msgid ""
 "Use a light-on-dark theme variant, when it's supported by the GTK theme. "
 "This is generally sensible for image editors and media viewers."
-msgstr "GTK テーマで使用可能な場合、暗い色が基調で明るい文字のテーマを使用します。これは画像を扱うプログラムやビュワーでは通常、賢明な対応です。"
+msgstr ""
+"GTK テーマで使用可能な場合、暗い色が基調で明るい文字のテーマを使用します。こ"
+"れは画像を扱うプログラムやビュワーでは通常、賢明な対応です。"
 
 #: ../po/tmp/preferenceswindow.glade.h:67
 msgid "Some of these settings require MyPaint to be restarted."
@@ -3546,8 +4500,10 @@ msgid ""
 "Draw a real checkerboard pattern to show transparency.\n"
 "This slows down the display, but can be less confusing."
 msgstr ""
-"透明部分を表示するのに、キャンバスの拡大縮小に関わらず同一サイズの市松模様で表現します。\n"
-"表示が若干遅くなるかもしれませんが、絵の模様と透明部分を混乱することは減るでしょう。"
+"透明部分を表示するのに、キャンバスの拡大縮小に関わらず同一サイズの市松模様で"
+"表現します。\n"
+"表示が若干遅くなるかもしれませんが、絵の模様と透明部分を混乱することは減るで"
+"しょう。"
 
 #: ../po/tmp/preferenceswindow.glade.h:73
 msgid "When showing transparency:"
@@ -3578,23 +4534,47 @@ msgid ""
 "Scrolling to pan the view needs this setting to be turned on, and for your "
 "device to be configured to send bidirectional scroll events."
 msgstr ""
-"スムーズスクロール機能はジェスチャやホイールでのスクロールをステップ単位より滑らかにします。しかしながら、タッチパッドには便利でも、マウスのスクロールホイ"
-"ールを使用している場合は苛立たしいこともあります。\n"
-"もしスムーズスクロールを使用している場合でも、スクロールと同時にシフトキーを押している間はステップ単位に戻すことができます。\n"
-"スクロール機能をビューの表示位置変更に使用する場合は、このオプションをチェックする必要があり、またデバイス側も双方向スクロールが出来るよう設定しておく必要"
-"があります。"
+"スムーズスクロール機能はジェスチャやホイールでのスクロールをステップ単位より"
+"滑らかにします。しかしながら、タッチパッドには便利でも、マウスのスクロールホ"
+"イールを使用している場合は苛立たしいこともあります。\n"
+"もしスムーズスクロールを使用している場合でも、スクロールと同時にシフトキーを"
+"押している間はステップ単位に戻すことができます。\n"
+"スクロール機能をビューの表示位置変更に使用する場合は、このオプションをチェッ"
+"クする必要があり、またデバイス側も双方向スクロールが出来るよう設定しておく必"
+"要があります。"
 
 #: ../po/tmp/preferenceswindow.glade.h:81
 msgid "Hide cursor while painting"
 msgstr "描画中にカーソルを非表示にする"
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+#, fuzzy
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr "有効"
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr "表示"
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
@@ -3603,61 +4583,66 @@ msgstr ""
 "カラーホイール上で原色として使われる色の組み合わせです。\n"
 "それぞれの伝統ごとに異なる色彩調和を持ちます。"
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr "原色の組み合わせ:"
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr "デジタルでは標準的な赤/緑/青"
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
-"&apos;コンピュータのモニタ&apos;の信号に使われている赤、緑、青を、均等にホイール上に並べたものです。緑の反対側がマゼンタになります。"
+"&apos;コンピュータのモニタ&apos;の信号に使われている赤、緑、青を、均等にホ"
+"イール上に並べたものです。緑の反対側がマゼンタになります。"
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
-msgstr "'コンピュータのモニタ'の信号に使われている赤、緑、青を、均等にホイール上に並べたものです。緑の反対側がマゼンタになります。"
+msgstr ""
+"'コンピュータのモニタ'の信号に使われている赤、緑、青を、均等にホイール上に並"
+"べたものです。緑の反対側がマゼンタになります。"
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr "伝統的な芸術家の赤/黄/青"
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
-"18 "
-"世紀から多くの芸術家に使われている赤/黄/青の伝統的な配置のホイールです。純粋な表示色に近似され、均等にホイール上に配置されています。緑の反対側は赤です。"
+"18 世紀から多くの芸術家に使われている赤/黄/青の伝統的な配置のホイールです。純"
+"粋な表示色に近似され、均等にホイール上に配置されています。緑の反対側は赤で"
+"す。"
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
-"18世紀から多くの芸術家に使われている赤/黄/青の伝統的な配置のホイールです。純粋な表示色に近似され、均等にホイール上に配置されています。緑の反対側は赤で"
+"18世紀から多くの芸術家に使われている赤/黄/青の伝統的な配置のホイールです。純"
+"粋な表示色に近似され、均等にホイール上に配置されています。緑の反対側は赤で"
 "す。"
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr "赤-緑と青-黄の反対色のペア"
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3665,11 +4650,13 @@ msgid ""
 "and yellow is opposite blue. CIECAM02 and NCS present a similar model. Here "
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
-"四つの&apos;心理学的原色&apos; もしくは &apos;独自の色相&apos; を用いる反対色過程色説での原色を (拙速に) "
-"近似し、それらを四方点における反対の色として配置したホイールです。赤は緑の反対側であり、黄は青の反対側です。 CIECAM02 と NCS "
-"は、同様のモデルを提示します。ここでは、4 原色として純粋な赤、黄などを使用します。"
+"四つの&apos;心理学的原色&apos; もしくは &apos;独自の色相&apos; を用いる反対色"
+"過程色説での原色を (拙速に) 近似し、それらを四方点における反対の色として配置"
+"したホイールです。赤は緑の反対側であり、黄は青の反対側です。 CIECAM02 と NCS "
+"は、同様のモデルを提示します。ここでは、4 原色として純粋な赤、黄などを使用し"
+"ます。"
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3678,33 +4665,34 @@ msgid ""
 "blue. CIECAM02 and NCS present a similar model. Here we use pure display "
 "red, yellow etc. as the four primaries."
 msgstr ""
-"四つの '心理学的原色' もしくは '独自の色相' を用いる反対色過程色説での原色を (拙速に) "
-"近似し、それらを四方点における反対の色として配置したホイールです。赤は緑の反対側であり、黄は青の反対側です。 CIECAM02 と NCS "
-"は、同様のモデルを提示します。ここでは、4 原色として純粋な赤、黄などを使用します。"
+"四つの '心理学的原色' もしくは '独自の色相' を用いる反対色過程色説での原色を "
+"(拙速に) 近似し、それらを四方点における反対の色として配置したホイールです。赤"
+"は緑の反対側であり、黄は青の反対側です。 CIECAM02 と NCS は、同様のモデルを提"
+"示します。ここでは、4 原色として純粋な赤、黄などを使用します。"
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr "<b>カラーホイール</b>"
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr "色"
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr "スクリーン (通常)"
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr "無効 (筆圧感知なし)"
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr "ウィンドウ (非推奨)"
@@ -3765,1832 +4753,2269 @@ msgid "Reload the file your current work was loaded from."
 msgstr "現在のファイルを、開いた時の状態に戻します。"
 
 #: ../po/tmp/resources.xml.h:12
+#, fuzzy
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Import Layers…"
+msgstr "ブラシをインポート…"
+
+#: ../po/tmp/resources.xml.h:13
+msgctxt "Accel Editor (descriptions)"
+msgid "Import layers from one or more files."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save"
 msgstr "保存"
 
-#: ../po/tmp/resources.xml.h:13
+#: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file."
 msgstr "現在のドキュメントをファイルとして保存します。"
 
-#: ../po/tmp/resources.xml.h:14
+#: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As…"
 msgstr "名前を付けて保存…"
 
-#: ../po/tmp/resources.xml.h:15
+#: ../po/tmp/resources.xml.h:17
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file, assigning it a new name."
 msgstr "現在のドキュメントを、新しいファイル名を指定して保存します。"
 
-#: ../po/tmp/resources.xml.h:16
+#: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Export…"
 msgstr "エクスポート…"
 
-#: ../po/tmp/resources.xml.h:17
+#: ../po/tmp/resources.xml.h:19
 msgid "Export your work to a file, but keep working on the same file."
-msgstr "作品を別のファイルにエクスポートしますが、作業は今までと同じファイルで継続します。"
+msgstr ""
+"作品を別のファイルにエクスポートしますが、作業は今までと同じファイルで継続し"
+"ます。"
 
-#: ../po/tmp/resources.xml.h:18
+#: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As Scrap"
 msgstr "スクラップとして保存"
 
-#: ../po/tmp/resources.xml.h:19
+#: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
 msgid "Save to a new scrap file, or save a new revision if already a scrap."
-msgstr "新しいスクラップファイルとして保存するか、もし既にスクラップで保存されているならば新しいリビジョンのスクラップにします。"
+msgstr ""
+"新しいスクラップファイルとして保存するか、もし既にスクラップで保存されている"
+"ならば新しいリビジョンのスクラップにします。"
 
-#: ../po/tmp/resources.xml.h:20
+#: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Previous Scrap"
 msgstr "前のスクラップを開く"
 
-#: ../po/tmp/resources.xml.h:21
+#: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file before the current one."
 msgstr "前のスクラップファイルを読み込み、現在の画像と置き換えます。"
 
-#: ../po/tmp/resources.xml.h:22
+#: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Next Scrap"
 msgstr "次のスクラップを開く"
 
-#: ../po/tmp/resources.xml.h:23
+#: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file after the current one."
 msgstr "次のスクラップファイルを読み込み、現在の画像と置き換えます。"
 
-#: ../po/tmp/resources.xml.h:24
+#: ../po/tmp/resources.xml.h:26
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Recover File from an Automated Backup…"
 msgstr "自動バックアップからファイルを復帰…"
 
-#: ../po/tmp/resources.xml.h:25
+#: ../po/tmp/resources.xml.h:27
 msgctxt "Accel Editor (descriptions)"
 msgid "Try to save and resume interrupted unsaved work."
 msgstr "中断され保存されていない作品に対し、再開もしくは保存を試みます。"
 
-#: ../po/tmp/resources.xml.h:26
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr "ブラシグループ"
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr "ブラシ"
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr "ブラシグループの一覧です。"
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr "カラーセレクター"
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr "色"
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr "使用可能なカラーセレクターの一覧です。"
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr "モード"
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr "モード"
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr "現在のレイヤーの合成モードです。"
 
-#: ../po/tmp/resources.xml.h:35
+#: ../po/tmp/resources.xml.h:37
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Pressure"
+msgstr "始点の筆圧"
+
+#: ../po/tmp/resources.xml.h:38
+msgctxt "Accel Editor (descriptions)"
+msgid "Send harder pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:39
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Pressure"
+msgstr "始点の筆圧"
+
+#: ../po/tmp/resources.xml.h:40
+msgctxt "Accel Editor (descriptions)"
+msgid "Send softer pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:41
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Rotation"
+msgstr "彩度を上げる"
+
+#: ../po/tmp/resources.xml.h:42
+msgctxt "Accel Editor (descriptions)"
+msgid "Increase barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:43
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
+msgstr "彩度を下げる"
+
+#: ../po/tmp/resources.xml.h:44
+msgctxt "Accel Editor (descriptions)"
+msgid "Decrease barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:45
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Size"
 msgstr "ブラシを大きくする"
 
-#: ../po/tmp/resources.xml.h:36
+#: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush bigger."
 msgstr "使用中のブラシを大きくします。"
 
-#: ../po/tmp/resources.xml.h:37
+#: ../po/tmp/resources.xml.h:47
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Size"
 msgstr "ブラシを小さくする"
 
-#: ../po/tmp/resources.xml.h:38
+#: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush smaller."
 msgstr "使用中のブラシを小さくします。"
 
-#: ../po/tmp/resources.xml.h:39
+#: ../po/tmp/resources.xml.h:49
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Opacity"
 msgstr "ブラシの不透明度を上げる"
 
-#: ../po/tmp/resources.xml.h:40
+#: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush more opaque."
 msgstr "使用中のブラシをより不透明にします。"
 
-#: ../po/tmp/resources.xml.h:41
+#: ../po/tmp/resources.xml.h:51
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Opacity"
 msgstr "ブラシの不透明度を下げる"
 
-#: ../po/tmp/resources.xml.h:42
+#: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush less opaque."
 msgstr "使用中のブラシをより透明にします。"
 
-#: ../po/tmp/resources.xml.h:43
+#: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Lighten Painting Color"
 msgstr "描画色を明るく"
 
-#: ../po/tmp/resources.xml.h:44
+#: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase the lightness of the current painting color."
 msgstr "現在の描画色を明るくします。"
 
-#: ../po/tmp/resources.xml.h:45
+#: ../po/tmp/resources.xml.h:55
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Darken Painting Color"
 msgstr "描画色を暗く"
 
-#: ../po/tmp/resources.xml.h:46
+#: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease the lightness of the current painting color."
 msgstr "現在の描画色を暗くします。"
 
-#: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
-msgstr "色相を反時計回りに変更"
-
-#: ../po/tmp/resources.xml.h:48
-msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
-msgstr "描画色をカラーホイール上で反時計回りに回転させて色相を変更します。"
-
-#: ../po/tmp/resources.xml.h:49
+#: ../po/tmp/resources.xml.h:57
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Change Hue Clockwise"
 msgstr "色相を時計回りに変更"
 
-#: ../po/tmp/resources.xml.h:50
+#: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
 msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr "描画色の色相をカラーホイール上で時計回りに回転させます。"
 
-#: ../po/tmp/resources.xml.h:51
+#: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr "色相を反時計回りに変更"
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr "描画色をカラーホイール上で反時計回りに回転させて色相を変更します。"
+
+#: ../po/tmp/resources.xml.h:61
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Increase Saturation"
 msgstr "彩度を上げる"
 
-#: ../po/tmp/resources.xml.h:52
+#: ../po/tmp/resources.xml.h:62
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color more saturated (more colorful, purer)."
 msgstr "描画色の彩度を高めます (よりカラフルに、原色に近づきます)。"
 
-#: ../po/tmp/resources.xml.h:53
+#: ../po/tmp/resources.xml.h:63
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Decrease Saturation"
 msgstr "彩度を下げる"
 
-#: ../po/tmp/resources.xml.h:54
+#: ../po/tmp/resources.xml.h:64
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color less saturated (grayer)."
 msgstr "描画色の彩度を落とします (灰色に近づきます)。"
 
-#: ../po/tmp/resources.xml.h:55
+#: ../po/tmp/resources.xml.h:65
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Reload Brush Settings"
 msgstr "ブラシ設定を再読み込み"
 
-#: ../po/tmp/resources.xml.h:56
+#: ../po/tmp/resources.xml.h:66
 msgctxt "Accel Editor (descriptions)"
 msgid "Restore all brush settings to the current brush’s saved values."
 msgstr "ブラシの設定を登録時の既定値に戻します。"
 
-#: ../po/tmp/resources.xml.h:57
+#: ../po/tmp/resources.xml.h:67
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Pick Stroke and Layer"
 msgstr "ストロークとレイヤを採取"
 
-#: ../po/tmp/resources.xml.h:58
+#: ../po/tmp/resources.xml.h:68
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
-msgstr "キャンバスからブラシストロークを採取し、ブラシと色を戻し、描画されているレイヤへ移動します。"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+"キャンバスからブラシストロークを採取し、ブラシと色を戻し、描画されているレイ"
+"ヤへ移動します。"
 
-#: ../po/tmp/resources.xml.h:59
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr "ブラシショートカットキーは色も復元する"
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
-msgstr "ブラシショートカットキーでブラシを切り替えた際、色も登録時のものに戻すように振る舞うかどうかを切り替えます。"
+msgstr ""
+"ブラシショートカットキーでブラシを切り替えた際、色も登録時のものに戻すように"
+"振る舞うかどうかを切り替えます。"
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr "直前に使用されたブラシショートカットに保存"
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
-msgstr "直前に使用されたブラシショートカットキーに、現在のブラシと色を保存します。"
+msgstr ""
+"直前に使用されたブラシショートカットキーに、現在のブラシと色を保存します。"
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "レイヤーをクリア"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr "現在のレイヤーの内容を消去します。"
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+#, fuzzy
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr "ツールオプション"
+
+#: ../po/tmp/resources.xml.h:76
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr "レイヤーをフレームサイズで切り抜く"
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr "現在のレイヤーの内容のうち、フレーム外にはみ出した部分を消去します。"
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr "現在のレイヤーの内容のうち、フレーム外にはみ出した部分を消去します。"
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "下に新しいレイヤーグループを作成"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "下に新しいレイヤーグループを作成"
+
+#: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr "レイヤーをクリップボードにコピー"
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr "現在のレイヤーの内容をクリップボードにコピーします。"
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr "クリップボードからレイヤーに貼り付け"
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr "現在のレイヤーを、クリップボードの内容と置き換えます。"
 
-#: ../po/tmp/resources.xml.h:71
+#: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Edit Layer in External App…"
 msgstr "レイヤーを他のアプリケーションで編集…"
 
-#: ../po/tmp/resources.xml.h:72
+#: ../po/tmp/resources.xml.h:90
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
+msgid "Edit the active layer in an external application."
 msgstr "現在のレイヤーの、他のアプリケーションでの編集を開始します。"
 
-#: ../po/tmp/resources.xml.h:73
+#: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Update Layer with External Edits"
 msgstr "他のアプリケーションで編集したレイヤーを更新"
 
-#: ../po/tmp/resources.xml.h:74
+#: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
 msgid "Commit changes saved from the external app (normally automatic)."
 msgstr "他のアプリケーションでの変更内容を取り込みます (通常は自動)。"
 
-#: ../po/tmp/resources.xml.h:75
+#: ../po/tmp/resources.xml.h:93
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer at Cursor"
 msgstr "カーソル位置にあるレイヤーに移動"
 
-#: ../po/tmp/resources.xml.h:76
+#: ../po/tmp/resources.xml.h:94
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr "カーソル位置にあるピクセルが属しているレイヤーを選択します。"
 
-#: ../po/tmp/resources.xml.h:77
+#: ../po/tmp/resources.xml.h:95
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Above"
 msgstr "上のレイヤーに移動"
 
-#: ../po/tmp/resources.xml.h:78
+#: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer up in the layer stack."
 msgstr "レイヤースタックにおける一つ上のレイヤーに移動します。"
 
-#: ../po/tmp/resources.xml.h:79
+#: ../po/tmp/resources.xml.h:97
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Below"
 msgstr "下のレイヤーに移動"
 
-#: ../po/tmp/resources.xml.h:80
+#: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer down in the layer stack."
 msgstr "レイヤースタックにおける一つ下のレイヤーに移動します。"
 
-#: ../po/tmp/resources.xml.h:81
+#: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer"
 msgstr "新しい描画レイヤー"
 
-#: ../po/tmp/resources.xml.h:82
+#: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer above the current layer."
 msgstr "現在のレイヤーの上に新しい描画レイヤーを作成します。"
 
-#: ../po/tmp/resources.xml.h:83
+#: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer…"
 msgstr "新しいベクターレイヤー…"
 
-#: ../po/tmp/resources.xml.h:84
+#: ../po/tmp/resources.xml.h:102
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer above the current layer, and begin editing it."
-msgstr "現在のレイヤーの上に新しいベクターレイヤーを作成して、編集を開始します。"
+msgstr ""
+"現在のレイヤーの上に新しいベクターレイヤーを作成して、編集を開始します。"
 
-#: ../po/tmp/resources.xml.h:85
+#: ../po/tmp/resources.xml.h:103
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group"
 msgstr "新しいレイヤーグループ"
 
-#: ../po/tmp/resources.xml.h:86
+#: ../po/tmp/resources.xml.h:104
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group above the current layer."
 msgstr "現在のレイヤーの上に新しいレイヤーグループを作成します。"
 
-#: ../po/tmp/resources.xml.h:87
+#: ../po/tmp/resources.xml.h:105
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer Below"
 msgstr "下に新しいレイヤーを作成"
 
-#: ../po/tmp/resources.xml.h:88
+#: ../po/tmp/resources.xml.h:106
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer below the current layer."
 msgstr "現在のレイヤーの下に新しい描画レイヤーを作成します。"
 
-#: ../po/tmp/resources.xml.h:89
+#: ../po/tmp/resources.xml.h:107
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer Below…"
 msgstr "下に新しいレイヤーを作成…"
 
-#: ../po/tmp/resources.xml.h:90
+#: ../po/tmp/resources.xml.h:108
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer below the current layer, and begin editing it."
-msgstr "現在のレイヤーの下に新しいベクターレイヤーを作成して、編集を開始します。"
+msgstr ""
+"現在のレイヤーの下に新しいベクターレイヤーを作成して、編集を開始します。"
 
-#: ../po/tmp/resources.xml.h:91
+#: ../po/tmp/resources.xml.h:109
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group Below"
 msgstr "下に新しいレイヤーグループを作成"
 
-#: ../po/tmp/resources.xml.h:92
+#: ../po/tmp/resources.xml.h:110
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group below the current layer."
 msgstr "現在のレイヤーの下に新しいレイヤーグループを作成します。"
 
-#: ../po/tmp/resources.xml.h:93
+#: ../po/tmp/resources.xml.h:111
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Layer Down"
 msgstr "下のレイヤーと統合"
 
-#: ../po/tmp/resources.xml.h:94
+#: ../po/tmp/resources.xml.h:112
 msgctxt "Accel Editor (descriptions)"
 msgid "Merge the current layer with the layer beneath it."
 msgstr "現在のレイヤーを下のレイヤーと統合します。"
 
-#: ../po/tmp/resources.xml.h:95
+#: ../po/tmp/resources.xml.h:113
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Visible Layers"
 msgstr "可視レイヤーを統合"
 
-#: ../po/tmp/resources.xml.h:96
+#: ../po/tmp/resources.xml.h:114
 msgctxt "Accel Editor (descriptions)"
 msgid "Consolidate all visible layers, and delete the originals."
 msgstr "すべての可視レイヤーを統合し、元のレイヤーを全削除します。"
 
-#: ../po/tmp/resources.xml.h:97
+#: ../po/tmp/resources.xml.h:115
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer from Visible"
 msgstr "可視部分から新規レイヤーを作成"
 
-#: ../po/tmp/resources.xml.h:98
+#: ../po/tmp/resources.xml.h:116
 msgctxt "Accel Editor (descriptions)"
 msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
-msgstr "可視レイヤーを統合したレイヤーを作成しますが、元のレイヤーは削除せず残します。"
+msgstr ""
+"可視レイヤーを統合したレイヤーを作成しますが、元のレイヤーは削除せず残しま"
+"す。"
 
-#: ../po/tmp/resources.xml.h:99
+#: ../po/tmp/resources.xml.h:117
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Delete Layer"
 msgstr "レイヤーを削除"
 
-#: ../po/tmp/resources.xml.h:100
+#: ../po/tmp/resources.xml.h:118
 msgctxt "Accel Editor (descriptions)"
 msgid "Remove the current layer from the layer stack."
 msgstr "現在のレイヤーを削除します。"
 
-#: ../po/tmp/resources.xml.h:101
+#: ../po/tmp/resources.xml.h:119
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Convert to Normal Painting Layer"
 msgstr "標準モードの描画レイヤーに変換"
 
-#: ../po/tmp/resources.xml.h:102
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
-msgstr "現在のレイヤーもしくはレイヤーグループを、見た目は保持したままで合成モード「標準」に変換します。"
+msgstr ""
+"現在のレイヤーもしくはレイヤーグループを、見た目は保持したままで合成モード"
+"「標準」に変換します。"
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr "レイヤーの不透明度を上げる"
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr "レイヤーをより不透明にします。"
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr "レイヤーの不透明度を下げる"
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr "レイヤーをより透明にします。"
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr "レイヤーを前面へ"
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr "現在のレイヤーを、前面に 1 つ移動します。"
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr "レイヤーを背面へ"
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr "現在のレイヤーを、背面に 1 つ移動します。"
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr "レイヤーを複製"
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr "現在のレイヤーと同じ内容のレイヤーを作成します。"
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
+#, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
-msgstr "レイヤーの名前を変更…"
+msgid "Layer Properties…"
+msgstr "プロパティ"
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
-msgstr "現在のレイヤーに新しい名前を指定します。"
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr "レイヤーをロックする"
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
-msgstr "現在のレイヤーのロック状態を切り替えます。ロックされたレイヤーは編集できません。"
+msgstr ""
+"現在のレイヤーのロック状態を切り替えます。ロックされたレイヤーは編集できませ"
+"ん。"
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr "レイヤーを表示する"
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr "現在のレイヤの可視状態を切り替えます。"
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr "背景を表示"
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr "背景レイヤーの可視状態をトグルします。"
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr "現在のレイヤーを削除します。"
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr "表示をリセットして画像を中央に移動"
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
-msgstr "拡大率、回転、反転表示をリセットし、ドキュメントの表示位置を中央に戻します。"
+msgstr ""
+"拡大率、回転、反転表示をリセットし、ドキュメントの表示位置を中央に戻します。"
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr "ビューに合わせる"
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr "画像の表示範囲を、ウィンドウいっぱいに合わせるかどうかを切り替えます。"
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr "リセット"
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr "拡大・縮小をリセット"
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr "表示領域の拡大率をデフォルトに戻します。"
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr "回転をリセット"
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr "表示領域の回転の角度を 0 度に戻します"
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr "反転表示を解除"
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
-msgstr "表示領域の反転を元に戻します。"
+msgid "Reset the view's mirroring."
+msgstr "反転表示を解除"
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr "拡大"
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr "拡大率を上げます。"
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "縮小"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr "拡大率を下げます。"
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
+#, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
-msgstr "反時計回りに回転"
+msgid "Pan Left"
+msgstr "表示領域を移動"
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
-msgstr "表示領域を反時計回りに回転します。"
+msgid "Move your view of the canvas to the left."
+msgstr "表示領域を回転: キャンバスを傾けて表示します。"
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr "ハードライト"
+
+#: ../po/tmp/resources.xml.h:159
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+"表示領域の移動: キャンバスの表示領域を、水平または垂直方向に移動します。"
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr "表示領域を回転: キャンバスを傾けて表示します。"
+
+#: ../po/tmp/resources.xml.h:162
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr "表示領域を移動"
+
+#: ../po/tmp/resources.xml.h:163
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr "表示領域を回転: キャンバスを傾けて表示します。"
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr "時計回りに回転"
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr "表示領域を時計回りに回転します。"
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr "反時計回りに回転"
+
+#: ../po/tmp/resources.xml.h:167
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr "表示領域を反時計回りに回転します。"
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr "左右反転"
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr "表示領域を左右反転します。"
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr "上下反転"
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr "表示領域を上下反転します。"
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr "現在のレイヤーのみ表示"
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr "現在のレイヤーのみ表示するかどうかを切り替えます。"
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr "対称描画を有効化"
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr "ブラシストロークを、対称軸を中心に反転して複写"
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr "フレームを使用"
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr "画像フレームの表示/非表示を切り替えます。"
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr "ブラシの入力値をコンソールに表示"
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr "ブラシエンジンで内部生成された入力値をコンソールに出力します。"
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr "レンダリングを視覚的に表示"
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr "デバッグ用に、レンダリングで更新される部分をスクリーンに表示します。"
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr "ダブルバッファリングを無効化"
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
-msgstr "GTK のダブルバッファリング機能を無効化します。通常は有効になっています。"
+msgstr ""
+"GTK のダブルバッファリング機能を無効化します。通常は有効になっています。"
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+#, fuzzy
+msgid "Delete Point"
+msgstr "制御点を削除"
+
+#: ../po/tmp/resources.xml.h:187
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr "現在選択している制御点を削除します"
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr "描画モード"
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr "描画モード: 通常"
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr "色を普通に描画します。"
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr "描画モード: 消しゴム"
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr "現在のブラシを消しゴムとして使います。"
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr "描画モード: アルファロック"
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr "レイヤの透明部分を保持したまま描画します。"
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr "描画モード: 彩色"
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr "現在のレイヤーに対し明るさと透明部分を保持したまま色を塗ります。"
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "ファイル"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "終了"
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr "メインウィンドウを閉じて MyPaint を終了します。"
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "編集"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr "使用中のツール"
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "色"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr "描画色の調整"
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr "色の履歴"
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr "カーソル直下に最近使った色の一覧をポップアップします。"
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr "色の詳細"
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr "Web カラーの表示欄付きで色の詳細を示すダイアログを表示します。"
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr "パレットの次の色"
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr "現在のパレットにおける次の色を描画色に設定します。"
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr "パレットの前の色"
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr "現在のパレットにおける前の色を描画色に設定します。"
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr "色をパレットに追加"
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr "現在の描画色をパレットに追加します。"
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "レイヤー"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr "不透明度"
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr "レイヤーに移動"
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr "新規レイヤーを背面側に作成"
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr "プロパティ"
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr "作業パレット"
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr "新規の作業パレット"
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr "新しい作業パレットとしてデフォルトの作業パレットを読み込みます。"
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr "作業パレットを開く…"
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr "作業パレットにディスク上のファイルを読み込みます。"
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr "作業パレットを保存"
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr "作業パレットをディスク上の元ファイルに書き込みます。"
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr "作業パレットをエクスポート…"
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr "ファイル名を選択して作業パレットをエクスポートします。"
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr "作業パレットを元に戻す"
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr "作業パレットを、最後に保存したときの状態に戻します。"
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr "デフォルトの作業パレットとして保存"
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
-msgstr "新規の作業パレットの元絵となるデフォルトの作業パレットとして保存します。"
+msgstr ""
+"新規の作業パレットの元絵となるデフォルトの作業パレットとして保存します。"
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr "デフォルトの作業パレットを消去"
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr "デフォルトの作業パレットを消去します。"
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr "背景を作業パレットにコピー"
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr "現在のキャンバスの作品の背景を作業パレットにコピーします。"
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "ウィンドウ"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "ブラシ"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr "ショートカットキー"
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr "ブラシショートカットキーのヘルプ"
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr "ショートカット・キーの機能の説明を表示します。"
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "ブラシを変更…"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr "カーソル位置でブラシ変更ダイアログを呼び出します。"
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "色を変更…"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr "カーソル位置にフル機能の色選択ダイアログを表示します。"
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "色を変更 (簡略版)…"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr "カーソル位置にシングルクリック版の色選択ダイアログを表示します。"
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr "追加のブラシを入手…"
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr "MyPaint ウィキからブラシパックをダウンロードします。"
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr "ブラシをインポート…"
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr "ブラシパックをディスクから読み込みます。"
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "ヘルプ"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr "オンラインヘルプ"
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr "オンラインヘルプを開きます。"
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "MyPaint について"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr "MyPaint のライセンス、バージョン番号、クレジットを表示します。"
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "デバッグ"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr "コンソールへメモリリーク情報を表示します (低速！)"
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr "メモリリークについてデバッグします。"
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr "ガベージコレクタを今すぐ実行"
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
-msgstr "Python オブジェクトが占有している、もう使用することのないメモリ領域を開放します。"
+msgstr ""
+"Python オブジェクトが占有している、もう使用することのないメモリ領域を開放しま"
+"す。"
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr "プロファイリングを開始/停止…"
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr "Python プロファイル (cProfile) の取得を開始/停止"
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr "クラッシュ状態を再現…"
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr "クラッシュ報告ダイアログをテストするために例外を故意に発生します。"
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "表示"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr "フィードバック"
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr "画面表示の調整"
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
+#, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr "ポップアップメニュー"
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr "メインメニューをポップアップとして表示します。"
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "フルスクリーン"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr "フルスクリーンとウィンドウ表示モードを切り替えます。"
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "設定を編集"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr "MyPaint 全体の設定を行います。"
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr "入力デバイスをテスト"
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
-msgstr "入力デバイスが送信してくるすべてのイベントを捕捉するダイアログを表示します。"
+msgstr ""
+"入力デバイスが送信してくるすべてのイベントを捕捉するダイアログを表示します。"
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr "背景の選択"
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr "背景のテクスチャを変更します。"
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr "ブラシ設定エディター"
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr "アクティブなブラシの詳細な設定を行います。"
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr "ブラシアイコンエディター"
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr "ブラシアイコンを編集します。"
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr "レイヤーパネル"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
-msgstr "レイヤーパネルをトグルします (レイヤーを配列したり、モードを指定するものです)。"
+msgid "Dockable panel for managing layers."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr "レイヤーパネルを表示"
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
-msgstr "レイヤーパネルを表示します (レイヤーを配列したり、モードを指定するものです)。"
+msgstr ""
+"レイヤーパネルを表示します (レイヤーを配列したり、モードを指定するものです)。"
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr "HCY ホイール"
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
-msgstr "ドッキング可能な、色相/彩度/輝度の色空間を円筒で模したカラーセレクターです。円の内部 (円筒の断面) は同一の輝度となります。"
+msgstr ""
+"ドッキング可能な、色相/彩度/輝度の色空間を円筒で模したカラーセレクターです。"
+"円の内部 (円筒の断面) は同一の輝度となります。"
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "カラーパレット"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr "パレットから色を選択できる、ドッキング可能なカラーパレットです。"
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr "HSV ホイール"
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr "彩度と明度で色を指定する、ドッキング可能なカラーチェンジャーです。"
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr "HSV 三角形"
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr "旧式な GTK のカラートライアングルのドッキング可能なカラーセレクターです。"
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr "HSV キューブ"
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
-msgstr "HSV を立方体で表現し、面ごとに回転させることのできる、ドッキング可能なカラーセレクターです。"
+msgstr ""
+"HSV を立方体で表現し、面ごとに回転させることのできる、ドッキング可能なカラー"
+"セレクターです。"
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr "HSV 正方形"
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
-msgstr "HSV を中央の彩度・明度を示す正方形と色相のホイールで表現した、ドッキング可能なカラーセレクターです。"
+msgid "Dockable color selector: HSV square with Hue ring."
+msgstr "HSV の同心環で色を選択する、ドッキング可能なカラーセレクターです。"
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr "色成分スライダー"
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr "色の詳細な成分を表示する、ドッキング可能なカラーセレクターです。"
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr "リキッドウォッシュ"
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
-msgstr "近傍色と水彩のウォッシュ技法のように混ぜて表示する、ドッキング可能なカラーセレクターです。"
+msgstr ""
+"近傍色と水彩のウォッシュ技法のように混ぜて表示する、ドッキング可能なカラーセ"
+"レクターです。"
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr "同心円"
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr "HSV の同心環で色を選択する、ドッキング可能なカラーセレクターです。"
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr "十字とボウル"
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
-msgstr "放射状の色のボウルと、その上を横断する HSV ランプから色を選択する、ドッキング可能なカラーセレクターです。"
+msgstr ""
+"放射状の色のボウルと、その上を横断する HSV ランプから色を選択する、ドッキング"
+"可能なカラーセレクターです。"
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr "作業パレットパネル"
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
-msgstr "作業パレットをトグルします (色を混ぜたりスケッチできます)。"
+msgid "Dockable Panel for mixing colors and testing brushes."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr "作業パレットパネルを表示"
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr "作業パレットを表示します (色を混ぜたりスケッチできます)。"
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr "プレビューパネル"
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
-msgstr "プレビューパネルをトグルします (キャンバス全体を見渡すことができます)。"
+msgid "Dockable panel for an overview and navigation of the whole canvas."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "プレビュー"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr "プレビューパネルを表示します (キャンバス全体を見渡すことができます)。"
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr "ツールオプションパネル"
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
-msgstr "ツールオプションパネルをトグルします (現在のツールのオプション設定です)。"
+msgid "Dockable panel for adjusting the options with the activated tool."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr "ツールオプションパネルを表示"
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
-msgstr "ツールオプションパネルを表示します (現在のツールのオプション設定です)。"
+msgstr ""
+"ツールオプションパネルを表示します (現在のツールのオプション設定です)。"
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr "ブラシと色の履歴パネル"
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
-msgstr "履歴パネルをトグルします (最近使ったブラシと色の履歴です)。"
+msgid "Dockable panel for viewing recently changed colors and brushes."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr "最近使用したブラシと色"
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr "履歴パネルを表示します (最近使ったブラシと色の履歴です)。"
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr "全画面モードでインターフェイスを隠す"
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
-msgstr "全画面モード時にユーザーインターフェースを自動で隠すかどうかをトグルします。"
+msgstr ""
+"全画面モード時にユーザーインターフェースを自動で隠すかどうかをトグルします。"
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr "拡大率を表示"
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr "拡大率の表示をトグルします。"
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr "最後の描画位置を表示"
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr "直近のストロークの終点の表示をトグルします。"
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr "表示フィルター"
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr "色を通常通り表示"
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr "色を通常通りに表示します。"
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr "色をグレースケールで表示"
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr "輝度だけを表示します。(HCY/YCbCr Luma)"
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr "色を反転して表示"
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr "画像の色を反転させます。黒は白になり、赤はシアンになります。"
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr "赤色に対する不感受性を再現した色を表示"
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr "2 型色覚 (頻度の高い種類の色覚異常) における色の見え方を再現します。"
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr "緑色に対する不感受性を再現した色を表示"
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr "1 型色覚 (頻度の高い種類の色覚異常) における色の見え方を再現します。"
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr "青色に対する不感受性を再現した色を表示"
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr "3 型色覚 (頻度の低い種類の色覚異常) における色の見え方を再現します。"
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr "フリーハンド"
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr "フリーハンド"
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr "フリーハンド: 自由な形状の線を描画します。"
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr "フリーハンド"
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr "自由な形状の線を描画します。"
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr "表示領域を移動"
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr "表示領域の移動"
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
-msgstr "表示領域の移動: キャンバスの表示領域を、水平または垂直方向に移動します。"
+msgstr ""
+"表示領域の移動: キャンバスの表示領域を、水平または垂直方向に移動します。"
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr "表示領域を移動"
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr "キャンバスの表示領域を水平・垂直に移動します。"
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr "表示領域を回転"
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr "表示領域の回転"
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr "表示領域を回転: キャンバスを傾けて表示します。"
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr "表示領域を回転"
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr "好みの角度にキャンバスを回転させます。"
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr "表示領域を拡大・縮小"
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr "表示領域の拡大・縮小"
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr "表示領域を拡大・縮小: キャンバスを拡大・縮小して表示します。"
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr "表示領域を拡大・縮小"
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr "キャンバスの表示領域を拡大・縮小します。"
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr "直線と曲線"
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr "直線"
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr "直線と曲線: 直線または曲線を描画します。"
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr "直線と曲線"
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr "直線または曲線を描画します。"
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr "連結線"
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr "連結線"
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr "連結線: 直線または曲線を連続で描画します。"
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr "連結線"
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr "直線または曲線を連続で描画します。"
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr "円"
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr "楕円"
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr "楕円や円のような円形の形状を描きます。"
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr "円"
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr "真円や楕円を描画します。"
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr "ペン入れ"
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr "ペン入れ"
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr "ペン入れ: 制御点で編集できる、滑らかな線で描画します。"
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr "ペン入れ"
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr "制御点で編集できる滑らかな線で描画します。"
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr "レイヤーの位置を変更"
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr "レイヤー位置"
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
-msgstr "レイヤーの位置を変更: 現在のレイヤーの、キャンバス上での位置を変更します。"
+msgstr ""
+"レイヤーの位置を変更: 現在のレイヤーの、キャンバス上での位置を変更します。"
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr "レイヤーの位置を変更"
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr "ユーザー操作で現在のレイヤーをキャンバス上で動かします。"
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr "フレームを調整"
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr "フレーム"
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr "フレームを調整: 画像の周囲にフレームを設定し、画像の範囲を限定します。"
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr "フレームを調整"
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr "画像の周囲にユーザー操作でフレームを設定し、画像の範囲を限定します。"
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "対称軸を編集"
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr "対称"
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr "対称描画の中心軸の位置を調整します。"
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "対称軸を編集"
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr "対称描画の中心軸をユーザー操作で調整します。"
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr "色を採取"
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr "色を採取"
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr "色を採取: 画面上のピクセルから描画色を採取して設定します。"
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "色を採取"
+
+#: ../po/tmp/resources.xml.h:401
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr "画面上の色から描画色を設定します。"
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "色を採取"
+
+#: ../po/tmp/resources.xml.h:403
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr "画面上の色から描画色を設定します。"
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "色を採取"
+
+#: ../po/tmp/resources.xml.h:405
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr "画面上の色から描画色を設定します。"
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr "色を採取"
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr "画面上の色から描画色を設定します。"
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr "塗りつぶし"
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr "塗りつぶし"
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr "塗りつぶし: 連続した領域を指定した色で塗りつぶします。"
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr "塗りつぶし"
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr "連続した領域を指定した色で塗りつぶします。"
+
+#~ msgctxt "Accelerator map editor: action column markup"
+#~ msgid ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+#~ msgstr ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+
+#~ msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
+#~ msgid "{action_label} {action_desc} {accel_label}"
+#~ msgstr "{action_label} {action_desc} {accel_label}"
+
+#~ msgctxt "brush list context menu"
+#~ msgid "Delete"
+#~ msgstr "削除"
+
+#~ msgctxt "brush list commands"
+#~ msgid "Really delete brush from disk?"
+#~ msgstr "ブラシを本当にディスクから削除しますか？"
+
+#~ msgid "HSV Triangle"
+#~ msgstr "HSV 三角形"
+
+#~ msgid "The standard GTK color selector"
+#~ msgstr "GTK 標準カラーセレクタ"
+
+#~ msgid "Pick a color from the screen"
+#~ msgstr "スクリーンから色を採取"
+
+#~ msgid "Layer Name"
+#~ msgstr "レイヤー名"
+
+#~ msgid ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+#~ msgstr ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+
+#~ msgid "Save..."
+#~ msgstr "保存..."
+
+#~ msgid "Confirm"
+#~ msgstr "了解"
+
+#~ msgid "Open..."
+#~ msgstr "開く..."
+
+#~ msgid "{default_name} at {path}"
+#~ msgstr "{path}の{default_name}"
+
+#~ msgid "Type"
+#~ msgstr "種類"
+
+#~ msgid "Mode:"
+#~ msgstr "モード:"
+
+#~ msgid ""
+#~ "Blending mode: how the current layer combines with the layers underneath "
+#~ "it."
+#~ msgstr ""
+#~ "合成モード: 現在のレイヤーを下のレイヤーとどのように合成するかを指定しま"
+#~ "す。"
+
+#~ msgid ""
+#~ "Layer opacity: how much of the current layer to use. Smaller values make "
+#~ "it more transparent."
+#~ msgstr ""
+#~ "レイヤー不透明度: 現在のレイヤーを合成する割合です。値が小さいほど透明にな"
+#~ "ります。"
+
+#~ msgid "%s: edit properties"
+#~ msgstr "%s: プロパティを編集"
+
+#~ msgctxt "layer unique names: match regex (leave untranslated if unsure)"
+#~ msgid "^(.*?)\\s*(\\d+)$"
+#~ msgstr "^(.*?)\\s*(\\d+)$"
+
+#~ msgctxt "layer default names"
+#~ msgid "Unknown Bitmap Layer"
+#~ msgstr "不明なビットマップレイヤー"
+
+#~ msgctxt "Autosave Recovery dialog|"
+#~ msgid "_Ignore for Now"
+#~ msgstr "今は無視する(_I)"
+
+#~ msgid "Setting name:"
+#~ msgstr "設定名:"
+
+#~ msgid "Base value:"
+#~ msgstr "基本となる値:"
+
+#~ msgid "Reset the base value to its default"
+#~ msgstr "基本値をデフォルトに戻します"
+
+#~ msgid "<ymin>"
+#~ msgstr "<ymin>"
+
+#~ msgid "<ymax>"
+#~ msgstr "<ymax>"
+
+#~ msgid "<xmin>"
+#~ msgstr "<xmin>"
+
+#~ msgid "<xmax>"
+#~ msgstr "<xmax>"
+
+#~ msgid "Edit Setting"
+#~ msgstr "設定を編集"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Trim Layer to Frame"
+#~ msgstr "レイヤーをフレームサイズで切り抜く"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Rename Layer…"
+#~ msgstr "レイヤーの名前を変更…"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Enter a new name for the current layer."
+#~ msgstr "現在のレイヤーに新しい名前を指定します。"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Turn off mirroring of the view."
+#~ msgstr "表示領域の反転を元に戻します。"
+
+#~ msgctxt "Menu→Edit (labels)"
+#~ msgid "Current Tool"
+#~ msgstr "使用中のツール"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+#~ msgstr ""
+#~ "レイヤーパネルをトグルします (レイヤーを配列したり、モードを指定するもので"
+#~ "す)。"
+
+#~ msgctxt "Menu→Color (labels), Accel Editor (labels)"
+#~ msgid "HSV Triangle"
+#~ msgstr "HSV 三角形"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Dockable color selector: the old GTK color triangle."
+#~ msgstr ""
+#~ "旧式な GTK のカラートライアングルのドッキング可能なカラーセレクターです。"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid ""
+#~ "Dockable color selector: HSV square which can be rotated to show "
+#~ "different hues."
+#~ msgstr ""
+#~ "HSV を中央の彩度・明度を示す正方形と色相のホイールで表現した、ドッキング可"
+#~ "能なカラーセレクターです。"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+#~ msgstr "作業パレットをトグルします (色を混ぜたりスケッチできます)。"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+#~ msgstr ""
+#~ "プレビューパネルをトグルします (キャンバス全体を見渡すことができます)。"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+#~ msgstr ""
+#~ "ツールオプションパネルをトグルします (現在のツールのオプション設定です)。"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the History panel (recently used brushes and colors)."
+#~ msgstr "履歴パネルをトグルします (最近使ったブラシと色の履歴です)。"
 
 #~ msgid "Add As New"
 #~ msgstr "新規ブラシとして追加"
@@ -5699,9 +7124,6 @@ msgstr "連続した領域を指定した色で塗りつぶします。"
 #~ "は、ツールチップとして利用可能です。それらを見るにはラベルの上にマウスを置"
 #~ "きます。\n"
 
-#~ msgid "Open Recent files"
-#~ msgstr "最近開いたファイル"
-
 #~ msgid "This will discard %d second of unsaved painting."
 #~ msgid_plural "This will discard %d seconds of unsaved painting."
 #~ msgstr[0] "保存されていない %d 秒間の描画は、破棄されます。"
@@ -5807,9 +7229,6 @@ msgstr "連続した領域を指定した色で塗りつぶします。"
 #~ msgid "Brush Blend Mode"
 #~ msgstr "ブラシの描画モード"
 
-#~ msgid "Add Layer"
-#~ msgstr "レイヤーの追加"
-
 #~ msgid "Move Layer on Canvas"
 #~ msgstr "レイヤーを移動"
 
@@ -5849,9 +7268,6 @@ msgstr "連続した領域を指定した色で塗りつぶします。"
 #~ msgctxt "Menu|File|"
 #~ msgid "Save"
 #~ msgstr "保存"
-
-#~ msgid "Export to a file"
-#~ msgstr "ファイルにエクスポートする"
 
 #, fuzzy
 #~ msgid ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -540,18 +540,18 @@ msgstr "MyPaint ブラシパッケージ (*.zip)"
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
-msgstr "新しいグループ..."
+msgid "New Group…"
+msgstr "新しいグループ…"
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
-msgstr "ブラシをインポート..."
+msgid "Import Brushes…"
+msgstr "ブラシをインポート…"
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
-msgstr "追加のブラシを入手..."
+msgid "Get More Brushes…"
+msgstr "追加のブラシを入手…"
 
 #: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
@@ -1238,13 +1238,13 @@ msgstr "種類"
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
-msgstr "用途は..."
+msgid "Use for…"
+msgstr "用途は…"
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
-msgstr "スクロール機能は..."
+msgid "Scroll…"
+msgstr "スクロール機能は…"
 
 #. Name and preview column: will be indented
 #: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
@@ -1468,8 +1468,8 @@ msgid "_Quit"
 msgstr "終了"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
-msgstr "ブラシパッケージのインポート..."
+msgid "Import brush package…"
+msgstr "ブラシパッケージのインポート…"
 
 #: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
@@ -1525,8 +1525,8 @@ msgstr ""
 "プリケーションを使用しますか？"
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
-msgstr "他のアプリケーションで編集..."
+msgid "Open With…"
+msgstr "他のアプリケーションで編集…"
 
 #: ../gui/externalapp.py:123
 msgid "Icon"
@@ -1718,13 +1718,13 @@ msgstr "JPEG (90%の品質) (*.jpg; *.jpeg)"
 
 #: ../gui/filehandling.py:576
 #, fuzzy
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr "エクスポート…"
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "名前を付けて保存…"
 
@@ -1795,8 +1795,8 @@ msgstr "最近開いたファイル"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
-msgstr "作業パレットを開く..."
+msgid "Open Scratchpad…"
+msgstr "作業パレットを開く…"
 
 #: ../gui/filehandling.py:1099
 #, fuzzy
@@ -2251,13 +2251,13 @@ msgstr ""
 "を追跡する仕組みです) を使って知らせてくださると幸いです。"
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
-msgstr "トラッカーを検索..."
+msgid "Search Tracker…"
+msgstr "トラッカーを検索…"
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
-msgstr "エラーを報告..."
+msgid "Report…"
+msgstr "エラーを報告…"
 
 #: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
@@ -2268,8 +2268,8 @@ msgid "Quit MyPaint"
 msgstr "MyPaint を終了"
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
-msgstr "詳細..."
+msgid "Details…"
+msgstr "詳細…"
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
@@ -2481,8 +2481,8 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
-msgstr "レイヤーの並び替え..."
+msgid "Move layer in stack…"
+msgstr "レイヤーの並び替え…"
 
 #: ../gui/layerswindow.py:110
 msgid ""
@@ -2553,8 +2553,8 @@ msgid "Stroke trail-off beginning"
 msgstr "「抜き」の開始点"
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
-msgstr "筆圧の変動グラフ..."
+msgid "Pressure variation…"
+msgstr "筆圧の変動グラフ…"
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
@@ -3744,7 +3744,7 @@ msgstr "このブラシをディスクから削除"
 #, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid "_Recover & Save…"
-msgstr "バックアップから保存(_R)..."
+msgstr "バックアップから保存(_R)…"
 
 #: ../po/tmp/autorecover.glade.h:12
 #, fuzzy

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:18+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Georgian <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -19,27 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -47,39 +27,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -87,214 +67,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "ფერი"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr ""
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -333,142 +323,177 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "შენახვა"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "ახალი"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -476,58 +501,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -536,51 +561,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -590,137 +639,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -728,162 +777,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -891,373 +932,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "სახელი"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "ბრძანების გაუქმება"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "ბრძანების აღდგენა"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1267,324 +1305,673 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "მთელს ეკრანზე"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "გამორთე"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "გამორთე"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
+msgstr ""
+
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
+msgstr ""
+
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "შენახვა"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
 #, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr ""
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "ფაილი"
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1427
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1432
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr ""
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1592,130 +1979,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1724,35 +2123,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1776,45 +2175,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1822,153 +2225,217 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr ""
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr ""
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr ""
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1980,256 +2447,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2237,188 +2729,212 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+msgid "Import Layers"
+msgstr ""
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2427,13 +2943,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2443,7 +2959,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2451,13 +2967,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2465,7 +2981,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2473,7 +2989,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2484,7 +3000,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2492,7 +3008,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2502,7 +3023,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2513,285 +3034,394 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr ""
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2801,7 +3431,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2810,52 +3460,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2877,17 +3558,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2916,112 +3595,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3034,7 +3688,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3075,6 +3729,133 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "სახელი"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3444,56 +4225,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3501,12 +4302,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3515,7 +4316,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3526,28 +4327,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3609,1828 +4410,2018 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "დაპატარავება"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "ფაილი"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/ka.po
+++ b/po/ka.po
@@ -513,17 +513,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1184,12 +1184,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1405,7 +1405,7 @@ msgid "_Quit"
 msgstr "გამორთე"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1455,7 +1455,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1632,13 +1632,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "შენახვა"
 
@@ -1704,7 +1704,7 @@ msgstr "ფაილი"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -2124,12 +2124,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2141,7 +2141,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2326,7 +2326,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2396,7 +2396,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/kab.po
+++ b/po/kab.po
@@ -514,17 +514,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1185,12 +1185,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1407,7 +1407,7 @@ msgid "_Quit"
 msgstr "Ffeɣ"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1457,7 +1457,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1634,13 +1634,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Sekles s yisem…"
 
@@ -1708,7 +1708,7 @@ msgstr "Afaylu"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr "Attafttar n uzenziɣ"
 
 #: ../gui/filehandling.py:1099
@@ -2134,12 +2134,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2151,7 +2151,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2338,7 +2338,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2408,7 +2408,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/kab.po
+++ b/po/kab.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2018-08-22 12:38+0000\n"
 "Last-Translator: ButterflyOfFire <ButterflyOfFire@protonmail.com>\n"
 "Language-Team: Kabyle <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -19,27 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.2-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "Tigawt"
 
@@ -47,39 +27,39 @@ msgstr "Tigawt"
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "Tigawt :"
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "Abrid:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "Taqeffalt:"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "Tugawt tarussint"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr "Ldi akaram “{folder_basename}”…"
@@ -87,214 +67,224 @@ msgstr "Ldi akaram “{folder_basename}”…"
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "IH"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "Agilal"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr ""
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -333,142 +323,178 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr ""
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
+msgstr "Ẓreg timceṭ"
+
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -476,58 +502,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -536,51 +562,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -590,137 +640,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -728,162 +778,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -891,373 +933,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr ""
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr "Uɣal %s"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Semmet"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr ""
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1267,324 +1306,682 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Ldi…"
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr ""
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr ""
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Ffeɣ"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
+msgstr ""
+
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
+msgstr ""
+
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Sekles s yisem…"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
 #, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
-msgstr ""
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr "Ldi…"
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr ""
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Afaylu"
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
+msgstr "Attafttar n uzenziɣ"
+
+#: ../gui/filehandling.py:1099
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Ldi…"
+
+#: ../gui/filehandling.py:1427
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Ldi…"
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Ldi…"
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+#, fuzzy
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr "Semsasa iẓṛi"
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
-msgstr ""
+msgstr "Aggay amaynut isewaḍen"
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr ""
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "Ekkes asewwaḍ"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1592,130 +1989,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1724,35 +2133,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1776,45 +2185,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1822,153 +2235,219 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+#, fuzzy
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr "Timeẓlyin"
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Tissi"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr ""
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr ""
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1980,256 +2459,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2237,188 +2741,213 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "Aggay amaynut isewaḍen"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+msgid "Import Layers"
+msgstr ""
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2427,13 +2956,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2443,7 +2972,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2451,13 +2980,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2465,7 +2994,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2473,7 +3002,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2484,7 +3013,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2492,7 +3021,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2502,7 +3036,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2513,285 +3047,399 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
-msgctxt "layer default names"
-msgid "Vector Layer"
-msgstr ""
-
 #: ../lib/layer/data.py:1153
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Vectors"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
+#: ../lib/layer/data.py:1158
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Vector Layer"
+msgstr "Sizdeg asewwaḍ"
+
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Data Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr "Tugawt tarussint"
+
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "Asewwaḍ amaynut i tajeggirt"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "Aggay amaynut isewaḍen"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+#, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "Sken"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2801,7 +3449,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2810,52 +3478,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2877,17 +3576,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2916,112 +3613,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3034,7 +3706,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3075,6 +3747,132 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr ""
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3444,56 +4242,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3501,12 +4319,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3515,7 +4333,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3526,28 +4344,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3608,1831 +4426,2029 @@ msgid "Reload the file your current work was loaded from."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
-#, fuzzy
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
-msgstr "Sekles"
+msgid "Import Layers…"
+msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 #, fuzzy
 msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Save"
+msgstr "Sekles"
+
+#: ../po/tmp/resources.xml.h:15
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:16
+#, fuzzy
+msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As…"
 msgstr "Sekles s yisem…"
 
-#: ../po/tmp/resources.xml.h:15
+#: ../po/tmp/resources.xml.h:17
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:16
+#: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Export…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:18
-msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "Sizdeg asewwaḍ"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "Aggay amaynut isewaḍen"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "Aggay amaynut isewaḍen"
+
+#: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:71
+#: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Edit Layer in External App…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
-msgstr "Asewwaḍ amaynut i tajeggirt"
-
-#: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:85
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
-msgstr "Aggay amaynut isewaḍen"
-
-#: ../po/tmp/resources.xml.h:86
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:87
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:88
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:89
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
-msgstr "Ekkes asewwaḍ"
+msgid "New Painting Layer"
+msgstr "Asewwaḍ amaynut i tajeggirt"
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr "Aggay amaynut isewaḍen"
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr "Ekkes asewwaḍ"
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
+#, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
-msgstr ""
+msgid "Layer Properties…"
+msgstr "Timeẓlyin"
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr "Semsasa iẓṛi"
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Afaylu"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "Ffeɣ"
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr "Mdel asfaylu agejdan sakin ffeγ seg usnas."
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "Ẓreg"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr "Afecku urmid"
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "Ini"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr "Seggem ini"
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "Tissi"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr "Timeẓlyin"
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr "Attafttar n uzenziɣ"
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "Asfaylu"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "Timceṭ"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr "Inegzumen n unasiw"
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "Snifel timceṭ…"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "Senfel ini…"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "Snifel ini (ddaw-tagrumma arurad)…"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr "Ugar n tmecḍin…"
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Tallalt"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr "Tallalt seg izirig"
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "Γef MyPaint"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "Sken"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "Agdil aččuran"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "Ẓreg ismenyifen"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr "Asenqed n ibenkan n unekcum"
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr "Ẓreg timceṭ"
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr "Umuɣ n isewaḍen"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr "Beqqeḍ isfuyla n isewaḍen"
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "Tiɣruḍin n initen"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr "Beqqeḍ attafttar n izenziɣen"
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr "Asfaylu tastasenselkimt"
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "Tastasenselkimt"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr "Asfaylu iḍaɣaṛen n ufecku"
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr "Beqqeḍ iḍaɣaren n ufecku"
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr "Amezruy n initen ed timecḍin"
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr "timecḍin ed initen tinayin"
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr "Afus yulin"
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr "Afus yulin"
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr "Izirigen ed izligen"
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr "Izirigen yeqqnen"
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr "Ellipses ed tiwinestin"
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr "Idwi"
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""
+
+#~ msgctxt "Menu→Edit (labels)"
+#~ msgid "Current Tool"
+#~ msgstr "Afecku urmid"

--- a/po/kk.po
+++ b/po/kk.po
@@ -513,17 +513,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1184,12 +1184,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1372,7 +1372,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Open dragged file confirm dialog: continue button"
 msgid "_Open"
-msgstr "Ашу..."
+msgstr "Ашу…"
 
 #: ../gui/drawwindow.py:486
 msgid "Set current color"
@@ -1406,7 +1406,7 @@ msgid "_Quit"
 msgstr "Шығу"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1456,7 +1456,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1633,13 +1633,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Сақтау"
 
@@ -1705,7 +1705,7 @@ msgstr "Файл"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -1722,7 +1722,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Ашу..."
+msgstr "Ашу…"
 
 #: ../gui/filehandling.py:1427
 #, fuzzy
@@ -1734,7 +1734,7 @@ msgstr "Жуырда ашылған"
 #, fuzzy
 msgctxt "File→Open Most Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Ашу..."
+msgstr "Ашу…"
 
 #: ../gui/filehandling.py:1446
 msgctxt "File→Open Next/Prev Scrap: error message"
@@ -1755,7 +1755,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
 msgid "_Open"
-msgstr "Ашу..."
+msgstr "Ашу…"
 
 #: ../gui/filehandling.py:1487
 msgctxt "File→Revert: status message: canvas has no filename yet"
@@ -2129,12 +2129,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2146,7 +2146,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2331,7 +2331,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2401,7 +2401,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/kk.po
+++ b/po/kk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:19+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Kazakh <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -19,27 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -47,39 +27,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -87,214 +67,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Түсі"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Қалау бойынша"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -333,142 +323,177 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Сақтау"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Жаңа"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -476,58 +501,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -536,51 +561,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -590,137 +639,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -728,162 +777,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -891,373 +932,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Аты"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Қайту"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Қайталау"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1267,324 +1305,678 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Ашу..."
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr ""
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Шығу"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Шығу"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Ашу..."
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Сақтау"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr ""
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr ""
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Файл"
+
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Ашу..."
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Жуырда ашылған"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Ашу..."
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Ашу..."
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr ""
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1592,130 +1984,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1724,35 +2128,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1776,45 +2180,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1822,153 +2230,217 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr ""
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr ""
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr ""
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1980,256 +2452,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2237,188 +2734,212 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+msgid "Import Layers"
+msgstr ""
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2427,13 +2948,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2443,7 +2964,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2451,13 +2972,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2465,7 +2986,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2473,7 +2994,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2484,7 +3005,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2492,7 +3013,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2502,7 +3028,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2513,285 +3039,394 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr ""
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2801,7 +3436,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2810,52 +3465,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2877,17 +3563,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2916,112 +3600,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3034,7 +3693,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3075,6 +3734,133 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Аты"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3444,56 +4230,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3501,12 +4307,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3515,7 +4321,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3526,28 +4332,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3609,1828 +4415,2018 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Алыстау"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Файл"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Анықтама"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/kn.po
+++ b/po/kn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:19+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Kannada <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -19,27 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -47,39 +27,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -87,214 +67,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "ವಿನ್ಯಾಸ"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "ಬಣ್ಣ"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "ಇಚ್ಛೆಯ"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -333,142 +323,177 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "ಉಳಿಸು"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "ಹೊಸ"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -476,58 +501,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -536,51 +561,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -590,137 +639,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -728,162 +777,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -891,373 +932,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "ಹೆಸರು"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "ರದ್ದುಗೊಳಿಸು"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "ಪುನಃಮಾಡು"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1267,324 +1305,674 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "ಪೂರ್ಣತೆರೆ"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "ತ್ಯಜಿಸು"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "ತ್ಯಜಿಸು"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
+msgstr ""
+
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
+msgstr ""
+
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "ಉಳಿಸು"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
 #, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr ""
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "ಕಡತ"
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "ಪದರಗಳು"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1412
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1427
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1432
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr ""
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1592,130 +1980,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1724,35 +2124,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1776,45 +2176,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1822,153 +2226,218 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "ಪದರಗಳು"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "ಪದರಗಳು"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr ""
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1980,256 +2449,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2237,188 +2731,213 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "ಪದರಗಳು"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2427,13 +2946,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2443,7 +2962,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2451,13 +2970,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2465,7 +2984,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2473,7 +2992,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2484,7 +3003,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2492,7 +3011,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2502,7 +3026,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2513,285 +3037,394 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr ""
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2801,7 +3434,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2810,52 +3463,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2877,17 +3561,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2916,112 +3598,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3034,7 +3691,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3075,6 +3732,133 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "ಹೆಸರು"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3444,56 +4228,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3501,12 +4305,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3515,7 +4319,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3526,28 +4330,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3609,1828 +4413,2019 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "ಕುಗ್ಗಿಸು"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "ಕಡತ"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "ದೋಷನಿವಾರಣೆ"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
-msgstr ""
+msgstr "ಪದರಗಳು"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/kn.po
+++ b/po/kn.po
@@ -513,17 +513,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1184,12 +1184,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1405,7 +1405,7 @@ msgid "_Quit"
 msgstr "ತ್ಯಜಿಸು"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1455,7 +1455,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1632,13 +1632,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "ಉಳಿಸು"
 
@@ -1704,7 +1704,7 @@ msgstr "ಕಡತ"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -2125,12 +2125,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2142,7 +2142,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2328,7 +2328,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2398,7 +2398,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/ko.po
+++ b/po/ko.po
@@ -529,18 +529,18 @@ msgstr "MyPaint 브러쉬 패키지 (*.zip)"
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
-msgstr "새로운 그룹 ..."
+msgid "New Group…"
+msgstr "새로운 그룹…"
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
-msgstr "브러시를 가져오기..."
+msgid "Import Brushes…"
+msgstr "브러시를 가져오기…"
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
-msgstr "더 많은 브러시를 얻기..."
+msgid "Get More Brushes…"
+msgstr "더 많은 브러시를 얻기…"
 
 #: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
@@ -1220,13 +1220,13 @@ msgstr "유형"
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
-msgstr "다음에 대한 사용..."
+msgid "Use for…"
+msgstr "다음에 대한 사용…"
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
-msgstr "스크롤..."
+msgid "Scroll…"
+msgstr "스크롤…"
 
 #. Name and preview column: will be indented
 #: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
@@ -1448,8 +1448,8 @@ msgid "_Quit"
 msgstr "종료"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
-msgstr "브러쉬 패키지 불러오기 ..."
+msgid "Import brush package…"
+msgstr "브러쉬 패키지 불러오기…"
 
 #: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
@@ -1506,8 +1506,8 @@ msgstr ""
 "을 사용합니까?"
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
-msgstr "다음으로 열기..."
+msgid "Open With…"
+msgstr "다음으로 열기…"
 
 #: ../gui/externalapp.py:123
 msgid "Icon"
@@ -1699,13 +1699,13 @@ msgstr "JPEG 90% 품질의 이미지 (*.jpg; *.jpeg)"
 
 #: ../gui/filehandling.py:576
 #, fuzzy
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr "내보내기…"
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "다른 이름으로 저장…"
 
@@ -1776,8 +1776,8 @@ msgstr "최근 파일 열기"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
-msgstr "스크래치 패드 열기 ..."
+msgid "Open Scratchpad…"
+msgstr "스크래치 패드 열기…"
 
 #: ../gui/filehandling.py:1099
 #, fuzzy
@@ -2230,13 +2230,13 @@ msgstr ""
 "시오."
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
-msgstr "트랙커를 검색 ..."
+msgid "Search Tracker…"
+msgstr "트랙커를 검색…"
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
-msgstr "보고서..."
+msgid "Report…"
+msgstr "보고서…"
 
 #: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
@@ -2247,8 +2247,8 @@ msgid "Quit MyPaint"
 msgstr "MyPaint를 종료"
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
-msgstr "세부 정보..."
+msgid "Details…"
+msgstr "세부 정보…"
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
@@ -2454,8 +2454,8 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
-msgstr "스택에서 레이어를 이동..."
+msgid "Move layer in stack…"
+msgstr "스택에서 레이어를 이동…"
 
 #: ../gui/layerswindow.py:110
 msgid ""
@@ -2525,8 +2525,8 @@ msgid "Stroke trail-off beginning"
 msgstr "획 트레일 오프 부터 시작"
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
-msgstr "압력 변화..."
+msgid "Pressure variation…"
+msgstr "압력 변화…"
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
@@ -3705,7 +3705,7 @@ msgstr "디스크에서 이 브러시를 삭제"
 #, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid "_Recover & Save…"
-msgstr "_복구 및 저장..."
+msgstr "_복구 및 저장…"
 
 #: ../po/tmp/autorecover.glade.h:12
 #, fuzzy

--- a/po/ko.po
+++ b/po/ko.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.9.0 -git\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-08-31 19:09+0000\n"
 "Last-Translator: geun-tak Jeong <beroberos@gmail.com>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -17,29 +17,7 @@ msgstr ""
 "X-Generator: Weblate 3.9-dev\n"
 "X-Poedit-SourceCharset: utf-8\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr "<big><b>{accel_label}</b></big>"
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr "{action_label} {action_desc} {accel_label}"
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "작업"
 
@@ -47,39 +25,41 @@ msgstr "작업"
 msgid "Key combination"
 msgstr "단축키"
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr "'%s'에 대한 단축키 편집"
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "작업:"
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "경로:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "키:"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr "자판을 눌러 단축키를 할당합니다"
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "알 수 없는 작업"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
-msgstr "<b>{accel}은(는) '{action}'의 단축키로 이미 사용중입니다. 기존 키와 대체합니다.</b>"
+msgstr ""
+"<b>{accel}은(는) '{action}'의 단축키로 이미 사용중입니다. 기존 키와 대체합니"
+"다.</b>"
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr "폴더를 열기 “{folder_basename}”…"
@@ -87,193 +67,205 @@ msgstr "폴더를 열기 “{folder_basename}”…"
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "OK"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr "캐쉬에서 백업을 찾을 수 없습니다."
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr "사용 가능한 백업이 없음"
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr "캐시 폴더를 열기…"
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr "백업 복구 실패"
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr "백업 폴더를 열기…"
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr "{iso_datetime}.ora 에서 복구된 파일"
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "기본 값으로 저장"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "배경"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "패턴"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "색상"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "패턴에 색상을 추가"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr "하나 이상의 배경을 불러 올 수 없습니다"
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr "배경 불러오는 중 오류가 발생"
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr "불러올 수 없는 파일을 제거하거나, libgdkpixbuf 설치를 확인해 주십시오."
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
-msgstr "Gdk-Pixbuf가 \"{error}\"로 인해 파일 \"{filename}\"을 불러올 수 없습니다."
+msgstr ""
+"Gdk-Pixbuf가 \"{error}\"로 인해 파일 \"{filename}\"을 불러올 수 없습니다."
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr "{filename}이 빈 파일입니다. (w={w}, h={h})"
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr "브러쉬 설정 편집기"
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr "정보"
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "실험적인"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr "기본"
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr "불투명도"
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr "덧칠"
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "자국"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr "속도"
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+#, fuzzy
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr "방향 필터"
+
+#: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr "트래킹"
 
-#: ../gui/brusheditor.py:359
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "선획"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr "색상"
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "사용자 정의"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr "목록에 해당 브러시가 없습니다. \"브러시 추가\"를 먼저 하십시오."
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr "선택한 브러시가 없음!"
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "브러쉬 이름 변경"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "이 이름을 가진 브러시가 이미 존재합니다!"
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr "브러시 선택이 없음!"
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr "정말 디스크에서 \"{brush_name}” 브러시를 삭제 하시겠습니까?"
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr "(이름 없는 브러시)"
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr "{brush_name} [저장 안 됨]"
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr "브러쉬 아이콘"
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr "브러쉬 아이콘 (편집하기)"
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr "선택한 브러시가 없음"
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -282,7 +274,7 @@ msgstr ""
 "<b>%s</b>\n"
 "<small>먼저 유효한 브러시 선택</small>"
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
@@ -291,7 +283,7 @@ msgstr ""
 "<b>%s</b> <i>(수정됨)</i>\n"
 "<small>변경사항이 저장되지 않았습니다</small>"
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
@@ -300,7 +292,7 @@ msgstr ""
 "<b>%s</b> (편집 중)\n"
 "<small>브러시 또는 색으로 그리기</small>"
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -341,141 +333,181 @@ msgstr "자동"
 msgid "Use the default icon"
 msgstr "기본 아이콘을 사용"
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "저장"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr "미리보기 아이콘을 저장하고 편집을 완료"
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr "마지막 & 찾기"
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr "삭제된"
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr "즐겨 찾기"
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr "잉크"
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr "클래식"
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr "설정#1"
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr "설정#2"
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr "설정#3"
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr "설정#4"
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr "설정#5"
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr "실험"
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "새로 작성"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr "알 수없는 브러쉬"
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr "즐겨 찾기에 추가"
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr "즐겨 찾기에서 제거"
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr "클론"
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr "브러시 설정을 편집"
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
-msgstr "삭제"
+#: ../gui/brushselectionwindow.py:250
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
+msgstr "그룹 이름을 변경"
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
-msgstr "정말 디스크에서 브러시를 삭제 하시겠습니까?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, fuzzy, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
+msgstr "정말 디스크에서 \"{brush_name}” 브러시를 삭제 하시겠습니까?"
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] "%d 브러쉬"
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr "그룹 “{group_name}”"
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr "그룹 이름을 변경"
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr "다른 Zip 압축된 브러시 설정으로 내보내기"
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr "그룹을 삭제"
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr "그룹 이름을 변경"
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "이 이름을 가진 그룹이 이미 존재합니다!"
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr "정말 “{group_name}” 그룹을 삭제 합니까?"
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -485,58 +517,58 @@ msgstr ""
 "그룹 “{group_name}” 을 삭제할 수 없습니다.\n"
 "특별한 그룹은 삭제할 수 없습니다."
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr "브러쉬를 내보내기"
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr "MyPaint 브러쉬 패키지 (*.zip)"
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "새로운 그룹 ..."
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr "브러시를 가져오기..."
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr "더 많은 브러시를 얻기..."
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "그룹을 만들기"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr "버튼"
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr "Btn"
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr "버튼 누르기"
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr "새로운 바인딩을 추가"
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr "현재 바인딩을 제거"
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr "'%s'의 바인딩 편집"
@@ -545,52 +577,83 @@ msgstr "'%s'의 바인딩 편집"
 msgid "Button press:"
 msgstr "버튼 누르기:"
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
-msgstr "새로운 바인딩을 설정하려면, 보조 키를 누른 채로 이 텍스트위의 단추를 누릅니다."
+msgstr ""
+"새로운 바인딩을 설정하려면, 보조 키를 누른 채로 이 텍스트위의 단추를 누릅니"
+"다."
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
-msgstr "{button}은(는) 보조 키 없이 바인팅될 수 없습니다 (고정을 의미, 죄송합니다)"
+msgstr ""
+"{button}은(는) 보조 키 없이 바인팅될 수 없습니다 (고정을 의미, 죄송합니다)"
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr "{button_combination}는 이미 '{action_name}'을 작업할 가능성이 큽니다"
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr "색상을 선택"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr "페인팅에 사용할 색상을 설정"
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+#, fuzzy
+msgid "Set the color Hue used for painting"
+msgstr "페인팅에 사용할 색상을 설정"
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "색상을 선택."
+
+#: ../gui/colorpicker.py:296
+#, fuzzy
+msgid "Set the color Chroma used for painting"
+msgstr "페인팅에 사용할 색상을 설정"
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+#, fuzzy
+msgid "Set the color Luma used for painting"
+msgstr "페인팅에 사용할 색상을 설정"
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr "색상 세부 정보"
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr "현재 브러시 색, 및 가장 최근에 그림에 사용된 색"
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr "전체 마스크 활성"
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr "전체 마스크를 사용하여 특정 분위기에 대한 팔레트를 제한합니다."
@@ -600,300 +663,301 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr "HCY 색조 및 채도."
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
-msgstr "색상 범위 편집기. 마우스 중간 단추를 눌러 만들거나 모양을 고친다. 원판 가장자리에서 하면 마스크가 돌아간다."
+msgstr ""
+"색상 범위 편집기. 마우스 중간 단추를 눌러 만들거나 모양을 고친다. 원판 가장자"
+"리에서 하면 마스크가 돌아간다."
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr "대기 3배색"
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr "분위기 있으며 몽환적이다. 1개 원색과 약한 2개 주색으로 되어 있다."
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr "떨어진 3배색"
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr "기본색 쪽으로 강조되어 있음."
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr "보색 배색"
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
-msgstr "반대색으로 대비되며, 색상환에서 두색 사이에 있는 중앙의 무채색으로 안정을 꾀합니다."
+msgstr ""
+"반대색으로 대비되며, 색상환에서 두색 사이에 있는 중앙의 무채색으로 안정을 꾀"
+"합니다."
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr "분위기 있으면서 주목을 끔"
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
-msgstr "단일 주색상 범위 내의 색깔들을 쓰며, 변화와 강조 용도로 주목을 끄는 하나의 보색을 넣는다."
+msgstr ""
+"단일 주색상 범위 내의 색깔들을 쓰며, 변화와 강조 용도로 주목을 끄는 하나의 보"
+"색을 넣는다."
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr "분할 보색 배색"
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
-msgstr "인접색 2개 및 이에 대응하는 보색류 1개를 쓴다. 다른 중간색은 쓰지 않는다."
+msgstr ""
+"인접색 2개 및 이에 대응하는 보색류 1개를 쓴다. 다른 중간색은 쓰지 않는다."
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr "템플릿에서 새로운 전체 대 마스크"
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr "전체 마스크 편집기"
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr "활성"
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr "도움말…"
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr "템플릿에서 마스크를 만듭니다."
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr "GIMP 파레트 파일로 마스크를 불러오기."
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr "GIMP 파레트 파일로 마스크를 저장하기."
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr "마스크를 지우기."
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr "웹 브라우저에서이 대화 상자에 대한 온라인 도움말을 엽니다."
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr "김프 팔레트 파일에서 마스크를 저장하기"
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr "김프 팔레트 파일에서 마스크를 불러오기"
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr "전체 마스크를 설정."
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr "HCY 원형"
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
 "are equiluminant."
-msgstr "원통형 색 공간에서 색상/명도/채도를 이용해 색을 설정하십시오. 각각의 원형 색 단면 안의 색상들은 서로 같은 명도를 가집니다."
+msgstr ""
+"원통형 색 공간에서 색상/명도/채도를 이용해 색을 설정하십시오. 각각의 원형 색 "
+"단면 안의 색상들은 서로 같은 명도를 가집니다."
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr "HSV 색상"
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr "HSV 채도"
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr "HSV 값"
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr "HSV 채도 및 값"
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr "HSV 색상 및 값"
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr "HSV 색조 및 채도"
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr "큐브를 회전 (다른 축 표시)"
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr "HSV 큐브"
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr "다른 평면 조각을 표시하도록 회전 하는 HSV 큐브."
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr "HSV 사각형"
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr "HSV 사각형을 회전시켜 다양한 색조를 표현할 수 있습니다."
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr "HSV 삼각형"
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr "표준 GTK 색상 선택기"
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr "HSV 원형"
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr "채도 및 명암 컬러 체인저."
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr "팔레트 등록 정보"
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr "팔레트"
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr "불러올 수 있는 팔레트 중 편집 가능한 것에서 색을 설정합니다."
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr "제목 없는 팔레트"
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr "팔레트 편집기"
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr "GIMP 팔레트 파일 불러오기"
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr "GIMP 팔레트 파일로 저장하기"
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr "비어있는 새 견본을 추가"
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr "현재 견본을 제거"
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr "모든 견본 제거"
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr "제목:"
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr "이 팔레트의 이름 또는 설명"
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr "세로줄:"
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr "세로줄의 수"
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr "색상 이름:"
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr "현재 색상의 이름"
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr "빈 팔레트 슬롯"
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr "팔레트 불러오기"
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr "팔레트 저장하기"
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -904,378 +968,375 @@ msgstr ""
 "여기에 색상을 놓은 다음,\n"
 "드래그하여 정리합니다."
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr "빈 팔레트 슬롯 (여기에 색상을 드래그)"
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr "빈 슬롯 추가"
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr "가로줄 삽입"
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr "세로줄 삽입"
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr "빈 부분 채우기 (RGB)"
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr "빈 부분 채우기 (HCY)"
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr "빈 부분 채우기 (HSV)"
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "GIMP 팔레트 파일 (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr "모든 파일 (*.*)"
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "GIMP 팔레트 파일 (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr "모든 파일 (*.*)"
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr "화면에서 색상을 선택"
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr "R"
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr "G"
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr "B"
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr "H"
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr "C"
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr "Y"
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr "구성 요소 슬라이더"
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr "색상의 개별 구성 요소를 조절합니다."
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr "RGB 빨강"
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr "RGB 초록"
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr "RGB 파랑"
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr "HSV 색조"
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr "HSV 채도"
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr "HSV 명암"
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr "HCY 색조"
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr "HCY 크로마(채도)"
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr "HCY 루마 (Y')"
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr "수묵 담채"
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr "가까운 색상을 사용하여 색상을 변경합니다."
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr "동심 링"
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr "동심 HSV 링을 사용하여 색상을 변경합니다."
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr "교차 그릇"
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr "이 레이어 커버만 배경을 사용합니다. 다른 모든 것은 무시됩니다."
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr "커서/퍽"
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr "지우개"
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr "키보드"
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr "마우스"
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr "펜"
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr "터치패드"
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr "터치스크린"
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr "무시하기"
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr "모든 작업"
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr "페인팅 외 작업"
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr "탐색만"
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr "확대"
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr "화면 이동"
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr "장치"
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr "축"
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr "유형"
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr "다음에 대한 사용..."
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr "스크롤..."
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "이름"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr "브러시를 덮어쓸까요?"
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr "교체"
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr "이름 바꾸기"
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr "모두 교체"
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr "모든 이름 바꾸기"
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr "불러온 브러시"
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr "현재 있는 브러시"
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 "<b>`%s' 이름의 브러시가 이미 존재 합니다.</b>\n"
 "기존 브러시를 덮어씁니까, 아니면 다른 이름으로 저장합니까?"
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr "브러시 그룹을 덮어쓸까요?"
 
-#: ../gui/dialogs.py:190
-#, python-brace-format
+#: ../gui/dialogs.py:220
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 "<b>`{groupname}' 라는 그룹 이름이 이미 존재 합니다.</b>\n"
 "기존 그룹의 이름을 덮어씁니까, 아니면 다른 이름으로 저장합니까?\n"
 "그룹을 덮어쓰면, 브러시는 `{deleted_groupname}' 그룹에 포함됩니다."
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr "브러시 패키지를 불러올까요?"
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, fuzzy, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr "<b>정말로 `%s'패키지를 불러올까요?</b>"
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr "%d 단축키에 있는 브러시 설정을 읽습니다"
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr "%d 단축키 슬록에 브러시 설정을 저장합니다"
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr "%d 브러시 복원"
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr "%d 브러시 저장"
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr "되돌리기 %s"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "되돌리기"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr "%s 재실행"
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "재실행"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr "{button_combination}은 {resultant_action}"
@@ -1285,289 +1346,570 @@ msgstr "{button_combination}은 {resultant_action}"
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ";  "
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr "{modifiers} 누르고 있을 때:  {button_actions}."
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
-msgstr "레이어 이름"
-
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
-#, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
-"<b>{name}</b>\n"
-"{description}"
+
+#: ../gui/document.py:909
+#, python-brace-format
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
+msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr "%s - MyPaint"
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr "MyPaint"
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "열기"
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr "현재 색상을 설정"
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr "전체 화면 모드를 종료"
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr "전체 화면 종료"
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr "전체 화면 모드로 전환"
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "전체 화면"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "종료"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+#, fuzzy
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr "정말로 종료합니까?"
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "종료"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr "브러쉬 패키지 불러오기 ..."
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr "MyPaint 브러시 패키지 (*.zip)"
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr "레이어 “{layer_name}”을 편집하기 위해 실행된 {app_name} 어플리케이션"
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
-msgstr "오류: 레이어 “{layer_name}”을 편집하려 했지만 {app_name} 어플리케이션을 실행하지 못했습니다"
+msgstr ""
+"오류: 레이어 “{layer_name}”을 편집하려 했지만 {app_name} 어플리케이션을 실행"
+"하지 못했습니다"
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
-msgstr "수정이 취소되었습니다. 레이어 메뉴에서 \"{layer_name}\"을 수정하실 수 있습니다."
+msgstr ""
+"수정이 취소되었습니다. 레이어 메뉴에서 \"{layer_name}\"을 수정하실 수 있습니"
+"다."
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr "추가적인 수정으로 “{layer_name}” 갱신"
 
-#: ../gui/externalapp.py:46
-#, python-brace-format
-msgid ""
-"MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
-"application should it use?"
-msgstr ""
-"MyPaint는 “{type_name}” 타입({content_type}) 파일을 수정해야 합니다. 어떤 어플리케이션에서 그 파일을 "
-"사용할 수 있나요?"
-
-#: ../gui/externalapp.py:50
-#, python-brace-format
-msgid ""
-"What application should MyPaint use for editing files of type "
-"“{type_name}” ({content_type})?"
-msgstr "“{type_name}” 타입({content_type})의 파일들을 편집하기 위해 어떤 어플리케이션을 사용합니까?"
-
-#: ../gui/externalapp.py:56
-msgid "Open With..."
-msgstr "다음으로 열기..."
-
-#: ../gui/externalapp.py:107
-msgid "Icon"
-msgstr "아이콘"
-
-#: ../gui/externalapp.py:150
-msgid "no description"
-msgstr "설명이 없습니다"
-
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr "모든 인식 가능한 형식"
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr "OpenRaster (*.ora)"
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr "PNG (*.png)"
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr "JPEG (*.jpg; *.jpeg)"
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr "선택안함 (기본 저장 형식)"
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr "배경과 그림이 하나인 이미지 (*.png)"
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr "투명 배경 이미지 (*.png)"
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr "레이어를 여러개의 이미지로 나누어 저장 (*.XXX.png)"
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr "JPEG 90% 품질의 이미지 (*.jpg; *.jpeg)"
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr "저장하기…"
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr "저장하는 형식 :"
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr "확인"
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr "정말 계속하시겠습니까?"
-
-#: ../gui/filehandling.py:234
-#, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
-msgstr "{abbreviated_time} 시간만큼 작업한 내용을 잃어버리게 될 것입니다"
-
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr "스크랩으로 저장(_S)"
-
-#: ../gui/filehandling.py:282
-#, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
-msgstr "불러오기 “{file_basename}”…"
-
-#: ../gui/filehandling.py:296
+#: ../gui/externalapp.py:48
 #, python-brace-format
 msgctxt "file handling: open failed (statusbar)"
 msgid "Could not load “{file_basename}”."
 msgstr "“{file_basename}”을 로드할 수 없습니다."
 
-#: ../gui/filehandling.py:321
+#: ../gui/externalapp.py:61
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
-msgstr "“{file_basename}”을 불러옴."
+msgid ""
+"MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
+"application should it use?"
+msgstr ""
+"MyPaint는 “{type_name}” 타입({content_type}) 파일을 수정해야 합니다. 어떤 어"
+"플리케이션에서 그 파일을 사용할 수 있나요?"
 
-#: ../gui/filehandling.py:422
+#: ../gui/externalapp.py:65
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
-msgstr "“{file_basename}”로 내보내기…"
+msgid ""
+"What application should MyPaint use for editing files of type "
+"“{type_name}” ({content_type})?"
+msgstr ""
+"“{type_name}” 타입({content_type})의 파일들을 편집하기 위해 어떤 어플리케이션"
+"을 사용합니까?"
 
-#: ../gui/filehandling.py:427
+#: ../gui/externalapp.py:71
+msgid "Open With..."
+msgstr "다음으로 열기..."
+
+#: ../gui/externalapp.py:123
+msgid "Icon"
+msgstr "아이콘"
+
+#: ../gui/externalapp.py:166
+msgid "no description"
+msgstr "설명이 없습니다"
+
+#: ../gui/filehandling.py:126
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
+msgstr "불러오기 “{file_basename}”…"
+
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:134
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr "“{file_basename}”을 저장하기…"
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:138
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
+msgstr "“{file_basename}”로 내보내기…"
+
+#: ../gui/filehandling.py:145
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
 msgstr "“{file_basename}”로 내보내기 실패함."
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:149
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
 msgstr "“{file_basename}”로 저장하기 실패함."
 
-#: ../gui/filehandling.py:476
+#: ../gui/filehandling.py:153
 #, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr "“{file_basename}”을 로드할 수 없습니다."
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "팔레트 저장하기"
+
+#: ../gui/filehandling.py:168
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr "파일로 내보내기"
+
+#: ../gui/filehandling.py:172
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr "파일로 내보내기"
+
+#: ../gui/filehandling.py:176
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr "최근 파일 열기"
+
+#: ../gui/filehandling.py:183
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
 msgstr "“{file_basename}”을 성공적으로 내보냄."
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:187
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
 msgstr "“{file_basename}”을 저장함."
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "열기..."
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:195
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr "“{file_basename}”을 불러옴."
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+
+#: ../gui/filehandling.py:221
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
+msgstr "“{file_basename}”을 불러옴."
+
+#: ../gui/filehandling.py:427
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
+msgstr "모든 인식 가능한 형식"
+
+#: ../gui/filehandling.py:432
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:437
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:442
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
+msgstr "JPEG (*.jpg; *.jpeg)"
+
+#: ../gui/filehandling.py:490
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
+msgstr "선택안함 (기본 저장 형식)"
+
+#: ../gui/filehandling.py:494
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:498
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr "배경과 그림이 하나인 이미지 (*.png)"
+
+#: ../gui/filehandling.py:502
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:506
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr "투명 배경 이미지 (*.png)"
+
+#: ../gui/filehandling.py:510
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr "레이어를 여러개의 이미지로 나누어 저장 (*.XXX.png)"
+
+#: ../gui/filehandling.py:514
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr "레이어를 여러개의 이미지로 나누어 저장 (*.XXX.png)"
+
+#: ../gui/filehandling.py:518
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr "JPEG 90% 품질의 이미지 (*.jpg; *.jpeg)"
+
+#: ../gui/filehandling.py:576
+#, fuzzy
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr "내보내기…"
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "다른 이름으로 저장…"
+
+#: ../gui/filehandling.py:601
+#, fuzzy
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr "저장하는 형식 :"
+
+#: ../gui/filehandling.py:668
+#, fuzzy
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr "정말 계속하시겠습니까?"
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+#, fuzzy
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr "스크랩으로 저장(_S)"
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, fuzzy, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr "{abbreviated_time} 시간만큼 작업한 내용을 잃어버리게 될 것입니다"
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr "열기…"
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "최근 파일 열기"
+
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr "스크래치 패드 열기 ..."
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "불러온 브러시"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "열기"
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "가장 최근 작업을 열기"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "열기"
+
+#: ../gui/filehandling.py:1446
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
 msgstr "스크랩 파일 \"%s\"이(가) 생성되지 않았습니다."
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1455
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr "다음 스크랩을 열기"
+
+#: ../gui/filehandling.py:1463
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr "이전 스크랩을 열기"
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "열기"
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+#, fuzzy
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr "되돌리기"
+
+#: ../gui/fill.py:121
+#, fuzzy
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr "색상 영역 채우기"
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+#, fuzzy
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr "색상 영역 채우기"
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+#, fuzzy
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr "오차 범위:"
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+#, fuzzy
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr "채우기 툴이 적용될 색상 범위 조절"
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+#, fuzzy
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr "소스:"
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
-msgstr "표시되는 레이어 중 채울 레이어"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
+msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+#, fuzzy
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr "샘플 합침"
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+#, fuzzy
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
@@ -1576,19 +1918,50 @@ msgstr ""
 "채우기 툴을 사용하기 전, 현재 레이어 아래에\n"
 "표시된 레이어를 일시적으로 합쳐놓으세요"
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+#, fuzzy
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr "보기에 맞춤"
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+#, fuzzy
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr "대상:"
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+#, fuzzy
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr "결과물의 위치"
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr "새로운 레이어 (한번)"
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+#, fuzzy
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
@@ -1596,21 +1969,109 @@ msgstr ""
 "색 채우기를 한 상태로 새 레이어를 생성.\n"
 "사용 후 자동으로 해제됩니다."
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "불투명도 :"
+
+#: ../gui/fill.py:706
+#, fuzzy
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr "불투명도 곱하기"
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr "초기화"
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+#, fuzzy
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr "옵션을 기본 값으로 초기화"
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "레이어를 선택"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr "<b>{brush_name}</b>"
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1620,130 +2081,142 @@ msgstr ""
 "<b>{brush_name}</b>\n"
 "{brush_desc}"
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr "프레임을 편집"
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr "문서 프레임을 수정"
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr "프레임 크기"
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr "px"
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr "높이:"
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr "넓이:"
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr "해상도:"
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr "DPI"
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr "인치 당 도트 수 (실제 픽셀 당 인치)"
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr "색상:"
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr "프레임 색상"
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr "<b>프레임 크기</b>"
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr "<b>픽셀 밀도</b>"
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr "프레임을 레이어로 설정"
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr "프레임을 현재 레이어의 범위로 설정"
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr "문서에 프레임을 설정"
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr "프레임을 모든 레이어의 조합으로 설정"
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr "레이어를 프레임으로 다듬기"
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr "현재 레이어의 프레임 외의 부분 잘라내기"
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr "사용"
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr "{width:g}×{height:g} {units}"
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr "인치"
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr "cm"
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr "mm"
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr "자유형 그리기"
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr "자유로운 형태의 브러시 획 그리기"
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr "스무스:"
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr "압력:"
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr "버그 발견"
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr "<big><b>프로그래밍 오류가 감지되었습니다.</b></big>"
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1751,38 +2224,40 @@ msgid ""
 "Please tell the developers about this using the issue tracker if no-one else "
 "has reported it yet."
 msgstr ""
-"이 에러를 무시하고 작업을 계속할 수 있지만, 즉시 작업을 저장하시는 것을 추천합니다.\n"
-"이 문제가 아직 보고되지 않았다면 이슈 트래커를 이용해 개발자들에게 알려 주십시오."
+"이 에러를 무시하고 작업을 계속할 수 있지만, 즉시 작업을 저장하시는 것을 추천"
+"합니다.\n"
+"이 문제가 아직 보고되지 않았다면 이슈 트래커를 이용해 개발자들에게 알려 주십"
+"시오."
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr "트랙커를 검색 ..."
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr "보고서..."
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr "오류를 무시"
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr "MyPaint를 종료"
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr "세부 정보..."
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr "동작 도중 예기치 않았던 이상 상태가 발생하였습니다."
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1823,45 +2298,50 @@ msgstr ""
 "            #### Traceback\n"
 "        "
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr "잉크 제도"
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr "그린 다음 부드러운 선 조절하기"
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr "입력 장치 테스트"
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr "(압력 없음)"
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr "압력:"
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr "(기울기 없음)"
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr "기울기:"
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr "(장치 없음)"
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
 msgstr "장치 :"
 
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+#, fuzzy
+msgid "Barrel Rotation:"
+msgstr "회전을 재설정"
+
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr "레이어를 이동"
 
@@ -1869,157 +2349,231 @@ msgstr "레이어를 이동"
 msgid "Move the current layer"
 msgstr "현재 레이어를 이동"
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
-msgstr "{path}에서 {default_name}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
+msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
-msgstr "유형"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
+msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+#, fuzzy
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr "속성"
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr "보임"
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "레이어"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+#, fuzzy
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr "잠금"
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+#, fuzzy
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ", "
+
+#: ../gui/layers.py:990
+#, fuzzy, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr "추가{layer_default_name}"
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "레이어"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr "레이어를 정렬 및 효과를 할당"
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr "레이어 불투명도: %d%%"
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr "스택에서 레이어를 이동..."
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr "스택에서 레이어를 이동 (일반 레이어에 드롭하면 새 그룹을 만들기)"
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr "레이어"
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
-msgstr "모드 :"
+#: ../gui/layervis.py:53
+#, fuzzy, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
+msgstr "<b>{brush_name}</b>"
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
-msgstr "레이어 혼합 모드: 현재 레이어와 아래 레이어 간의 색상 혼합 방법을 지정."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
+msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "불투명도 :"
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "뷰를 회전"
 
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr "레이어 불투명도: 현재 레이어의 불투명도를 조절합니다. 값을 낮출수록 더 투명해질 것입니다."
-
-#: ../gui/linemode.py:37
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr "입구 압력"
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr "선 도구에 대한 획 입구 압력"
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr "중간 압력"
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr "선 도구에 대한 중간 획 압력"
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr "압력 종료"
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr "선 도구에 대한 획 출구 압력"
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr "해드"
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 msgid "Stroke lead-in end"
 msgstr "획 리드 인 끝"
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr "꼬리"
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr "획 트레일 오프 부터 시작"
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr "압력 변화..."
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr "직선과 곡선"
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr "일반 라인/곡선 모드"
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
-msgstr "직선을 그립니다. Ctrl을 누르며 그리면 고정된 각에 맞추어 그리고, 그린 후 Shift를 누르면 곡선으로 변형할 수 있습니다"
+msgstr ""
+"직선을 그립니다. Ctrl을 누르며 그리면 고정된 각에 맞추어 그리고, 그린 후 "
+"Shift를 누르면 곡선으로 변형할 수 있습니다"
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr "연결된 라인"
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
-"여러 개의 직선을 이어서 그립니다. Ctrl을 누르며 그리면 고정된 각에 맞추어 그리고, 그린 후 Shift를 누르면 곡선으로 변형할 수 "
-"있습니다"
+"여러 개의 직선을 이어서 그립니다. Ctrl을 누르며 그리면 고정된 각에 맞추어 그"
+"리고, 그린 후 Shift를 누르면 곡선으로 변형할 수 있습니다"
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr "타원과 원"
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
-msgstr "원/타원을 그립니다. Ctrl을 누르며 그리면 고정된 각에 맞추어 그리고, Shift를 누르며 그리면 회전할 수 있습니다"
+msgstr ""
+"원/타원을 그립니다. Ctrl을 누르며 그리면 고정된 각에 맞추어 그리고, Shift를 "
+"누르며 그리면 회전할 수 있습니다"
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
+#, fuzzy
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 "Copyright (C) 2005-2015\n"
 "  마틴 RENOLD과 MyPaint 개발 팀"
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -2030,262 +2584,293 @@ msgid ""
 "This program is distributed in the hope that it will be useful, but WITHOUT "
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
-"MyPaint는 무료 소프트웨어입니다. 무료 소프트웨어 재단의 GNU 일반 공증 허가서를 준수할 경우 자유롭게 수정, 배포할 수 있습니다("
-"이 허가서의 제2판, 혹은(사용자의 선택에 따라) 그 이후 버전 이용가능).\n"
+"MyPaint는 무료 소프트웨어입니다. 무료 소프트웨어 재단의 GNU 일반 공증 허가서"
+"를 준수할 경우 자유롭게 수정, 배포할 수 있습니다(이 허가서의 제2판, 혹은(사용"
+"자의 선택에 따라) 그 이후 버전 이용가능).\n"
 "\n"
-"MyPaint가 유용하게 사용되기를 바랍니다. 하지만 사용상의 어떠한 보장도 하지 않습니다. 이에 대한 자세한 사항은 COPYING  "
-"파일을 참고하시기 바랍니다."
+"MyPaint가 유용하게 사용되기를 바랍니다. 하지만 사용상의 어떠한 보장도 하지 않"
+"습니다. 이에 대한 자세한 사항은 COPYING  파일을 참고하시기 바랍니다."
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr "프로그래밍"
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr "호환성"
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr "프로젝트 관리"
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr "브러시"
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr "패턴"
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr "도구 아이콘"
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr "바탕화면 아이콘"
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr "팔레트"
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr "문서"
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr "지원"
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr "봉사 활동"
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr "커뮤니티"
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ", "
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr "번역가-크레딧"
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr "크기:"
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr "불투명하게:"
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr "선명하게:"
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr "이득:"
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr "도구 옵션"
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr "현재 편집중인 도구를 위한 독특한 설정"
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr "<b>{mode_name}</b>"
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr "<i>사용 가능한 옵션이 없음</i>"
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr "줌: %.01f%%"
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr "브러시 획 설정, 획 색상, 및 레이어 선택…"
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr "색상을 선택…"
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr "환경 설정"
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr "미리보기"
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr "전체 그리는 영역의 미리보기"
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr "뷰 파인더를 표시"
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr "스크래치 패드"
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr "각각의 스크랩 페이지에 스케치를 하거나 색을 혼합할 수 있음"
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr "이전 항목"
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr "다음 항목"
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
 msgstr "(표시할 것 없음)"
 
-#: ../gui/symmetry.py:76
+#: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Place axis"
 msgstr "장소 축"
 
-#: ../gui/symmetry.py:80
+#: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Move axis"
 msgstr "축을 이동"
 
-#: ../gui/symmetry.py:84
+#: ../gui/symmetry.py:88
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr "축을 제거"
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr "대칭 축을 편집"
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr "페인팅 대칭축을 조절합니다."
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
+#, fuzzy
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr "위치:"
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr "위치:"
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr "없음"
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr "%d px"
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr "알파:"
 
-#: ../gui/symmetry.py:352
+#: ../gui/symmetry.py:376
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
+msgstr "대칭"
+
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+#, fuzzy
 msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+msgid "X axis Position"
 msgstr "축 위치"
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:477
+#, fuzzy
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr "축 위치"
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr "사용됨"
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr "파일 처리"
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr "스크랩 스위처"
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr "실행 취소 및 다시 실행"
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr "혼합 모드"
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr "라인 모드"
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr "보기 (메인)"
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr "보기 (보조 / 대체)"
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr "보기 (재설정)"
 
@@ -2293,188 +2878,214 @@ msgstr "보기 (재설정)"
 msgid "<b>MyPaint</b>"
 msgstr "<b>MyPaint</b>"
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr "스크롤 보기"
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr "캔버스 보기를 드래그"
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr "뷰를 줌"
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr "캔버스 보기를 줌"
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr "뷰를 회전"
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr "캔버스 뷰를 회전"
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, fuzzy, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr "%s: 탭을 닫기"
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
-msgstr "%s: 등록 정보를 편집"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
+msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr "알 수 없는 명령"
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr "정의되지 않음 (명령은 아직 시작되지 않음)"
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr "{brush_name}로 {seconds:.01f}초간 칠하기"
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr "색상 영역 채우기"
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr "레이어를 다듬기"
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "그룹 이름을 변경"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr "레이어를 지우기"
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr "레이어를 붙여넣기"
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr "보이는 상태에서 새로운 레이어"
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr "보이는 레이어를 병합"
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr "아래로 병합"
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr "노멀라이즈 레이어 모드"
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "불러온 브러시"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr "추가{layer_default_name}"
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr "레이어를 제거"
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr "레이어를 선택"
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr "레이어를 복제"
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr "레이어를 위로 이동"
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr "레이어를 아래로 이동"
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr "스택에서 레이어를 이동"
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr "레이어 이름 바꾸기"
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr "레이어 보이게 만들기"
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr "레이어 숨기기"
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr "레이어 잠금"
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr "레이어 잠금 해제"
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr "레이어 불투명도를 설정: %0.1f%%"
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr "알 수 없는 모드"
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr "레이어 모드를 설정: %s"
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr "프레임을 사용"
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr "프레임을 사용 중지"
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr "프레임을 업데이트"
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr "레이어를 외부에서 편집"
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr "“{basename}”을 불러오기 오류."
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr "이 에러에 대한 자세한 사항은 로그를 참고해주세요."
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr "지금부터"
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr "전에"
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2486,13 +3097,13 @@ msgstr ""
 "MyPaint를 여러 번 실행하셨나요?\n"
 "애플리케이션을 닫고 {cache_update_interval}초 후 다시 시도하세요."
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr "불완전 백업 {last_modified_time}{ago} 업데이트됨"
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2505,7 +3116,7 @@ msgstr ""
 "크기: {autosave.width}×{autosave.height}픽셀, 레이어: {autosave.num_layers}\n"
 "{unsaved_time}동안의 저장되지 않은 그림 포함."
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2515,13 +3126,13 @@ msgstr ""
 "“{filename}”을(를) 저장할 수 없습니다: {err}\n"
 "저장장치에 남은 공간이 충분합니까?"
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr "“{filename}”으로 저장할 수 없습니다: {err}"
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2531,7 +3142,7 @@ msgstr ""
 "{error_loading_common}\n"
 "파일이 존재하지 않습니다."
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2541,7 +3152,7 @@ msgstr ""
 "{error_loading_common}\n"
 "파일을 여는 데 필요한 권한이 없습니다."
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2557,7 +3168,7 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2567,7 +3178,13 @@ msgstr ""
 "{error_loading_common}\n"
 "알 수 없는 파일 형식 확장명: {ext}"
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+#, fuzzy
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr "불러온 브러시"
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2578,9 +3195,10 @@ msgid ""
 msgstr ""
 "JPEG로 저장할 수 없습니다: {original_msg}\n"
 "\n"
-"기기의 메모리가 충분치 않다면, PNG 확장자로 대신 저장해보십시오. MyPaint의 PNG 저장 기능은 더 효율적입니다."
+"기기의 메모리가 충분치 않다면, PNG 확장자로 대신 저장해보십시오. MyPaint의 "
+"PNG 저장 기능은 더 효율적입니다."
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2596,285 +3214,418 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/helpers.py:402
-#, python-brace-format
+#: ../lib/floodfill.py:131
+#, fuzzy
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr "채우기"
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr "{days}일 {hours}시"
 
-#: ../lib/helpers.py:404
-#, python-brace-format
+#: ../lib/helpers.py:537
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr "{hours}시 {minutes}분"
 
-#: ../lib/helpers.py:406
-#, python-brace-format
+#: ../lib/helpers.py:539
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr "{minutes}분 {seconds}초"
 
-#: ../lib/helpers.py:408
-#, python-brace-format
+#: ../lib/helpers.py:541
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr "{seconds}초"
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr "레이어"
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr "%(name)s %(number)d"
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr "^(.*?)\\s*(\\d+)$"
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
+#, fuzzy
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr "벡터 레이어"
+
+#: ../lib/layer/data.py:1158
+#, fuzzy
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr "벡터 레이어"
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
-msgstr "알 수 없는 비트맵 레이어"
+msgid "Bitmap"
+msgstr ""
 
-#: ../lib/layer/data.py:1169
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1244
 msgctxt "layer default names"
-msgid "Unknown Data Layer"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
 msgstr "알 수 없는 데이터 레이어"
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "새로운 페인트 레이어"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr "그룹"
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "새로운 레이어 그룹"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr "견본"
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr "루트"
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ", "
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+#, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "보기"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+#, fuzzy
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr "레이어를 추가"
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+#, fuzzy
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr "레이어를 제거"
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr "레이어 잠금"
+
+#: ../lib/layervis.py:697
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr "레이어 잠금 해제"
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr "통과를 통해"
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr "그룹 안의 요소들은 그룹의 배경에 직접 적용됩니다"
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr "노멀"
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr "혼합 색상이 없는 유일한 상단 레이어."
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr "곱하기"
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
-msgstr "프로젝터에 슬라이드 두 개를 불러와 합친 결과를 보여주는 것과 비슷합니다."
+msgstr ""
+"프로젝터에 슬라이드 두 개를 불러와 합친 결과를 보여주는 것과 비슷합니다."
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr "스크린"
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
-msgstr "각각 다른 두 개의 슬라이드 프로젝터를 스크린 하나에 동시에 비추는 것과 같습니다. '곱하기'의 반대와 같습니다."
+msgstr ""
+"각각 다른 두 개의 슬라이드 프로젝터를 스크린 하나에 동시에 비추는 것과 같습니"
+"다. '곱하기'의 반대와 같습니다."
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr "오버레이"
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
-msgstr "배경의 하이라이트와 그림자를 보존한 상태로, 위쪽 레이어를 덮어씌웁니다. '하드 라이트'의 반대의 기능을 합니다."
+msgstr ""
+"배경의 하이라이트와 그림자를 보존한 상태로, 위쪽 레이어를 덮어씌웁니다. '하"
+"드 라이트'의 반대의 기능을 합니다."
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr "어둡게"
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr "위쪽 레이어가 배경보다 색이 어두운 곳에 사용됩니다."
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr "밝게"
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr "위쪽 레이어가 배경보다 밝은 곳에 사용됩니다."
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr "닷지"
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
-msgstr "위쪽 레이어를 이용해 배경을 밝게 합니다. 이 효과는 그림자의 대비를 높입니다."
+msgstr ""
+"위쪽 레이어를 이용해 배경을 밝게 합니다. 이 효과는 그림자의 대비를 높입니다."
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr "번"
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
-msgstr "위쪽 레이어를 사용해 배경을 어둡게 합니다. 과도하게 밝은 하이라이트를 줄입니다."
+msgstr ""
+"위쪽 레이어를 사용해 배경을 어둡게 합니다. 과도하게 밝은 하이라이트를 줄입니"
+"다."
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr "하드 라이트"
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr "배경에 강한 스포트라이트를 비추는 것과 비슷합니다."
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr "소프트 라이트"
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr "배경에 확산광 스포트라이트 (diffuse spotlight)를 비추는 것과 같습니다."
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr "차이"
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr "두 가지 라이터에서 어두운 색상을 뺍니다."
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr "제외"
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr "'차이'모드와 비슷하지만 그에 비해서는 더 낮습니다."
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr "색조"
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr "배경의 채도와 밝기를 맨 위 레이어의 색조와 결합합니다."
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr "채도"
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr "맨 위 레이어 색상의 채도를 배경의 색조와 밝기에 적용합니다."
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr "맨 위 레이어의 채도와 색조를 배경의 밝기에 적용합니다."
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr "밝기"
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr "맨 위 레이어의 밝기를 배경의 채도와 색조에 적용합니다."
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr "더하기"
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr "이 계층과 그 배경은 단순히 함께 추가됩니다."
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr "아래가 들어오게"
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr "레이어가 덮은 배경만을 사용합니다. 다른 모든 것은 무시됩니다."
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr "아래가 나가게"
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr "레이어가 덮지 않은 배경만을 사용합니다. 다른 모든 것은 무시됩니다."
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr "여기 위에다"
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
-msgstr "목적지가 겹쳐진 소스는 목적지를 바꿉니다. 목적지는 다른 곳으로 지정되었습니다."
+msgstr ""
+"목적지가 겹쳐진 소스는 목적지를 바꿉니다. 목적지는 다른 곳으로 지정되었습니"
+"다."
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr "아래 위에다"
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
-msgstr "소스가 겹쳐진 목적지는 소스를 바꿉니다. 소스는 다른 곳으로 지정되었습니다."
+msgstr ""
+"소스가 겹쳐진 목적지는 소스를 바꿉니다. 소스는 다른 곳으로 지정되었습니다."
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, fuzzy, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr "%(name)s %(number)d"
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
-msgstr "필수 내부 오브젝트 생성이 불가능합니다. 당신의 시스템이 작동을 실행하기에 필요한 충분한 메모리가 없습니다."
+msgstr ""
+"필수 내부 오브젝트 생성이 불가능합니다. 당신의 시스템이 작동을 실행하기에 필"
+"요한 충분한 메모리가 없습니다."
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2888,7 +3639,30 @@ msgstr ""
 "이유:{err}\n"
 "대상 폴더: “{dirname}”."
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+#, fuzzy
+msgid "Vertical"
+msgstr "수직으로 미러"
+
+#: ../lib/tiledsurface.py:49
+#, fuzzy
+msgid "Horizontal"
+msgstr "수평으로 미러"
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+#, fuzzy
+msgid "Rotational"
+msgstr "회전을 재설정"
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr "PNG 읽기 실패함: %s"
@@ -2897,55 +3671,93 @@ msgstr "PNG 읽기 실패함: %s"
 msgid "Recover interrupted work?"
 msgstr "중단된 작업을 복구합니까?"
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
-msgstr "_복구 및 저장..."
+msgid "_Look for backups at startup"
+msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
-msgid "Save this backup to disk, then continue working on it."
-msgstr "이 백업을 디스크에 저장합니다. 그 뒤 이 파일로 계속 작업할 수 있습니다."
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+#, fuzzy
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
-msgstr "_지금은 무시"
+msgid "_Delete…"
+msgstr "삭제"
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:9
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr "디스크에서 이 브러시를 삭제"
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr "_복구 및 저장..."
+
+#: ../po/tmp/autorecover.glade.h:12
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Recover button|"
+msgid "Save this backup to disk, then continue working on it."
+msgstr ""
+"이 백업을 디스크에 저장합니다. 그 뒤 이 파일로 계속 작업할 수 있습니다."
+
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
+msgctxt "Autosave Recovery dialog|"
+msgid "Decide _Later"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr "새로운 캔버스에서 작업을 시작합니다. 현재 백업은 유지됩니다."
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
+#, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
-"MYPanit가 저장되지 않은 작업으로 작동이 중단됬지만 백업 파일을 만들어 두었습니다. 당신은 파일을 당장 되살리거나, 적어도 당신이 "
-"다시 MYPaint를 킬 때까지 보관해 놓을수 있습니다."
+"MYPanit가 저장되지 않은 작업으로 작동이 중단됬지만 백업 파일을 만들어 두었습"
+"니다. 당신은 파일을 당장 되살리거나, 적어도 당신이 다시 MYPaint를 킬 때까지 "
+"보관해 놓을수 있습니다."
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr "썸네일"
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr "설명"
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
-msgstr "새로 복사"
+msgid "Live update"
+msgstr "실시간 업데이트"
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
-msgstr "새로운 브러시에 현재 설정과 현재의 브러시의 아이콘을 복사"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
+msgstr "실시간으로, 이 창의 설정으로 캔버스의 마지막 스트로크를 업데이트"
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
-msgstr "이 브러시의 이름을 바꿉니다"
+msgid "Save these settings to the brush"
+msgstr "브러시에 설정을 저장"
 
 #: ../po/tmp/brusheditor.glade.h:5
 msgid "Edit Icon"
@@ -2955,7 +3767,8 @@ msgstr "아이콘을 편집"
 msgid ""
 "Edit this brush's icon in a separate window (you will be able to use any "
 "brush to draw it)"
-msgstr "별도의 창에서 이 브러시의 아이콘을 편집 (어떤 브러시라도 편집에 사용 가능)"
+msgstr ""
+"별도의 창에서 이 브러시의 아이콘을 편집 (어떤 브러시라도 편집에 사용 가능)"
 
 #: ../po/tmp/brusheditor.glade.h:7
 msgid "Delete"
@@ -2966,18 +3779,16 @@ msgid "Delete this brush from the disk"
 msgstr "디스크에서 이 브러시를 삭제"
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
-msgstr "실시간 업데이트"
+msgid "Copy to New"
+msgstr "새로 복사"
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
-msgstr "실시간으로, 이 창의 설정으로 캔버스의 마지막 스트로크를 업데이트"
+msgid "Copy these settings and the current brush's icon to a new brush"
+msgstr "새로운 브러시에 현재 설정과 현재의 브러시의 아이콘을 복사"
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
-msgstr "브러시에 설정을 저장"
+msgid "Rename this brush"
+msgstr "이 브러시의 이름을 바꿉니다"
 
 #: ../po/tmp/brusheditor.glade.h:13
 msgid "Brush Setting"
@@ -3005,30 +3816,23 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr "참고:"
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr "설정 이름:"
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
-msgstr "이 브러시 설정의 시작 값입니다. 아래의 브러시 역학이 이에 따라 행동합니다."
+msgstr ""
+"이 브러시 설정의 시작 값입니다. 아래의 브러시 역학이 이에 따라 행동합니다."
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
-msgstr "기초 값 :"
+#: ../po/tmp/brusheditor.glade.h:22
+#, fuzzy
+msgid "Value:"
+msgstr "HSV 값"
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr "그것의 기본 값으로 기초 값을 재설정"
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr "설정에 영향을 미치지 않음 이 입력을 재설정"
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
@@ -3036,11 +3840,7 @@ msgstr ""
 "출력 축의 최소값입니다.\n"
 "{dname}의 메인 슬라이더를 사용하여 설정할 수 있습니다."
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr "<ymin>"
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
@@ -3048,27 +3848,23 @@ msgstr ""
 "출력 축의 최대값입니다.\n"
 "{dname}의 메인 슬라이더를 사용하여 설정할 수 있습니다."
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr "<ymax>"
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr "출력"
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr "입력"
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr "최대 값을 조절합니다"
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr "최소 값을 조절합니다"
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
@@ -3076,11 +3872,7 @@ msgstr ""
 "입력 축의 최소값입니다.\n"
 "팝업 스케일을 사용하여 이를 조절합니다."
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr "<xmin>"
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
@@ -3088,38 +3880,36 @@ msgstr ""
 "입력 축의 최대값입니다.\n"
 "팝업 스케일을 사용하여 이를 조절합니다."
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr "<xmax>"
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr "스타일러스 입력 및 기타 기준에 따른 베이스 값의 변화"
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr "브러쉬 역학"
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr "이 설정에 대한 기본 사항"
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr "편집 설정"
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr "세부 사항에서 이 입력 매핑을 조절하기"
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr "{tooltip}"
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
 msgstr "{dname}:"
+
+#: ../po/tmp/brusheditor.glade.h:42
+#, fuzzy
+msgid "Brush dynamics are not available for this setting."
+msgstr "이 설정에 대한 기본 사항"
+
+#: ../po/tmp/brusheditor.glade.h:43
+#, fuzzy
+msgid "<big><b>No Brush Dynamics</b></big>"
+msgstr "<big><b>{accel_label}</b></big>"
 
 #: ../po/tmp/inktool.glade.h:1
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
@@ -3131,7 +3921,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr "누르기:"
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3176,6 +3966,141 @@ msgstr "포인트를 삭제"
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
 msgstr "현재 선택된 포인트을 삭제"
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+#, fuzzy
+msgid "Insert Point"
+msgstr "가로줄 삽입"
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+#, fuzzy
+msgid "Cull Points"
+msgstr "포인트를 삭제"
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "이름"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr "모드"
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "불투명도"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr "현재 활성화 된 레이어 자르기 프레임"
+
+#: ../po/tmp/layervis.glade.h:2
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr "캔버스 뷰를 회전"
+
+#: ../po/tmp/layervis.glade.h:3
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr "캔버스 뷰를 회전"
+
+#: ../po/tmp/layervis.glade.h:4
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr "표시되는 레이어 중 채울 레이어"
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
+msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
 msgctxt "footer: color picker button: tooltip"
@@ -3314,8 +4239,8 @@ msgid ""
 "Here you can restrict pointing devices to specific tasks on the canvas, or "
 "have them ignored completely if they glitch your drawing."
 msgstr ""
-"여기서 당신은 마우스 포인터를 캔버스의 특정 지역만 사용가능하게 제한하거나 포인터가 드로잉에 작은 문제가 된다면 무시하게 만들 수 "
-"있습니다."
+"여기서 당신은 마우스 포인터를 캔버스의 특정 지역만 사용가능하게 제한하거나 포"
+"인터가 드로잉에 작은 문제가 된다면 무시하게 만들 수 있습니다."
 
 #: ../po/tmp/preferenceswindow.glade.h:29
 msgctxt "Prefs Dialog|Button|"
@@ -3397,12 +4322,14 @@ msgid ""
 "monitors. If you know your display is radically different from this, use the "
 "\"no automatic conversions or tagging\" setting instead."
 msgstr ""
-"<i>전체</i> 색상 공간 정보가 포함된 이미지를 MyPaint에 불러올 때 이미지의 색상 공간을 sRGB로 변환합니다. "
-"MyPaint가 이미지를 저장하면 다른 프로그램이 올바르게 렌더링 할 수 있도록 힌트를 이미지에 추가합니다.\n"
+"<i>전체</i> 색상 공간 정보가 포함된 이미지를 MyPaint에 불러올 때 이미지의 색"
+"상 공간을 sRGB로 변환합니다. MyPaint가 이미지를 저장하면 다른 프로그램이 올바"
+"르게 렌더링 할 수 있도록 힌트를 이미지에 추가합니다.\n"
 "\n"
-"MyPaint에서는 디스플레이가 웹의 표준 색 공간 인 sRGB에 가까운 색상 공간으로 보정되고 대부분의 사용자 PC 모니터가 비관 "
-"근사치로 사용된다고 가정하고 있기 때문입니다. 사용하는 디스플레이가 이와 완전히 다른 경우 \"자동 전환 또는 태그 없음\" 설정을 대신 "
-"사용하십시오."
+"MyPaint에서는 디스플레이가 웹의 표준 색 공간 인 sRGB에 가까운 색상 공간으로 "
+"보정되고 대부분의 사용자 PC 모니터가 비관 근사치로 사용된다고 가정하고 있기 "
+"때문입니다. 사용하는 디스플레이가 이와 완전히 다른 경우 \"자동 전환 또는 태"
+"그 없음\" 설정을 대신 사용하십시오."
 
 #: ../po/tmp/preferenceswindow.glade.h:47
 msgctxt "Prefs Dialog|Load & Save|Color Management|"
@@ -3418,9 +4345,11 @@ msgid ""
 "This is MyPaint's old behaviour, and can be used as a stopgap for non-sRGB "
 "working."
 msgstr ""
-"불러올 때 색상 변환이 수행되지 않으며 컬러 메니지먼트 정보 없이 파일이 저장됩니다.\n"
+"불러올 때 색상 변환이 수행되지 않으며 컬러 메니지먼트 정보 없이 파일이 저장됩"
+"니다.\n"
 "\n"
-"이것은 MyPaint의 오래된 방식이며, 비 sRGB 작업에 대한 임시방편으로 사용될 수 있습니다."
+"이것은 MyPaint의 오래된 방식이며, 비 sRGB 작업에 대한 임시방편으로 사용될 수 "
+"있습니다."
 
 #: ../po/tmp/preferenceswindow.glade.h:51
 msgctxt "Prefs Dialog|Load & Save|"
@@ -3446,8 +4375,8 @@ msgid ""
 "the program crashes, you'll have a chance to restore what you were working "
 "on."
 msgstr ""
-"백그라운드에서 MyPaint의 디스크 캐시에 작업을 순차적으로 백업합니다. 만약 프로그램이 충돌할 경우, 현재 작업하고 있는 작업물을 재 "
-"저장할 수 있게 됩니다."
+"백그라운드에서 MyPaint의 디스크 캐시에 작업을 순차적으로 백업합니다. 만약 프"
+"로그램이 충돌할 경우, 현재 작업하고 있는 작업물을 재 저장할 수 있게 됩니다."
 
 #: ../po/tmp/preferenceswindow.glade.h:56
 msgctxt "Prefs Dialog|Load & Save|Automated Backups|interval label"
@@ -3500,8 +4429,8 @@ msgid ""
 "Use a light-on-dark theme variant, when it's supported by the GTK theme. "
 "This is generally sensible for image editors and media viewers."
 msgstr ""
-"GTK 테마가 지원할 때 light-on-dark 테마 변형을 사용하십시오. 이 작업은 일반적으로 이미지 편집자와 미디어 뷰어에게 "
-"추천합니다."
+"GTK 테마가 지원할 때 light-on-dark 테마 변형을 사용하십시오. 이 작업은 일반적"
+"으로 이미지 편집자와 미디어 뷰어에게 추천합니다."
 
 #: ../po/tmp/preferenceswindow.glade.h:67
 msgid "Some of these settings require MyPaint to be restarted."
@@ -3560,24 +4489,48 @@ msgid ""
 "Scrolling to pan the view needs this setting to be turned on, and for your "
 "device to be configured to send bidirectional scroll events."
 msgstr ""
-"부드러운 스크롤 지원으로 일부 장치의 스크롤 제스처 및 스크롤 휠 이벤트를 단계적으로 처리하지 않고 부드럽게 만듭니다. 터치 패드 사용할 "
-"경우 추천하지만 마우스 스크롤에 익숙한 경우 추천하지 않습니다.\n"
+"부드러운 스크롤 지원으로 일부 장치의 스크롤 제스처 및 스크롤 휠 이벤트를 단계"
+"적으로 처리하지 않고 부드럽게 만듭니다. 터치 패드 사용할 경우 추천하지만 마우"
+"스 스크롤에 익숙한 경우 추천하지 않습니다.\n"
 "\n"
-"부드러운 스크롤이 사용되는 경우 스크롤하는 동안 Shift 키를 누른 상태에서 단계적 스크롤을 잠시 다시 켤 수 있습니다.\n"
+"부드러운 스크롤이 사용되는 경우 스크롤하는 동안 Shift 키를 누른 상태에서 단계"
+"적 스크롤을 잠시 다시 켤 수 있습니다.\n"
 "\n"
-"화면 이동을 위해 스크롤하려면 이 설정이 켜져 있어야하고 장치가 양방향 스크롤 이벤트를 보내도록 구성되어 있어야합니다."
+"화면 이동을 위해 스크롤하려면 이 설정이 켜져 있어야하고 장치가 양방향 스크롤 "
+"이벤트를 보내도록 구성되어 있어야합니다."
 
 #: ../po/tmp/preferenceswindow.glade.h:81
 msgid "Hide cursor while painting"
 msgstr "페인팅 동안 커서 숨기기"
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+#, fuzzy
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr "사용"
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr "보기"
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
@@ -3586,60 +4539,66 @@ msgstr ""
 "디스크 스타일 색상환에 기본 색상으로 표시할 색상 설정입니다.\n"
 "다른 전통은 다른 색상 조화를 가지고 있습니다."
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr "원색:"
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr "표준 디지털 레드/그린/ 블루"
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
-msgstr "레드, 그린 및 블루 &apos;컴퓨터 모니터&apos;기본, 원 주위에 균일하게 배열되어있다. 그린은 마젠타 반대입니다."
+msgstr ""
+"레드, 그린 및 블루 &apos;컴퓨터 모니터&apos;기본, 원 주위에 균일하게 배열되어"
+"있다. 그린은 마젠타 반대입니다."
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
-msgstr "레드, 그린 및 블루 '컴퓨터 모니터' 원색이 원 주위에 고르게 배열되어 있습니다. 그린은 마젠타의 보색입니다."
+msgstr ""
+"레드, 그린 및 블루 '컴퓨터 모니터' 원색이 원 주위에 고르게 배열되어 있습니"
+"다. 그린은 마젠타의 보색입니다."
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr "전통적인 작가 레드/옐로우/블루"
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
-"18세기 이후 많은 예술가들이 사용했던 전통적인 배치로 레드/옐로/블루 휠은 원 주위에 균등하게 배열된 순수한 표시 색상으로 근사됩니다. "
-"그린은 레드의 보색입니다."
+"18세기 이후 많은 예술가들이 사용했던 전통적인 배치로 레드/옐로/블루 휠은 원 "
+"주위에 균등하게 배열된 순수한 표시 색상으로 근사됩니다. 그린은 레드의 보색입"
+"니다."
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
-"18세기 이후 많은 예술가들이 사용했던 전통적인 배치로 레드/옐로/블루 휠은 원 주위에 균등하게 배열된 순수한 표시 색상으로 근사됩니다. "
-"그린은 레드의 보색입니다."
+"18세기 이후 많은 예술가들이 사용했던 전통적인 배치로 레드/옐로/블루 휠은 원 "
+"주위에 균등하게 배열된 순수한 표시 색상으로 근사됩니다. 그린은 레드의 보색입"
+"니다."
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr "레드-그린 및 블루-엘로우 상대 쌍"
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3648,7 +4607,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3659,28 +4618,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr "<b>컬러 원형</b>"
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr "색상"
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr "스크린 (노멀)"
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr "장애 (어떤 압력 감도 없음)"
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr "창 (권장하지 않음)"
@@ -3741,1832 +4700,2246 @@ msgid "Reload the file your current work was loaded from."
 msgstr "현재 작업이 불러와진 파일을 다시 불러옵니다."
 
 #: ../po/tmp/resources.xml.h:12
+#, fuzzy
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Import Layers…"
+msgstr "브러시 가져오기…"
+
+#: ../po/tmp/resources.xml.h:13
+msgctxt "Accel Editor (descriptions)"
+msgid "Import layers from one or more files."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save"
 msgstr "저장하기"
 
-#: ../po/tmp/resources.xml.h:13
+#: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file."
 msgstr "파일로 작업 내용을 저장합니다."
 
-#: ../po/tmp/resources.xml.h:14
+#: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As…"
 msgstr "다른 이름으로 저장…"
 
-#: ../po/tmp/resources.xml.h:15
+#: ../po/tmp/resources.xml.h:17
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file, assigning it a new name."
 msgstr "파일을 새 이름으로 저장합니다."
 
-#: ../po/tmp/resources.xml.h:16
+#: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Export…"
 msgstr "내보내기…"
 
-#: ../po/tmp/resources.xml.h:17
+#: ../po/tmp/resources.xml.h:19
 msgid "Export your work to a file, but keep working on the same file."
-msgstr "작업을 파일로 내보내지만 사용자는 동일한 파일에서 계속 작업을 진행합니다."
+msgstr ""
+"작업을 파일로 내보내지만 사용자는 동일한 파일에서 계속 작업을 진행합니다."
 
-#: ../po/tmp/resources.xml.h:18
+#: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As Scrap"
 msgstr "다른 스크랩으로 저장"
 
-#: ../po/tmp/resources.xml.h:19
+#: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
 msgid "Save to a new scrap file, or save a new revision if already a scrap."
-msgstr "새로운 스크랩 파일에 저장하거나 이미 스크랩이 존재하는 경우 변화된 새로운 파일을 저장합니다."
+msgstr ""
+"새로운 스크랩 파일에 저장하거나 이미 스크랩이 존재하는 경우 변화된 새로운 파"
+"일을 저장합니다."
 
-#: ../po/tmp/resources.xml.h:20
+#: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Previous Scrap"
 msgstr "이전 스크랩을 열기"
 
-#: ../po/tmp/resources.xml.h:21
+#: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file before the current one."
 msgstr "현재 이전 스크랩 파일을 불러옵니다."
 
-#: ../po/tmp/resources.xml.h:22
+#: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Next Scrap"
 msgstr "다음 스크랩을 열기"
 
-#: ../po/tmp/resources.xml.h:23
+#: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file after the current one."
 msgstr "현재 이후 스크랩 파일을 불러옵니다."
 
-#: ../po/tmp/resources.xml.h:24
+#: ../po/tmp/resources.xml.h:26
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Recover File from an Automated Backup…"
 msgstr "자동 백업파일에서 파일 복구를 진행합니다…"
 
-#: ../po/tmp/resources.xml.h:25
+#: ../po/tmp/resources.xml.h:27
 msgctxt "Accel Editor (descriptions)"
 msgid "Try to save and resume interrupted unsaved work."
 msgstr "저장되지 않는 작업을 중단하고 다시 저장을 진행하세요."
 
-#: ../po/tmp/resources.xml.h:26
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr "브러시 그룹"
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr "브러시"
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr "브러시 그룹의 목록."
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr "색상 조절기"
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr "색상"
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr "사용 가능한 색상 조절기."
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr "모드"
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr "모드"
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr "현재 레이어의 합성 모드."
 
-#: ../po/tmp/resources.xml.h:35
+#: ../po/tmp/resources.xml.h:37
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Pressure"
+msgstr "입구 압력"
+
+#: ../po/tmp/resources.xml.h:38
+msgctxt "Accel Editor (descriptions)"
+msgid "Send harder pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:39
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Pressure"
+msgstr "입구 압력"
+
+#: ../po/tmp/resources.xml.h:40
+msgctxt "Accel Editor (descriptions)"
+msgid "Send softer pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:41
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Rotation"
+msgstr "채도를 증가"
+
+#: ../po/tmp/resources.xml.h:42
+msgctxt "Accel Editor (descriptions)"
+msgid "Increase barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:43
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
+msgstr "채도 감소"
+
+#: ../po/tmp/resources.xml.h:44
+msgctxt "Accel Editor (descriptions)"
+msgid "Decrease barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:45
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Size"
 msgstr "브러시 크기를 증가"
 
-#: ../po/tmp/resources.xml.h:36
+#: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush bigger."
 msgstr "작업 브러시가 더 커집니다."
 
-#: ../po/tmp/resources.xml.h:37
+#: ../po/tmp/resources.xml.h:47
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Size"
 msgstr "브러시 크기를 감소"
 
-#: ../po/tmp/resources.xml.h:38
+#: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush smaller."
 msgstr "작업 브러시가 더 작아집니다."
 
-#: ../po/tmp/resources.xml.h:39
+#: ../po/tmp/resources.xml.h:49
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Opacity"
 msgstr "브러시 불투명도를 증가"
 
-#: ../po/tmp/resources.xml.h:40
+#: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush more opaque."
 msgstr "작업 브러시가 더 불투명해집니다."
 
-#: ../po/tmp/resources.xml.h:41
+#: ../po/tmp/resources.xml.h:51
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Opacity"
 msgstr "브러시 불투명도를 감소"
 
-#: ../po/tmp/resources.xml.h:42
+#: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush less opaque."
 msgstr "작업 브러시가 더 투명해집니다."
 
-#: ../po/tmp/resources.xml.h:43
+#: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Lighten Painting Color"
 msgstr "페인팅 색상을 밝게"
 
-#: ../po/tmp/resources.xml.h:44
+#: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase the lightness of the current painting color."
 msgstr "현재 페인팅 색상의 밝기를 증가 시킵니다."
 
-#: ../po/tmp/resources.xml.h:45
+#: ../po/tmp/resources.xml.h:55
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Darken Painting Color"
 msgstr "페인팅 색상을 어둠게"
 
-#: ../po/tmp/resources.xml.h:46
+#: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease the lightness of the current painting color."
 msgstr "현재 페인팅 색상의 밝기를 감소 시킵니다."
 
-#: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
-msgstr "색조을 반 시계 방향으로 변경"
-
-#: ../po/tmp/resources.xml.h:48
-msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
-msgstr "페인팅 색상의 색조를 색상 원형의 시계 반대 방향으로 돌립니다."
-
-#: ../po/tmp/resources.xml.h:49
+#: ../po/tmp/resources.xml.h:57
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Change Hue Clockwise"
 msgstr "색조을 시계 방향으로 변경"
 
-#: ../po/tmp/resources.xml.h:50
+#: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
 msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr "페인팅 색상의 색조를 색상 원형의 시계 방향으로 돌립니다."
 
-#: ../po/tmp/resources.xml.h:51
+#: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr "색조을 반 시계 방향으로 변경"
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr "페인팅 색상의 색조를 색상 원형의 시계 반대 방향으로 돌립니다."
+
+#: ../po/tmp/resources.xml.h:61
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Increase Saturation"
 msgstr "채도를 증가"
 
-#: ../po/tmp/resources.xml.h:52
+#: ../po/tmp/resources.xml.h:62
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color more saturated (more colorful, purer)."
 msgstr "패인팅 색상 체도를 증가(더 화려한, 순수한) 시킵니다."
 
-#: ../po/tmp/resources.xml.h:53
+#: ../po/tmp/resources.xml.h:63
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Decrease Saturation"
 msgstr "채도 감소"
 
-#: ../po/tmp/resources.xml.h:54
+#: ../po/tmp/resources.xml.h:64
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color less saturated (grayer)."
 msgstr "패인팅 색상 체도를 감소(회색) 시킵니다."
 
-#: ../po/tmp/resources.xml.h:55
+#: ../po/tmp/resources.xml.h:65
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Reload Brush Settings"
 msgstr "브러쉬 설정을 다시 불러오기"
 
-#: ../po/tmp/resources.xml.h:56
+#: ../po/tmp/resources.xml.h:66
 msgctxt "Accel Editor (descriptions)"
 msgid "Restore all brush settings to the current brush’s saved values."
 msgstr "현재 브러시의 저장 값으로 모든 브러시 설정을 복원합니다."
 
-#: ../po/tmp/resources.xml.h:57
+#: ../po/tmp/resources.xml.h:67
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Pick Stroke and Layer"
 msgstr "선및 및 레이어를 선택"
 
-#: ../po/tmp/resources.xml.h:58
+#: ../po/tmp/resources.xml.h:68
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
 msgstr "캔버스에서 브러시 스트로크 선택: 브러시, 색상과 레이어를 복원합니다."
 
-#: ../po/tmp/resources.xml.h:59
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr "브러쉬  단축 키 색상을 복원"
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
-msgstr "바로 가기 키에서 브러시를 복원해도 저장된 색상이 복원되는지 여부를 토글합니다."
+msgstr ""
+"바로 가기 키에서 브러시를 복원해도 저장된 색상이 복원되는지 여부를 토글합니"
+"다."
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr "가장 최근 단축 키에 브러시를 저장"
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr "가장 최근에 사용되는 단축 키에 브러시 설정을 저장합니다."
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "레이어 지우기"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr "현재 레이어의 내용을 지웁니다."
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+#, fuzzy
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr "도구 옵션"
+
+#: ../po/tmp/resources.xml.h:76
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr "레이어를 프레임으로 다듬기"
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr "현재 레이어에서 프레임 외부의 일부 내용을 지웁니다."
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr "현재 레이어에서 프레임 외부의 일부 내용을 지웁니다."
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "아래에 새 레이어 그룹"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "아래에 새 레이어 그룹"
+
+#: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr "레이어를 클립보드에 복사"
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr "현재 레이어의 내용을 클립보드에 복사합니다."
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr "레이어를 클립보드에서 붙여넣기"
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr "현재 레이어를 클립 보드의 내용으로 대체합니다."
 
-#: ../po/tmp/resources.xml.h:71
+#: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Edit Layer in External App…"
 msgstr "레이어를 외부 응용 프로그램에서 편집…"
 
-#: ../po/tmp/resources.xml.h:72
+#: ../po/tmp/resources.xml.h:90
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
+msgid "Edit the active layer in an external application."
 msgstr "현재 레이어를 외부 응용 프로그램으로 편집합니다."
 
-#: ../po/tmp/resources.xml.h:73
+#: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Update Layer with External Edits"
 msgstr "외부 편집한 레이어를 업데이트"
 
-#: ../po/tmp/resources.xml.h:74
+#: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
 msgid "Commit changes saved from the external app (normally automatic)."
-msgstr "외부 응용 프로그램(일반적으로 자동)에서 저장 한 변경 사항을 반영합니다."
+msgstr ""
+"외부 응용 프로그램(일반적으로 자동)에서 저장 한 변경 사항을 반영합니다."
 
-#: ../po/tmp/resources.xml.h:75
+#: ../po/tmp/resources.xml.h:93
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer at Cursor"
 msgstr "커서에서 레이어로 이동"
 
-#: ../po/tmp/resources.xml.h:76
+#: ../po/tmp/resources.xml.h:94
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr "개체 선택에 의해 레이어를 선택합니다."
 
-#: ../po/tmp/resources.xml.h:77
+#: ../po/tmp/resources.xml.h:95
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Above"
 msgstr "레이어 위로 이동"
 
-#: ../po/tmp/resources.xml.h:78
+#: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer up in the layer stack."
 msgstr "레이어 스택에서 한 레이어 위로 이동합니다."
 
-#: ../po/tmp/resources.xml.h:79
+#: ../po/tmp/resources.xml.h:97
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Below"
 msgstr "레이어 아래로 이동"
 
-#: ../po/tmp/resources.xml.h:80
+#: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer down in the layer stack."
 msgstr "레이어 스택에서 한 레이어 아래로 이동합니다."
 
-#: ../po/tmp/resources.xml.h:81
+#: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer"
 msgstr "새로운 페인트 레이어"
 
-#: ../po/tmp/resources.xml.h:82
+#: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer above the current layer."
 msgstr "현재 레이어 위에 새 페인팅 레이어를 추가합니다."
 
-#: ../po/tmp/resources.xml.h:83
+#: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer…"
 msgstr "새로운 벡터 레이어…"
 
-#: ../po/tmp/resources.xml.h:84
+#: ../po/tmp/resources.xml.h:102
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer above the current layer, and begin editing it."
 msgstr "현재 레이어 위에 새로운 벡터 레이어를 추가하고 편집을 시작합니다."
 
-#: ../po/tmp/resources.xml.h:85
+#: ../po/tmp/resources.xml.h:103
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group"
 msgstr "새로운 레이어 그룹"
 
-#: ../po/tmp/resources.xml.h:86
+#: ../po/tmp/resources.xml.h:104
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group above the current layer."
 msgstr "현재 레이어 위에 새로운 레이어 그룹을 추가합니다."
 
-#: ../po/tmp/resources.xml.h:87
+#: ../po/tmp/resources.xml.h:105
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer Below"
 msgstr "아래에 새로운 페인트 레이어"
 
-#: ../po/tmp/resources.xml.h:88
+#: ../po/tmp/resources.xml.h:106
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer below the current layer."
 msgstr "현재 레이어 아래에 새로운 페인팅 레이어를 추가합니다."
 
-#: ../po/tmp/resources.xml.h:89
+#: ../po/tmp/resources.xml.h:107
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer Below…"
 msgstr "아래에 새로운 레이어 그룹…"
 
-#: ../po/tmp/resources.xml.h:90
+#: ../po/tmp/resources.xml.h:108
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer below the current layer, and begin editing it."
 msgstr "현재 레이어 아래에 새 벡터 레이어를 추가하고 편집을 시작합니다."
 
-#: ../po/tmp/resources.xml.h:91
+#: ../po/tmp/resources.xml.h:109
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group Below"
 msgstr "아래에 새 레이어 그룹"
 
-#: ../po/tmp/resources.xml.h:92
+#: ../po/tmp/resources.xml.h:110
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group below the current layer."
 msgstr "현재 레이어 아래에 새 레이어 그룹을 추가합니다."
 
-#: ../po/tmp/resources.xml.h:93
+#: ../po/tmp/resources.xml.h:111
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Layer Down"
 msgstr "아래에 레이어를 병합"
 
-#: ../po/tmp/resources.xml.h:94
+#: ../po/tmp/resources.xml.h:112
 msgctxt "Accel Editor (descriptions)"
 msgid "Merge the current layer with the layer beneath it."
 msgstr "아래의 레이어와 현재 레이어를 병합합니다."
 
-#: ../po/tmp/resources.xml.h:95
+#: ../po/tmp/resources.xml.h:113
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Visible Layers"
 msgstr "보이는 레이어를 병합"
 
-#: ../po/tmp/resources.xml.h:96
+#: ../po/tmp/resources.xml.h:114
 msgctxt "Accel Editor (descriptions)"
 msgid "Consolidate all visible layers, and delete the originals."
 msgstr "보이는 모든 레이어를 통합하고, 원본을 삭제합니다."
 
-#: ../po/tmp/resources.xml.h:97
+#: ../po/tmp/resources.xml.h:115
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer from Visible"
 msgstr "표시 상태에서 새 레이어"
 
-#: ../po/tmp/resources.xml.h:98
+#: ../po/tmp/resources.xml.h:116
 msgctxt "Accel Editor (descriptions)"
 msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
 msgstr "'보이는 레이어 병합'과 비슷하지만, 원본을 삭제하지 않습니다."
 
-#: ../po/tmp/resources.xml.h:99
+#: ../po/tmp/resources.xml.h:117
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Delete Layer"
 msgstr "레이어를 삭제"
 
-#: ../po/tmp/resources.xml.h:100
+#: ../po/tmp/resources.xml.h:118
 msgctxt "Accel Editor (descriptions)"
 msgid "Remove the current layer from the layer stack."
 msgstr "레이어 스택에서 현재 레이어를 제거합니다."
 
-#: ../po/tmp/resources.xml.h:101
+#: ../po/tmp/resources.xml.h:119
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Convert to Normal Painting Layer"
 msgstr "일반 페인팅 레이어로 변환"
 
-#: ../po/tmp/resources.xml.h:102
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
-msgstr "현재의 모습은 유치하면서 현재의 레이어 또는 그룹을 '노멀'모드의 페인팅 레이어로 변환합니다."
+msgstr ""
+"현재의 모습은 유치하면서 현재의 레이어 또는 그룹을 '노멀'모드의 페인팅 레이어"
+"로 변환합니다."
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr "레이어의 불투명도를 증가"
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr "레이어를 불투명하게 만듭니다."
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr "레이어의 불투명도를 감소"
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr "레이어를 투명하게 만듭니다."
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr "레이어를 올리기"
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr "레이어 스택의 현재 레이어 한 단계 올립니다."
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr "레이어를 내리기"
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr "레이어 스택의 현재 레이어 한 단계 내립니다."
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr "레이어를 복제"
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr "현재 레이어의 정확한 복제를 만듭니다."
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
+#, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
-msgstr "레이어 이름 바꾸기…"
+msgid "Layer Properties…"
+msgstr "속성"
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
-msgstr "현재 레이어의 새 이름을 입력합니다."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr "잠긴 레이어"
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
-msgstr "현재 레이어의 잠금 상태를 토글합니다. 잠긴 레이어는 수정할 수 없습니다."
+msgstr ""
+"현재 레이어의 잠금 상태를 토글합니다. 잠긴 레이어는 수정할 수 없습니다."
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr "레이어 보이기"
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr "현재 레이어의 가시성 상태를 전환합니다."
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr "배경을 표시"
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr "배경 레이어의 가시성을 전환합니다."
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr "레이어 스택에서 현재 레이어를 제거합니다."
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr "재설정 및 중앙을 보기"
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr "확대/축소, 회전 및 미러링을 재설정하고 문서를 가운데로 설정합니다."
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr "보기에 맞춤"
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr "재설정"
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr "줌 재설정"
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr "기본으로 뷰의 줌을 복원합니다."
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr "회전을 재설정"
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr "0°로  뷰의 회전을 복원"
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr "미러링을 재설정"
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
-msgstr "뷰의 미러링을 끕니다."
+msgid "Reset the view's mirroring."
+msgstr "미러링을 재설정"
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr "줌 확대"
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr "배율을 높입니다."
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "줌 축소"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr "배율을 줄입니다."
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
+#, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
-msgstr "반 시계 방향으로 회전"
+msgid "Pan Left"
+msgstr "보기를 화면 이동"
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
-msgstr "보기를 반 시계방향으로 돌립니다."
+msgid "Move your view of the canvas to the left."
+msgstr "보기를 회전 : 캔버스의 보기를 회전합니다."
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr "하드 라이트"
+
+#: ../po/tmp/resources.xml.h:159
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr "화면 이동: 수평 또는 수직으로 캔버스의 보기를 이동합니다."
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr "보기를 회전 : 캔버스의 보기를 회전합니다."
+
+#: ../po/tmp/resources.xml.h:162
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr "보기를 화면 이동"
+
+#: ../po/tmp/resources.xml.h:163
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr "보기를 회전 : 캔버스의 보기를 회전합니다."
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr "시계 방향으로 회전"
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr "보기를 시계 방향으로 돌립니다."
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr "반 시계 방향으로 회전"
+
+#: ../po/tmp/resources.xml.h:167
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr "보기를 반 시계방향으로 돌립니다."
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr "수평으로 미러"
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr "보기를 좌우로 뒤집습니다."
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr "수직으로 미러"
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr "보기를 위아래로 뒤집습니다."
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr "레이어 단독"
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr "표시된 현재 레이어만 전환합니다."
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr "대칭 페인팅 활성"
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr "대칭 축을 따라 브러쉬 스트로크를 미러합니다"
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr "프레임 사용"
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr "문서 프레임의 가시성을 전환."
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr "콘솔에 브러시 입력 값을 출력"
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr "콘솔에 브러시 엔진의 내부 생성 입력을 표시합니다."
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr "렌더링을 시각화"
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr "디버깅을 위해, 화면에 렌더링 업데이트를 표시합니다."
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr "이중 버퍼링이 없음"
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr "일반적으로 활성화된 GTK의 이중 버퍼링을 끕니다."
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+#, fuzzy
+msgid "Delete Point"
+msgstr "포인트를 삭제"
+
+#: ../po/tmp/resources.xml.h:187
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr "현재 선택된 포인트을 삭제"
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr "페인트 모드"
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr "페인트 모드: 노멀"
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr "페인팅 시 일반적인 색상을 적용합니다."
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr "페인트 모드: 지우개"
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr "현재의 브러시를 지우개로 사용합니다."
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr "페인트 모드: 알파 잠금"
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr "브러시를 적용하면 레이어의 불투명도가 변경되지 않습니다."
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr "페인트 모드: 색상화"
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr "밝기 또는 불투명도에 영향을 주지 않고 현재 레이어에 색상을 적용합니다."
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "파일"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "종료"
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr "메인 창을 닫고 응용 프로그램을 종료합니다."
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "편집"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr "현재 도구"
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "색상"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr "색상 조절"
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr "색상 기록 팝업"
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr "커서 아래에 최근 색상의 타임라인을 팝업합니다."
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr "색상 정보 대화 상자"
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr "자세한 색상 정보 대화 상자를 표시합니다."
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr "다음 팔레트 색상"
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr "팔레트에서 다음 색상으로 페인팅 색상을 설정."
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr "이전 팔레트 색상"
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr "팔레트에서 이전 색상으로 페인팅 색상을 설정."
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr "팔레트에 색상 추가"
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr "팔레트에 현재의 페인팅 색상을 추가합니다."
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "레이어"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr "불투명도"
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr "레이어로 이동"
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr "아래에 새로운 레이어"
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr "속성"
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr "스크래치 패드"
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr "새로운 스크래치 패드"
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr "새로운 스크래치 패드로 캔버스와 같은 기본 스크래치 패드를 불러옵니다."
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr "스크래치 패드 열기…"
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr "스크래치 패드로 디스크의 이미지 파일을 불러옵니다."
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr "스크래치 패드 저장"
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr "디스크에 있는 기존 파일에 스크래치 패드를 저장합니다."
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr "다른 스크래치 패드로 내보내기…"
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr "원하는 파일 이름으로 디스크에 스크래치 패드를 내보냅니다."
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr "스크래치 패드 되돌리기"
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr "마지막으로 저장된 상태로 스크래치 패드로 되돌립니다."
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr "기본 값으로 스크래치 패드 저장"
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr "'새로운 스크래치 패드'에 대한 기본 값으로 스크래치 패드를 저장합니다."
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr "기본 스크래치 패드 지우기"
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr "빈 캔버스를 기본 스크래치 패드로 만듭니다."
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr "스크래치 패드에 메인 배경 복사"
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr "스크래치 패드로 작업 문서의 배경 이미지를 복사합니다."
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "창"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "브러시"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr "단축 키"
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr "브러시 단축 키 도움말"
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr "단축 키 작동 방법에 대한 설명을 표시합니다."
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "브러시를 변경…"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr "커서 아래에 브러시 변경을 팝업합니다."
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "색상을 변경…"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr "나열된 모든 색상 선택기로 커서 아래에 색상 변경기를 팝업합니다."
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "색상을 변경 (빠른 하위설정)…"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr "나열된 단일 클릭 선택기로 커서 아래에 색상 변경기를 팝업합니다."
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr "더 많은 브러쉬를 가져오기…"
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr "MyPaint 위키에서 브러시 팩을 다운로드하십시오."
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr "브러시 가져오기…"
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr "디스크에서 브러시팩를 불러옵니다."
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "도움말"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr "온라인 도움말"
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr "MyPaint의 위키 문서로 이동합니다."
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "MyPaint 정보"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr "MyPaint의 라이선스, 버전 번호 및 제작자를 표시합니다."
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "디버그"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr "콘솔에 메모리 누수 정보 출력 (느림!)"
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr "디버그 메모리 누수."
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr "지금 가비지 수집기를 실행"
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr "더 이상 사용하지 않는 Python 객체에 사용되는 사용 가능한 메모리."
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr "프로파일링을 시작/정지…"
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr "파이썬 프로파일링을 시작 또는 중지 (cProfile)"
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr "충돌을 시뮬레이션…"
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr "크래시 대화 상자를 테스트하기 위해 Python 예외를 발생시킵니다."
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "보기"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr "피드백"
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr "보기 조절"
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
+#, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr "팝업 메뉴"
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr "메인 메뉴를 팝업으로 표시합니다."
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "전체 화면"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr "전체 화면과 창 모드 사이를 전환."
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "환경 설정을 편집"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr "MyPaint의 전역 설정을 편집합니다."
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr "입력 장치를 테스트"
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr "입력 장치가 전송하는 모든 이벤트를 캡처하는 대화 상자를 표시합니다."
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr "배경 선택기"
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr "배경 종이 질감을 변경합니다."
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr "브러쉬 설정 편집기"
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr "활성 브러시의 설정을 편집합니다."
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr "브러시 아이콘 편집기"
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr "브러시 아이콘을 편집합니다."
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr "레이어 패널"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
-msgstr "레이어 고정 표시기 전환 (레이어 배치, 또는 모드 할당)."
+msgid "Dockable panel for managing layers."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr "레이어 패널을 보기"
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr "레이어 고정 표시기 보이기 (레이어 배치, 또는 모드 할당)."
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr "HCY 원형"
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
-msgstr "고정 가능한 원통형 색조/크로마/루마 색상 선택기. 원형 조각은 동일합니다."
+msgstr ""
+"고정 가능한 원통형 색조/크로마/루마 색상 선택기. 원형 조각은 동일합니다."
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "색상 팔레트"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr "고정 가능한 팔레트 색상 선택기."
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr "HSV 원형"
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr "고정 가능한 채도 및 값 컬러 체인저."
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr "HSV 삼각형"
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr "고정 가능한 색상 선택: 이전 GTK 색상 삼각형."
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr "HSV 큐브"
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
-msgstr "고정 가능한 색상 선택기: 다른 평면 조각을 보여주기 위해 회전 하는 HSV 큐브."
+msgstr ""
+"고정 가능한 색상 선택기: 다른 평면 조각을 보여주기 위해 회전 하는 HSV 큐브."
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr "HSV 사각형"
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
-msgstr "고정 가능한 색상 선택기: 다른 평면 조각을 보여주기 위해 회전 하는 HSV 사각형."
+msgid "Dockable color selector: HSV square with Hue ring."
+msgstr "동심 HSV 링이있는 고정 가능한 색상 선택기."
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr "구성 요소 슬라이더"
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr "색상의 개별 구성 요소를 나타내는 고정 가능한 색상 선택기."
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr "액체 담채"
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr "액체 처럼 씻은 인근 색상을 보여주는 고정 가능한 색상 선택기."
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr "동심 링"
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr "동심 HSV 링이있는 고정 가능한 색상 선택기."
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr "교차 그릇"
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
-msgstr "방사형 색상 그릇을 가로 지르는 HSV 램프가 있는 고정 가능한 색상 선택기."
+msgstr ""
+"방사형 색상 그릇을 가로 지르는 HSV 램프가 있는 고정 가능한 색상 선택기."
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr "스크래치 패드 패널"
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
-msgstr "스크래치 패드 독패널을 전환 (색상을 혼합하고 스케치를 만들기)."
+msgid "Dockable Panel for mixing colors and testing brushes."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr "스크래치 패드 패널을 보기"
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr "스크래치 패드 독패널을 보이기 (색상을 혼합하고 스케치를 만들기)."
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr "미리보기 패널"
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
-msgstr "미리보기 독패널을 전환 (그리기 전체 캔퍼스 영역의 개요)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "미리보기"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr "미리보기 독패널을 보이기 (그리기 전체 캔퍼스 영역의 개요)."
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr "도구 옵션 패널"
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
-msgstr "도구 옵션 독패널을 전환 (현재 도구에 대한 옵션)."
+msgid "Dockable panel for adjusting the options with the activated tool."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr "도구 옵션 패널을 보기"
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr "도구 옵션 독패널을 보이기 (현재 도구에 대한 옵션)."
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr "브러시 & 색상 기록 패널"
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
-msgstr "작업 내역 패널(최근에 사용 된 브러시 및 색상)을 토글합니다."
+msgid "Dockable panel for viewing recently changed colors and brushes."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr "최근 브러쉬 & 색상"
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr "작업 내역 패널(최근에 사용된 브러시 및 색상)을 표시합니다."
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr "전체 화면에서 컨트롤을 숨기기"
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr "사용자 인터페이스 자동 숨기는 전체 화면으로 토글합니다."
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr "줌 레벨을 표시"
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr "줌 레벨 피드백을 전환."
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr "마지막 패인팅 위치를 표시"
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr "마지막 스트로크가 끝난 위치를 보여주는 피드백을 토글합니다."
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr "필터를 표시"
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr "색상 노멀라이즈를 표시"
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr "필터 색상: 색상 변경을 표시."
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr "그레이 스케일로 색상을 표시"
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr "필터 색상 : 밝기만 표시 (HCY/YCbCr 루마)"
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr "색상 반전을 표시"
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr "필터 색상 : 비디오를 반전. 검은 색은 흰색과 빨간색은 시안."
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr "레드에 대한 모의 감도가 없는 디스플레이 색상"
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
-msgstr "색맹의 일반적인 형태인 제2색약(녹색약)을 시뮬레이션하기 위해 색상을 필터링합니다."
+msgstr ""
+"색맹의 일반적인 형태인 제2색약(녹색약)을 시뮬레이션하기 위해 색상을 필터링합"
+"니다."
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr "그린에 대한 모의 감도가없는 디스플레이 색상"
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
-msgstr "색맹의 일반적인 형태인 제1색맹(적색맹)을 시뮬레이션하기 위해 색상을 필터링합니다."
+msgstr ""
+"색맹의 일반적인 형태인 제1색맹(적색맹)을 시뮬레이션하기 위해 색상을 필터링합"
+"니다."
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr "블루에 대한 모의 감도가없는 디스플레이 색상"
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
-msgstr "드문 형태의 색맹인 제3색맹(청색맹)를 시뮬레이션하기 위해 색상을 필터링합니다."
+msgstr ""
+"드문 형태의 색맹인 제3색맹(청색맹)를 시뮬레이션하기 위해 색상을 필터링합니다."
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr "자유형"
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr "자유형"
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr "자유형 : 그리기 및 기하학적 제약 없이 자유롭게 페인트."
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr "자유형"
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr "기하학적 제약없이 자유롭게 그리고 페인트 할 수 있습니다."
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr "보기를 화면 이동"
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr "화면 이동"
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr "화면 이동: 수평 또는 수직으로 캔버스의 보기를 이동합니다."
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr "보기를 화면 이동"
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr "대화형으로 수평 또는 수직으로 캔버스의 보기를 이동합니다."
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr "보기를 회전"
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr "회전"
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr "보기를 회전 : 캔버스의 보기를 회전합니다."
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr "보기를 회전"
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr "대화형으로 캔버스의 보기를 회전 할 수 있습니다."
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr "줌 보기"
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr "줌"
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr "보기를 줌: 캔버스를 확대 또는 축소합니다."
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr "줌 보기"
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr "캔버스를 대화형으로 확대 또는 축소합니다."
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr "직선과 곡선"
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr "직선"
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr "직선과 곡선: 직선 또는 곡선을 그립니다."
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr "직선과 곡선"
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr "직선 또는 곡선을 그립니다."
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr "연결된 라인"
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr "연결된 라인"
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr "연결된 라인: 직선 또는 곡선의 시퀀스를 그립니다."
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr "연결된 라인"
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr "직선 또는 곡선의 시퀀스를 그립니다."
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr "타원과 원"
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr "타원"
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr "타원과 원 : 둥근 원모양을 그립니다."
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr "타원과 원"
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr "원과 타원을 그립니다."
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr "잉크 제도"
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr "잉크"
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr "잉크 제도: 제어된 선을 부드럽게 그립니다."
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr "잉크 제도"
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr "매끄럽게 제어된 선을 그립니다."
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr "레이어 위치를 조정"
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr "레이어 순위."
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr "레이어 위치를 조정: 캔버스에 현재 레이어를 이동합니다."
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr "레이어 위치 조정"
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr "캔버스에 현재 레이어를 대화형 이동합니다."
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr "프레임을 편집"
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr "프레임"
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
-msgstr "프레임을 편집: 그것을 유한한 크기를 사용하기 위해 문서 주위에 프레임을 정의합니다."
+msgstr ""
+"프레임을 편집: 그것을 유한한 크기를 사용하기 위해 문서 주위에 프레임을 정의합"
+"니다."
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr "프레임 편집"
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
-msgstr "문서 주위에 프레임을 대화식으로 정의하여 유한한 캔퍼스 크기를 정의합니다."
+msgstr ""
+"문서 주위에 프레임을 대화식으로 정의하여 유한한 캔퍼스 크기를 정의합니다."
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "페인팅 대칭을 편집"
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr "대칭"
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr "패인티 대칭을 편집 : 대칭 페인팅에 사용 된 축을 조정합니다."
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "페인팅 대칭을 편집"
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr "대칭 페인팅에 사용되는 축을 대화식으로 조정합니다."
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr "색상을 선택"
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr "색상을 선택."
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr "색상을 선택 : 화면 픽셀에서 페인팅 색상을 설정합니다."
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "색상을 선택"
+
+#: ../po/tmp/resources.xml.h:401
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr "화면 픽셀에서 페인팅 색상을 설정합니다."
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "색상을 선택"
+
+#: ../po/tmp/resources.xml.h:403
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr "화면 픽셀에서 페인팅 색상을 설정합니다."
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "색상을 선택"
+
+#: ../po/tmp/resources.xml.h:405
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr "화면 픽셀에서 페인팅 색상을 설정합니다."
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr "색상을 선택"
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr "화면 픽셀에서 페인팅 색상을 설정합니다."
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr "색상 영역 채우기"
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr "채우기"
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr "색상 영역 채우기: 색상으로 영역을 채웁니다."
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr "색상 영역 채우기"
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr "색상으로 영역을 채웁니다."
+
+#~ msgctxt "Accelerator map editor: action column markup"
+#~ msgid ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+#~ msgstr ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+
+#~ msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
+#~ msgid "{action_label} {action_desc} {accel_label}"
+#~ msgstr "{action_label} {action_desc} {accel_label}"
+
+#~ msgctxt "brush list context menu"
+#~ msgid "Delete"
+#~ msgstr "삭제"
+
+#~ msgctxt "brush list commands"
+#~ msgid "Really delete brush from disk?"
+#~ msgstr "정말 디스크에서 브러시를 삭제 하시겠습니까?"
+
+#~ msgid "HSV Triangle"
+#~ msgstr "HSV 삼각형"
+
+#~ msgid "The standard GTK color selector"
+#~ msgstr "표준 GTK 색상 선택기"
+
+#~ msgid "Pick a color from the screen"
+#~ msgstr "화면에서 색상을 선택"
+
+#~ msgid "Layer Name"
+#~ msgstr "레이어 이름"
+
+#~ msgid ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+#~ msgstr ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+
+#~ msgid "Save..."
+#~ msgstr "저장하기…"
+
+#~ msgid "Confirm"
+#~ msgstr "확인"
+
+#~ msgid "Open..."
+#~ msgstr "열기..."
+
+#~ msgid "{default_name} at {path}"
+#~ msgstr "{path}에서 {default_name}"
+
+#~ msgid "Type"
+#~ msgstr "유형"
+
+#~ msgid "Mode:"
+#~ msgstr "모드 :"
+
+#~ msgid ""
+#~ "Blending mode: how the current layer combines with the layers underneath "
+#~ "it."
+#~ msgstr ""
+#~ "레이어 혼합 모드: 현재 레이어와 아래 레이어 간의 색상 혼합 방법을 지정."
+
+#~ msgid ""
+#~ "Layer opacity: how much of the current layer to use. Smaller values make "
+#~ "it more transparent."
+#~ msgstr ""
+#~ "레이어 불투명도: 현재 레이어의 불투명도를 조절합니다. 값을 낮출수록 더 투"
+#~ "명해질 것입니다."
+
+#~ msgid "%s: edit properties"
+#~ msgstr "%s: 등록 정보를 편집"
+
+#~ msgctxt "layer unique names: match regex (leave untranslated if unsure)"
+#~ msgid "^(.*?)\\s*(\\d+)$"
+#~ msgstr "^(.*?)\\s*(\\d+)$"
+
+#~ msgctxt "layer default names"
+#~ msgid "Unknown Bitmap Layer"
+#~ msgstr "알 수 없는 비트맵 레이어"
+
+#~ msgctxt "Autosave Recovery dialog|"
+#~ msgid "_Ignore for Now"
+#~ msgstr "_지금은 무시"
+
+#~ msgid "Setting name:"
+#~ msgstr "설정 이름:"
+
+#~ msgid "Base value:"
+#~ msgstr "기초 값 :"
+
+#~ msgid "Reset the base value to its default"
+#~ msgstr "그것의 기본 값으로 기초 값을 재설정"
+
+#~ msgid "<ymin>"
+#~ msgstr "<ymin>"
+
+#~ msgid "<ymax>"
+#~ msgstr "<ymax>"
+
+#~ msgid "<xmin>"
+#~ msgstr "<xmin>"
+
+#~ msgid "<xmax>"
+#~ msgstr "<xmax>"
+
+#~ msgid "Edit Setting"
+#~ msgstr "편집 설정"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Trim Layer to Frame"
+#~ msgstr "레이어를 프레임으로 다듬기"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Rename Layer…"
+#~ msgstr "레이어 이름 바꾸기…"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Enter a new name for the current layer."
+#~ msgstr "현재 레이어의 새 이름을 입력합니다."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Turn off mirroring of the view."
+#~ msgstr "뷰의 미러링을 끕니다."
+
+#~ msgctxt "Menu→Edit (labels)"
+#~ msgid "Current Tool"
+#~ msgstr "현재 도구"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+#~ msgstr "레이어 고정 표시기 전환 (레이어 배치, 또는 모드 할당)."
+
+#~ msgctxt "Menu→Color (labels), Accel Editor (labels)"
+#~ msgid "HSV Triangle"
+#~ msgstr "HSV 삼각형"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Dockable color selector: the old GTK color triangle."
+#~ msgstr "고정 가능한 색상 선택: 이전 GTK 색상 삼각형."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid ""
+#~ "Dockable color selector: HSV square which can be rotated to show "
+#~ "different hues."
+#~ msgstr ""
+#~ "고정 가능한 색상 선택기: 다른 평면 조각을 보여주기 위해 회전 하는 HSV 사각"
+#~ "형."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+#~ msgstr "스크래치 패드 독패널을 전환 (색상을 혼합하고 스케치를 만들기)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+#~ msgstr "미리보기 독패널을 전환 (그리기 전체 캔퍼스 영역의 개요)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+#~ msgstr "도구 옵션 독패널을 전환 (현재 도구에 대한 옵션)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the History panel (recently used brushes and colors)."
+#~ msgstr "작업 내역 패널(최근에 사용 된 브러시 및 색상)을 토글합니다."
 
 #~ msgid "Add As New"
 #~ msgstr "새로 추가"
@@ -5655,9 +7028,6 @@ msgstr "색상으로 영역을 채웁니다."
 #~ "있습니다. 하지만 한글판에서는 이부분에 대한 정확한 번역이 이루어 져있지 않"
 #~ "습니다.\n"
 
-#~ msgid "Open Recent files"
-#~ msgstr "최근 파일 열기"
-
 #, fuzzy
 #~ msgid "This will discard %d second of unsaved painting."
 #~ msgid_plural "This will discard %d seconds of unsaved painting."
@@ -5672,10 +7042,6 @@ msgstr "색상으로 영역을 채웁니다."
 
 #~ msgid "Crop to Current Layer"
 #~ msgstr "현재 레이어로 자르기"
-
-#, fuzzy
-#~ msgid "Crop frame to the currently active layer"
-#~ msgstr "현재 활성화 된 레이어 자르기 프레임"
 
 #~ msgid "Details"
 #~ msgstr "세부 정보"
@@ -5761,9 +7127,6 @@ msgstr "색상으로 영역을 채웁니다."
 #~ msgid "Brush Blend Mode"
 #~ msgstr "브러시 혼합 모드"
 
-#~ msgid "Add Layer"
-#~ msgstr "레이어를 추가"
-
 #~ msgid "Move Layer on Canvas"
 #~ msgstr "캔버스에 레이어를 이동"
 
@@ -5801,9 +7164,6 @@ msgstr "색상으로 영역을 채웁니다."
 #~ msgctxt "Menu|File|"
 #~ msgid "Save"
 #~ msgstr "저장"
-
-#~ msgid "Export to a file"
-#~ msgstr "파일로 내보내기"
 
 #~ msgctxt "Menu|Brush|"
 #~ msgid "Bigger"
@@ -6236,9 +7596,6 @@ msgstr "색상으로 영역을 채웁니다."
 #~ "브러시의 전체 불투명도를 설정 합니다. 0 에 가가울 수 록 투명해지며 1 에 가"
 #~ "까울수록 부투명해 집니다."
 
-#~ msgid "Opacity multiply"
-#~ msgstr "불투명도 곱하기"
-
 #~ msgid ""
 #~ "This gets multiplied with opaque. You should only change the pressure "
 #~ "input of this setting. Use 'opaque' instead to make opacity depend on "
@@ -6621,9 +7978,6 @@ msgstr "색상으로 영역을 채웁니다."
 #~ " 0.0 수평 분사\n"
 #~ " 45.0 45도 시계 방향으로 기울어져 분사\n"
 #~ " 180.0 수평 분사"
-
-#~ msgid "Direction filter"
-#~ msgstr "방향 필터"
 
 #~ msgid ""
 #~ "a low value will make the direction input adapt more quickly, a high "

--- a/po/lt.po
+++ b/po/lt.po
@@ -516,17 +516,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1187,12 +1187,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1375,7 +1375,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Open dragged file confirm dialog: continue button"
 msgid "_Open"
-msgstr "Atverti..."
+msgstr "Atverti…"
 
 #: ../gui/drawwindow.py:486
 msgid "Set current color"
@@ -1409,7 +1409,7 @@ msgid "_Quit"
 msgstr "Išeiti"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1459,7 +1459,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1637,13 +1637,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Įrašyti"
 
@@ -1709,7 +1709,7 @@ msgstr "Failas"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -1727,7 +1727,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Atverti..."
+msgstr "Atverti…"
 
 #: ../gui/filehandling.py:1427
 #, fuzzy
@@ -1739,7 +1739,7 @@ msgstr "Atverti paskutinį naudotą"
 #, fuzzy
 msgctxt "File→Open Most Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Atverti..."
+msgstr "Atverti…"
 
 #: ../gui/filehandling.py:1446
 msgctxt "File→Open Next/Prev Scrap: error message"
@@ -1760,7 +1760,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
 msgid "_Open"
-msgstr "Atverti..."
+msgstr "Atverti…"
 
 #: ../gui/filehandling.py:1487
 msgctxt "File→Revert: status message: canvas has no filename yet"
@@ -2134,12 +2134,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2151,7 +2151,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2337,7 +2337,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2407,7 +2407,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/lt.po
+++ b/po/lt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-23 08:18+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Lithuanian <https://hosted.weblate.org/projects/mypaint/"
@@ -21,27 +21,7 @@ msgstr ""
 "1 : 2);\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -49,39 +29,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -89,214 +69,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "Fonas"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "Šablonas"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Spalvota"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Savadarbis"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -335,98 +325,133 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Įrašyti"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Naujas"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
@@ -434,44 +459,44 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -479,58 +504,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -539,51 +564,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -593,137 +642,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -731,162 +780,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -894,373 +935,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Vardas"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Atšaukti"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Pakartoti"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1270,324 +1308,680 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Atverti..."
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Visame ekrane"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Išeiti"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Išeiti"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Atverti..."
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Įrašyti"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr ""
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr ""
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Failas"
+
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Sluoksniai"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Atverti..."
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Atverti paskutinį naudotą"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Atverti..."
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Atverti..."
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr ""
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1595,130 +1989,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1727,35 +2133,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1779,45 +2185,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1825,153 +2235,218 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Sluoksniai"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Sluoksniai"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr ""
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1983,256 +2458,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2240,188 +2740,213 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Sluoksniai"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2430,13 +2955,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2446,7 +2971,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2454,13 +2979,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2468,7 +2993,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2476,7 +3001,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2487,7 +3012,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2495,7 +3020,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2505,7 +3035,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2516,285 +3046,394 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr ""
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2804,7 +3443,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2813,52 +3472,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2880,17 +3570,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2919,112 +3607,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3037,7 +3700,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3078,6 +3741,133 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Vardas"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3447,56 +4237,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3504,12 +4314,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3518,7 +4328,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3529,28 +4339,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3612,1828 +4422,2019 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Atitraukti"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Failas"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Pagalba"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Derinimas"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
-msgstr ""
+msgstr "Sluoksniai"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-04-03 20:04+0000\n"
 "Last-Translator: Arnis Saltums <psas@inbox.lv>\n"
 "Language-Team: Latvian <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -20,27 +20,7 @@ msgstr ""
 "19) ? 0 : ((n % 10 == 1 && n % 100 != 11) ? 1 : 2);\n"
 "X-Generator: Weblate 3.6-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -48,39 +28,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -88,214 +68,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "Raksts"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Krāsu"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Pielāgots"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -334,98 +324,133 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Saglabāt"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Jauns"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
@@ -433,44 +458,44 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -478,58 +503,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -538,51 +563,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -592,137 +641,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -730,162 +779,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -893,373 +934,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Nosaukums"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Atcelt"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Atkārtot"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1269,324 +1307,680 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Atvērt ..."
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Pilnekrāns"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Iziet"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Iziet"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Atvērt ..."
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Saglabāt"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr ""
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr ""
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Fails"
+
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Slāņi"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Atvērt ..."
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Atvērt Jaunākos"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Atvērt ..."
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Atvērt ..."
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Necaurspīdīgums:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1594,130 +1988,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1726,35 +2132,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1778,45 +2184,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1824,153 +2234,218 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "slānis"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Slāņi"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Necaurspīdīgums:"
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1982,256 +2457,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2239,188 +2739,213 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Slāņi"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2429,13 +2954,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2445,7 +2970,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2453,13 +2978,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2467,7 +2992,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2475,7 +3000,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2486,7 +3011,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2494,7 +3019,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2504,7 +3034,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2515,285 +3045,395 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "slānis"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2803,7 +3443,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2812,52 +3472,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2879,17 +3570,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2918,112 +3607,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3036,7 +3700,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3077,6 +3741,134 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Nosaukums"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Necaurspīdīgums:"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3446,56 +4238,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3503,12 +4315,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3517,7 +4329,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3528,28 +4340,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3611,1828 +4423,2019 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Tālināt"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Fails"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "rediģēt"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "krāsa"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "slānis"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Palīdzība"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Atkļūdot"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
-msgstr ""
+msgstr "Slāņi"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/lv.po
+++ b/po/lv.po
@@ -515,17 +515,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1186,12 +1186,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1374,7 +1374,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Open dragged file confirm dialog: continue button"
 msgid "_Open"
-msgstr "Atvērt ..."
+msgstr "Atvērt…"
 
 #: ../gui/drawwindow.py:486
 msgid "Set current color"
@@ -1408,7 +1408,7 @@ msgid "_Quit"
 msgstr "Iziet"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1458,7 +1458,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1636,13 +1636,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Saglabāt"
 
@@ -1708,7 +1708,7 @@ msgstr "Fails"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -1726,7 +1726,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Atvērt ..."
+msgstr "Atvērt…"
 
 #: ../gui/filehandling.py:1427
 #, fuzzy
@@ -1738,7 +1738,7 @@ msgstr "Atvērt Jaunākos"
 #, fuzzy
 msgctxt "File→Open Most Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Atvērt ..."
+msgstr "Atvērt…"
 
 #: ../gui/filehandling.py:1446
 msgctxt "File→Open Next/Prev Scrap: error message"
@@ -1759,7 +1759,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
 msgid "_Open"
-msgstr "Atvērt ..."
+msgstr "Atvērt…"
 
 #: ../gui/filehandling.py:1487
 msgctxt "File→Revert: status message: canvas has no filename yet"
@@ -2133,12 +2133,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2150,7 +2150,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2336,7 +2336,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2406,7 +2406,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/mai.po
+++ b/po/mai.po
@@ -513,17 +513,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1184,12 +1184,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1405,7 +1405,7 @@ msgid "_Quit"
 msgstr "बाहर"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1455,7 +1455,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1632,13 +1632,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "सहेजू"
 
@@ -1704,7 +1704,7 @@ msgstr "फाइल"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -2125,12 +2125,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2142,7 +2142,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2328,7 +2328,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2398,7 +2398,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/mai.po
+++ b/po/mai.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:19+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Maithili <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -19,27 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -47,39 +27,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -87,214 +67,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "रंग"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "पसंदीदा"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -333,142 +323,177 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "सहेजू"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "नवीन"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -476,58 +501,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -536,51 +561,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -590,137 +639,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -728,162 +777,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -891,373 +932,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "नाम"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "अनावृत्ति"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "फिनु सँ करू"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1267,324 +1305,674 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr ""
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "बाहर"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "बाहर"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
+msgstr ""
+
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
+msgstr ""
+
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "सहेजू"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
 #, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr ""
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "फाइल"
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "परतसभ"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1412
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1427
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1432
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr ""
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1592,130 +1980,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1724,35 +2124,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1776,45 +2176,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1822,153 +2226,218 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "परतसभ"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "परतसभ"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr ""
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1980,256 +2449,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2237,188 +2731,213 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "परतसभ"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2427,13 +2946,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2443,7 +2962,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2451,13 +2970,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2465,7 +2984,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2473,7 +2992,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2484,7 +3003,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2492,7 +3011,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2502,7 +3026,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2513,285 +3037,394 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr ""
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2801,7 +3434,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2810,52 +3463,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2877,17 +3561,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2916,112 +3598,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3034,7 +3691,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3075,6 +3732,133 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "नाम"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3444,56 +4228,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3501,12 +4305,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3515,7 +4319,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3526,28 +4330,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3609,1828 +4413,2019 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "ज़ूम आउट"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "फाइल"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "मद्दति "
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "डिबग"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
-msgstr ""
+msgstr "परतसभ"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/ml.po
+++ b/po/ml.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,27 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -45,39 +25,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -85,214 +65,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr ""
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -331,142 +321,177 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr ""
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -474,58 +499,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -534,51 +559,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -588,137 +637,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -726,162 +775,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -889,373 +930,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr ""
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr ""
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr ""
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1265,324 +1303,670 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr ""
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr ""
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr ""
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
+msgstr ""
+
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
+msgstr ""
+
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr ""
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
 #, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
+#: ../gui/filehandling.py:1015
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
 msgstr ""
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1427
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1432
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr ""
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1590,130 +1974,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1722,35 +2118,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1774,45 +2170,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1820,153 +2220,217 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr ""
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr ""
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr ""
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1978,256 +2442,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2235,188 +2724,212 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+msgid "Import Layers"
+msgstr ""
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2425,13 +2938,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2441,7 +2954,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2449,13 +2962,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2463,7 +2976,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2471,7 +2984,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2482,7 +2995,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2490,7 +3003,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2500,7 +3018,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2511,285 +3029,394 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr ""
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2799,7 +3426,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2808,52 +3455,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2875,17 +3553,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2914,112 +3590,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3032,7 +3683,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3073,6 +3724,132 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr ""
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3442,56 +4219,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3499,12 +4296,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3513,7 +4310,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3524,28 +4321,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3607,1828 +4404,2018 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/ml.po
+++ b/po/ml.po
@@ -511,17 +511,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1182,12 +1182,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1402,7 +1402,7 @@ msgid "_Quit"
 msgstr ""
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1452,7 +1452,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1629,12 +1629,12 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr ""
 
@@ -1699,7 +1699,7 @@ msgstr ""
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -2119,12 +2119,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2136,7 +2136,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2321,7 +2321,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2391,7 +2391,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/mn.po
+++ b/po/mn.po
@@ -513,17 +513,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1184,12 +1184,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1372,7 +1372,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Open dragged file confirm dialog: continue button"
 msgid "_Open"
-msgstr "Нээх..."
+msgstr "Нээх…"
 
 #: ../gui/drawwindow.py:486
 msgid "Set current color"
@@ -1406,7 +1406,7 @@ msgid "_Quit"
 msgstr "Дуусгах"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1456,7 +1456,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1633,13 +1633,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Хадгалах"
 
@@ -1705,7 +1705,7 @@ msgstr "Файл"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -1723,7 +1723,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Нээх..."
+msgstr "Нээх…"
 
 #: ../gui/filehandling.py:1427
 #, fuzzy
@@ -1735,7 +1735,7 @@ msgstr "Сүүлд нээгдсэн Файлууд"
 #, fuzzy
 msgctxt "File→Open Most Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Нээх..."
+msgstr "Нээх…"
 
 #: ../gui/filehandling.py:1446
 msgctxt "File→Open Next/Prev Scrap: error message"
@@ -1756,7 +1756,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
 msgid "_Open"
-msgstr "Нээх..."
+msgstr "Нээх…"
 
 #: ../gui/filehandling.py:1487
 msgctxt "File→Revert: status message: canvas has no filename yet"
@@ -2130,12 +2130,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2147,7 +2147,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2333,7 +2333,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2403,7 +2403,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/mn.po
+++ b/po/mn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:19+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Mongolian <https://hosted.weblate.org/projects/mypaint/"
@@ -19,27 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -47,39 +27,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -87,214 +67,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Өнгө"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Хэрэглэгч тод."
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -333,142 +323,177 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Хадгалах"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Шинэ"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -476,58 +501,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -536,51 +561,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -590,137 +639,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -728,162 +777,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -891,373 +932,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Нэр"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Цуцлах"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Сэргээх"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1267,324 +1305,679 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Нээх..."
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr ""
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Дуусгах"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Дуусгах"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Нээх..."
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Хадгалах"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr ""
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr ""
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Файл"
+
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Давхарга"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Нээх..."
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Сүүлд нээгдсэн Файлууд"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Нээх..."
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Нээх..."
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr ""
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1592,130 +1985,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1724,35 +2129,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1776,45 +2181,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1822,153 +2231,218 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Давхарга"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Давхарга"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr ""
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1980,256 +2454,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2237,188 +2736,213 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Давхарга"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2427,13 +2951,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2443,7 +2967,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2451,13 +2975,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2465,7 +2989,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2473,7 +2997,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2484,7 +3008,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2492,7 +3016,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2502,7 +3031,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2513,285 +3042,394 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr ""
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2801,7 +3439,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2810,52 +3468,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2877,17 +3566,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2916,112 +3603,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3034,7 +3696,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3075,6 +3737,133 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Нэр"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3444,56 +4233,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3501,12 +4310,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3515,7 +4324,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3526,28 +4335,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3609,1828 +4418,2019 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Зургийг жижигрүүлэх"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Файл"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Тусламж"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
-msgstr ""
+msgstr "Давхарга"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:19+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -19,27 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -47,39 +27,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -87,214 +67,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "रचना"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "रंग"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "स्वपसंत"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -333,142 +323,177 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "साठवा"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr ""
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -476,58 +501,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -536,51 +561,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -590,137 +639,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -728,162 +777,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -891,373 +932,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "नाव"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "निरस्त करा"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "पुन्हा करा"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1267,324 +1305,674 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "पडदाभर"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "बाहेर पडा"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "बाहेर पडा"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
+msgstr ""
+
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
+msgstr ""
+
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "साठवा"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
 #, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr ""
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "फाइल"
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "स्तर"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1412
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1427
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1432
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr ""
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1592,130 +1980,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1724,35 +2124,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1776,45 +2176,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1822,153 +2226,218 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "स्तर"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "स्तर"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr ""
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1980,256 +2449,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2237,188 +2731,213 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "स्तर"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2427,13 +2946,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2443,7 +2962,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2451,13 +2970,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2465,7 +2984,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2473,7 +2992,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2484,7 +3003,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2492,7 +3011,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2502,7 +3026,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2513,285 +3037,394 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr ""
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2801,7 +3434,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2810,52 +3463,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2877,17 +3561,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2916,112 +3598,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3034,7 +3691,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3075,6 +3732,133 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "नाव"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3444,56 +4228,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3501,12 +4305,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3515,7 +4319,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3526,28 +4330,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3609,1828 +4413,2019 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "लहान करा"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "फाइल"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "डीबग"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
-msgstr ""
+msgstr "स्तर"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/mr.po
+++ b/po/mr.po
@@ -513,17 +513,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1184,12 +1184,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1405,7 +1405,7 @@ msgid "_Quit"
 msgstr "बाहेर पडा"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1455,7 +1455,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1632,13 +1632,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "साठवा"
 
@@ -1704,7 +1704,7 @@ msgstr "फाइल"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -2125,12 +2125,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2142,7 +2142,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2328,7 +2328,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2398,7 +2398,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/ms.po
+++ b/po/ms.po
@@ -517,17 +517,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
-msgstr "Kumpulan baru..."
+msgid "New Group…"
+msgstr "Kumpulan baru…"
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1189,12 +1189,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1377,7 +1377,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Open dragged file confirm dialog: continue button"
 msgid "_Open"
-msgstr "Buka..."
+msgstr "Buka…"
 
 #: ../gui/drawwindow.py:486
 msgid "Set current color"
@@ -1412,7 +1412,7 @@ msgid "_Quit"
 msgstr "Keluar"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1462,7 +1462,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1649,13 +1649,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr "JPEG kualiti 90% (*.jpg; *.jpeg)"
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Simpan…"
 
@@ -1725,7 +1725,7 @@ msgstr "Fail"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr "Pad Lakaran"
 
 #: ../gui/filehandling.py:1099
@@ -1743,7 +1743,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Buka..."
+msgstr "Buka…"
 
 #: ../gui/filehandling.py:1427
 #, fuzzy
@@ -1755,7 +1755,7 @@ msgstr "Buka Baru-Baru Ini"
 #, fuzzy
 msgctxt "File→Open Most Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Buka..."
+msgstr "Buka…"
 
 #: ../gui/filehandling.py:1446
 #, fuzzy
@@ -1779,7 +1779,7 @@ msgstr "Buka Skrap Terdahulu"
 #, fuzzy
 msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
 msgid "_Open"
-msgstr "Buka..."
+msgstr "Buka…"
 
 #: ../gui/filehandling.py:1487
 msgctxt "File→Revert: status message: canvas has no filename yet"
@@ -2157,13 +2157,13 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
-msgstr "Lapor..."
+msgid "Report…"
+msgstr "Lapor…"
 
 #: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
@@ -2174,8 +2174,8 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
-msgstr "Perincian..."
+msgid "Details…"
+msgstr "Perincian…"
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
@@ -2360,7 +2360,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2431,7 +2431,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/ms.po
+++ b/po/ms.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:19+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Malay <https://hosted.weblate.org/projects/mypaint/mypaint/ms/"
@@ -19,29 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-
-#: ../gui/accelmap.py:59
-#, fuzzy, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr "<big><b>{accel_label}</b></big>"
-
-#: ../gui/accelmap.py:63
-#, fuzzy, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr "{action_label} {action_desc} {accel_label}"
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "Aksi"
 
@@ -49,41 +27,41 @@ msgstr "Aksi"
 msgid "Key combination"
 msgstr "Kombinasi Kekunci"
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr "Sunting Kekunci '%s'"
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "Aksi:"
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "Laluan:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "Kekunci:"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr "Tekan kekunci untuk kemaskini tugasan ini"
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "Aksi Tak Diketahui"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
-"<b>{accel} telah digunapakai '{action}'. Tugasan sedia ada akan "
-"ditukarganti.</b>"
+"<b>{accel} telah digunapakai '{action}'. Tugasan sedia ada akan ditukarganti."
+"</b>"
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr "Buka Folder “{folder_basename}”…"
@@ -91,216 +69,226 @@ msgstr "Buka Folder “{folder_basename}”…"
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "OK"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr "Salinan sandaran tidak dijumpai di cache."
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr "Sandaran Tidak Wujud"
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr "Buka Folder Cache…"
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr "Gagal Memulih Sandaran"
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr "Buka Folder Sandaran…"
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr "Fail Pemulihan bertarikh {iso_datetime}.ora"
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "Simpan sebagai Asal"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "Latar"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "Corak"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Warna"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "Tambah warna pada Corak"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr "Muatan satu dan lebiham latar gagal diperoleh"
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr "Latar gagal dimuatkan"
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 "Sila keluarkan fail yang tak dimuat turun, atau periksa pemasangan "
 "libgdkpixbuf."
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr "Gdk-Pixbuf tak muat naik \"{filename}\", dan repot \"{error}\""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr "{filename} saiz kosong (w={w}, h={h})"
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr "Seting Edit Berus"
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr "Tentang"
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "Eksperimen"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr "Asas"
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr "Opasiti"
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "comotan"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr ""
+
+#: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr ""
 
-#: ../gui/brusheditor.py:359
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "Lejang"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Suai"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "Nama Semula Berus"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "Satu berus dengan nama ini sudah wujud!"
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -339,141 +327,177 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Simpan"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Baharu"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
+msgstr "Seting Edit Berus"
+
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
-msgstr "Pasti ingin memadam berus dari cakera?"
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
+msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "Satu kumpulan dengan nama ini sudah wujud!"
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -481,58 +505,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "Kumpulan baru..."
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "Cipta kumpulan"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -541,51 +565,76 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr "Ambil Warna"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "Ambil Warna"
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -595,137 +644,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -733,162 +782,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -896,373 +937,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr "pemadam"
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Nama"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr "Pulihkan Berus %d"
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr "Simpan ke Berus %d"
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr "Undur %s"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Undur"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Buat Semula"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1272,324 +1310,701 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Buka..."
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Skrin Penuh"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Keluar"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+#, fuzzy
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr "Pasti Ingin Keluar?"
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Keluar"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr "Semua Format Dikenali"
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr "OpenRaster (*.ora)"
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr "PNG (*.png)"
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr "JPEG (*.jpg; *.jpeg)"
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr "PNG lutsinar (*.png)"
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr "PNG lutsinar berbilang (*.XXX.png)"
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr "JPEG kualiti 90% (*.jpg; *.jpeg)"
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr "_Simpan sebagai Skrap"
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "Simpan sebagai Asal"
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
+msgstr "Semua Format Dikenali"
+
+#: ../gui/filehandling.py:432
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:437
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:442
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
+msgstr "JPEG (*.jpg; *.jpeg)"
+
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:494
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:502
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:506
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr "PNG lutsinar (*.png)"
+
+#: ../gui/filehandling.py:510
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr "PNG lutsinar berbilang (*.XXX.png)"
+
+#: ../gui/filehandling.py:514
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr "PNG lutsinar berbilang (*.XXX.png)"
+
+#: ../gui/filehandling.py:518
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr "JPEG kualiti 90% (*.jpg; *.jpeg)"
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Simpan…"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:668
+#, fuzzy
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr "Pasti Ingin Keluar?"
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
+#: ../gui/filehandling.py:705
+#, fuzzy
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr "_Simpan sebagai Skrap"
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr ""
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr "Buka…"
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Fail"
+
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
+msgid "Open Scratchpad..."
+msgstr "Pad Lakaran"
+
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Lapisan"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
 msgstr "Buka..."
 
-#: ../gui/filehandling.py:552
-msgid "Open Scratchpad..."
-msgstr ""
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Buka Baru-Baru Ini"
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Buka..."
+
+#: ../gui/filehandling.py:1446
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
 msgstr "Tiada fail skrap bernama \"%s\" lagi."
 
-#: ../gui/fill.py:75 ../lib/command.py:459
-msgid "Flood Fill"
+#: ../gui/filehandling.py:1455
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr "Buka Skrap Berikutnya"
+
+#: ../gui/filehandling.py:1463
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr "Buka Skrap Terdahulu"
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Buka..."
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+#, fuzzy
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
+msgid "Flood Fill"
+msgstr "Isian"
+
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+#, fuzzy
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr "Muat ikut Pandangan"
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
-msgstr ""
+msgstr "Grup Lapisan Baru"
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Kelegapan:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "Padam Lapisan"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1597,130 +2012,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr "Pepijat Dikesan"
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr "<big><b>Satu ralat pengaturcaraan telah dikesan.</b></big>"
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1729,35 +2156,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr "Lapor..."
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr "Perincian..."
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1781,45 +2208,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1827,153 +2258,219 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Lapisan"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Lapisan"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Kelegapan:"
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "Nama Semula Berus"
 
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr ""
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr ""
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr ""
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr ""
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 msgid "Stroke lead-in end"
 msgstr ""
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr ""
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1986,262 +2483,287 @@ msgid ""
 msgstr ""
 "Program ini adalah perisian bebas; anda boleh mengedarkannya semula dan/"
 "ataumengubah suai di bawah syarat-syarat GNU General Public License seperti "
-"yang diterbitkan oleh Free Software Foundation; sama ada Lesen versi 2 atau ("
-"atas pilihan anda) mana-mana versi selepas ini.\n"
+"yang diterbitkan oleh Free Software Foundation; sama ada Lesen versi 2 atau "
+"(atas pilihan anda) mana-mana versi selepas ini.\n"
 "\n"
 "Program ini diedar dengan harapan ia akan berguna, tetapi TANPA SEBARANG "
 "JAMINAN. Rujuk fail COPYING untuk perincian lanjut."
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr "pengaturcaraan"
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr "kemudahalihan"
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr "ikon dekstop"
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2249,188 +2771,214 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "Cipta kumpulan"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr "Gabungkan"
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Lapisan"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2439,13 +2987,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2455,7 +3003,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2463,13 +3011,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2477,7 +3025,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2485,7 +3033,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2496,7 +3044,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2504,7 +3052,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2514,7 +3067,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2525,285 +3078,399 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
-msgctxt "layer default names"
-msgid "Vector Layer"
-msgstr ""
-
 #: ../lib/layer/data.py:1153
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Vectors"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
+#: ../lib/layer/data.py:1158
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Vector Layer"
+msgstr "Padam Lapisan"
+
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Data Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr "Aksi Tak Diketahui"
+
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "Lukis Lapisan Baru"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "Grup Lapisan Baru"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+#, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "Pandangan"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2813,7 +3480,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2822,52 +3509,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2889,17 +3607,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2928,113 +3644,89 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
 msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+#, fuzzy
+msgid "<big><b>No Brush Dynamics</b></big>"
+msgstr "<big><b>{accel_label}</b></big>"
 
 #: ../po/tmp/inktool.glade.h:1
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
@@ -3046,7 +3738,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3087,6 +3779,134 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Nama"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Opasiti"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3456,56 +4276,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3513,12 +4353,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3527,7 +4367,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3538,28 +4378,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3621,1828 +4461,2043 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
-msgstr "Simpan"
+msgid "Import Layers…"
+msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
-msgstr "Simpan…"
+msgid "Save"
+msgstr "Simpan"
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
-msgstr ""
+msgid "Save As…"
+msgstr "Simpan…"
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
-msgstr "Simpan Sebagai Skrap"
+msgid "Export…"
+msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
-msgstr "Buka Skrap Terdahulu"
+msgid "Save As Scrap"
+msgstr "Simpan Sebagai Skrap"
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
-msgstr "Buka Skrap Berikutnya"
+msgid "Open Previous Scrap"
+msgstr "Buka Skrap Terdahulu"
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Open Next Scrap"
+msgstr "Buka Skrap Berikutnya"
+
+#: ../po/tmp/resources.xml.h:25
+msgctxt "Accel Editor (descriptions)"
+msgid "Load the scrap file after the current one."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Recover File from an Automated Backup…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:25
+#: ../po/tmp/resources.xml.h:27
 msgctxt "Accel Editor (descriptions)"
 msgid "Try to save and resume interrupted unsaved work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:26
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "Padam Lapisan"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "Grup Lapisan Baru"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "Grup Lapisan Baru"
+
+#: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:71
+#: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Edit Layer in External App…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
-msgstr "Lukis Lapisan Baru"
-
-#: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:85
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
-msgstr "Grup Lapisan Baru"
-
-#: ../po/tmp/resources.xml.h:86
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:87
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:88
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:89
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
-msgstr "Padam Lapisan"
+msgid "New Painting Layer"
+msgstr "Lukis Lapisan Baru"
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr "Grup Lapisan Baru"
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr "Padam Lapisan"
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr "Muat ikut Pandangan"
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Zum Keluar"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
-msgstr "Putar Lawan Jam"
-
-#: ../po/tmp/resources.xml.h:137
-msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:157
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the left."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr "Putar Ikut Jam"
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
-msgstr ""
+msgid "Rotate the canvas clockwise."
+msgstr "Putar Lawan Jam"
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr "Putar Lawan Jam"
+
+#: ../po/tmp/resources.xml.h:167
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr "Putar Lawan Jam"
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr "Lapisan Solo"
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr "Visualkan Penerapan"
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Fail"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "Keluar"
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "Sunting"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "Warna"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "Lapisan"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr "Pad Lakaran"
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "Tetingkap"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "Berus"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "Tukar Berus…"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "Tukar Warna…"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "Tukar Warna (subset cepat)…"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr "Berus Tambahan…"
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Bantuan"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr "Bantuan Atas Talian"
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "Perihal MyPaint"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Menyahpepijat"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "Pandangan"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "Skrin penuh"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "Edit Citarasa"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr "Penyunting Tetapan Berus"
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr "Panel Lapisan"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr "Papar Panel Lapisan"
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "Warna Palet"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr "Papar Panel Lakaran"
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr "Panel Pralihat"
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "Pralihat"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr "Panel Tetapan Alat"
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr "Papar Panel Tetapan Alat"
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr "Panel Sejarah Berus & Warna"
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr "Sejarah Berus & Warna"
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr "Gaya bebas"
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr "Gaya bebas"
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr "Garis dan Bentuk"
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr "Garisan Bersambung"
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr "Elips dan Bulatan"
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr "Dakwat"
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr "Lapisan Peralihan"
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr "Edit Bingkai"
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Edit Simetri Lukisan"
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "Ambil Warna"
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "Ambil Warna"
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "Ambil Warna"
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr "Pilih Warna"
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr "Isian"
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""
+
+#~ msgctxt "Accelerator map editor: action column markup"
+#~ msgid ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+#~ msgstr ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+
+#, fuzzy
+#~ msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
+#~ msgid "{action_label} {action_desc} {accel_label}"
+#~ msgstr "{action_label} {action_desc} {accel_label}"
+
+#~ msgctxt "brush list commands"
+#~ msgid "Really delete brush from disk?"
+#~ msgstr "Pasti ingin memadam berus dari cakera?"

--- a/po/mypaint.pot
+++ b/po/mypaint.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,27 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -46,39 +26,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -86,214 +66,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr ""
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -332,142 +322,177 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr ""
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -475,58 +500,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -535,51 +560,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -589,137 +638,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -727,162 +776,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -890,373 +931,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr ""
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr ""
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr ""
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1266,324 +1304,670 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr ""
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr ""
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr ""
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
+msgstr ""
+
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
+msgstr ""
+
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr ""
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
 #, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
+#: ../gui/filehandling.py:1015
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
 msgstr ""
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1427
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1432
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr ""
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1591,130 +1975,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1723,35 +2119,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1775,45 +2171,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1821,153 +2221,217 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr ""
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr ""
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr ""
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1979,256 +2443,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2236,188 +2725,212 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+msgid "Import Layers"
+msgstr ""
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2426,13 +2939,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2442,7 +2955,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2450,13 +2963,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2464,7 +2977,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2472,7 +2985,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2483,7 +2996,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2491,7 +3004,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2501,7 +3019,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2512,285 +3030,394 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr ""
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2800,7 +3427,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2809,52 +3456,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2876,17 +3554,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2915,112 +3591,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3033,7 +3684,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3074,6 +3725,132 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr ""
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3443,56 +4220,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3500,12 +4297,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3514,7 +4311,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3525,28 +4322,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3608,1828 +4405,2018 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/mypaint.pot
+++ b/po/mypaint.pot
@@ -512,17 +512,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1183,12 +1183,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1403,7 +1403,7 @@ msgid "_Quit"
 msgstr ""
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1453,7 +1453,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1700,7 +1700,7 @@ msgstr ""
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -2120,12 +2120,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2137,7 +2137,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2322,7 +2322,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2392,7 +2392,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/nb.po
+++ b/po/nb.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.7.1-git\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-07-08 06:00+0000\n"
 "Last-Translator: Allan Nordhøy <epost@anotheragency.no>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/mypaint/"
@@ -16,29 +16,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.8-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr "<big><b>{accel_label}</b></big>"
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr "{action_label} {action_desc} {accel_label}"
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "Handling"
 
@@ -46,32 +24,32 @@ msgstr "Handling"
 msgid "Key combination"
 msgstr "Tastekombinasjon"
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr "Rediger tast for \"%s\""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "Handling:"
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "Sti:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "Tast:"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr "Trykk en tast for å oppdatere denne tildelningen"
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "Ukjent handling"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
@@ -80,7 +58,7 @@ msgstr ""
 "<b>{accel} er allerde i bruk for '{action}'. Eksisterende tildeling vil bli "
 "erstattet.</b>"
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr "Åpne mappen \"{folder_basename}\"…"
@@ -88,196 +66,206 @@ msgstr "Åpne mappen \"{folder_basename}\"…"
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "OK"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr "Fant ingen sikkerhetskopier i hurtiglageret."
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr "Ingen sikkerhetskopier tilgjengelig"
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr "Åpne hurtiglagermappen…"
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr "Gjenoppretting av sikkerhetskopi mislyktes"
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr "Åpne sikkerhetskopi-mappen…"
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr "Gjenopprettet fil fra {iso_datetime}.ora"
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "Sett som standard"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "Bakgrunn"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "Mønster"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Farge"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "Legg fargen til mønstrene"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr "Kunne ikke laste inn ett eller flere bakgrunnsbilder"
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr "Feil under lasting av bakgrunner"
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 "Vennligst fjern filene som ikke kunne lastes, eller sjekk din libgdkpixbuf "
 "innstalasjon."
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr "Gdk-Pixbuf kunne ikke laste \"{filename}\", og meldte \"{error}\""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr "{filename} har ingen størrelse (w={w}, h={h})"
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr "Penselinnstillinger"
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr "Om"
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "Eksperimentiell"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr "Grunnleggende"
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr "Dekkevne"
 
 # # Dab = flekk
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr "Flekk"
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "Gnieffekt"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr "Fart"
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr ""
+
+#: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr "Sporing"
 
-#: ../gui/brusheditor.py:359
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "Penselstrøk"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr "Farge"
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Egendefinert"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr "Ingen pensel valgt, vennligst bruk \"Legg til som ny\" istedet."
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr "Ingen pensel valgt!"
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "Gi pensel nytt navn"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "En pensel med dette navnet eksisterer allerede!"
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr "Ingen pensel valgt!"
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, fuzzy, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr "VIL du virkelig slette penselen \"{brush_name}\" fra disken?"
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr "(pensel uten navn)"
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr "{brush_name} [ulagret]"
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr "Rediger Penselikon"
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr "Penselinstillinger"
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr "Ingen pensel valgt"
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -286,7 +274,7 @@ msgstr ""
 "<b>%s</b>\n"
 "<small>Velg en gyldig pensel først</small>"
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
@@ -295,7 +283,7 @@ msgstr ""
 "<b>%s</b> <i>(endret)</i>\n"
 "<small>Endringene har ikke blitt lagret enda</small>"
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
@@ -304,7 +292,7 @@ msgstr ""
 "<b>%s</b> (editing)\n"
 "<small>Mal med valgfri pensel eller farge</small>"
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -345,142 +333,182 @@ msgstr "Auto"
 msgid "Use the default icon"
 msgstr "Tilbakestill til opprinnelig verdi"
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Lagre"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr "Lagre dette forhåndsvisningsikonet, og fullfør redigering"
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr "Tapt&Funnet"
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr "Slettet"
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr "Favoritter"
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr "Blekk"
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr "Klassisk"
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr "Set#1"
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr "Set#2"
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr "Set#3"
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr "Set#4"
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr "Set#5"
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr "Eksperimentiell"
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Ny"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr "Ukjent pensel"
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr "Favoritter"
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr "Fjern fra favoritter"
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr "Klon"
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr "Detaljerte penselinnstillinger"
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
-msgstr "Slett"
+#: ../gui/brushselectionwindow.py:250
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
+msgstr "Endre gruppenavn"
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
-msgstr "Er du sikker på at du vil slette denne penselen?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, fuzzy, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
+msgstr "VIL du virkelig slette penselen \"{brush_name}\" fra disken?"
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] "%d pensel"
 msgstr[1] "%d pensler"
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr "Gruppe “{group_name}”"
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr "Endre gruppenavn"
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr "Eksporter som komprimert penselpakke"
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr "Slett gruppe"
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr "Endre gruppenavn"
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "En gruppe med dette navnet eksisterer allerede!"
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr "Er du sikker på at du vil slette gruppen %{group_name}?"
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -490,58 +518,58 @@ msgstr ""
 "Kunne ikke slette gruppen “{group_name}”.\n"
 "Noen spesialgrupper kan ikke slettes."
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr "Eksporter penselpakke"
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr "MyPaint penselpakke (*.zip)"
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "Ny gruppe…"
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr "Importer penselpakke..."
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr "Last ned flere pensler..."
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "Opprett gruppe"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr "Knappers"
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr "Knappers"
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr "Knappetrykk"
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr "Legg til en ny tastatursnarvei"
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr "Gjennåpne nåværende filen"
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr "Rediger tastatursnarvei for \"%s\""
@@ -550,7 +578,7 @@ msgstr "Rediger tastatursnarvei for \"%s\""
 msgid "Button press:"
 msgstr "Knappetrykk:"
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
@@ -558,7 +586,7 @@ msgstr ""
 "Hold nede modifiseringstaster, og trykk på knappen over denne teksten for å "
 "sette en ny tastatursnarvei."
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
@@ -566,40 +594,68 @@ msgstr ""
 "{button} kan ikke tilknyttes uten modifiseringstast (dens hensikt er "
 "fastsatt, beklager)"
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr "{button_combination} er allerede tilknyttet handlingen '{action_name}'"
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr "Plukk farge"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr "Sett fargen brukt for maling"
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+#, fuzzy
+msgid "Set the color Hue used for painting"
+msgstr "Sett fargen brukt for maling"
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "Plukk farge"
+
+#: ../gui/colorpicker.py:296
+#, fuzzy
+msgid "Set the color Chroma used for painting"
+msgstr "Sett fargen brukt for maling"
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+#, fuzzy
+msgid "Set the color Luma used for painting"
+msgstr "Sett fargen brukt for maling"
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr "Fargedetaljer"
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr "Nåværende børstefarge, og fargen nyligst brukt for maling"
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr "Fargeromsmaske aktiv"
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr "Begrens din palett for gitte stemninger ved bruk av en fargeromsmaske."
@@ -609,7 +665,7 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr "HCY-nyanse og kulørthet."
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
@@ -618,12 +674,12 @@ msgstr ""
 "Fargeromsmaskeredigerer. Klikk i midten for å opprette eller manipulere "
 "figurer eller roter masken ved hjelp av kantene på disken."
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr "Atmosfærisk triade"
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
@@ -632,22 +688,22 @@ msgstr ""
 "Emosjonell og subjektiv, definert av én hovedfarge og to primærfarger som er "
 "mindre intense."
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr "Forskyvd triade"
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr "Vektet sterkere mot den dominante fargen."
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr "Komplimentær"
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
@@ -656,12 +712,12 @@ msgstr ""
 "Motsatser i kontrast til hverandre, balansert ved å ha sentrale nøytrale "
 "farger mellom dem på fargehjulet."
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr "Humør og antoning"
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
@@ -669,12 +725,12 @@ msgid ""
 msgstr ""
 "Et hovedutvalg av farger, med komplimenterende aksent for variasjon og fokus."
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr "Splittet komplimentær"
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
@@ -683,74 +739,74 @@ msgstr ""
 "To sammenlignbare farger og en komplimentærfarge til dem, uten noen "
 "sekundærfarger mellom dem."
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr "Ny fargeromsmaske fra mal"
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr "Behandler for fargeromsmaske"
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr "Handling"
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr "Hjelp…"
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr "Opprett ny maske fra mal."
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr "Last palett fil..."
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 #, fuzzy
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr "Lagre maske til GIMP-palettfil."
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr "Slett masken."
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr "Åpne nettbasert hjelp for denne dialogen i en nettleser."
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr "Lagre som en fil"
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 #, fuzzy
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr "Last inn maske fra GIMP-palett"
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr "Sett fargeromsmaske."
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr "HCY-fargehjul"
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -758,162 +814,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr "HSV-fargetone"
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr "HSV-metning"
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr "Grunnverdi"
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr "Endre verdi/metning"
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr "HSV-farge og -verdi"
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr "HSV-fargetone og -metning"
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr "Roter kube (vis forskjellige akser)"
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr "HSV-kube"
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr "Grunnverdi"
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr "Fargetriangel"
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr "MyPaint fargevelger"
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr "HSV-hjul"
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr "Endre verdi/metning."
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr "Palett editor"
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr "Palett"
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr "Sett fargen fra en lastbar, redigerbar fargepalett."
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr "Lag uten navn #%d"
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr "Palett editor"
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr "Last inn fra en GIMP-palettfil"
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr "Lagre som en fil"
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr "Legg til ny tom fargeprøve"
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr "Gjennåpne nåværende filen"
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr "Gjennåpne nåværende filen"
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr "Tittel:"
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr "Navn eller beskrivelse av denne fargepaletten"
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr "Kolonner:"
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr "Antall kolonner"
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr "Harmoni farge-velger:"
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr "Nåværende vs. sist brukte farge"
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr "GIMP palettformat"
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr "Last palett fil"
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr "Lagre innstillinger"
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -924,379 +972,377 @@ msgstr ""
 "Slipp farger her,\n"
 "dra dem for å organisere."
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr "GIMP palettformat"
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr "Legg til tom plass"
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr "Sett in rad"
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr "Sett inn kolonne"
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr "Fyll tomrom (RGB)"
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr "Fyll tomrom (HCY)"
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr "Fyll tomrom (HSV)"
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "Lagre som en fil"
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr "Alle filer (*)"
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "Lagre som en fil"
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr "Alle filer (*)"
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr "Velg en farge fra skjermen"
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr "R"
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr "G"
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr "B"
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr "Komponentglidebrytere"
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr "Juster individuelle komponenter av fargen."
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr "RGB-rød"
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr "RGB-grønn"
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr "RGB-blå"
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr "Grunnverdi"
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr "Rotasjon"
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr "Grunnverdi"
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr "RGB-fargetone"
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr "RGB-krominans"
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr "RGB-luminans (Y')"
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr "Flytende vask"
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
-msgstr "Endre farge ved bruk av vaskemiddellignende vask av nærliggende farger."
+msgstr ""
+"Endre farge ved bruk av vaskemiddellignende vask av nærliggende farger."
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr "Konsentriske ringer"
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr "Endre farge ved bruk av konsentriske HSV-ringer."
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr "Kryssende skål"
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr "Endre farger med HSV-ramper som krysser en radial fargeskål."
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr "Peker/puck"
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr "Viskelærmodus"
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr "Tastatur"
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr "Mus"
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr "Mønster"
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr "Pekeflate"
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr "Fullskjerm"
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr "Ignorer"
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr "Enhver oppgave"
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr "Oppgaver som ikke har med maling å gjøre"
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr "Kun navigering"
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr "Zoomnivå"
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr "Mønster"
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr "Enhet"
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr "Akser"
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr "Type"
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr "Bruk for…"
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr "Rulling…"
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Navn"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr "Overskriv pensel?"
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr "Erstatt"
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr "Gi nytt navn"
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr "Erstatt alle"
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr "Gi nytt navn til alle"
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr "Importert pensel"
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr "Eksisterende pensel"
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 "<b>Penselenz `%s' eksisterer allerede.</b>\n"
 "Vil du erstatte den, eller skal den nye penselen bli omdøpt?"
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr "Overskriv penselgruppe?"
 
-#: ../gui/dialogs.py:190
-#, python-brace-format
+#: ../gui/dialogs.py:220
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 "<b>Gruppen `{groupname}' eksisterer allerede.</b>\n"
 "Vil du erstatte den, eller skal den nye penselen bli omdøpt?\n"
 "Dersom du erstatter den, vil penselene muligens bli flyttet til "
 "gruppen`{deleted_groupname}'."
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr "Importer penselpakke?"
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, fuzzy, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr "<b>Vil du virkelig importere pakken `%s'?</b>"
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr "Last penselinnstillinger fra snarveisplass %d"
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr "Lagre penselsinnstillinger i snarveisplass %d"
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr "Bruk pensel %d"
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr "Lagre til pensel %d"
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr "Angre %s"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Angre"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr "Gjenta %s"
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Gjenta"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1306,309 +1352,613 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ",  "
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
-msgstr "Navn på lag"
-
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
-#, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
-"<b>{name}</b>\n"
-"{description}"
+
+#: ../gui/document.py:909
+#, python-brace-format
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
+msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr "%s - MyPaint"
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr "MyPaint"
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Åpne..."
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr "Sett nåværende farge"
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr "Deaktiver fullskjerm-modus"
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr "Deaktiver fullskjerm-modus"
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr "Aktiver fullskjerm-modus"
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Fullskjerm"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Avslutt"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+#, fuzzy
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr "Er du sikker på at du vil avslutte?"
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Avslutt"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr "Importer penselpakke..."
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr "MyPaint penselpakke (*.zip)"
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr "Startet {app_name} for å redigere “{layer_name}”-laget"
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr "Kunne ikke laste “{file_basename}”."
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr "Åpne..."
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr "Ikon"
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr "ingen beskrivelse"
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
+#: ../gui/filehandling.py:126
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
+msgstr "Laster “{file_basename}”…"
+
+#: ../gui/filehandling.py:130
+#, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:134
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
+msgstr "Lagrer “{file_basename}”…"
+
+#: ../gui/filehandling.py:138
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
+msgstr "Eksporterer til “{file_basename}”…"
+
+#: ../gui/filehandling.py:145
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr "Klarte ikke å eksportere til “{file_basename}”."
+
+#: ../gui/filehandling.py:149
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr "Klarte ikke å lagre “{file_basename}”."
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr "Kunne ikke laste “{file_basename}”."
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "Lagre innstillinger"
+
+#: ../gui/filehandling.py:168
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr "Ekspoter til en fil"
+
+#: ../gui/filehandling.py:172
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr "Ekspoter til en fil"
+
+#: ../gui/filehandling.py:176
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr "Åpne nylige filer"
+
+#: ../gui/filehandling.py:183
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr "Eksporterte til “{file_basename}”."
+
+#: ../gui/filehandling.py:187
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr "“{file_basename}” lagret."
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr "Lastet inn “{file_basename}”."
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
+msgstr "Lastet inn “{file_basename}”."
+
+#: ../gui/filehandling.py:427
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "All Recognized Formats"
 msgstr "Alle kjente format"
 
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
+#: ../gui/filehandling.py:432
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "OpenRaster (*.ora)"
 msgstr "OpenRaster (*.ora)"
 
-#: ../gui/filehandling.py:95
+#: ../gui/filehandling.py:437
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "PNG (*.png)"
 msgstr "PNG (*.png)"
 
-#: ../gui/filehandling.py:96
+#: ../gui/filehandling.py:442
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "JPEG (*.jpg; *.jpeg)"
 msgstr "JPEG (*.jpg; *.jpeg)"
 
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
+#: ../gui/filehandling.py:490
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "By extension (prefer default format)"
 msgstr "Etter utvidelse (foretrekk standard format)"
 
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
+#: ../gui/filehandling.py:494
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:498
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
 msgstr "PNG med bakgrunn (*.png)"
 
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
+#: ../gui/filehandling.py:502
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:506
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
 msgstr "PNG transparent (*.png)"
 
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
+#: ../gui/filehandling.py:510
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
 msgstr "Flerfils transparent PNG (*.XXX.png)"
 
-#: ../gui/filehandling.py:113
+#: ../gui/filehandling.py:514
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr "Flerfils transparent PNG (*.XXX.png)"
+
+#: ../gui/filehandling.py:518
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr "JPEG 90% kvalitet (*.jpg; *.jpeg)"
 
-# duplication?
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr "Lagre..."
+#: ../gui/filehandling.py:576
+#, fuzzy
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr "Eksporter…"
 
-#: ../gui/filehandling.py:177
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Lagre som…"
+
+#: ../gui/filehandling.py:601
+#, fuzzy
+msgctxt "save dialogs: formats and options: (label)"
 msgid "Format to save as:"
 msgstr "Lagringsformat:"
 
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr "Bekreft"
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
+#: ../gui/filehandling.py:668
+#, fuzzy
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
 msgstr "Er du sikker på at du vil fortsette?"
 
-#: ../gui/filehandling.py:234
-#, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
-msgstr "Dette vil forkaste {abbreviated_time} minutt maling som ikke er lagret"
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
 
 # "Scrap" -> "kladd"
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
+#: ../gui/filehandling.py:705
+#, fuzzy
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
 msgstr "_Lagre som kladd"
 
-#: ../gui/filehandling.py:282
-#, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
-msgstr "Laster “{file_basename}”…"
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
 
-#: ../gui/filehandling.py:296
-#, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
-msgstr "Kunne ikke laste “{file_basename}”."
+#: ../gui/filehandling.py:734
+#, fuzzy, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr "Dette vil forkaste {abbreviated_time} minutt maling som ikke er lagret"
 
-#: ../gui/filehandling.py:321
-#, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
-msgstr "Lastet inn “{file_basename}”."
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
 
-#: ../gui/filehandling.py:422
-#, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
-msgstr "Eksporterer til “{file_basename}”…"
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
 
-#: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
-msgstr "Lagrer “{file_basename}”…"
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
-msgstr "Klarte ikke å eksportere til “{file_basename}”."
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr "Åpne…"
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
-msgstr "Klarte ikke å lagre “{file_basename}”."
-
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
-msgstr "Eksporterte til “{file_basename}”."
-
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
-msgstr "“{file_basename}” lagret."
-
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Åpne..."
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Åpne nylige filer"
 
 # "Scrap" -> "kladd"
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr "Åpne kladdebok..."
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
-msgstr "Det er ingen kladder ved navn \"%s\" enda."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Importert pensel"
 
-#: ../gui/fill.py:75 ../lib/command.py:459
-msgid "Flood Fill"
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Åpne..."
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Åpne nylig brukte"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Åpne..."
+
+#: ../gui/filehandling.py:1446
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr "Det er ingen kladder ved navn \"%s\" enda."
+
+# "Scrap" -> "kladd"
+#: ../gui/filehandling.py:1455
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr "Lagre neste kladd"
+
+#: ../gui/filehandling.py:1463
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr "Åpne forrige kladd"
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Åpne..."
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+#, fuzzy
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr "Tilbakestill"
+
+#: ../gui/fill.py:121
+#, fuzzy
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
+msgid "Flood Fill"
+msgstr "Bøttefylling"
+
+#: ../gui/fill.py:127
+#, fuzzy
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr "Fyll områder med farge"
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+#, fuzzy
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr "Toleranse:"
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+#, fuzzy
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr "Kilde:"
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
-msgstr "Hvilke farger skal fylles"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
+msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+#, fuzzy
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr "Roter"
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+#, fuzzy
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr "Mål:"
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+#, fuzzy
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr "Hvor utdataen skal"
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr "Nytt lag (én gang)"
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+#, fuzzy
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
@@ -1616,21 +1966,108 @@ msgstr ""
 "Lag et nytt lag med resultatet av fyllingen.\n"
 "Dette blir skrudd av automatisk etter bruk."
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Synlighet:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr "Tilbakestill"
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+#, fuzzy
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr "Tilbakestill til opprinnelig verdi"
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "Velg lag"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr "<b>{brush_name}</b>"
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1640,131 +2077,143 @@ msgstr ""
 "<b>{brush_name}</b>\n"
 "{brush_desc}"
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr "Rediger ramme"
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr "Juster dokumentrammen"
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr "Ramme"
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr "Høyde:"
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr "Bredde:"
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr "Oppløsning:"
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr "Farge:"
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr "Rammens farge"
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr "<b>Fullskjerm</b>"
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr "<b>Pikseltetthet</b>"
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr "Døp om lag"
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr "Forskjellinge metninger fra nåværende farge"
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr "Kutt til dokumentets størrelse"
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr "Kutt ramme til kombinasjonen av alle lagene"
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr "Navn på lag"
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr "Aktivert"
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr "{width:g}×{height:g} {units}"
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr "\""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr "cm"
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr "mm"
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr "Filhåndtering"
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr "Mal frihåndsstrøk"
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr "Utglatting:"
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr "Trykk:"
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr "Feil oppdaget"
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 "<big><b>En feil har blitt oppdaget under kjøring av programmet .</b></big>"
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1773,35 +2222,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr "Rapporter…"
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr "Ignorer feil"
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr "Om MyPaint"
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr "Detaljer..."
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr "Feil under analyse av feilen."
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1825,45 +2274,50 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr "Tegn, og glatt så ut linjene"
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr "Test av pekerenheter"
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr "(null trykk)"
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr "Trykk:"
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr "(null helning)"
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr "Helning:"
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr "(ingen enhet)"
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
 msgstr "Enhet:"
 
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+#, fuzzy
+msgid "Barrel Rotation:"
+msgstr "Rotasjon"
+
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr "Beveg lag"
 
@@ -1871,159 +2325,226 @@ msgstr "Beveg lag"
 msgid "Move the current layer"
 msgstr "Gjennåpne nåværende filen"
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
-msgstr "{default_name} på {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
+msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
-msgstr "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
+msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+#, fuzzy
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr "Egenskaper"
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr "Synlig"
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Lag"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+#, fuzzy
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr "Låst"
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+#, fuzzy
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ", "
+
+#: ../gui/layers.py:990
+#, fuzzy, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr "Legg til {layer_default_name}"
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Lag"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr "Organiser lag og legg til effekter"
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr "Lagets dekkevne: %d%%"
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr "Endre lagets nivå..."
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 "Flytt laget i stabelen (å legge til et vanlig lag vil opprette en ny gruppe)"
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr "Lag"
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
-msgstr "Modus:"
+#: ../gui/layervis.py:53
+#, fuzzy, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
+msgstr "<b>{brush_name}</b>"
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
-"Blandingsmodus: Hvordan gjeldende lag skal kombineres med lagene under det."
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Synlighet:"
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "Roter"
 
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-"Lag-dekkevne: Hvor mye av gjeldende lag som skal brukes. Mindre verdier gjør "
-"det mer gjennomsiktig."
-
-#: ../gui/linemode.py:37
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr "Trykk fra penn"
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr "Inngsngstrykk for linjeverktøy"
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr "Trykk fra penn"
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr "Midtpunktstrykk for linjeverktøy"
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr "Trykk"
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr "Utgangstrykk for linjeverktøy"
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr "Hode"
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 msgid "Stroke lead-in end"
 msgstr "Penselstrøk holdetid"
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr "Hale"
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr "Strøkets uttoningsbegynnelse"
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr "Trykkvariasjon…"
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr "Linjer og kurver"
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr "Sammenhengende linjer"
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr "Ellipser og sirkler"
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
+#, fuzzy
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 "Opphavsrett (C) 2005-2012\n"
 "Martin Renold og MyPaint utviklingsteamet"
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -2035,72 +2556,72 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr "programmering"
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr "portabilitet"
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr "prosjektstyring"
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr "pensler"
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr "mønstre"
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr "verktøyikoner"
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr "skrivebordsikon"
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr "Palett"
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr "Rotasjon"
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr "brukerstøtte"
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr "oppsøkning"
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr "gemenskap"
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ", "
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
@@ -2108,186 +2629,216 @@ msgstr ""
 "Kommentarer til oversettelsen kan sendes\n"
 "per e-post til: epost@anotheragency.no"
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr "Størrelse:"
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr "Dekkevne:"
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr "Skarphet:"
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr "Forsterkningsnivå:"
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr "verktøyikoner"
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr "Åpne en fil. Erstatter nåværende fil-visning"
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr "<b>{mode_name}</b>"
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr "Forstørrelsesnivå: %.01f%%"
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr "Plukk farge…"
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr "Innstillinger"
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr "Forrige"
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr "Vis/skjul verktøyvinduer"
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr "Kladdeblokk"
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr "Forrige"
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr "Neste"
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
 msgstr "(Ingenting å vise)"
 
-#: ../gui/symmetry.py:76
+#: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Place axis"
 msgstr "Plasser akse"
 
-#: ../gui/symmetry.py:80
+#: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Move axis"
 msgstr "Beveg lag"
 
-#: ../gui/symmetry.py:84
+#: ../gui/symmetry.py:88
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr "Fjern lag"
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
+#, fuzzy
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr "Handling:"
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr "Handling:"
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr "Alfa:"
 
-#: ../gui/symmetry.py:352
+#: ../gui/symmetry.py:376
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
+msgstr "Symmetri"
+
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+#, fuzzy
 msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+msgid "X axis Position"
 msgstr "Akseposisjon"
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:477
+#, fuzzy
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr "Akseposisjon"
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr "Aktivert"
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr "Filhåndtering"
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr "Kladd-bytter"
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr "Angre og gjenta"
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr "Malemodus"
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2295,188 +2846,214 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr "<b>Lagring</b>"
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr "Rullingsvisning"
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr "Dra lerretsvisningen"
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr "Zoom inn"
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr "Forstørr lerretsvisningen"
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr "Roter"
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr "Roter visning mot klokken"
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, fuzzy, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr "%s: lukk fane"
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
-msgstr "%s: rediger egenskaper"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
+msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr "Ukjent handling"
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr "Udefinert (kommandoen har ikke blitt startet enda)"
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr "Klarer lag"
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "Endre gruppenavn"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr "Klarer lag"
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr "Døp om lag"
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr "Gjør laget synlig"
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr "Spleis lag"
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr "Flett sammen nedover"
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr "Endre lagmodus"
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Importert pensel"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr "Legg til {layer_default_name}"
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr "Fjern lag"
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr "Velg lag"
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr "Dupliser lag"
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr "Beveg lag"
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr "Beveg lag"
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr "Endre lagets nivå"
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr "Døp om lag"
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr "Gjør laget synlig"
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr "Gjør lagets unsynlig"
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr "Lås lag"
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr "Lås opp lag"
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr "Angi dekkevne for lag: %0.1f%%"
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr "Ukjent handling"
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr "Rediger ramme"
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr "Rediger ramme"
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr "Rediger ramme"
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr "Rediger lag eksternt"
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr "Loggfilene kan ha flere detaljer vedrørende denne feilen."
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr "fra nå av"
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr "siden"
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2485,13 +3062,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr "Ufullstending sikkerhetskopi oppdatert {last_modified_time} {ago}"
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2501,11 +3078,11 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 "Sikkerhetskopi oppdatert {last_modified_time} {ago}\n"
-"Størrelse: {autosave.width}×{autosave.height} piksler, Lag: "
-"{autosave.num_layers}\n"
+"Størrelse: {autosave.width}×{autosave.height} piksler, Lag: {autosave."
+"num_layers}\n"
 "Inneholder {unsaved_time} av ulagret maleri."
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2515,13 +3092,13 @@ msgstr ""
 "Kunne ikke lagre: “{filename}1”: {err}2\n"
 "Har du nok plass på harddisken?"
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr "Klarte ikke å skrive til “{filename}”: {err}"
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2531,7 +3108,7 @@ msgstr ""
 "{error_loading_common}\n"
 "Fila finnes ikke."
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2539,7 +3116,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2555,7 +3132,7 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2563,7 +3140,13 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+#, fuzzy
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr "Importert pensel"
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2577,7 +3160,7 @@ msgstr ""
 "Prøv å lagre som PNG i steden for, dersom maskinen din har lite minne. PNG-"
 "lagringsfunksjonen i MyPaint er mer effektiv."
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2593,144 +3176,253 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/helpers.py:402
-#, python-brace-format
+#: ../lib/floodfill.py:131
+#, fuzzy
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr "Fyll"
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr "{days}d{hours}t"
 
-#: ../lib/helpers.py:404
-#, python-brace-format
+#: ../lib/helpers.py:537
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr "{hours}t{minutes}m"
 
-#: ../lib/helpers.py:406
-#, python-brace-format
+#: ../lib/helpers.py:539
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr "{minutes}m{seconds}s"
 
-#: ../lib/helpers.py:408
-#, python-brace-format
+#: ../lib/helpers.py:541
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr "{seconds}s"
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr "Lag"
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr "%(name)s %(number)d"
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr "^(.*?)\\s*(\\d+)$"
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
+#, fuzzy
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr "Velg lag"
+
+#: ../lib/layer/data.py:1158
+#, fuzzy
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr "Velg lag"
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
-msgstr "Ukjent pensel"
+msgid "Bitmap"
+msgstr ""
 
-#: ../lib/layer/data.py:1169
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1244
 msgctxt "layer default names"
-msgid "Unknown Data Layer"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
 msgstr "Åpne lag"
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "Maling"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr "Gruppe"
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "Ny laggruppe"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr "Plassholder"
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ", "
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+#, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "Visning"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+#, fuzzy
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr "Legg til lag"
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+#, fuzzy
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr "Fjern lag"
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr "Lås lag"
+
+#: ../lib/layervis.py:697
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr "Lås opp lag"
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr "Normal"
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr "Multipliser"
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr "Screen"
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr "Mørkere"
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr "Lysere"
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr "Dodge"
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
@@ -2738,141 +3430,152 @@ msgid ""
 msgstr ""
 
 # # Bruker engelske ord for blending modes
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr "Burn"
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr "Høyde"
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr "Innstillinger"
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr "Rotasjon"
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, fuzzy, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr "%(name)s %(number)d"
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2882,7 +3585,30 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+#, fuzzy
+msgid "Vertical"
+msgstr "Speil vertikalt"
+
+#: ../lib/tiledsurface.py:49
+#, fuzzy
+msgid "Horizontal"
+msgstr "Speil horisontalt"
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+#, fuzzy
+msgid "Rotational"
+msgstr "Rotasjon"
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2891,53 +3617,86 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr "Slett"
+
+#: ../po/tmp/autorecover.glade.h:9
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr "Er du sikker på at du vil slette denne penselen"
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr "Beskrivelse"
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
-msgstr "Kopi av %s"
+msgid "Live update"
+msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
-msgstr "Nullstill alle penselinstillinger til tidligere lagrede verdier"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
+msgstr "Levende oppdatering av siste penselstrøk på lerrettet"
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
-msgstr "Gi nytt navn til pensel"
+msgid "Save these settings to the brush"
+msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
 msgid "Edit Icon"
@@ -2958,18 +3717,16 @@ msgid "Delete this brush from the disk"
 msgstr "Er du sikker på at du vil slette denne penselen"
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
-msgstr ""
+msgid "Copy to New"
+msgstr "Kopi av %s"
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
-msgstr "Levende oppdatering av siste penselstrøk på lerrettet"
+msgid "Copy these settings and the current brush's icon to a new brush"
+msgstr "Nullstill alle penselinstillinger til tidligere lagrede verdier"
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
-msgstr ""
+msgid "Rename this brush"
+msgstr "Gi nytt navn til pensel"
 
 #: ../po/tmp/brusheditor.glade.h:13
 msgid "Brush Setting"
@@ -2997,113 +3754,91 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr "Merknader:"
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr "Penselinnstillinger:"
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
-msgstr "Grunnverdi:"
+#: ../po/tmp/brusheditor.glade.h:22
+#, fuzzy
+msgid "Value:"
+msgstr "Grunnverdi"
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr "<ymin>"
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr "<ymax>"
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr "Utdata"
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr "Peker"
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr "Anpasser maksimumsverdien"
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr "Anpasser minimumsverdien"
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr "<xmin>"
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr "<xmax>"
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr "Penselinnstillinger"
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr "Lagre innstillinger"
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
 msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+#, fuzzy
+msgid "Brush dynamics are not available for this setting."
+msgstr "Penselinnstillinger"
+
+#: ../po/tmp/brusheditor.glade.h:43
+#, fuzzy
+msgid "<big><b>No Brush Dynamics</b></big>"
+msgstr "<big><b>{accel_label}</b></big>"
 
 #: ../po/tmp/inktool.glade.h:1
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
@@ -3115,7 +3850,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr "Trykk:"
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3157,6 +3892,141 @@ msgstr "Slett gruppe"
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
 msgstr "Gjennåpne nåværende filen"
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+#, fuzzy
+msgid "Insert Point"
+msgstr "Sett in rad"
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+#, fuzzy
+msgid "Cull Points"
+msgstr "Slett gruppe"
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Navn"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr "Modus"
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Dekkevne"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr "Kutt rammen til størrelsen på nåværende lag"
+
+#: ../po/tmp/layervis.glade.h:2
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr "Roter visning mot klokken"
+
+#: ../po/tmp/layervis.glade.h:3
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr "Roter visning mot klokken"
+
+#: ../po/tmp/layervis.glade.h:4
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr "Hvilke farger skal fylles"
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
+msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
 msgctxt "footer: color picker button: tooltip"
@@ -3526,56 +4396,77 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+#, fuzzy
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr "Aktivert"
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr "Visning"
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3583,12 +4474,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3597,7 +4488,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3608,28 +4499,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr "<b>Fullskjerm</b>"
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr "Farge"
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr "Skjerm (standard)"
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr "Deaktivert (ingen trykksensitivitet)"
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr "Vindu (ikke anbefalt)"
@@ -3690,1751 +4581,1932 @@ msgid "Reload the file your current work was loaded from."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
+#, fuzzy
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Import Layers…"
+msgstr "Importer penselpakke…"
+
+#: ../po/tmp/resources.xml.h:13
+msgctxt "Accel Editor (descriptions)"
+msgid "Import layers from one or more files."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save"
 msgstr "Lagre"
 
-#: ../po/tmp/resources.xml.h:13
+#: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file."
 msgstr "Lagre som en fil."
 
-#: ../po/tmp/resources.xml.h:14
+#: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As…"
 msgstr "Lagre som…"
 
-#: ../po/tmp/resources.xml.h:15
+#: ../po/tmp/resources.xml.h:17
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file, assigning it a new name."
 msgstr "Lagre til en fil ved samme navn."
 
-#: ../po/tmp/resources.xml.h:16
+#: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Export…"
 msgstr "Eksporter…"
 
-#: ../po/tmp/resources.xml.h:17
+#: ../po/tmp/resources.xml.h:19
 msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 # "Scrap" -> "kladd"
-#: ../po/tmp/resources.xml.h:18
+#: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As Scrap"
 msgstr "Lagre som kladd"
 
-#: ../po/tmp/resources.xml.h:19
+#: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
 msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:20
+#: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Previous Scrap"
 msgstr "Åpne forrige kladd"
 
-#: ../po/tmp/resources.xml.h:21
+#: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file before the current one."
 msgstr "Last neste kladd, istedet for nåværende dokument."
 
 # "Scrap" -> "kladd"
-#: ../po/tmp/resources.xml.h:22
+#: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Next Scrap"
 msgstr "Lagre neste kladd"
 
-#: ../po/tmp/resources.xml.h:23
+#: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file after the current one."
 msgstr "Last neste kladd, istedet for nåværende dokument."
 
-#: ../po/tmp/resources.xml.h:24
+#: ../po/tmp/resources.xml.h:26
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Recover File from an Automated Backup…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:25
+#: ../po/tmp/resources.xml.h:27
 msgctxt "Accel Editor (descriptions)"
 msgid "Try to save and resume interrupted unsaved work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:26
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr "Pensler"
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr "Pensler"
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr "Overskriv penselgruppe."
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr "Fargedetaljer"
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr "Farger"
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr "Modus"
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr "Modus"
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
+#: ../po/tmp/resources.xml.h:37
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Pressure"
+msgstr "Trykk fra penn"
+
+#: ../po/tmp/resources.xml.h:38
+msgctxt "Accel Editor (descriptions)"
+msgid "Send harder pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:39
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Pressure"
+msgstr "Trykk fra penn"
+
+#: ../po/tmp/resources.xml.h:40
+msgctxt "Accel Editor (descriptions)"
+msgid "Send softer pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:41
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Rotation"
+msgstr "Zoom inn"
+
+#: ../po/tmp/resources.xml.h:42
+msgctxt "Accel Editor (descriptions)"
+msgid "Increase barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:43
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
+msgstr "Zoom ut"
+
+#: ../po/tmp/resources.xml.h:44
+msgctxt "Accel Editor (descriptions)"
+msgid "Decrease barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:45
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Size"
 msgstr "Mink gjennomsiktighet"
 
-#: ../po/tmp/resources.xml.h:36
+#: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush bigger."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:37
+#: ../po/tmp/resources.xml.h:47
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Size"
 msgstr "Øk gjennomsiktighet"
 
-#: ../po/tmp/resources.xml.h:38
+#: ../po/tmp/resources.xml.h:48
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush smaller."
 msgstr "Gjør arbeidspenselen mindre."
 
-#: ../po/tmp/resources.xml.h:39
+#: ../po/tmp/resources.xml.h:49
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Opacity"
 msgstr "Mink penselens gjennomsiktighet"
 
-#: ../po/tmp/resources.xml.h:40
+#: ../po/tmp/resources.xml.h:50
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush more opaque."
 msgstr "Gjør arbeidspenselen mer dekkende."
 
-#: ../po/tmp/resources.xml.h:41
+#: ../po/tmp/resources.xml.h:51
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Opacity"
 msgstr "Øk penselens gjennomsiktighet"
 
-#: ../po/tmp/resources.xml.h:42
+#: ../po/tmp/resources.xml.h:52
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush less opaque."
 msgstr "Gjør arbeidspenselen mindre dekkende."
 
-#: ../po/tmp/resources.xml.h:43
+#: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Lighten Painting Color"
 msgstr "Lysne malingsfarge"
 
-#: ../po/tmp/resources.xml.h:44
+#: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase the lightness of the current painting color."
 msgstr "Åpne en fil. Erstatter nåværende fil-visning."
 
-#: ../po/tmp/resources.xml.h:45
+#: ../po/tmp/resources.xml.h:55
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Darken Painting Color"
 msgstr "Mørkne malingsfarge"
 
-#: ../po/tmp/resources.xml.h:46
+#: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease the lightness of the current painting color."
 msgstr "Åpne en fil. Erstatter nåværende fil-visning."
 
-#: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
-msgstr "Roter mot klokken"
-
-#: ../po/tmp/resources.xml.h:48
-msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
-msgstr "Roter mot klokken."
-
-#: ../po/tmp/resources.xml.h:49
+#: ../po/tmp/resources.xml.h:57
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Change Hue Clockwise"
 msgstr "Roter med klokken"
 
-#: ../po/tmp/resources.xml.h:50
+#: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
 msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:51
+#: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr "Roter mot klokken"
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr "Roter mot klokken."
+
+#: ../po/tmp/resources.xml.h:61
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Increase Saturation"
 msgstr "Zoom inn"
 
-#: ../po/tmp/resources.xml.h:52
+#: ../po/tmp/resources.xml.h:62
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color more saturated (more colorful, purer)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:53
+#: ../po/tmp/resources.xml.h:63
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Decrease Saturation"
 msgstr "Zoom ut"
 
-#: ../po/tmp/resources.xml.h:54
+#: ../po/tmp/resources.xml.h:64
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color less saturated (grayer)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:55
+#: ../po/tmp/resources.xml.h:65
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Reload Brush Settings"
 msgstr "Detaljerte penselinnstillinger"
 
-#: ../po/tmp/resources.xml.h:56
+#: ../po/tmp/resources.xml.h:66
 msgctxt "Accel Editor (descriptions)"
 msgid "Restore all brush settings to the current brush’s saved values."
 msgstr "Nullstill alle penselinstillinger til tidligere lagrede verdier."
 
-#: ../po/tmp/resources.xml.h:57
+#: ../po/tmp/resources.xml.h:67
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Pick Stroke and Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:58
+#: ../po/tmp/resources.xml.h:68
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:59
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr "Lagre til sist brukte"
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr "Lagre til sist brukte."
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "Klarer lag"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr "Gjennåpne nåværende filen."
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+#, fuzzy
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr "verktøyikoner"
+
+#: ../po/tmp/resources.xml.h:76
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr "Navn på lag"
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "Ny laggruppe under"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "Ny laggruppe under"
+
+#: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr "Kopier lag til utklippstavle"
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr "Kopier nåværende lags innhold til utklippstavlen"
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr "Lim inn lag fra utklippstavle"
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr "Erstatter nåværende lag med innholdet i utklippstavlen."
 
-#: ../po/tmp/resources.xml.h:71
+#: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Edit Layer in External App…"
 msgstr "Rediger lag i eksternt program…"
 
-#: ../po/tmp/resources.xml.h:72
+#: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:73
+#: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Update Layer with External Edits"
 msgstr "Oppdater lag med eksterne redigeringer"
 
-#: ../po/tmp/resources.xml.h:74
+#: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
 msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:75
+#: ../po/tmp/resources.xml.h:93
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer at Cursor"
 msgstr "Åpne lag"
 
-#: ../po/tmp/resources.xml.h:76
+#: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:77
+#: ../po/tmp/resources.xml.h:95
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Above"
 msgstr "Åpne lag"
 
-#: ../po/tmp/resources.xml.h:78
+#: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer up in the layer stack."
 msgstr "Gå til laget over."
 
-#: ../po/tmp/resources.xml.h:79
+#: ../po/tmp/resources.xml.h:97
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Below"
 msgstr "Åpne lag"
 
-#: ../po/tmp/resources.xml.h:80
+#: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer down in the layer stack."
 msgstr "Gå til laget under."
 
-#: ../po/tmp/resources.xml.h:81
+#: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer"
 msgstr "Maling"
 
-#: ../po/tmp/resources.xml.h:82
+#: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer above the current layer."
 msgstr "Legg til ett nytt lag over det nåværende."
 
-#: ../po/tmp/resources.xml.h:83
+#: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer…"
 msgstr "Velg lag…"
 
-#: ../po/tmp/resources.xml.h:84
+#: ../po/tmp/resources.xml.h:102
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer above the current layer, and begin editing it."
 msgstr "Legg til ett nytt lag over det nåværende."
 
-#: ../po/tmp/resources.xml.h:85
+#: ../po/tmp/resources.xml.h:103
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group"
 msgstr "Ny laggruppe"
 
-#: ../po/tmp/resources.xml.h:86
+#: ../po/tmp/resources.xml.h:104
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group above the current layer."
 msgstr "Legg til ett nytt lag over det nåværende."
 
-#: ../po/tmp/resources.xml.h:87
+#: ../po/tmp/resources.xml.h:105
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer Below"
 msgstr "Nytt tegningslag under"
 
-#: ../po/tmp/resources.xml.h:88
+#: ../po/tmp/resources.xml.h:106
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer below the current layer."
 msgstr "Legg til ett nytt lag under det nåværende."
 
-#: ../po/tmp/resources.xml.h:89
+#: ../po/tmp/resources.xml.h:107
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer Below…"
 msgstr "Nytt vektorielt lag under…"
 
-#: ../po/tmp/resources.xml.h:90
+#: ../po/tmp/resources.xml.h:108
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer below the current layer, and begin editing it."
 msgstr "Legg til ett nytt lag under det nåværende."
 
-#: ../po/tmp/resources.xml.h:91
+#: ../po/tmp/resources.xml.h:109
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group Below"
 msgstr "Ny laggruppe under"
 
-#: ../po/tmp/resources.xml.h:92
+#: ../po/tmp/resources.xml.h:110
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group below the current layer."
 msgstr "Legg til ett nytt lag under det nåværende."
 
-#: ../po/tmp/resources.xml.h:93
+#: ../po/tmp/resources.xml.h:111
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Layer Down"
 msgstr "Spleis lag"
 
-#: ../po/tmp/resources.xml.h:94
+#: ../po/tmp/resources.xml.h:112
 msgctxt "Accel Editor (descriptions)"
 msgid "Merge the current layer with the layer beneath it."
 msgstr "Spleis nåværende lag med laget under."
 
-#: ../po/tmp/resources.xml.h:95
+#: ../po/tmp/resources.xml.h:113
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Visible Layers"
 msgstr "Spleis lag"
 
-#: ../po/tmp/resources.xml.h:96
+#: ../po/tmp/resources.xml.h:114
 msgctxt "Accel Editor (descriptions)"
 msgid "Consolidate all visible layers, and delete the originals."
 msgstr "Fletter alle synlige lag, og sletter originalene."
 
-#: ../po/tmp/resources.xml.h:97
+#: ../po/tmp/resources.xml.h:115
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer from Visible"
 msgstr "Gjør laget synlig"
 
-#: ../po/tmp/resources.xml.h:98
+#: ../po/tmp/resources.xml.h:116
 msgctxt "Accel Editor (descriptions)"
 msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:99
+#: ../po/tmp/resources.xml.h:117
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Delete Layer"
 msgstr "Velg lag"
 
-#: ../po/tmp/resources.xml.h:100
+#: ../po/tmp/resources.xml.h:118
 msgctxt "Accel Editor (descriptions)"
 msgid "Remove the current layer from the layer stack."
 msgstr "Gå til laget under."
 
-#: ../po/tmp/resources.xml.h:101
+#: ../po/tmp/resources.xml.h:119
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Convert to Normal Painting Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:102
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr "Mink gjennomsiktighet"
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr "Gjør laget mindre gjennomsiktig."
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr "Øk gjennomsiktighet"
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr "Gjør laget mer gjennomsiktig."
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr "Døp om lag"
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr "Gå til laget under."
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr "Åpne lag"
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr "Gå til laget under."
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr "Dupliser lag"
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr "Forskjellinge metninger fra nåværende farge."
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
+#, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
-msgstr "Døp om lag…"
+msgid "Layer Properties…"
+msgstr "Egenskaper"
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
-msgstr "Legg til ett nytt lag over det nåværende."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr "Låst"
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr "Gjør laget synlig"
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr "Bakgrunn"
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr "Veksle visning av bakgrunnslaget."
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr "Gå til laget under."
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr "Tilbakestil og sentrer"
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr "Tilbakestill zoomnivå, rotasjon og speiling, og sentrer dokumentet."
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr "Roter"
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr "Tilbakestill"
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr "Tilbakestill"
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr "Gjenopprett visningens forstørrelsesnivå til forvalg"
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr "Rotasjon"
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr "Gjenopprett visningens rotasjon til 0°"
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr "Tilbakestill speiling"
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
-msgstr "Skru av speiling av visningen."
+msgid "Reset the view's mirroring."
+msgstr "Tilbakestill speiling"
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr "Zoom inn"
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr "Zoom inn."
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Forminsk"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr "Zoom ut."
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
+#, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
-msgstr "Roter mot klokken"
+msgid "Pan Left"
+msgstr "Visning"
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
-msgstr "Roter mot klokken."
+msgid "Move your view of the canvas to the left."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr "Høyde"
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr "Visning"
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr "Roter med klokken"
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr "Roter visning mot klokken."
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr "Roter mot klokken"
+
+#: ../po/tmp/resources.xml.h:167
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr "Roter mot klokken."
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr "Speil horisontalt"
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr "Speil: speil visning horisontalt."
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr "Speil vertikalt"
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr "Speil visning vertikalt."
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr "Ettlags-visning"
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr "Gjennåpne nåværende filen."
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr "Aktivert"
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr "Skriv ut penselens innverdier til konsoll"
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr "Visualiser tegning"
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr "Skru av GTK Double Buffering"
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+#, fuzzy
+msgid "Delete Point"
+msgstr "Slett gruppe"
+
+#: ../po/tmp/resources.xml.h:187
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr "Gjennåpne nåværende filen"
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr "Malemodus"
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr "Mal normalt"
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr "Viskelærmodus: fjern malestrøk med penselen."
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 #, fuzzy
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr "Malingsmodus: Lås alfa"
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr "Å skru på penselen har ingen innvirkning på lagets dekkevne."
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Fil"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "Avslutt"
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "Rediger"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr "Nåværende farge"
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "Farge"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr "Nåværende farge"
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr "Fargehistorikk"
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr "Fargedetaljer"
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr "Forrige"
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr "Forrige"
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr "Legg fargen til mønstrene"
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "Lag"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr "Dekkevne"
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr "Åpne lag"
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr "Ettlags-visning"
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr "Egenskaper"
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr "Kladdeblokk"
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr "Ny kladdeblokk"
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
 # "Scrap" -> "kladd"
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr "Åpne kladdebok…"
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr "Lagre kladdeblokk som"
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr "Tilbakestill kladdeblokk…"
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr "Tilbakestill kladdeblokk"
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr "Lagre kladdeblokk som"
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr "Sett som standard"
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr "Bakgrunn"
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "Fargering"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "Pensel"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr "Snarveier"
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr "Snarveier"
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "Endre pensel…"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "Endre farge…"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "Endre farge…"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr "Last ned flere pensler…"
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr "Importer penselpakke…"
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr "Er du sikker på at du vil slette denne penselen."
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Hjelp"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr "Hjelp på nett"
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr "Gå til MyPaints dokumentasjonswiki."
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "Om MyPaint"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr "Vis MyPaints lisens, versjonsnummer, og bidragsyterliste."
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Feilsøking"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr "Print minnelekkasjeinformasjon til konsoll (tregt!)"
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr "Start minnerydding"
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr "Start/Stopp Python profilering (cProfile)"
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr "Simuler et kræsj…"
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "Visning"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr "Nåværende farge"
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
+#, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr "Popup meny"
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr "Vis hovedmenyen som oppsprett."
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "Fullskjerm"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "Innstillinger"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr "Test pekerenheter"
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr "Bakgrunn"
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr "Endre bakgrunnens papirtekstur."
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr "Penselinnstillinger"
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr "Detaljerte penselinnstillinger."
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr "Penselinnstillinger"
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr "Rediger Penselikon."
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr "Navn på lag"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr "Vis lagpanelet"
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "Legg fargen til mønstrene"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr "Endre verdi/metning."
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr "Fargetriangel"
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr "Grunnverdi"
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr "Grunnverdi"
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr "Konsentriske ringer"
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr "Kladdeblokk"
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr "Ny kladdeblokk"
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr "Forhåndsvis panel"
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "Forrige"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr "Verktøysvalgpanel"
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr "Vis panelet for verktøysvalg"
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr "Fargehistorikk"
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr "Bruk pensel %d"
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr "Vis forstørrelsesnivå"
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 #, fuzzy
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr "Vis siste malingsposisjon"
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr "Filhåndtering"
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr "Filhåndtering"
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr "Filhåndtering"
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr "Visning"
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr "Mønster"
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr "Visning"
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr "Roter"
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr "Roter"
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr "Roter"
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr "Zoom inn"
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr "Zoomnivå"
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr "Zoom inn"
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr "Linjer"
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr "Linjer og kurver"
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr "Sammenknyttede linjer"
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr "Ellipser og sirkler"
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr "Ellipse"
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr "Ellipser og sirkler"
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr "Blekk"
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr "Tusjing"
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr "Åpne lag"
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr "Lag"
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr "Åpne lag"
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr "Rediger ramme"
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr "Ramme"
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
@@ -5442,12 +6514,12 @@ msgstr ""
 "Rediger ramme: definer en ramme rundt dokumentet for å gi det en bestemt "
 "størrelse. Rammen brukes når bildet eksporteres."
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr "Rediger ramme"
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
@@ -5455,81 +6527,245 @@ msgstr ""
 "Rediger ramme: definer en ramme rundt dokumentet for å gi det en bestemt "
 "størrelse. Rammen brukes når bildet eksporteres."
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr "Symmetri"
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Rediger malingssymmetri"
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr "Plukk farge"
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr "Plukk farge"
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "Plukk farge"
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "Plukk farge"
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "Plukk farge"
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr "Plukk farge"
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr "Bøttefylling"
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr "Fyll"
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 #, fuzzy
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr "Bøttefylling: Fyll et område med farge."
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr "Bøttefylling"
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr "Fyll et område med farge."
+
+#~ msgctxt "Accelerator map editor: action column markup"
+#~ msgid ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+#~ msgstr ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+
+#~ msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
+#~ msgid "{action_label} {action_desc} {accel_label}"
+#~ msgstr "{action_label} {action_desc} {accel_label}"
+
+#~ msgctxt "brush list context menu"
+#~ msgid "Delete"
+#~ msgstr "Slett"
+
+#~ msgctxt "brush list commands"
+#~ msgid "Really delete brush from disk?"
+#~ msgstr "Er du sikker på at du vil slette denne penselen?"
+
+#~ msgid "HSV Triangle"
+#~ msgstr "Fargetriangel"
+
+#~ msgid "The standard GTK color selector"
+#~ msgstr "MyPaint fargevelger"
+
+#~ msgid "Pick a color from the screen"
+#~ msgstr "Velg en farge fra skjermen"
+
+#~ msgid "Layer Name"
+#~ msgstr "Navn på lag"
+
+#~ msgid ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+#~ msgstr ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+
+# duplication?
+#~ msgid "Save..."
+#~ msgstr "Lagre..."
+
+#~ msgid "Confirm"
+#~ msgstr "Bekreft"
+
+#~ msgid "Open..."
+#~ msgstr "Åpne..."
+
+#~ msgid "{default_name} at {path}"
+#~ msgstr "{default_name} på {path}"
+
+#~ msgid "Type"
+#~ msgstr "Type"
+
+#~ msgid "Mode:"
+#~ msgstr "Modus:"
+
+#~ msgid ""
+#~ "Blending mode: how the current layer combines with the layers underneath "
+#~ "it."
+#~ msgstr ""
+#~ "Blandingsmodus: Hvordan gjeldende lag skal kombineres med lagene under "
+#~ "det."
+
+#~ msgid ""
+#~ "Layer opacity: how much of the current layer to use. Smaller values make "
+#~ "it more transparent."
+#~ msgstr ""
+#~ "Lag-dekkevne: Hvor mye av gjeldende lag som skal brukes. Mindre verdier "
+#~ "gjør det mer gjennomsiktig."
+
+#~ msgid "%s: edit properties"
+#~ msgstr "%s: rediger egenskaper"
+
+#~ msgctxt "layer unique names: match regex (leave untranslated if unsure)"
+#~ msgid "^(.*?)\\s*(\\d+)$"
+#~ msgstr "^(.*?)\\s*(\\d+)$"
+
+#~ msgctxt "layer default names"
+#~ msgid "Unknown Bitmap Layer"
+#~ msgstr "Ukjent pensel"
+
+#~ msgid "Setting name:"
+#~ msgstr "Penselinnstillinger:"
+
+#~ msgid "Base value:"
+#~ msgstr "Grunnverdi:"
+
+#~ msgid "<ymin>"
+#~ msgstr "<ymin>"
+
+#~ msgid "<ymax>"
+#~ msgstr "<ymax>"
+
+#~ msgid "<xmin>"
+#~ msgstr "<xmin>"
+
+#~ msgid "<xmax>"
+#~ msgstr "<xmax>"
+
+#~ msgid "Edit Setting"
+#~ msgstr "Lagre innstillinger"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Trim Layer to Frame"
+#~ msgstr "Navn på lag"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Rename Layer…"
+#~ msgstr "Døp om lag…"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Enter a new name for the current layer."
+#~ msgstr "Legg til ett nytt lag over det nåværende."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Turn off mirroring of the view."
+#~ msgstr "Skru av speiling av visningen."
+
+#~ msgctxt "Menu→Edit (labels)"
+#~ msgid "Current Tool"
+#~ msgstr "Nåværende farge"
+
+#~ msgctxt "Menu→Color (labels), Accel Editor (labels)"
+#~ msgid "HSV Triangle"
+#~ msgstr "Fargetriangel"
 
 #~ msgid "Add As New"
 #~ msgstr "Legg til som ny"
@@ -5630,9 +6866,6 @@ msgstr "Fyll et område med farge."
 #~ "Forklaringer om penselens innstillinger finnes som \"tooltips\".Hold "
 #~ "musen over innstillingen for å se de. \n"
 
-#~ msgid "Open Recent files"
-#~ msgstr "Åpne nylige filer"
-
 #~ msgid "This will discard %d second of unsaved painting."
 #~ msgid_plural "This will discard %d seconds of unsaved painting."
 #~ msgstr[0] "Dette vil forkaste %d sekund maling som ikke er lagret."
@@ -5640,9 +6873,6 @@ msgstr "Fyll et område med farge."
 
 #~ msgid "Crop to Current Layer"
 #~ msgstr "Flytt lag"
-
-#~ msgid "Crop frame to the currently active layer"
-#~ msgstr "Kutt rammen til størrelsen på nåværende lag"
 
 #~ msgid ""
 #~ "While the frame is enabled, it \n"
@@ -5739,9 +6969,6 @@ msgstr "Fyll et område med farge."
 #~ msgid "Brush Blend Mode"
 #~ msgstr "Pensel malemodus"
 
-#~ msgid "Add Layer"
-#~ msgstr "Legg til lag"
-
 #~ msgid "Move Layer on Canvas"
 #~ msgstr "Flytt lag på lerret"
 
@@ -5776,9 +7003,6 @@ msgstr "Fyll et område med farge."
 #~ msgctxt "Menu|File|"
 #~ msgid "Save"
 #~ msgstr "Lagre"
-
-#~ msgid "Export to a file"
-#~ msgstr "Ekspoter til en fil"
 
 #~ msgid ""
 #~ "Saves to a new scrap file. If the drawing is currently saved as a scrap, "

--- a/po/nb.po
+++ b/po/nb.po
@@ -530,18 +530,18 @@ msgstr "MyPaint penselpakke (*.zip)"
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr "Ny gruppe…"
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
-msgstr "Importer penselpakke..."
+msgid "Import Brushes…"
+msgstr "Importer penselpakke…"
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
-msgstr "Last ned flere pensler..."
+msgid "Get More Brushes…"
+msgstr "Last ned flere pensler…"
 
 #: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
@@ -767,7 +767,7 @@ msgstr "Opprett ny maske fra mal."
 #: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
-msgstr "Last palett fil..."
+msgstr "Last palett fil…"
 
 #: ../gui/colors/hcywheel.py:1116
 #, fuzzy
@@ -1225,12 +1225,12 @@ msgstr "Type"
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr "Bruk for…"
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr "Rulling…"
 
 #. Name and preview column: will be indented
@@ -1419,7 +1419,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Open dragged file confirm dialog: continue button"
 msgid "_Open"
-msgstr "Åpne..."
+msgstr "Åpne…"
 
 #: ../gui/drawwindow.py:486
 msgid "Set current color"
@@ -1454,8 +1454,8 @@ msgid "_Quit"
 msgstr "Avslutt"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
-msgstr "Importer penselpakke..."
+msgid "Import brush package…"
+msgstr "Importer penselpakke…"
 
 #: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
@@ -1504,8 +1504,8 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
-msgstr "Åpne..."
+msgid "Open With…"
+msgstr "Åpne…"
 
 #: ../gui/externalapp.py:123
 msgid "Icon"
@@ -1698,13 +1698,13 @@ msgstr "JPEG 90% kvalitet (*.jpg; *.jpeg)"
 
 #: ../gui/filehandling.py:576
 #, fuzzy
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr "Eksporter…"
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Lagre som…"
 
@@ -1777,8 +1777,8 @@ msgstr "Åpne nylige filer"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
-msgstr "Åpne kladdebok..."
+msgid "Open Scratchpad…"
+msgstr "Åpne kladdebok…"
 
 #: ../gui/filehandling.py:1099
 #, fuzzy
@@ -1795,7 +1795,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Åpne..."
+msgstr "Åpne…"
 
 #: ../gui/filehandling.py:1427
 #, fuzzy
@@ -1807,7 +1807,7 @@ msgstr "Åpne nylig brukte"
 #, fuzzy
 msgctxt "File→Open Most Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Åpne..."
+msgstr "Åpne…"
 
 #: ../gui/filehandling.py:1446
 #, fuzzy
@@ -1832,7 +1832,7 @@ msgstr "Åpne forrige kladd"
 #, fuzzy
 msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
 msgid "_Open"
-msgstr "Åpne..."
+msgstr "Åpne…"
 
 #: ../gui/filehandling.py:1487
 msgctxt "File→Revert: status message: canvas has no filename yet"
@@ -2223,12 +2223,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr "Rapporter…"
 
 #: ../gui/gtkexcepthook.py:180
@@ -2240,8 +2240,8 @@ msgid "Quit MyPaint"
 msgstr "Om MyPaint"
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
-msgstr "Detaljer..."
+msgid "Details…"
+msgstr "Detaljer…"
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
@@ -2430,8 +2430,8 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
-msgstr "Endre lagets nivå..."
+msgid "Move layer in stack…"
+msgstr "Endre lagets nivå…"
 
 #: ../gui/layerswindow.py:110
 msgid ""
@@ -2502,7 +2502,7 @@ msgid "Stroke trail-off beginning"
 msgstr "Strøkets uttoningsbegynnelse"
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr "Trykkvariasjon…"
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777
@@ -4548,7 +4548,7 @@ msgstr "Åpne…"
 #: ../po/tmp/resources.xml.h:5
 msgctxt "Toolbar (short labels)"
 msgid "Open"
-msgstr "Åpne..."
+msgstr "Åpne…"
 
 #: ../po/tmp/resources.xml.h:6
 msgctxt "Toolbar (tooltips), Accel Editor (descriptions)"

--- a/po/nl.po
+++ b/po/nl.po
@@ -532,18 +532,18 @@ msgstr "MyPaint penseelpakket (*.zip)"
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
-msgstr "Nieuwe groep..."
+msgid "New Group…"
+msgstr "Nieuwe groep…"
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
-msgstr "Penseelpakket importeren..."
+msgid "Import Brushes…"
+msgstr "Penseelpakket importeren…"
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
-msgstr "Meer penselen ophalen..."
+msgid "Get More Brushes…"
+msgstr "Meer penselen ophalen…"
 
 #: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
@@ -1228,13 +1228,13 @@ msgstr "Soort"
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
-msgstr "Doel..."
+msgid "Use for…"
+msgstr "Doel…"
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
-msgstr "Beweging..."
+msgid "Scroll…"
+msgstr "Beweging…"
 
 #. Name and preview column: will be indented
 #: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
@@ -1457,8 +1457,8 @@ msgid "_Quit"
 msgstr "Afsluiten"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
-msgstr "Penseelpakket importeren..."
+msgid "Import brush package…"
+msgstr "Penseelpakket importeren…"
 
 #: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
@@ -1514,8 +1514,8 @@ msgstr ""
 "\"{type_name}\" {content_type}?"
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
-msgstr "Openen met..."
+msgid "Open With…"
+msgstr "Openen met…"
 
 #: ../gui/externalapp.py:123
 msgid "Icon"
@@ -1705,13 +1705,13 @@ msgstr "JPEG 90% kwaliteit (*.jpg; *.jpeg)"
 
 #: ../gui/filehandling.py:576
 #, fuzzy
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr "Exporteren…"
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Opslaan als…"
 
@@ -1782,8 +1782,8 @@ msgstr "Openen"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
-msgstr "Open Kladblok..."
+msgid "Open Scratchpad…"
+msgstr "Open Kladblok…"
 
 #: ../gui/filehandling.py:1099
 #, fuzzy
@@ -2233,13 +2233,13 @@ msgstr ""
 "tijdig op."
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
-msgstr "Zoek de tracker..."
+msgid "Search Tracker…"
+msgstr "Zoek de tracker…"
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
-msgstr "Rapporteren..."
+msgid "Report…"
+msgstr "Rapporteren…"
 
 #: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
@@ -2250,8 +2250,8 @@ msgid "Quit MyPaint"
 msgstr "MyPaint afsluiten"
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
-msgstr "Details..."
+msgid "Details…"
+msgstr "Details…"
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
@@ -2460,8 +2460,8 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
-msgstr "Vlak verplaatsen in de stapel..."
+msgid "Move layer in stack…"
+msgstr "Vlak verplaatsen in de stapel…"
 
 #: ../gui/layerswindow.py:110
 msgid ""
@@ -2533,7 +2533,7 @@ msgid "Stroke trail-off beginning"
 msgstr "Begin einddeel"
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr "Drukvariatie."
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777
@@ -3731,7 +3731,7 @@ msgstr "Penseel van schijf verwijderen"
 #, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid "_Recover & Save…"
-msgstr "Terughalen en opslaan..."
+msgstr "Terughalen en opslaan…"
 
 #: ../po/tmp/autorecover.glade.h:12
 #, fuzzy

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2017-09-15 10:45+0000\n"
 "Last-Translator: Just Vecht <justvecht@ziggo.nl>\n"
-"Language-Team: Dutch "
-"<https://hosted.weblate.org/projects/mypaint/mypaint/nl/>\n"
+"Language-Team: Dutch <https://hosted.weblate.org/projects/mypaint/mypaint/nl/"
+">\n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,29 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 2.17-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr "<big><b>{accel_label}</b></big>"
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr "{action_label} {action_desc} {accel_label}"
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "Uitvoeren"
 
@@ -49,32 +27,32 @@ msgstr "Uitvoeren"
 msgid "Key combination"
 msgstr "Toetscombinatie"
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr "Bewerk sneltoets voor '%s'"
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "Uitvoeren:"
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "Pad:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "Toets:"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr "Druk op de toetsen om de toewijzing vast te leggen"
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "Onbekende aktie"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
@@ -83,7 +61,7 @@ msgstr ""
 "<b>{accel} is al voor '{action}' in gebruik. De bestaande toewijzing wordt "
 "vervangen.</b>"
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr "Open map “{folder_basename} 1”…"
@@ -91,195 +69,205 @@ msgstr "Open map “{folder_basename} 1”…"
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "OK"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr "Geen backups aangetroffen in de cache."
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr "Geen beschikbare backups"
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr "Open de Cache map…"
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr "Het openen van de backup is mislukt"
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr "Open de Backup map…"
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr "Uit de backup van {iso_datetime}.ora teruggehaald"
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "Als standaard opslaan"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "Achtergrond"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "Patroon"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Kleur"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "Kleur toevoegen bij patronen"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr "Een of meerdere achtergronden konden niet worden geopend"
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr "Fout bij het openen van achtergronden"
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 "Verwijder de niet te openen bestanden (controleer eventueel de installatie "
 "van libgdkpixbuf)."
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr "Gdk-Pixbuf kan \"{filename}\" niet openen met de melding: \"{error}\""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr "{filename} heeft als grootte nul  (w={w}, h={h})"
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr "Penseel voorkeuren"
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr "Over"
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "Experimenteel"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr "Basis"
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr "Dekking"
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr "Penseelstreek"
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "Wrijven"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr "Snelheid"
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr ""
+
+#: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr "Tracking"
 
-#: ../gui/brusheditor.py:359
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "Streek"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr "Kleur"
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Custom"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr "Geen penseel gekozen, gebruik \"Voeg toe als Nieuw\"."
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr "Geen penseel gekozen!"
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "Hernoem het penseel"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "Een penseel met deze naam bestaat al!"
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr "Geen penseel gekozen!"
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr "Penseel  \"{brush_name}\" echt verwijderen?"
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr "(penseel zonder naam)"
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr "{brush_name} [niet bewaard]"
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr "penseel pictogram"
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr "Penseel pictogram (bewerken)"
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr "geen penseel gekozen"
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -288,7 +276,7 @@ msgstr ""
 "<b>%s</b>\n"
 "<small>Kies eerst een bestaand penseel</small>"
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
@@ -297,7 +285,7 @@ msgstr ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>De veranderingen zijn nog niet opgeslagen</small>"
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
@@ -306,7 +294,7 @@ msgstr ""
 "<b>%s</b> (editing)\n"
 "<small>Teken met een penseel of kleur van je keuze</small>"
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -347,142 +335,182 @@ msgstr "Auto"
 msgid "Use the default icon"
 msgstr "Standaard pictogram gebruiken"
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Opslaan"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr "Sla dit voorbeeld pictogram op en sluit bewerken"
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr "Gevonden bestanden"
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr "Verwijderd"
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr "Favorieten"
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr "Inkt"
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr "Klassiek"
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr "Set #1"
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr "Set #2"
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr "Set #3"
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr "Set #4"
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr "Set #5"
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr "Experimenteel"
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Nieuw"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr "Onbekend penseel"
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr "Toevoegen aan favorieten"
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr "Verwijder uit favorieten"
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr "Klonen"
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr "Bewerk penseelinstellingen"
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
-msgstr "Verwijderen"
+#: ../gui/brushselectionwindow.py:250
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
+msgstr "Groep hernoemen"
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
-msgstr "Penseel echt verwijderen?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, fuzzy, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
+msgstr "Penseel  \"{brush_name}\" echt verwijderen?"
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] "%d penseel"
 msgstr[1] "%d penselen"
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr "Groep \"{group_name}\""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr "Groep hernoemen"
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr "Export als gezipte penseelset"
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr "Verwijder groep"
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr "Groep hernoemen"
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "Een groep met deze naam bestaat al!"
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr "Groep \"{group_name}\" echt verwijderen?"
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -492,58 +520,58 @@ msgstr ""
 "Kan groep “{group_name}” niet verwijderen.\n"
 "Sommige bijzondere groepen kunnen niet verwijderd worden."
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr "Penselen exporteren"
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr "MyPaint penseelpakket (*.zip)"
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "Nieuwe groep..."
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr "Penseelpakket importeren..."
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr "Meer penselen ophalen..."
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "Maak groep"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr "Muistoets"
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr "Toets"
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr "Muisklik"
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr "Maak een nieuwe sneltoetscombinatie"
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr "Verwijder de huidige sneltoetscombinatie"
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr "Bewerk de sneltoetscombinatie voor '%s'"
@@ -552,7 +580,7 @@ msgstr "Bewerk de sneltoetscombinatie voor '%s'"
 msgid "Button press:"
 msgstr "Muisklik:"
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
@@ -560,7 +588,7 @@ msgstr ""
 "Druk (Ctrl, Alt of Shift) plus een muistoets in op deze tekst om een nieuwe "
 "sneltoetscombinatie vast te leggen."
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
@@ -568,39 +596,67 @@ msgstr ""
 "{button} moet in een sneltoetscombinatie met andere toetsen worden opgenomen "
 "(heeft op zichzelf al een vaste waarde)"
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr "{button_combination} al vastgelegd als sneltoets voor '{action_name}'"
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr "Kleuren pipet"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr "Kies de kleur om te tekenen"
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+#, fuzzy
+msgid "Set the color Hue used for painting"
+msgstr "Kies de kleur om te tekenen"
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "Kies kleur"
+
+#: ../gui/colorpicker.py:296
+#, fuzzy
+msgid "Set the color Chroma used for painting"
+msgstr "Kies de kleur om te tekenen"
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+#, fuzzy
+msgid "Set the color Luma used for painting"
+msgstr "Kies de kleur om te tekenen"
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr "Kleur details"
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr "Huidige penseelkleur en de laatst gebruikte kleur"
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr "Online Help"
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr "Actief gamma masker"
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr "Begrens je palet voor bepaalde situaties met een gamma masker."
@@ -610,7 +666,7 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr "HCY tint en verzadiging."
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
@@ -619,12 +675,12 @@ msgstr ""
 "Gamma masker bewerken. Klik in het midden om vormen te maken of aan te "
 "passen, of roteer het masker met de rand van de schijf."
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr "Atmosferische driehoek"
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
@@ -633,22 +689,22 @@ msgstr ""
 "Stemmig en subjectief, met een dominante basiskleur en twee minder "
 "verzadigde basiskleuren."
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr "Verschoven driehoek"
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr "Meer gericht op de dominante kleur."
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr "Complementair"
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
@@ -657,12 +713,12 @@ msgstr ""
 "Contrasterende waarden, in balans door tussenliggende centrale neutrale "
 "waarden op het kleurenwiel."
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr "Stemmig en accenten"
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
@@ -671,12 +727,12 @@ msgstr ""
 "Een hoofd bereik aan kleuren met een aanvullend bereik voor variatie en "
 "pieken."
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr "Complementaire split"
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
@@ -684,72 +740,72 @@ msgid ""
 msgstr ""
 "Twee aanliggende kleuren en een complementaire kleur zonder tussenkleuren."
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr "Nieuw gamma masker uit een sjabloon"
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr "Gamma masker editor"
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr "Actief"
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr "Help…"
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr "Maak masker uit een sjabloon."
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr "Laad masker uit een GIMP paletbestand."
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr "Masker opslaan in een GIMP paletbestand."
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr "Verwijder het masker."
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr "Open de online help voor deze dialoog in een browser."
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr "Sla het masker op als een GIMP palet"
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr "Open een masker van een GIMP palet"
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr "Sla gamma masker op."
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr "HCY kleurenwiel"
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -759,164 +815,156 @@ msgstr ""
 "cirkeldoorsneden hebben gelijke lichtheid (equiluminant)."
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr "HSV tint"
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr "HSV verzadiging"
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr "HSV waarde"
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr "HSV verzadiging en waarde"
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr "HSV tint en waarde"
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr "HSV tint en verzadiging"
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr "Roteer de kubus (toon verschillende assen)"
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr "HSV kubus"
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 "Een HSV kubux die kan worden gedraaid om verschillende doorsnedes te tonen."
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr "HSV vierkant"
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 "Een HSV vierkant die kan worden gedraaid om verschillende tinten te tonen."
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr "HSV driehoek"
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr "De standaard GTK kleurenkiezer"
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr "HSV kleurenwiel"
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr "Verzadiging en waarde kleuren bewerken."
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr "Paleteigenschappen"
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr "Palet"
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr "Kies de kleur van een te laden en bewerken palet."
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr "Palet zonder naam"
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr "Palet editor"
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr "GIMP palet openen"
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr "Opslaan als een GIMP palet"
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr "Voeg een nieuwe lege kleurstaal toe"
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr "Verwijder de huidige kleurstaal"
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr "Verwijder alle kleurstalen"
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr "Naam:"
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr "Naam of beschrijving voor dit palet"
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr "Kolommen:"
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr "Aantal kolommen"
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr "Naam van de kleur:"
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr "Naam van de huidige kleur"
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr "Leeg paletveld"
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr "Open palet"
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr "Sla palet op"
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -927,380 +975,377 @@ msgstr ""
 "Voeg kleuren toe (drop),\n"
 "Schuif ze op hun plek (drag)."
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr "Leeg paletvak (sleep er een kleur in)"
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr "Leeg vak toevoegen"
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr "Voeg rij toe"
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr "Voeg kolom toe"
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr "Opvullen (RGB)"
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr "Opvullen (HCY)"
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr "Opvullen (HSV)"
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "GIMP paletbestand (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr "Alle bestanden"
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "GIMP paletbestand (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr "Alle bestanden"
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr "Kies een kleur in beeld"
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr "R"
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr "G"
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr "B"
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr "H"
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr "C"
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr "Y"
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr "Kleurenbalken"
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr "Bewerk de kleuren individueel."
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr "RGB Rood"
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr "RGB Groen"
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr "RGB Blauw"
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr "HSV Tint"
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr "HSV Verzadiging"
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr "HSV Waarde"
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr "HCY Tint"
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr "HCY Dekking"
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr "HCY Lichtheid"
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr "Vloeiend verkleuren"
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 "Verander een kleur door een vloeiende vermenging met aangrenzende kleuren."
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr "Concentrische ringen"
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr "Kleuren bewerken met concentrische HSV ringen."
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr "Kruiswiel"
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr "Kleuren bewerken met het kruiswiel."
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr "Muisaanwijzer"
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr "Gum"
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr "Toetsenbord"
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr "Muis"
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr "Stylo"
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr "Aanraakveld"
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr "Touchscreen"
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr "Niet gebruiken"
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr "Alles"
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr "Alles zonder tekenen"
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr "Alleen verplaatsingen"
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr "In/uitzoomen"
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr "Verschuiven"
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr "Apparaat"
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr "Assen"
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr "Soort"
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr "Doel..."
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr "Beweging..."
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Naam"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr "Penseel overschrijven?"
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr "Vervangen"
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr "Hernoemen"
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr "Alles vervangen"
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr "Alles hernoemen"
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr "Geïmporteerde penseel"
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr "Bestaand penseel"
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 "<b>Een penseel met de naam `%s' bestaat al.</b>\n"
 "Moet hij overschreven worden, of moet dit penseel een andere naam krijgen?"
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr "Penseelgroep overschrijven?"
 
-#: ../gui/dialogs.py:190
-#, python-brace-format
+#: ../gui/dialogs.py:220
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 "<b>Een groep met de naam `{groupname}' bestaat al.</b>\n"
 "Moet hij overschreven worden, of moet de groep een andere naam krijgen?\n"
 "Als hij overschreven wordt, kunnen de penselen worden verplaatst naar een "
 "groep `{deleted_groupname}'."
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr "Penseelpakket importeren?"
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, fuzzy, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr "<b>Wil je echt pakket `%s' importeren?</b>"
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr "Herstel de penseelinstellingen vanuit sneltoets %d"
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr "Sla de penseelinstellingen op onder sneltoets %d"
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr "Herstel penseel %d"
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr "Sla op als penseel %d"
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr "Annuleren  %s"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Annuleren"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr "Herhaal %s"
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Herhaal"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr "{button_combination} is {resultant_action}"
@@ -1310,89 +1355,128 @@ msgstr "{button_combination} is {resultant_action}"
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ";  "
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr "Met {modifiers} ingedrukt:  {button_actions}."
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
-msgstr "Laagnaam"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
+msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
-msgstr "<b>{name}</b>{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
+msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr "%s -MyPaint"
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr "MyPaint"
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Openen"
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr "Kies huidige kleur"
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr "Verlaat schermvullende modus"
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr "Verlaat schermvullende modus"
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr "Schermvullende modus"
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Schermvullende modus"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Afsluiten"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+#, fuzzy
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr "Echt afsluiten?"
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Afsluiten"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr "Penseelpakket importeren..."
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr "Penseelpakket (*.zip)"
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr "{app_name} geopend om laag \"{layer_name}\" te bewerken"
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 "Fout: niet mogelijk om {app_name} te openen om laag {layer_name} te bewerken"
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
@@ -1400,12 +1484,18 @@ msgstr ""
 "Bewerking geannuleerd. Je kunt de {layer_name} altijd aanpassen in het "
 "laagvenster."
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr "Laag {layer_name} met externe aanpassingen bijgewerkt"
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr "Kan \"{file_basename}\" niet openen."
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
@@ -1414,188 +1504,418 @@ msgstr ""
 "MyPaint moet een bestand van type \"{type_name}\" {content_type} bewerken. "
 "Welk programma moet gebruikt worden?"
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
-"Welk programma moet MyPaint gebruiken voor bestanden van het type \""
-"{type_name}\" {content_type}?"
+"Welk programma moet MyPaint gebruiken voor bestanden van het type "
+"\"{type_name}\" {content_type}?"
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr "Openen met..."
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr "Pictogram"
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr "geen beschrijving"
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
+#: ../gui/filehandling.py:126
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
+msgstr "Open \"{file_basename}\"…"
+
+#: ../gui/filehandling.py:130
+#, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:134
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
+msgstr "Sla \"{file_basename}\" op…"
+
+#: ../gui/filehandling.py:138
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
+msgstr "Geexporteerd naar \"{file_basename}\"…"
+
+#: ../gui/filehandling.py:145
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr "Export naar \"{file_basename}\" mislukt."
+
+#: ../gui/filehandling.py:149
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr "Opslaan als \"{file_basename}\" mislukt."
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr "Kan \"{file_basename}\" niet openen."
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "Sla palet op"
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr "Met succes naar \"{file_basename}\" geëxporteerd."
+
+#: ../gui/filehandling.py:187
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr "Met succes opgeslagen als \"{file_basename}\"."
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr "\"{file_basename}\" geopend."
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
+msgstr "\"{file_basename}\" geopend."
+
+#: ../gui/filehandling.py:427
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "All Recognized Formats"
 msgstr "Alle ondersteunde formaten"
 
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
+#: ../gui/filehandling.py:432
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "OpenRaster (*.ora)"
 msgstr "OpenRaster (*.ora)"
 
-#: ../gui/filehandling.py:95
+#: ../gui/filehandling.py:437
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "PNG (*.png)"
 msgstr "PNG (*.png)"
 
-#: ../gui/filehandling.py:96
+#: ../gui/filehandling.py:442
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "JPEG (*.jpg; *.jpeg)"
 msgstr "JPEG (*.jpg; *.jpeg)"
 
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
+#: ../gui/filehandling.py:490
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "By extension (prefer default format)"
 msgstr "Volgens extensie"
 
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
+#: ../gui/filehandling.py:494
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:498
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
 msgstr "PNG zonder transparante achtergrond (*.png)"
 
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
+#: ../gui/filehandling.py:502
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:506
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
 msgstr "PNG met transparante achtergrond (*.png)"
 
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
+#: ../gui/filehandling.py:510
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
 msgstr "meerdere PNG met transparante achtergrond (*.XXX.png)"
 
-#: ../gui/filehandling.py:113
+#: ../gui/filehandling.py:514
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr "meerdere PNG met transparante achtergrond (*.XXX.png)"
+
+#: ../gui/filehandling.py:518
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr "JPEG 90% kwaliteit (*.jpg; *.jpeg)"
 
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr "Opslaan..."
+#: ../gui/filehandling.py:576
+#, fuzzy
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr "Exporteren…"
 
-#: ../gui/filehandling.py:177
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Opslaan als…"
+
+#: ../gui/filehandling.py:601
+#, fuzzy
+msgctxt "save dialogs: formats and options: (label)"
 msgid "Format to save as:"
 msgstr "Opslaan in formaat:"
 
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr "Bevestigen"
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
+#: ../gui/filehandling.py:668
+#, fuzzy
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
 msgstr "Echt doorgaan?"
 
-#: ../gui/filehandling.py:234
-#, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
-msgstr "Dit wist {abbreviated_time} aan niet-opgeslagen werk"
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
+#: ../gui/filehandling.py:705
+#, fuzzy
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
 msgstr "Opslaan als klad"
 
-#: ../gui/filehandling.py:282
-#, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
-msgstr "Open \"{file_basename}\"…"
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
 
-#: ../gui/filehandling.py:296
-#, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
-msgstr "Kan \"{file_basename}\" niet openen."
+#: ../gui/filehandling.py:734
+#, fuzzy, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr "Dit wist {abbreviated_time} aan niet-opgeslagen werk"
 
-#: ../gui/filehandling.py:321
-#, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
-msgstr "\"{file_basename}\" geopend."
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
 
-#: ../gui/filehandling.py:422
-#, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
-msgstr "Geexporteerd naar \"{file_basename}\"…"
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
 
-#: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
-msgstr "Sla \"{file_basename}\" op…"
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
-msgstr "Export naar \"{file_basename}\" mislukt."
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr "Openen…"
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
-msgstr "Opslaan als \"{file_basename}\" mislukt."
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Openen"
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
-msgstr "Met succes naar \"{file_basename}\" geëxporteerd."
-
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
-msgstr "Met succes opgeslagen als \"{file_basename}\"."
-
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Openen..."
-
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr "Open Kladblok..."
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Geïmporteerde penseel"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Openen"
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Open meest recente"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Openen"
+
+#: ../gui/filehandling.py:1446
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
 msgstr "Er is nog geen Kladblok met de naam \"%s\"."
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1455
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr "Volgende klad openen"
+
+#: ../gui/filehandling.py:1463
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr "Laatste klad openen"
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Openen"
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+#, fuzzy
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr "Annuleren"
+
+#: ../gui/fill.py:121
+#, fuzzy
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr "Emmer (vullen)"
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+#, fuzzy
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr "Selectie met kleur vullen"
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+#, fuzzy
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr "Tolerantie:"
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+#, fuzzy
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr "Toegestane kleurafwijking tot vullen niet meer gaat"
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+#, fuzzy
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr "Bron:"
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
-msgstr "Welke zichtbare lagen moet er gevuld worden"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
+msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+#, fuzzy
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr "Vlakken samenvoegen"
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+#, fuzzy
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
@@ -1604,19 +1924,50 @@ msgstr ""
 "Om het te vullen gebied te bepalen kan je alle zichtbare lagen samenvoegen "
 "in een  laag onder de huidige laag"
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+#, fuzzy
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr "Aanpassen aan beeld"
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+#, fuzzy
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr "Doel:"
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+#, fuzzy
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr "Waar het resultaat geplaatst moeten worden"
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr "Nieuwe laag (eenmalig)"
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+#, fuzzy
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
@@ -1624,21 +1975,108 @@ msgstr ""
 "Maak een nieuwe laag met het vulresultaat.\n"
 "Deze wordt na gebruik automatisch uitgezet."
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Dekking:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr "Ongedaan maken"
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+#, fuzzy
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr "Terugzetten op de standaard waarde(n)"
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "Kies laag"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr "<b>{brush_name}</b>"
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1648,130 +2086,142 @@ msgstr ""
 "<b>{brush_name}</b>\n"
 "{brush_desc}"
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr "Frame bewerken"
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr "Document frame aanpassen"
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr "Frame grootte"
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr "px"
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr "Hoogte:"
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr "Breedte:"
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr "Resolutie:"
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr "DPI"
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr "Dots per inch (daadwerkelijk: Pixels per inch)"
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr "Kleur:"
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr "Frame kleur"
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr "<b>Frame afmetingen</b>"
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr "<b>Pixeldichte</b>"
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr "Plaats frame in laag"
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr "Frame aanpassen aan laag grootte"
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr "Frame aanpassen aan document"
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr "Frame aanpassen aan de combinatie van alle lagen"
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr "Laag aanpassen aan frame"
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr "Laag afsnijden op alle delen buiten het frame"
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr "Actief"
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr "{width:g}×{height:g} {units}"
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr "inch"
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr "cm"
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr "mm"
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr "Vrijehand tekenen"
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr "Vrijehandtekenen met een penseel"
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr "Vloeiend:"
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr "Druk:"
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr "Bug aangetroffen"
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr "<big><b>Er heeft zich een programmafout voorgedaan.</b></big>"
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1782,35 +2232,35 @@ msgstr ""
 "Je kunt deze fout vermoedelijk negeren en doorwerken, maar sla je werk beter "
 "tijdig op."
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr "Zoek de tracker..."
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr "Rapporteren..."
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr "Fout negeren"
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr "MyPaint afsluiten"
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr "Details..."
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr "Fout bij het analyseren van de melding."
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1854,45 +2304,50 @@ msgstr ""
 "            #### Traceback\n"
 "        "
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr "Inkleuren"
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr "Tekenen en daarna de vloeiende lijnen aanpassen"
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr "Invoerapparaat test"
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr "(geen druk)"
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr "Druk:"
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr "(geen hoek)"
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr "Hoek:"
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr "(geen apparaat)"
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
 msgstr "Apparaat:"
 
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+#, fuzzy
+msgid "Barrel Rotation:"
+msgstr "De rotatie terugzetten"
+
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr "Laag verplaatsen"
 
@@ -1900,162 +2355,228 @@ msgstr "Laag verplaatsen"
 msgid "Move the current layer"
 msgstr "Huidige vlak verplaatsen"
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
-msgstr "{default_name} op {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
+msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
-msgstr "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
+msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+#, fuzzy
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr "Eigenschappen"
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr "Zichtbaar"
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Laag"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+#, fuzzy
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr "Vergrendeld"
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+#, fuzzy
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ", "
+
+#: ../gui/layers.py:990
+#, fuzzy, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr "{layer_default_name} toevoegen"
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Lagen"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr "Lagen ordenen en effecten instellen"
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr "Laagdekking: %d%%"
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr "Vlak verplaatsen in de stapel..."
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 "Vlak verplaatsen in de stapel (droppen in een normale laag maakt een nieuwe "
 "groep aan)"
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr "Laag"
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
-msgstr "Modus:"
+#: ../gui/layervis.py:53
+#, fuzzy, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
+msgstr "<b>{brush_name}</b>"
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
-"Combinatiemodus: hoe de huidige laag met de laag eronder moet worden "
-"gecombineerd."
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Dekking:"
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "Beeld draaien"
 
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-"Laagdekking:  hoe lager de waarde des te transparanter (doorzichtiger) de "
-"huidige laag."
-
-#: ../gui/linemode.py:37
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr "Aanvangsdruk"
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr "Aanvangsdruk voor lijngereedschap"
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr "MIddendruk"
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr "Druk in het midden voor lijngereedschap"
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr "Einddruk"
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr "Einddruk voor lijngereedschap"
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr "Kop"
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 msgid "Stroke lead-in end"
 msgstr "Einde aanvangsgedeelte"
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr "Einddeel"
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr "Begin einddeel"
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr "Drukvariatie."
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr "Lijnen en krommen"
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr "Standaard Lijnen/krommen modus"
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr "Rechte lijnen tekenen; Shift geeft krommen, Ctrl houdt hoeken vast"
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr "Verbonden lijnstukken"
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 "Meerdere lijnstukken tekenen; Shift geeft krommen, Ctrl houdt hoeken vast"
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr "Cirkels en Ellipsen"
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr "Ellipsen tekenen: Shift draait, Ctrl bepaalt de verhouding en de hoek"
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
+#, fuzzy
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 "Copyright (C) 2005-2015\n"
 "Martin Renold en het MyPaint Development Team"
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -2074,256 +2595,286 @@ msgstr ""
 "MyPaint wordt gedistribueerd in de hoop dat het nuttig zal zijn, maar ZONDER "
 "ENIGE GARANTIE. Zie het COPYING bestand voor meer informatie."
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr "programmeren"
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr "Porteren"
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr "Projectmanagement"
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr "Penseel"
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr "patronen"
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr "Gereedschapspictogrammen"
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr "Bureaubladpictogrammen"
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr "Paletten"
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr "Documentatie"
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr "Ondersteuning"
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr "Promotie"
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr "Gemeenschap"
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ", "
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr "Met dank voor de vertaling"
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr "Grootte:"
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr "Dekking:"
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr "Scherpte:"
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr "Groei:"
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr "Gereedschapsopties"
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr "Speciale instellingen voor het huidige gereedschap"
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr "<b>{mode_name}</b>"
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr "<i>Geen opties beschikbaar</i>"
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr "Zoom: %.01f%%"
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr "Kies penseelstreek opties, kleur en laag…"
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr "Kies kleur…"
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr "Instellingen"
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr "Voorbeeld"
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr "Voorbeeld van de totale tekening"
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr "Toon het blikveld"
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr "Kladblok"
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr "Meng kleuren en maak schetsen op aparte kladbladen"
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr "Vorig element"
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr "Volgend element"
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
 msgstr "(niets te tonen)"
 
-#: ../gui/symmetry.py:76
+#: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Place axis"
 msgstr "Plaats de middellijn"
 
-#: ../gui/symmetry.py:80
+#: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Move axis"
 msgstr "Verplaats de middellijn"
 
-#: ../gui/symmetry.py:84
+#: ../gui/symmetry.py:88
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr "Verwijder de middellijn"
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr "Bewerk de middellijn"
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr "Pas de middellijn aan."
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
+#, fuzzy
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr "Positie:"
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr "Positie:"
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr "Geen"
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr "%d px"
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr "Alfa:"
 
-#: ../gui/symmetry.py:352
+#: ../gui/symmetry.py:376
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
+msgstr "Symmetrie"
+
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+#, fuzzy
 msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+msgid "X axis Position"
 msgstr "Positie van de middellijn"
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:477
+#, fuzzy
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr "Positie van de middellijn"
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr "Aan"
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr "Bestandsbewerking"
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr "Kladblok kiezer"
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr "Ongedaan maken en opnieuw uitvoeren"
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr "Meng modi"
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr "Lijn modi"
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr "Beeld (primair)"
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr "Beeld (alternatief/secundair)"
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr "Beeld (terughalen)"
 
@@ -2331,188 +2882,214 @@ msgstr "Beeld (terughalen)"
 msgid "<b>MyPaint</b>"
 msgstr "<b>MyPaint</b>"
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr "Beeld verplaatsen"
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr "Verplaats het beeld op het canvas"
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr "Beeld zoomen"
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr "Beeld op het canvas zoomen"
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr "Beeld draaien"
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr "Beeld op het canvas draaien"
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, fuzzy, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr "%s: sluit tab"
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
-msgstr "%s: bewerk eigenschappen"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
+msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr "Onbekende opdracht"
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr "Onbekend (opdracht nog niet gegeven)"
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr "{seconds:.01f} tekenen met {brush_name}"
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr "Emmer (vullen)"
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr "Laag bijsnijden"
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "Groep hernoemen"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr "Laag verwijderen"
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr "Plak laag"
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr "Nieuwe laag uit het zichtbare"
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr "Combineer zichtbare lagen"
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr "Combineer naar onderen"
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr "Normaliseer laagmodus"
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Geïmporteerde penseel"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr "{layer_default_name} toevoegen"
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr "Verwijder laag"
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr "Kies laag"
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr "Kopieer laag"
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr "Laag naar boven verplaatsen"
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr "Laag naar onderen verplaatsen"
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr "Laag in de stapel verplaatsen"
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr "Laag hernoemen"
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr "Laag zichtbaar maken"
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr "Laag verbergen"
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr "Laag op slot zetten"
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr "Laag van slot zetten"
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr "Laagdekking instellen: %0.1f%%"
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr "Onbekende modus"
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr "Laagmodus kiezen: %s"
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr "Frame aanzetten"
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr "Frame uitzetten"
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr "Frame bijwerken"
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr "Laag extern bewerken"
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr "Fout bij het openen van \"{basename}\"."
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr "De logbestanden hebben wellicht meer informatie over deze fout."
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr "tot zover"
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr "tot"
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2525,13 +3102,13 @@ msgstr ""
 "Sluit de andere MyPaint en wacht {cache_update_interval} en probeer het "
 "opnieuw."
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr "Onvolledige backup {last_modified_time} {ago} bijgewerkt"
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2541,11 +3118,11 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 "Backup {last_modified_time} {ago} bijgewerkt.\n"
-"Grootte: {autosave.width} bij {autosave.height}, lagen: {autosave.num_layers}"
-"\n"
+"Grootte: {autosave.width} bij {autosave.height}, lagen: {autosave."
+"num_layers}\n"
 "Bevat {unsaved_time} nog niet bewaard tekenen."
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2555,13 +3132,13 @@ msgstr ""
 "Opslaan van {filename} mislukt: {err}\n"
 "Is er voldoende ruimte over op de schijf?"
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr "Opslaan van {filename} mislukt: {err}"
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2571,7 +3148,7 @@ msgstr ""
 "{error_loading_common}\n"
 "Het bestand bestaat niet."
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2581,7 +3158,7 @@ msgstr ""
 "{error_loading_common}\n"
 "Dit bestand kan niet worden geopend (geen rechten)."
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2597,7 +3174,7 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2607,7 +3184,13 @@ msgstr ""
 "{error_loading_common}\n"
 "Obekend formaat/extensie: \"{ext}\""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+#, fuzzy
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr "Geïmporteerde penseel"
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2621,7 +3204,7 @@ msgstr ""
 "Probeer op te slaan in PNG formaat als je machine niet veel geheugen heeft. "
 "Opslaan in PNG is in MyPaint effectiever."
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2637,98 +3220,207 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/helpers.py:402
-#, python-brace-format
+#: ../lib/floodfill.py:131
+#, fuzzy
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr "Vullen"
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr "{days}d{hours}h"
 
-#: ../lib/helpers.py:404
-#, python-brace-format
+#: ../lib/helpers.py:537
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr "{hours}h{minutes}m"
 
-#: ../lib/helpers.py:406
-#, python-brace-format
+#: ../lib/helpers.py:539
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr "{minutes}m{seconds}s"
 
-#: ../lib/helpers.py:408
-#, python-brace-format
+#: ../lib/helpers.py:541
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr "{seconds}s"
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr "Laag"
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr "%(name)s %(number)d"
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr "^(.*?)\\s*(\\d+)$"
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
+#, fuzzy
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr "Vector laag"
+
+#: ../lib/layer/data.py:1158
+#, fuzzy
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr "Vector laag"
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
-msgstr "Onbekende bitmap laag"
+msgid "Bitmap"
+msgstr ""
 
-#: ../lib/layer/data.py:1169
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1244
 msgctxt "layer default names"
-msgid "Unknown Data Layer"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
 msgstr "Onbekende data laag"
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "Nieuwe tekenlaag"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr "Groep"
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "Nieuwe laaggroep"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr "Placeholder"
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr "Bron"
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ", "
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+#, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "Beeld"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+#, fuzzy
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr "Laag zichtbaar"
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+#, fuzzy
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr "Verwijder laag"
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr "Laag op slot zetten"
+
+#: ../lib/layervis.py:697
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr "Laag van slot zetten"
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr "Doordrukken"
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr "Inhoud van de groep betreft rechtstreeks de achtergrond"
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr "Normaal"
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr "Alleen de bovenste laag, zonder de kleuren te mengen."
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr "Vermenigvuldigen"
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
@@ -2736,11 +3428,11 @@ msgstr ""
 "Gelijk aan twee dia's achter elkaar in de projector plaatsen en het "
 "geprojecteerde resultaat bekijken."
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr "Scherm"
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
@@ -2748,42 +3440,42 @@ msgstr ""
 "Als het projecteren van twee dia's op één scherm over elkaar heen. Dit is "
 "het omgekeerde van \"vermenigvuldigen\"."
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr "Over elkaar leggen"
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 "De bovenste laag over de achtergrond leggen, waarbij de hoge lichten en de "
-"schaduwen van de achtergrond behouden blijven. Dit is het omgekeerde van \""
-"hard licht\"."
+"schaduwen van de achtergrond behouden blijven. Dit is het omgekeerde van "
+"\"hard licht\"."
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr "Donkerder maken"
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 "De bovenste laag wordt gebruikt waar deze donkerder is dan de achtergrond."
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr "Lichter maken"
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 "De bovenste laag wordt gebruikt waar deze lichter is dan de achtergrond."
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr "Doordrukken"
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
@@ -2793,11 +3485,11 @@ msgstr ""
 "gelijk aan de donkere kamer techniek van dezelfde naam die gebruikt wordt "
 "voor het verbeteren van het contrast in de schaduw."
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr "Tegenhouden"
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
@@ -2807,43 +3499,43 @@ msgstr ""
 "is gelijk aan de donkere kamer techniek van dezelfde naam die gebruikt wordt "
 "voor het verbeteren van het contrast in de schaduw."
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr "Hard licht"
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr "Gelijk aan een scherpe lichtbron op de achtergrond."
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr "Zacht licht"
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr "Gelijk aan een diffuse lichtbron op de achtergrond."
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr "Verschil"
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr "Trekt de donkere kleur af van de lichtere van de beiden."
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr "Uitsluiten"
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr "Gelijk aan de \"verschil\" modus maar lager in het contrast."
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr "Tint"
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
@@ -2851,11 +3543,11 @@ msgstr ""
 "Combineert de tint van de bovenste laag met de verzadiging en lichtheid van "
 "de achtergrond."
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr "Verzadiging"
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
@@ -2863,7 +3555,7 @@ msgstr ""
 "Past de verzadiging van de bovenste laag toe op de tint en lichtheid van de "
 "achtergrond."
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
@@ -2871,11 +3563,11 @@ msgstr ""
 "Past de tint en de verzadiging van de bovenste laag toe op de lichtheid van "
 "de achtergrond."
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr "Lichtheid"
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
@@ -2883,19 +3575,19 @@ msgstr ""
 "Past de lichtheid van de bovenste laag toe op de tint en verzadiging van de "
 "achtergrond."
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr "Toevoegen"
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr "Deze laag en zijn achtergrond worden gewoon samengevoegd."
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr "Doel in"
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
@@ -2903,11 +3595,11 @@ msgstr ""
 "Gebruikt de achtergrond alleen waar deze laag het afdekt. De overige deel "
 "wordt genegeerd."
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr "Doel uit"
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
@@ -2915,11 +3607,11 @@ msgstr ""
 "Gebruikt de achtergrond alleen daar waar deze laag hem niet bedekt. Het "
 "overige deel wordt genegeerd."
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr "Bron bovenop"
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
@@ -2927,11 +3619,11 @@ msgstr ""
 "Bron die het doel overlapt vervangt het doel. Het doel wordt ergens anders "
 "neergezet."
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr "Doel bovenop"
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
@@ -2939,7 +3631,18 @@ msgstr ""
 "Doel dat de bron overlapt vervangt de bron. De bron wordt ergens anders "
 "neergezet."
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, fuzzy, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr "%(name)s %(number)d"
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
@@ -2948,7 +3651,7 @@ msgstr ""
 "Niet mogelijk een belangrijk intern object te maken. De computer heeft "
 "mogelijk niet genoeg geheugen om dit te doen."
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2962,7 +3665,30 @@ msgstr ""
 "Reden: {err}\n"
 "Doelmap: “{dirname}”."
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+#, fuzzy
+msgid "Vertical"
+msgstr "Spiegel vertikaal"
+
+#: ../lib/tiledsurface.py:49
+#, fuzzy
+msgid "Horizontal"
+msgstr "Spiegel horizontaal"
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+#, fuzzy
+msgid "Rotational"
+msgstr "De rotatie terugzetten"
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr "Openen van PNG bestand mislukt: %s"
@@ -2971,57 +3697,91 @@ msgstr "Openen van PNG bestand mislukt: %s"
 msgid "Recover interrupted work?"
 msgstr "Onderbroken werk terughalen?"
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
-msgstr "Terughalen en opslaan..."
+msgid "_Look for backups at startup"
+msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr "Verwijderen"
+
+#: ../po/tmp/autorecover.glade.h:9
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr "Penseel van schijf verwijderen"
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr "Terughalen en opslaan..."
+
+#: ../po/tmp/autorecover.glade.h:12
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr "Sla deze backup eerst op en werk er dan verder mee."
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
-msgstr "_Sla dit voor het moment maar over"
+msgid "Decide _Later"
+msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr "Begin te werken op een nieuw canvas. Deze backups worden bewaard."
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
+#, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 "MyPaint crashte met niet-opgeslagen werk, maar er zijn backups. Je kan "
 "backups terugzetten of ermee wachten tot MyPaint opnieuw gestart wordt."
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr "Thumbnail"
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr "Beschrijving"
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
-msgstr "Kopieer naar Nieuw"
+msgid "Live update"
+msgstr "Live voorbeeld"
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
-msgstr ""
-"Kopieer deze instellingen en het pictogram van deze penseel als een nieuwe "
-"penseel"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
+msgstr "Live bijwerken van de laatste penseelstreek"
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
-msgstr "Hernoem deze penseel"
+msgid "Save these settings to the brush"
+msgstr "Opslaan van deze instellingen van het penseel"
 
 #: ../po/tmp/brusheditor.glade.h:5
 msgid "Edit Icon"
@@ -3044,18 +3804,18 @@ msgid "Delete this brush from the disk"
 msgstr "Penseel van schijf verwijderen"
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
-msgstr "Live voorbeeld"
+msgid "Copy to New"
+msgstr "Kopieer naar Nieuw"
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
-msgstr "Live bijwerken van de laatste penseelstreek"
+msgid "Copy these settings and the current brush's icon to a new brush"
+msgstr ""
+"Kopieer deze instellingen en het pictogram van deze penseel als een nieuwe "
+"penseel"
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
-msgstr "Opslaan van deze instellingen van het penseel"
+msgid "Rename this brush"
+msgstr "Hernoem deze penseel"
 
 #: ../po/tmp/brusheditor.glade.h:13
 msgid "Brush Setting"
@@ -3083,12 +3843,7 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr "Notities:"
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr "Naam instelling:"
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
@@ -3096,20 +3851,17 @@ msgstr ""
 "dit toe."
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
-msgstr "Basiswaarde:"
+#: ../po/tmp/brusheditor.glade.h:22
+#, fuzzy
+msgid "Value:"
+msgstr "HSV waarde"
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr "Terugzetten naar de standaard basiswaarde"
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 "Terugzetten van deze ingave zodat het geen effect heeft op de instelling"
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
@@ -3117,11 +3869,7 @@ msgstr ""
 "Minimum waarde voor de uitvoer as\n"
 "Deze kan worden aangepast met de schuifregelaar voor {dname}."
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr "<ymin>"
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
@@ -3129,27 +3877,23 @@ msgstr ""
 "Maximum waarde voor de uitvoer as\n"
 "Deze kan worden aangepast met de schuifregelaar voor {dname}."
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr "<ymax>"
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr "Uitvoer"
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr "Ingave"
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr "Aanpassen van de maximumwaarde"
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr "Aanpassen van de minimumwaarde"
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
@@ -3157,11 +3901,7 @@ msgstr ""
 "Minimum waarde voor de ingave-as.\n"
 "Gebruik de popup schaal om deze aan te passen."
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr "<xmin>"
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
@@ -3169,38 +3909,36 @@ msgstr ""
 "Maximum waarde voor de ingave-as.\n"
 "Gebruik de popup schaal om deze aan te passen."
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr "<xmax>"
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr "Verandering van de basis waarde via de stylus en andere factoren"
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr "Penseel dynamiek"
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr "Basis waarden voor deze instelling"
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr "Instellingen bewerken"
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr "Ingave-instellingen bewerken"
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr "{tooltip}"
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
 msgstr "{dname}:"
+
+#: ../po/tmp/brusheditor.glade.h:42
+#, fuzzy
+msgid "Brush dynamics are not available for this setting."
+msgstr "Basis waarden voor deze instelling"
+
+#: ../po/tmp/brusheditor.glade.h:43
+#, fuzzy
+msgid "<big><b>No Brush Dynamics</b></big>"
+msgstr "<big><b>{accel_label}</b></big>"
 
 #: ../po/tmp/inktool.glade.h:1
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
@@ -3212,7 +3950,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr "Druk:"
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3257,6 +3995,141 @@ msgstr "Punt wissen"
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
 msgstr "Wist het nu gekozen punt"
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+#, fuzzy
+msgid "Insert Point"
+msgstr "Voeg rij toe"
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+#, fuzzy
+msgid "Cull Points"
+msgstr "Punt wissen"
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Naam"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr "Modus"
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Dekking"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr "De compositie modus van de huidige laag."
+
+#: ../po/tmp/layervis.glade.h:2
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr "Beeld op het canvas draaien"
+
+#: ../po/tmp/layervis.glade.h:3
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr "Beeld op het canvas draaien"
+
+#: ../po/tmp/layervis.glade.h:4
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr "Welke zichtbare lagen moet er gevuld worden"
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
+msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
 msgctxt "footer: color picker button: tooltip"
@@ -3664,13 +4537,34 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr "Verberg de aanwijzer onder het tekenen"
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+#, fuzzy
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr "Actief"
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr "Beeld"
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
@@ -3680,42 +4574,42 @@ msgstr ""
 "stijl).\n"
 "Verschillende tradities hebben hun eigen kleurencombinaties."
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr "Primaire kleuren:"
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr "Standaard digitaal Rood/Groen/Blauw"
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
-"De rode, groene en blauwe primaire kleuren &apos;als op een beeldscherm&apos;"
-", gelijkmatig rondom in een cirkel getoond. Groen is het tegenovergestelde "
-"van magenta."
+"De rode, groene en blauwe primaire kleuren &apos;als op een "
+"beeldscherm&apos;, gelijkmatig rondom in een cirkel getoond. Groen is het "
+"tegenovergestelde van magenta."
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
-"De rode, groene en blauwe primaire kleuren &apos;als op een beeldscherm&apos;"
-", gelijkmatig rondom in een cirkel getoond. Groen is het tegenovergestelde "
-"van magenta."
+"De rode, groene en blauwe primaire kleuren &apos;als op een "
+"beeldscherm&apos;, gelijkmatig rondom in een cirkel getoond. Groen is het "
+"tegenovergestelde van magenta."
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr "Traditioneel schilder's rood/geel/blauw"
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
@@ -3726,7 +4620,7 @@ msgstr ""
 "schermkleuren gelijkmatig verdeeld over de schijf. Groen is het "
 "tegenovergestelde van rood."
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3738,12 +4632,12 @@ msgstr ""
 "schermkleuren gelijkmatig verdeeld over de schijf. Groen is het "
 "tegenovergestelde van rood."
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr "Rood/groen en blauw/geel tegengestelde kleurenparen"
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3753,13 +4647,13 @@ msgid ""
 msgstr ""
 "Eenvoudige benadering van kleurenschijven  op basis van theorieën waarbij "
 "vier &apos;psychologische  primaire kleuren&apos;  of &apos;unieke "
-"kleurtinten&apos;  in tegenoverliggende paren op de kruispunten zijn gelegd."
-"\n"
+"kleurtinten&apos;  in tegenoverliggende paren op de kruispunten zijn "
+"gelegd.\n"
 "Rood tegenover groen en geel tegenover blauw.  CIECAM02 en NCS hebben "
 "soortgelijke modellen. Hier gebruiken we puur rood, geel enz. als de vier "
 "primaire kleuren."
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3776,28 +4670,28 @@ msgstr ""
 "primaire kleuren."
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr "<b>Kleurenschijf</b>"
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr "Kleur"
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr "Beeldscherm (normaal)"
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr "Niet actief (geen drukgevoeligheid)"
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr "Venster (niet aanbevolen)"
@@ -3858,255 +4752,313 @@ msgid "Reload the file your current work was loaded from."
 msgstr "Terughalen vanaf de harde schijf."
 
 #: ../po/tmp/resources.xml.h:12
+#, fuzzy
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Import Layers…"
+msgstr "Import penselen…"
+
+#: ../po/tmp/resources.xml.h:13
+msgctxt "Accel Editor (descriptions)"
+msgid "Import layers from one or more files."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save"
 msgstr "Opslaan"
 
-#: ../po/tmp/resources.xml.h:13
+#: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file."
 msgstr "Het werk opslaan in een bestand."
 
-#: ../po/tmp/resources.xml.h:14
+#: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As…"
 msgstr "Opslaan als…"
 
-#: ../po/tmp/resources.xml.h:15
+#: ../po/tmp/resources.xml.h:17
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file, assigning it a new name."
 msgstr "Werk opslaan in een bestand met een nieuwe naam."
 
-#: ../po/tmp/resources.xml.h:16
+#: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Export…"
 msgstr "Exporteren…"
 
-#: ../po/tmp/resources.xml.h:17
+#: ../po/tmp/resources.xml.h:19
 msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 "Het werk exporteren naar een bestand, maar blijven werken op het huidige "
 "bestand."
 
-#: ../po/tmp/resources.xml.h:18
+#: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As Scrap"
 msgstr "Als klad opslaan"
 
-#: ../po/tmp/resources.xml.h:19
+#: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
 msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 "Als nieuw klad opslaan of als een nieuwe revisie opslaan als er al een klad "
 "is opgeslagen."
 
-#: ../po/tmp/resources.xml.h:20
+#: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Previous Scrap"
 msgstr "Laatste klad openen"
 
-#: ../po/tmp/resources.xml.h:21
+#: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file before the current one."
 msgstr "Voorlaatste klad openen."
 
-#: ../po/tmp/resources.xml.h:22
+#: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Next Scrap"
 msgstr "Volgende klad openen"
 
-#: ../po/tmp/resources.xml.h:23
+#: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file after the current one."
 msgstr "Volgende klad openen."
 
-#: ../po/tmp/resources.xml.h:24
+#: ../po/tmp/resources.xml.h:26
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Recover File from an Automated Backup…"
 msgstr "Bestand terughalen uit een automatische backup…"
 
-#: ../po/tmp/resources.xml.h:25
+#: ../po/tmp/resources.xml.h:27
 msgctxt "Accel Editor (descriptions)"
 msgid "Try to save and resume interrupted unsaved work."
-msgstr "Probeer onderbroken niet-opgeslagen werk op te slaan en terug te halen."
+msgstr ""
+"Probeer onderbroken niet-opgeslagen werk op te slaan en terug te halen."
 
-#: ../po/tmp/resources.xml.h:26
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr "Penseelgroepen"
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr "Penselen"
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr "Lijst met penseelgroepen."
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr "Kleurenkiezers"
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr "Kleuren"
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr "Beschikbare kleurenkiezers."
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr "Modus"
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr "Modus"
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr "De compositie modus van de huidige laag."
 
-#: ../po/tmp/resources.xml.h:35
+#: ../po/tmp/resources.xml.h:37
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Pressure"
+msgstr "Aanvangsdruk"
+
+#: ../po/tmp/resources.xml.h:38
+msgctxt "Accel Editor (descriptions)"
+msgid "Send harder pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:39
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Pressure"
+msgstr "Aanvangsdruk"
+
+#: ../po/tmp/resources.xml.h:40
+msgctxt "Accel Editor (descriptions)"
+msgid "Send softer pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:41
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Rotation"
+msgstr "Kleurverzadiging verhogen"
+
+#: ../po/tmp/resources.xml.h:42
+msgctxt "Accel Editor (descriptions)"
+msgid "Increase barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:43
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
+msgstr "Kleurverzadiging terugbrengen"
+
+#: ../po/tmp/resources.xml.h:44
+msgctxt "Accel Editor (descriptions)"
+msgid "Decrease barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:45
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Size"
 msgstr "Penseelradius vergroten"
 
-#: ../po/tmp/resources.xml.h:36
+#: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush bigger."
 msgstr "De actieve penseelradius vergroten."
 
-#: ../po/tmp/resources.xml.h:37
+#: ../po/tmp/resources.xml.h:47
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Size"
 msgstr "Penseelradius verkleinen"
 
-#: ../po/tmp/resources.xml.h:38
+#: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush smaller."
 msgstr "De actieve penseelradius verkleinen."
 
-#: ../po/tmp/resources.xml.h:39
+#: ../po/tmp/resources.xml.h:49
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Opacity"
 msgstr "Penseeldekking vergroten"
 
-#: ../po/tmp/resources.xml.h:40
+#: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush more opaque."
 msgstr "De actieve penseel meer dekking geven."
 
-#: ../po/tmp/resources.xml.h:41
+#: ../po/tmp/resources.xml.h:51
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Opacity"
 msgstr "Penseeldekking verminderen"
 
-#: ../po/tmp/resources.xml.h:42
+#: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush less opaque."
 msgstr "De dekking van het actieve penseel verminderen."
 
-#: ../po/tmp/resources.xml.h:43
+#: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Lighten Painting Color"
 msgstr "Tekenkleur lichter maken"
 
-#: ../po/tmp/resources.xml.h:44
+#: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase the lightness of the current painting color."
 msgstr "De huidige tekenkleur lichter maken."
 
-#: ../po/tmp/resources.xml.h:45
+#: ../po/tmp/resources.xml.h:55
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Darken Painting Color"
 msgstr "Tekenkleur donkerder maken"
 
-#: ../po/tmp/resources.xml.h:46
+#: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease the lightness of the current painting color."
 msgstr "De huidige tekenkleur minder licht maken."
 
-#: ../po/tmp/resources.xml.h:47
+#: ../po/tmp/resources.xml.h:57
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
+msgstr "Tint klokgewijs veranderen"
+
+#: ../po/tmp/resources.xml.h:58
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgstr "De tint van de tekenkleur klokgewijs op het kleurwiel verdraaien."
+
+#: ../po/tmp/resources.xml.h:59
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Change Hue Anticlockwise"
 msgstr "De tint anti-klokwijs veranderen"
 
-#: ../po/tmp/resources.xml.h:48
+#: ../po/tmp/resources.xml.h:60
 msgctxt "Accel Editor (descriptions)"
 msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
 msgstr ""
 "De tint van de tekenkleur tegen de wijzers van de klok in op het kleurwiel "
 "verdraaien."
 
-#: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
-msgstr "Tint klokgewijs veranderen"
-
-#: ../po/tmp/resources.xml.h:50
-msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
-msgstr "De tint van de tekenkleur klokgewijs op het kleurwiel verdraaien."
-
-#: ../po/tmp/resources.xml.h:51
+#: ../po/tmp/resources.xml.h:61
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Increase Saturation"
 msgstr "Kleurverzadiging verhogen"
 
-#: ../po/tmp/resources.xml.h:52
+#: ../po/tmp/resources.xml.h:62
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color more saturated (more colorful, purer)."
 msgstr "Tekenkleur meer verzadigen (kleurrijker, voller)."
 
-#: ../po/tmp/resources.xml.h:53
+#: ../po/tmp/resources.xml.h:63
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Decrease Saturation"
 msgstr "Kleurverzadiging terugbrengen"
 
-#: ../po/tmp/resources.xml.h:54
+#: ../po/tmp/resources.xml.h:64
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color less saturated (grayer)."
 msgstr "Tekenkleur minder verzadigen (grauwer)."
 
-#: ../po/tmp/resources.xml.h:55
+#: ../po/tmp/resources.xml.h:65
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Reload Brush Settings"
 msgstr "Penseelinstellingen opnieuw instellen"
 
-#: ../po/tmp/resources.xml.h:56
+#: ../po/tmp/resources.xml.h:66
 msgctxt "Accel Editor (descriptions)"
 msgid "Restore all brush settings to the current brush’s saved values."
 msgstr ""
 "Alle penseelinstellingen naar de voor het huidige penseel opgeslagen waarden "
 "herstellen."
 
-#: ../po/tmp/resources.xml.h:57
+#: ../po/tmp/resources.xml.h:67
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Pick Stroke and Layer"
 msgstr "Penseel en laag kiezen"
 
-#: ../po/tmp/resources.xml.h:58
+#: ../po/tmp/resources.xml.h:68
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
 msgstr ""
 "Penseelstreek van het canvas kiezen: herstelt het penseel, de kleur en de "
 "laag."
 
-#: ../po/tmp/resources.xml.h:59
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr "Penseel sneltoetsen herstellen kleur"
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
@@ -4115,217 +5067,268 @@ msgstr ""
 "Keuze of het terughalen van een penseel via een sneltoets ook de tekenkleur "
 "aanpast of niet."
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr "Penseel opslaan onder de meest recent gebruikte sneltoets"
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr "Sla penseelinstellingen op onder de meest recent gebruikte sneltoets."
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "Laag wissen"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr "Wis de inhoud van de huidige laag."
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Trim Layer to Frame"
-msgstr "Pas de laag aan aan het frame"
+#: ../po/tmp/resources.xml.h:75
+#, fuzzy
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr "Gereedschapsopties"
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:76
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Trim Layer to Frame"
+msgstr "Laag aanpassen aan frame"
+
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr "Wis de delen van de huidige laag buiten het frame."
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr "Wis de delen van de huidige laag buiten het frame."
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "Nieuwe lagengroep er onder"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "Nieuwe lagengroep er onder"
+
+#: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr "Kopieer de laag naar het klembord"
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr "Kopieer de inhoud van de huidige laag naar het klembord."
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr "Plak de laag van het klembord"
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr "Vervang de huidige laag met de inhoud van het klembord."
 
-#: ../po/tmp/resources.xml.h:71
+#: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Edit Layer in External App…"
 msgstr "Bewerk de laag in een ander programma…"
 
-#: ../po/tmp/resources.xml.h:72
+#: ../po/tmp/resources.xml.h:90
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
+msgid "Edit the active layer in an external application."
 msgstr "De huidige laag in een ander programma bewerken."
 
-#: ../po/tmp/resources.xml.h:73
+#: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Update Layer with External Edits"
 msgstr "De laag bijwerken met externe aanpassingen"
 
-#: ../po/tmp/resources.xml.h:74
+#: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
 msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 "Veranderingen doorvoeren die bewaard zijn door een ander programma (normaal "
 "automatisch)."
 
-#: ../po/tmp/resources.xml.h:75
+#: ../po/tmp/resources.xml.h:93
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer at Cursor"
 msgstr "Ga naar de laag onder de aanwijzer"
 
-#: ../po/tmp/resources.xml.h:76
+#: ../po/tmp/resources.xml.h:94
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr "Laag selecteren via het aanklikken van een object er op."
 
-#: ../po/tmp/resources.xml.h:77
+#: ../po/tmp/resources.xml.h:95
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Above"
 msgstr "Ga naar de laag er boven"
 
-#: ../po/tmp/resources.xml.h:78
+#: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer up in the layer stack."
 msgstr "Ga één laag omhoog in de lagen."
 
-#: ../po/tmp/resources.xml.h:79
+#: ../po/tmp/resources.xml.h:97
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Below"
 msgstr "Ga één laag naar beneden"
 
-#: ../po/tmp/resources.xml.h:80
+#: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer down in the layer stack."
 msgstr "Ga één laag naar beneden in de lagen."
 
-#: ../po/tmp/resources.xml.h:81
+#: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer"
 msgstr "Nieuwe tekenlaag"
 
-#: ../po/tmp/resources.xml.h:82
+#: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer above the current layer."
 msgstr "Voeg een nieuwe tekenlaag toe boven de huidige laag."
 
-#: ../po/tmp/resources.xml.h:83
+#: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer…"
 msgstr "Nieuwe vector laag…"
 
-#: ../po/tmp/resources.xml.h:84
+#: ../po/tmp/resources.xml.h:102
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer above the current layer, and begin editing it."
 msgstr "Voeg een nieuwe vectorlaag toe boven de huidige en bewerk hem."
 
-#: ../po/tmp/resources.xml.h:85
+#: ../po/tmp/resources.xml.h:103
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group"
 msgstr "Nieuwe laaggroep"
 
-#: ../po/tmp/resources.xml.h:86
+#: ../po/tmp/resources.xml.h:104
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group above the current layer."
 msgstr "Voeg een nieuwe groep lagen toe boven de huidige laag."
 
-#: ../po/tmp/resources.xml.h:87
+#: ../po/tmp/resources.xml.h:105
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer Below"
 msgstr "Nieuwe tekenlaag eronder"
 
-#: ../po/tmp/resources.xml.h:88
+#: ../po/tmp/resources.xml.h:106
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer below the current layer."
 msgstr "Voeg een nieuwe tekenlaag toe onder de huidige."
 
-#: ../po/tmp/resources.xml.h:89
+#: ../po/tmp/resources.xml.h:107
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer Below…"
 msgstr "Nieuwe vectorlaag eronder…"
 
-#: ../po/tmp/resources.xml.h:90
+#: ../po/tmp/resources.xml.h:108
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer below the current layer, and begin editing it."
 msgstr "Voeg een nieuwe vectorlaag toe onder de huidige en bewerk hem."
 
-#: ../po/tmp/resources.xml.h:91
+#: ../po/tmp/resources.xml.h:109
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group Below"
 msgstr "Nieuwe lagengroep er onder"
 
-#: ../po/tmp/resources.xml.h:92
+#: ../po/tmp/resources.xml.h:110
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group below the current layer."
 msgstr "Voeg een nieuwe lagengroep toe onder de huidige."
 
-#: ../po/tmp/resources.xml.h:93
+#: ../po/tmp/resources.xml.h:111
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Layer Down"
 msgstr "Lagen naar onderen samenvoegen"
 
-#: ../po/tmp/resources.xml.h:94
+#: ../po/tmp/resources.xml.h:112
 msgctxt "Accel Editor (descriptions)"
 msgid "Merge the current layer with the layer beneath it."
 msgstr "Voeg de huidige laag samen met de laag er onder."
 
-#: ../po/tmp/resources.xml.h:95
+#: ../po/tmp/resources.xml.h:113
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Visible Layers"
 msgstr "Voeg zichtbare lagen samen"
 
-#: ../po/tmp/resources.xml.h:96
+#: ../po/tmp/resources.xml.h:114
 msgctxt "Accel Editor (descriptions)"
 msgid "Consolidate all visible layers, and delete the originals."
 msgstr ""
 "Voeg alle zichtbare lagen tezamen en verwijder de oorspronkelijke lagen."
 
-#: ../po/tmp/resources.xml.h:97
+#: ../po/tmp/resources.xml.h:115
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer from Visible"
 msgstr "Nieuwe laag uit zichtbare lagen"
 
-#: ../po/tmp/resources.xml.h:98
+#: ../po/tmp/resources.xml.h:116
 msgctxt "Accel Editor (descriptions)"
 msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
 msgstr ""
 "Als \"zichtbare lagen samenvoegen\", maar het wist niet de oorspronkelijke "
 "lagen."
 
-#: ../po/tmp/resources.xml.h:99
+#: ../po/tmp/resources.xml.h:117
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Delete Layer"
 msgstr "Laag verwijderen"
 
-#: ../po/tmp/resources.xml.h:100
+#: ../po/tmp/resources.xml.h:118
 msgctxt "Accel Editor (descriptions)"
 msgid "Remove the current layer from the layer stack."
 msgstr "Verwijder de huidige laag uit de reeks lagen."
 
-#: ../po/tmp/resources.xml.h:101
+#: ../po/tmp/resources.xml.h:119
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Convert to Normal Painting Layer"
 msgstr "In normale tekenlaag omzetten"
 
-#: ../po/tmp/resources.xml.h:102
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
@@ -4334,72 +5337,74 @@ msgstr ""
 "Zet de huidige laag of groep om naar een tekenlaag in modus \"Normaal\" met "
 "behoud van de inhoud."
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr "Dekking van de laag vergroten"
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr "Maak de laag minder doorschijnend."
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr "Dekking van de laag verminderen"
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr "Maak de laag meer doorschijnend."
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr "Breng de laag omhoog"
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr "Breng de huidige laag één positie hoger in de reeks lagen."
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr "Breng de laag omlaag"
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr "Breng de laag één positie omlaag in de reeks lagen."
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr "Laag dupliceren"
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr "Maak een exacte kopie van de huidige laag."
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
+#, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
-msgstr "Laag hernoemen…"
+msgid "Layer Properties…"
+msgstr "Eigenschappen"
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
-msgstr "Een nieuwe naam aan de huidige laag geven."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr "Laag op slot"
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
@@ -4407,243 +5412,337 @@ msgstr ""
 "De laag op slot of van slot zetten. Gesloten lagen kunnen niet veranderd "
 "worden."
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr "Laag zichtbaar"
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr "De zichtbaarheid van de huidige laag omzetten."
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr "Achtergrond tonen"
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr "De zichtbaarheid van de huidige laag omzetten."
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr "Verwijder de huidige laag uit de reeks lagen."
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr "Terugzetten en centreren beeld"
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
-msgstr "terugzetten zoom, rotatie en spiegelen, en het beeld opnieuw centreren."
+msgstr ""
+"terugzetten zoom, rotatie en spiegelen, en het beeld opnieuw centreren."
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr "Aanpassen aan beeld"
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr "Wisselen tussen een passend totaalbeeld en je werklocatie met zoom."
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr "Terugzetten"
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr "Terugzetten zoomniveau"
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr "Het zoomniveau van het beeld terugzetten op de standaardwaarde."
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr "De rotatie terugzetten"
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr "Rotatie van het beeld op 0°terugzetten"
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr "Spiegelen terugzetten"
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
-msgstr "Spiegelen van het beeld uitzetten."
+msgid "Reset the view's mirroring."
+msgstr "Spiegelen terugzetten"
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr "Inzoomen"
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr "Verhoog de vergroting."
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Uitzoomen"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr "Verklein de vergroting."
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
+#, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
-msgstr "Roteer tegen de klok in"
+msgid "Pan Left"
+msgstr "Verplaats beeld"
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
-msgstr "Draai het beeld tegen de klok in."
+msgid "Move your view of the canvas to the left."
+msgstr "Beeld roteren, draai je beeld op het canvas."
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr "Hard licht"
+
+#: ../po/tmp/resources.xml.h:159
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+"Beeld verplaatsen: verschuif je beeld op het canvas horizontaal of verticaal."
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr "Beeld roteren, draai je beeld op het canvas."
+
+#: ../po/tmp/resources.xml.h:162
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr "Verplaats beeld"
+
+#: ../po/tmp/resources.xml.h:163
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr "Beeld roteren, draai je beeld op het canvas."
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr "Draai met de klok mee"
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr "Draai met de klok mee."
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr "Roteer tegen de klok in"
+
+#: ../po/tmp/resources.xml.h:167
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr "Draai het beeld tegen de klok in."
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr "Spiegel horizontaal"
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr "Spiegel het beeld links naar rechts."
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr "Spiegel vertikaal"
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr "Spiegel het beeld ondersteboven."
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr "Enkele laag"
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr "Alleen de huidige laag tonen."
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr "Symmetrisch tekenen actief"
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr "Spiegel de tekenstrepen over de symmetrie-as"
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr "Frame actief"
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr "Zichtbaarheid van het document frame aan- of  uitzetten."
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr "Geef de penseel ingave waarden in het scherm"
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 "Geef de intern gegeneerde waarden van de penseel generator in het scherm."
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr "Zichtbaar rendering"
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr "Toon bijwerken rendering op het scherm voor debugging."
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr "Geen dubbele buffering"
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr "Dubbele buffering van GTK uitzetten, normaal aangezet."
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+#, fuzzy
+msgid "Delete Point"
+msgstr "Punt wissen"
+
+#: ../po/tmp/resources.xml.h:187
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr "Wist het nu gekozen punt"
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr "Teken modus"
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr "Teken modus: normaal"
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr "Bij tekenen de kleur normaal toepassen."
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr "Tekenmodus: wissen"
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr "Wissen met het huidige penseel."
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr "Tekenmodus: alfalaag op slot"
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr "De penseel gebruiken verandert de doorzichtigheid van de laag niet."
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr "Tekenmodus: inkleuren"
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
@@ -4651,244 +5750,240 @@ msgstr ""
 "Kleur op de huidige laag zetten zonder zijn helderheid of doorzichtigheid "
 "aan te passen."
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Bestand"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "Afsluiten"
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr "Sluit het hoofdvenster en verlaat het programma."
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "Bewerken"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr "Huidig gereedschap"
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "Kleur"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr "Pas de kleur aan"
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr "Kleurgeschiedenis popup"
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr "Toont de geschiedenis van de laatste gebruikte kleuren."
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr "Kleurdetails dialoog"
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr "Toon kleurdetails dialoog met tekstingave."
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr "Volgend kleurpalet"
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr "Zet de tekenkleur naast de volgende kleur in het palet."
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr "Vorige kleurpalet"
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr "Zet de tekenkleur naast de vorige kleur in het palet."
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr "Voeg de kleur aan het palet toe"
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr "Voeg de huidige kleur aan het palet toe."
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "Laag"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr "Dekking"
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr "Ga naar laag"
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr "Nieuwe laag onder"
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr "Eigenschappen"
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr "Kladblok"
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr "Nieuw kladblok"
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr "Open het standaard kladblok als een nieuw kladblok-canvas."
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr "Open kladblok…"
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr "Open een beeldbestand op schijf in het kladblok."
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr "Bewaar het kladblok"
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr "Sla het kladblok op op schijf onder zijn bestaande naam."
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr "Exporteer het kladblok als…"
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 "Exporteer het kladblok naar de harde schijf met een bestandsnaam naar keuze."
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr "Kladblok terughalen"
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr "Het kladblok terughalen van zijn laatst bewaarde status."
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr "Bewaar het kladblok als de standaard"
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr "Bewaar het kladblok als standaard voor een \"Nieuw kladblok\"."
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr "Wis standaard kladblok"
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr "Wis het standaard kladblok naar een leeg canvas."
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr "Kopieer de hoofdachtergrond naar het kladblok"
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
-msgstr "Kopieer het achtergrond beeld van het huidige document in het kladblok."
+msgstr ""
+"Kopieer het achtergrond beeld van het huidige document in het kladblok."
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "Venster"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "Penseel"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr "Sneltoetsen"
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr "Penseel sneltoetsen help"
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr "Toon een uitleg hoe de sneltoetsen werken."
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "Ander penseel…"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr "Pop up een penseel wisselaar onder de cursor."
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "Andere kleur…"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
@@ -4896,12 +5991,12 @@ msgstr ""
 "Pop up een kleurenwisselaar onder de cursor, alle kleuren selecties "
 "inbegrepen."
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "Andere kleur (snelkeuze)…"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
@@ -4910,209 +6005,212 @@ msgstr ""
 "Pop up een kleurenwisselaar onder de cursor, alleen met de enkele klik "
 "selecties."
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr "Meer penseelsets ophalen…"
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr "Download penseelsets van de MyPaint wiki."
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr "Import penselen…"
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr "Open een penselenset vanaf schijf."
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Help"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr "Online Help"
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr "Ga naar de MyPaint documentatie wiki."
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "Over MyPaint"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr "Toon de licentie, het versienummer en de credits van MyPaint."
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Debug"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr "Toon geheugenlek informatie in de terminal (langzaam!)"
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr "Debug geheugen lekken."
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr "Voer de garbage collector nu uit"
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr "Geheugen van niet meer gebruikte python objecten vrijmaken."
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr "Zet profiling aan/uit…"
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr "\"Python Profiling\" aan/uitzetten (cProfile)"
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr "Simuleer een crash…"
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr "Veroorzaak een python exception om de crash dialoog te testen."
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "Beeld"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr "Terugkoppeling"
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr "Beeld aanpassen"
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
+#, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr "Popup menu"
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr "Toon het hoofdmenu als een popup."
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "Schermvullend"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr "Wissel tussen volledig scherm en deelvenster."
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "Voorkeuren"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr "Pas de globale instellingen van MyPaint aan."
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr "Test input apparaten"
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr "Toon een dialoog die alle inbreng toont van de input apparaten."
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr "Achtergrond-kiezer"
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr "Pas de papier-patroon achtergrond aan."
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr "Penseelvoorkeuren"
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr "De instellingen van de huidige penseel bewerken."
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr "Penseel pictogram editor"
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr "Bewerk penseel pictogrammen."
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr "Lagenvenster"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
-"Zet het lagen dokpaneel aan of uit (plaats/verplaats lagen of kies de modus)."
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr "Toon lagenvenster"
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 "Toon het dokpaneel voor lagen (plaats/verplaats lagen of kies de modus)."
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr "HCY kleurenschijf"
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
@@ -5121,42 +6219,32 @@ msgstr ""
 "Dokbare cilindrische hue/chroma/luma kleurenkiezer. De circulaire snedes "
 "zijn van gelijke helderheid."
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "Kleurenpalet"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr "Dokbare kleurenpaletkiezer."
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr "HSV kleurenschijf"
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr "Dokbare verzadiging en kleurwaarde kleurenkiezer."
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr "HSV driehoek"
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr "Dokbare kleurenkiezer: de oude GTK kleurendriehoek."
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr "HSV kubus"
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
@@ -5165,492 +6253,484 @@ msgstr ""
 "Dokbare kleurenkiezer: HSV kubus die kan worden gedraaid om verschillende "
 "dwarsdoorsnedes te tonen."
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr "HSV vierkant"
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
-msgstr ""
-"Dokbare kleurenkiezer: HSV vierkant die kan worden om verschillende tinten "
-"te tonen."
+msgid "Dockable color selector: HSV square with Hue ring."
+msgstr "Dokbare kleurenkiezer met concentrische HSV ringen."
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr "Component schuiven"
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 "Dokbare kleurenkiezer die de verschillende individuele kleurcomponenten "
 "toont."
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr "Vloeiende kleuren"
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr "Dokbare kleurenselector, die vloeiend aansluitende kleuren toont."
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr "Concentrische ringen"
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr "Dokbare kleurenkiezer met concentrische HSV ringen."
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr "Kruiswiel"
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 "Dokbare kleurenkiezer met HSV stroken in een gekruisde radiale kleurenschijf."
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr "Kladblok paneel"
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
-msgstr "Zet het kladblok dokpaneel aan/uit (meng kleuren en maak schetsen)."
+msgid "Dockable Panel for mixing colors and testing brushes."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr "Toon kladblok"
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr "Toon het kladblok dokpaneel (meng kleuren en maak schetsen)."
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr "Preview venster"
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
-"Zet het voorbeeld dokpaneel aan/uit (voorbeeld van het totale tekengebied)."
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "Voorbeeld"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr "Toon het voorbeeld dokpaneel (voorbeeld van het totale tekengebied)."
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr "Gereedschapsopties"
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
-"Zet het dokpaneel voor de gereedschapsopties aan/uit (opties voor het "
-"huidige gereedschap)."
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr "Toon gereedschapsopties"
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 "Toon het dokpaneel voor de gereedschapsopties (opties voor het huidige "
 "gereedschap)."
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr "Gebruikte penselen en kleuren"
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
-"Zet het dokpaneel voor de geschiedenis aan/uit (recent gebruikte penselen en "
-"kleuren)."
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr "Recente penselen en kleuren"
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 "Toon het dokpaneel voor de geschiedenis (recent gebruikte penselen en "
 "kleuren)."
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr "Verberg het menu in volledig schermmodus"
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 "Zet het automatisch verbergen van de gebruikersinterface in volledig "
 "schermmodus aan/uit."
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr "Toon Zoom niveau"
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr "Zet de zoom niveau indicator aan/uit."
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr "Toon laatste tekenpositie"
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr "Zet de indicator voor het einde van de laatste streek aan/uit."
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr "Scherm filter"
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr "Toon kleuren normaal"
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr "Kleurenfilter: toon kleuren ongewijzigd."
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr "Toon kleuren in grijswaarden"
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr "Kleurenfilter: toon alleen de helderheid (HCY/YCbCr Luma)"
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr "Toon kleuren geïnverteerd"
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr "Kleurenfilter: geïnverteerd. Zwart is wit en rood is cyaan."
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr "Toon kleuren met gesimuleerde ongevoeligheid voor rood"
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 "Filter kleuren om deuteranoop te simuleren, een vorm van kleurenblindheid."
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr "Toon kleuren met een gesimuleerde ongevoeligheid voor groen"
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 "Filter kleuren om protanoop te simuleren, een vorm van kleurenblindheid."
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr "Toon kleuren met gesimuleerde ongevoeligheid voor blauw"
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 "Kleurenfilter om tritanoop te simuleren, een zeldzame vorm van "
 "kleurenblindheid."
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr "Vrijehand tekenen"
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr "Vrije hand"
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr "Vrijehand: teken en schilder vrij, zonder geometrische beperkingen."
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr "Vrijehand tekenen"
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr "Teken en schilder vrij, zonder geometrische beperkingen."
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr "Verplaats beeld"
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr "Verplaatsen"
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 "Beeld verplaatsen: verschuif je beeld op het canvas horizontaal of verticaal."
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr "Verplaats beeld"
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 "Verplaats het beeld op het canvas interactief  horizontaal of verticaal."
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr "Beeld roteren"
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr "Roteren"
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr "Beeld roteren, draai je beeld op het canvas."
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr "Beeld roteren"
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr "Interactief het beeld op het canvas draaien."
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr "Beeld zoomen"
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr "Zoom"
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr "Beeld zoomen: vergroot of verklein het beeld op het canvas."
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr "Beeld zoomen"
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr "Interactief het beeld op het canvas vergroten of verkleinen."
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr "Lijnen en krommen"
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr "Lijnen"
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr "Lijnen en krommen: teken rechte of kromme lijnen."
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr "Lijnen en krommen"
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr "Teken rechte of kromme lijnen."
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr "Verbonden lijnen"
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr "Verb. lijnen"
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr "Verbonden lijnen: teken opeenvolgingen van rechte en kromme lijnen."
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr "Verbonden lijnen"
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr "Teken opeenvolgingen van rechte en kromme lijnen."
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr "Ellipsen en cirkels"
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr "Ellipsen"
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr "Ellipsen en cirkels: teken ronde vormen."
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr "Ellipsen en cirkels"
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr "Teken cirkels en ellipsen."
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr "Inkten"
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr "Inkt"
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr "Inkten: teken gladde gecontroleerde lijnen."
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr "Inkten"
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr "Twkwn gladde gecontroleerde lijnen."
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr "Laag herpositioneren"
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr "Laag pos."
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr "Laag herpositioneren: verplaats de huidige laag op het canvas."
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr "Laag verplaatsen"
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr "Verplaats de huidige laag interactief op het canvas."
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr "Bewerk frame"
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr "Frame"
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
@@ -5658,90 +6738,301 @@ msgstr ""
 "Bewerk frame: leg een frame rond het document om het een eindige vorm te "
 "geven."
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr "Frame bewerken"
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 "Leg een frame interactief rond het document om het een eindige vorm te geven."
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Bewerk de symmetrie van de tekening"
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr "Symmetrie"
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 "Bewerk de symmetrie van de tekening: pas de as voor symmetrisch tekenen aan."
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Tekensymmetrie bewerken"
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr "Pas de as voor symmetrisch tekenen interactief aan."
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr "Kleurpipet"
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr "Kies kleur"
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr "Kleurpipet: kies de tekenkleur uit schermpixels."
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "Kleuren pipet"
+
+#: ../po/tmp/resources.xml.h:401
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr "Bepaal de tekenkleur uit schermpixels."
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "Kleuren pipet"
+
+#: ../po/tmp/resources.xml.h:403
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr "Bepaal de tekenkleur uit schermpixels."
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "Kleuren pipet"
+
+#: ../po/tmp/resources.xml.h:405
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr "Bepaal de tekenkleur uit schermpixels."
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr "Kleurenkiezer"
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr "Bepaal de tekenkleur uit schermpixels."
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr "Emmer vullen"
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr "Vullen"
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr "Emmer vullen: vul een gebied met kleur."
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr "Emmer (kleuren)"
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr "Vul een gebied met kleur."
+
+#~ msgctxt "Accelerator map editor: action column markup"
+#~ msgid ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+#~ msgstr ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+
+#~ msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
+#~ msgid "{action_label} {action_desc} {accel_label}"
+#~ msgstr "{action_label} {action_desc} {accel_label}"
+
+#~ msgctxt "brush list context menu"
+#~ msgid "Delete"
+#~ msgstr "Verwijderen"
+
+#~ msgctxt "brush list commands"
+#~ msgid "Really delete brush from disk?"
+#~ msgstr "Penseel echt verwijderen?"
+
+#~ msgid "HSV Triangle"
+#~ msgstr "HSV driehoek"
+
+#~ msgid "The standard GTK color selector"
+#~ msgstr "De standaard GTK kleurenkiezer"
+
+#~ msgid "Pick a color from the screen"
+#~ msgstr "Kies een kleur in beeld"
+
+#~ msgid "Layer Name"
+#~ msgstr "Laagnaam"
+
+#~ msgid ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+#~ msgstr "<b>{name}</b>{description}"
+
+#~ msgid "Save..."
+#~ msgstr "Opslaan..."
+
+#~ msgid "Confirm"
+#~ msgstr "Bevestigen"
+
+#~ msgid "Open..."
+#~ msgstr "Openen..."
+
+#~ msgid "{default_name} at {path}"
+#~ msgstr "{default_name} op {path}"
+
+#~ msgid "Type"
+#~ msgstr "Type"
+
+#~ msgid "Mode:"
+#~ msgstr "Modus:"
+
+#~ msgid ""
+#~ "Blending mode: how the current layer combines with the layers underneath "
+#~ "it."
+#~ msgstr ""
+#~ "Combinatiemodus: hoe de huidige laag met de laag eronder moet worden "
+#~ "gecombineerd."
+
+#~ msgid ""
+#~ "Layer opacity: how much of the current layer to use. Smaller values make "
+#~ "it more transparent."
+#~ msgstr ""
+#~ "Laagdekking:  hoe lager de waarde des te transparanter (doorzichtiger) de "
+#~ "huidige laag."
+
+#~ msgid "%s: edit properties"
+#~ msgstr "%s: bewerk eigenschappen"
+
+#~ msgctxt "layer unique names: match regex (leave untranslated if unsure)"
+#~ msgid "^(.*?)\\s*(\\d+)$"
+#~ msgstr "^(.*?)\\s*(\\d+)$"
+
+#~ msgctxt "layer default names"
+#~ msgid "Unknown Bitmap Layer"
+#~ msgstr "Onbekende bitmap laag"
+
+#~ msgctxt "Autosave Recovery dialog|"
+#~ msgid "_Ignore for Now"
+#~ msgstr "_Sla dit voor het moment maar over"
+
+#~ msgid "Setting name:"
+#~ msgstr "Naam instelling:"
+
+#~ msgid "Base value:"
+#~ msgstr "Basiswaarde:"
+
+#~ msgid "Reset the base value to its default"
+#~ msgstr "Terugzetten naar de standaard basiswaarde"
+
+#~ msgid "<ymin>"
+#~ msgstr "<ymin>"
+
+#~ msgid "<ymax>"
+#~ msgstr "<ymax>"
+
+#~ msgid "<xmin>"
+#~ msgstr "<xmin>"
+
+#~ msgid "<xmax>"
+#~ msgstr "<xmax>"
+
+#~ msgid "Edit Setting"
+#~ msgstr "Instellingen bewerken"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Trim Layer to Frame"
+#~ msgstr "Pas de laag aan aan het frame"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Rename Layer…"
+#~ msgstr "Laag hernoemen…"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Enter a new name for the current layer."
+#~ msgstr "Een nieuwe naam aan de huidige laag geven."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Turn off mirroring of the view."
+#~ msgstr "Spiegelen van het beeld uitzetten."
+
+#~ msgctxt "Menu→Edit (labels)"
+#~ msgid "Current Tool"
+#~ msgstr "Huidig gereedschap"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+#~ msgstr ""
+#~ "Zet het lagen dokpaneel aan of uit (plaats/verplaats lagen of kies de "
+#~ "modus)."
+
+#~ msgctxt "Menu→Color (labels), Accel Editor (labels)"
+#~ msgid "HSV Triangle"
+#~ msgstr "HSV driehoek"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Dockable color selector: the old GTK color triangle."
+#~ msgstr "Dokbare kleurenkiezer: de oude GTK kleurendriehoek."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid ""
+#~ "Dockable color selector: HSV square which can be rotated to show "
+#~ "different hues."
+#~ msgstr ""
+#~ "Dokbare kleurenkiezer: HSV vierkant die kan worden om verschillende "
+#~ "tinten te tonen."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+#~ msgstr "Zet het kladblok dokpaneel aan/uit (meng kleuren en maak schetsen)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+#~ msgstr ""
+#~ "Zet het voorbeeld dokpaneel aan/uit (voorbeeld van het totale "
+#~ "tekengebied)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+#~ msgstr ""
+#~ "Zet het dokpaneel voor de gereedschapsopties aan/uit (opties voor het "
+#~ "huidige gereedschap)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the History panel (recently used brushes and colors)."
+#~ msgstr ""
+#~ "Zet het dokpaneel voor de geschiedenis aan/uit (recent gebruikte penselen "
+#~ "en kleuren)."

--- a/po/nn_NO.po
+++ b/po/nn_NO.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.7.1-git\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:19+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Norwegian Nynorsk <https://hosted.weblate.org/projects/"
@@ -18,29 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr "<big><b>{accel_label}</b></big>"
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr "{action_label} {action_desc} {accel_label}"
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "Handling"
 
@@ -48,32 +26,32 @@ msgstr "Handling"
 msgid "Key combination"
 msgstr "Tastekombinasjon"
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr "Endre tast for «%s»"
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "Handling:"
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "Sti:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "Tast:"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr "Trykk tastane for å oppdatere denne tildelinga"
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "Ukjend handling"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
@@ -82,7 +60,7 @@ msgstr ""
 "<b>{accel} er allereie i bruk for «{action}». Den eksisterande tildelinga "
 "vil verte erstatta.</b>"
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr "Opne mappe «{folder_basename}» …"
@@ -90,195 +68,205 @@ msgstr "Opne mappe «{folder_basename}» …"
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "OK"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr "Ingen sikkerheitskopiar vart funne i mellomlageret."
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr "Ingen tilgjengelege sikkerheitskopiar"
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr "Opne mellomlagermappa …"
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr "Feil ved sikkerheitskopigjenoppretting"
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr "Opne mappa til sikkerheitskopien …"
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr "Gjenoppretta fila frå {iso_datetime}.ora"
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "Lagre som standard"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "Bakgrunn"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "Mønster"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Farge"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "Legg fargen til mønstra"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr "Kunne ikkje laste ein eller fleire bakgrunnar"
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr "Feil ved lasting av bakgrunnar"
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 "Fjern filene som ikkje kan lastast, eller sjekk libgdkpixbuf-installasjonen "
 "din."
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr "Gdk-Pixbuf kunne ikkje laste «{filename}», og rapporterte «{error}»"
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr "{filename} har størrelse null (w={w}, h={h})"
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr "Penselinnstillingsredigerar"
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr "Om"
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "Eksperimentell"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr "Grunnleggjande"
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr "Dekkevne"
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr "Klattar"
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "Gni ut"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr "Fart"
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr ""
+
+#: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr "Sporing"
 
-#: ../gui/brusheditor.py:359
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "Strok"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr "Farge"
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Eigendefinert"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr "Ingen pensel vald, bruk «Legg til som ny» i staden."
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr "Ingen pensel er vald!"
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "Gje nytt namn til pensel"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "Ein pensel med dette namnet eksisterer allereie!"
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr "Ingen pensel er vald!"
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr "Er du sikker på at du vil slette penselen «{brush_name}» frå disken?"
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr "(pensel utan namn)"
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr "{brush_name} [ikkje lagra]"
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr "Penselikon"
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr "Penselikon (redigerer)"
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr "Ingen pensel er vald"
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -287,7 +275,7 @@ msgstr ""
 "<b>%s</b>\n"
 "<small>Vel ein gyldig pensel først</small>"
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
@@ -296,7 +284,7 @@ msgstr ""
 "<b>%s</b> <i>(endra)</i>\n"
 "<small>Endringane har ikkje vorte lagra enno</small>"
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
@@ -305,7 +293,7 @@ msgstr ""
 "<b>%s</b> (redigerer)\n"
 "<small>Mål med kva som helst pensel eller farge</small>"
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -346,142 +334,182 @@ msgstr "Auto"
 msgid "Use the default icon"
 msgstr "Bruk standardikonet"
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Lagre"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr "Lagre dette førehandsvisningsikonet og avslutt redigeringa"
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr "Tapt og funne"
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr "Sletta"
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr "Favorittar"
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr "Blekk"
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr "Klassisk"
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr "Sett#1"
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr "Sett#2"
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr "Sett#3"
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr "Sett#4"
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr "Sett#5"
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr "Eksperimentell"
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Ny"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr "Ukjend pensel"
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr "Legg til i favorittar"
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr "Fjern frå favorittar"
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr "Klon"
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr "Rediger penselinnstillingar"
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
-msgstr "Slett"
+#: ../gui/brushselectionwindow.py:250
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
+msgstr "Endre gruppenamn"
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
-msgstr "Er du sikker på at du vil slette penselen frå disken?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, fuzzy, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
+msgstr "Er du sikker på at du vil slette penselen «{brush_name}» frå disken?"
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] "%d pensel"
 msgstr[1] "%d penslar"
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr "Gruppe «{group_name}»"
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr "Endre gruppenamn"
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr "Eksporter som zippa penselsett"
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr "Slett gruppe"
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr "Endre gruppenamn"
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "Ei gruppe med dette namnet eksisterer allereie!"
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr "Er du sikker på at du vil slette gruppa «{group_name}»?"
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -491,58 +519,58 @@ msgstr ""
 "Kunne ikkje slette gruppa «{group_name}».\n"
 "Nokre spesialgrupper kan ikkje slettast."
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr "Eksporter penslar"
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr "MyPaint penselpakke (*.zip)"
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "Ny gruppe …"
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr "Importer penslar …"
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr "Få fleire penslar …"
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "Opprett gruppe"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr "Tast"
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr "Tast"
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr "Tastetrykk"
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr "Legg til ei ny binding"
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr "Fjern den aktive bindinga"
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr "Rediger binding for «%s»"
@@ -551,7 +579,7 @@ msgstr "Rediger binding for «%s»"
 msgid "Button press:"
 msgstr "Tastetrykk:"
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
@@ -559,7 +587,7 @@ msgstr ""
 "Hold nede modifikatortastar og trykk ein tast over denne teksten for å sette "
 "ei ny binding."
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
@@ -567,40 +595,68 @@ msgstr ""
 "{button} kan ikkje bindast utan modifikatortastar (beklager, tydinga dens er "
 "fast)"
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr "{button_combination} er allereie bunden til handlinga «{action_name}»"
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr "Vel farge"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr "Sett fargen brukt til å måle"
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+#, fuzzy
+msgid "Set the color Hue used for painting"
+msgstr "Sett fargen brukt til å måle"
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "Plukk farge"
+
+#: ../gui/colorpicker.py:296
+#, fuzzy
+msgid "Set the color Chroma used for painting"
+msgstr "Sett fargen brukt til å måle"
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+#, fuzzy
+msgid "Set the color Luma used for painting"
+msgstr "Sett fargen brukt til å måle"
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr "Fargedetaljar"
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr "Aktiv penselfarge og fargen som sist vart brukt til å måle"
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr "Fargeromsmaske aktiv"
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -612,7 +668,7 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr "HCY kulør og krominans."
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
@@ -621,12 +677,12 @@ msgstr ""
 "Fargeromsmaskeredigerar. Klikk i midten for å lage eller manipulere former, "
 "eller roter maska ved å bruke kantane på sirkelen."
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr "Atmosfærisk triade"
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
@@ -635,22 +691,22 @@ msgstr ""
 "Lunefullt og subjektivt, definert av ein dominant primærfarge og to "
 "primærfargar som er mindre intense."
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr "Forskyvd triade"
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr "Vekta sterkare mot den dominante fargen."
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr "Komplementær"
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
@@ -659,12 +715,12 @@ msgstr ""
 "Kontrasterande motstykke, balansert ved å ha sentrale nøytrale mellom seg på "
 "fargehjulet."
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr "Stemning og aksent"
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
@@ -673,12 +729,12 @@ msgstr ""
 "Eit hovudutval av fargar, med ein komplementær aksent for variasjon og "
 "highlight."
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr "Splitta komplementær"
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
@@ -687,72 +743,72 @@ msgstr ""
 "To analoge fargar og eitt komplement til dei, utan nokon sekundærfargar "
 "mellom dei."
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr "Ny fargeromsmaske frå mal"
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr "Fargeromsmaskeredigerar"
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr "Aktiv"
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr "Hjelp …"
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr "Lag maske frå mal."
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr "Last maske frå GIMP-palettfil."
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr "Lagre maske til ei GIMP-palettfil."
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr "Slett maska."
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr "Opne onlinehjelpa for denne dialogen i ein nettlesar."
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr "Lagre maska som ein GIMP-palett"
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr "Last maska frå ein GIMP-palett"
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr "Sett fargeromsmaske."
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr "HCY-hjul"
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -760,162 +816,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr "HSV-kulør"
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr "HSV-metning"
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr "HSV-valør"
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr "HSV-metning og -valør"
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr "HSV-kulør og -valør"
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr "HSV-kulør og -metning"
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr "Roter kube (vis forskjellige aksar)"
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr "HSV-kube"
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr "Ei HSV-kube som kan roterast for å vise forskjellige planare skiver."
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr "HSV-kvadrat"
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr "Eit HSV-kvadrat som kan roterast for å vise forskjellige kulørar."
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr "HSV-triangel"
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr "GTK sin standard fargeveljar"
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr "HSV-hjul"
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr "Fargeendrar for metning og valør."
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr "Paletteigenskapar"
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr "Palett"
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr "Sett fargen frå ein last- og redigerbar palett."
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr "Palett utan namn"
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr "Palettredigerar"
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr "Last frå ei GIMP-palettfil"
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr "Lagre til ei GIMP-palettfil"
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr "Tittel:"
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr "Namn eller beskriving for denne paletten"
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr "Kolonner:"
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr "Antal kolonner"
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr "Fargenamn:"
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr "Namnet til den aktive fargen"
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr "Tom palettplass"
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr "Last palett"
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr "Lagre palett"
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -923,379 +971,376 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr "Tom palettplass (dra ein farge hit)"
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr "Legg til tom plass"
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr "Sett inn rad"
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr "Sett inn kolonne"
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr "Fyll tomrom (RGB)"
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr "Fyll tomrom (HCY)"
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr "Fyll tomrom (HSV)"
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "GIMP-palettfil (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr "Alle filer (*)"
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "GIMP-palettfil (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr "Alle filer (*)"
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr "Plukk ein farge frå skjermen"
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr "R"
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr "G"
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr "B"
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr "H"
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr "C"
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr "Y"
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr "Komponentglidebrytarar"
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr "Juster individuelle komponent av fargen."
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr "RGB Raud"
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr "RGB Grøn"
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr "RGB Blå"
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr "HSV-kulør"
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr "HSV-metning"
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr "HSV-valør"
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr "HCY-kulør"
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr "HCY-krominans"
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr "Konsentriske ringar"
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr "Endre farge ved å bruke konsentriske HSV-ringar."
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr "Kryssa bolle"
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr "Viskelêr"
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr "Tastatur"
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr "Mus"
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr "Penn"
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr "Peikeplate"
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr "Trykkskjerm"
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr "Ignorer"
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr "Alle oppgåver"
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr "Oppgåver utanom måling"
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr "Kun navigasjon"
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr "Forstørring"
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr "Panorer"
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr "Eining"
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr "Aksar"
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr "Type"
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr "Bruk for …"
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr "Rulling …"
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Namn"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr "Overskriv pensel?"
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr "Erstatt"
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr "Gje nytt namn"
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr "Erstatt alle"
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr "Gje nytt namn til alle"
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr "Importert pensel"
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr "Eksisterande pensel"
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 "<b>Ein pensel med namnet «%s» eksisterer allereie.</b>\n"
 "Vil du erstatte den, eller skal den nye penselen få eit nytt namn?"
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr "Overskriv penselgruppe?"
 
-#: ../gui/dialogs.py:190
-#, python-brace-format
+#: ../gui/dialogs.py:220
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 "<b>Ei gruppe med namnet «{groupname}» eksisterer allereie.</b>\n"
 "Vil du erstatte den, eller skal den nye gruppa få eit nytt namn?\n"
 "Dersom du erstattar den, kan penslane verte flytta til ei gruppe med namnet "
 "«{deleted_groupname}»."
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr "Importer penselpakke?"
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, fuzzy, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr "<b>Vil du verkeleg importere pakken «%s»?</b>"
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr "Bruk pensel %d"
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr "Lagre til pensel %d"
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr "Angre %s"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Angre"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr "Gjer om %s"
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Gjer om"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr "{button_combination} er {resultant_action}"
@@ -1305,103 +1350,146 @@ msgstr "{button_combination} er {resultant_action}"
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr "Med {modifiers} holdt nede:  {button_actions}."
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
-msgstr "Lagnamn"
-
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
-#, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
-"<b>{name}</b>\n"
-"{description}"
+
+#: ../gui/document.py:909
+#, python-brace-format
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
+msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr "%s - MyPaint"
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr "MyPaint"
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Opne"
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr "Sett aktiv farge"
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr "Forlat fullskjermmodus"
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr "Forlat fullskjermmodus"
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr "Gå inn i fullskjermmodus"
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Fullskjerm"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Avslutt"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+#, fuzzy
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr "Er du sikker på at du vil avslutte?"
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Avslutt"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr "Importer penselpakke …"
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr "MyPaint penselpakke (*.zip)"
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr "Starta {app_name} for å redigere laget «{layer_name}»"
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 "Feil: Klarte ikkje å starte {app_name} for å redigere laget «{layer_name}»"
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 "Redigering avbrote. Du kan framleis redigere «{layer_name}» frå lagmenyen."
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr "Oppdaterte laget «{layer_name}» med eksterne redigeringar"
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr "Kunne ikkje laste «{file_basename}»."
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
@@ -1410,210 +1498,469 @@ msgstr ""
 "MyPaint må redigere ei fil av typen «{type_name}» ({content_type}). Kva "
 "program skal brukast?"
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
-"Kva program skal MyPaint bruke for å redigere filer av typen «{type_name}» "
-"({content_type})?"
+"Kva program skal MyPaint bruke for å redigere filer av typen "
+"«{type_name}» ({content_type})?"
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr "Opne med …"
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr "Ikon"
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr "inga beskriving"
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
+#: ../gui/filehandling.py:126
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
+msgstr "Lastar «{file_basename}» …"
+
+#: ../gui/filehandling.py:130
+#, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:134
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
+msgstr "Lagrar «{file_basename}» …"
+
+#: ../gui/filehandling.py:138
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
+msgstr "Eksporterer til «{file_basename}» …"
+
+#: ../gui/filehandling.py:145
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr "Klarte ikkje å eksportere til «{file_basename}»."
+
+#: ../gui/filehandling.py:149
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr "Klarte ikkje å lagre «{file_basename}»."
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr "Kunne ikkje laste «{file_basename}»."
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "Lagre palett"
+
+#: ../gui/filehandling.py:168
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr "Eksporter til ei fil"
+
+#: ../gui/filehandling.py:172
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr "Eksporter til ei fil"
+
+#: ../gui/filehandling.py:176
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr "Opne nyleg brukte filer"
+
+#: ../gui/filehandling.py:183
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr "Lukkast i å eksportere til «{file_basename}»."
+
+#: ../gui/filehandling.py:187
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr "Lukkast i å lagre «{file_basename}»."
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr "Lasta fila «{file_basename}»."
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
+msgstr "Lasta fila «{file_basename}»."
+
+#: ../gui/filehandling.py:427
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "All Recognized Formats"
 msgstr "Alle kjende format"
 
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
+#: ../gui/filehandling.py:432
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "OpenRaster (*.ora)"
 msgstr "OpenRaster (*.ora)"
 
-#: ../gui/filehandling.py:95
+#: ../gui/filehandling.py:437
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "PNG (*.png)"
 msgstr "PNG (*.png)"
 
-#: ../gui/filehandling.py:96
+#: ../gui/filehandling.py:442
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "JPEG (*.jpg; *.jpeg)"
 msgstr "JPEG (*.jpg; *.jpeg)"
 
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
+#: ../gui/filehandling.py:490
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "By extension (prefer default format)"
 msgstr "Etter ending (føretrekk standardformatet)"
 
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
+#: ../gui/filehandling.py:494
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:498
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
 msgstr "PNG solid med bakgrunn (*.png)"
 
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
+#: ../gui/filehandling.py:502
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:506
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
 msgstr "PNG gjennomsiktig (*.png)"
 
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
+#: ../gui/filehandling.py:510
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
 msgstr "Fleire transparente PNG-filer (*.XXX.png)"
 
-#: ../gui/filehandling.py:113
+#: ../gui/filehandling.py:514
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr "Fleire transparente PNG-filer (*.XXX.png)"
+
+#: ../gui/filehandling.py:518
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr "JPEG 90% kvalitet (*.jpg; *.jpeg)"
 
-# duplication?
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr "Lagre …"
+#: ../gui/filehandling.py:576
+#, fuzzy
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr "Eksporter …"
 
-#: ../gui/filehandling.py:177
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Lagre som …"
+
+#: ../gui/filehandling.py:601
+#, fuzzy
+msgctxt "save dialogs: formats and options: (label)"
 msgid "Format to save as:"
 msgstr "Format å lagre som:"
 
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr "Bekreft"
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
+#: ../gui/filehandling.py:668
+#, fuzzy
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
 msgstr "Vil du fortsetje?"
 
-#: ../gui/filehandling.py:234
-#, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
-msgstr "Dette vil kassere {abbreviated_time} måling som ikkje er lagra"
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
 
 # "Scrap" -> "kladd"
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
+#: ../gui/filehandling.py:705
+#, fuzzy
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
 msgstr "_Lagre som kladd"
 
-#: ../gui/filehandling.py:282
-#, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
-msgstr "Lastar «{file_basename}» …"
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
 
-#: ../gui/filehandling.py:296
-#, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
-msgstr "Kunne ikkje laste «{file_basename}»."
+#: ../gui/filehandling.py:734
+#, fuzzy, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr "Dette vil kassere {abbreviated_time} måling som ikkje er lagra"
 
-#: ../gui/filehandling.py:321
-#, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
-msgstr "Lasta fila «{file_basename}»."
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
 
-#: ../gui/filehandling.py:422
-#, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
-msgstr "Eksporterer til «{file_basename}» …"
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
 
-#: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
-msgstr "Lagrar «{file_basename}» …"
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
-msgstr "Klarte ikkje å eksportere til «{file_basename}»."
-
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
-msgstr "Klarte ikkje å lagre «{file_basename}»."
-
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
-msgstr "Lukkast i å eksportere til «{file_basename}»."
-
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
-msgstr "Lukkast i å lagre «{file_basename}»."
-
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
 msgstr "Opne …"
 
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Opne nyleg brukte filer"
+
 # "Scrap" -> "kladd"
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr "Opne rableblokk …"
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Importert pensel"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Opne"
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Opne sist brukte"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Opne"
+
+#: ../gui/filehandling.py:1446
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
 msgstr "Det eksisterer ingen kladdefiler med namnet «%s» enno."
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+# "Scrap" -> "kladd"
+#: ../gui/filehandling.py:1455
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr "Opne neste kladd"
+
+#: ../gui/filehandling.py:1463
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr "Opne førre kladd"
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Opne"
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+#, fuzzy
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr "Tilbakestill"
+
+#: ../gui/fill.py:121
+#, fuzzy
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr "Fyll"
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+#, fuzzy
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr "Fyll område med farge"
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+#, fuzzy
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr "Toleranse:"
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+#, fuzzy
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr "Kjelde:"
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
-msgstr "Kva synlege lag som skal fyllast"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
+msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+#, fuzzy
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr "Mål:"
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr "Nytt lag (ein gong)"
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+#, fuzzy
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
@@ -1621,21 +1968,108 @@ msgstr ""
 "Lag eit nytt lag med resultatet av fyllinga.\n"
 "Dette vert skrudd av automatisk etter bruk."
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Dekkevne:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr "Tilbakestill"
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+#, fuzzy
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
-msgstr ""
+msgstr "Tilbakestill grunnverdien til standardverdien"
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "Vel lag"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr "<b>{brush_name}</b>"
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1645,131 +2079,143 @@ msgstr ""
 "<b>{brush_name}</b>\n"
 "{brush_desc}"
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr "Rediger ramme"
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr "Juster dokumentramma"
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr "Rammestørrelse"
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr "px"
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr "Høgde:"
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr "Breidde:"
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr "Oppløysing:"
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr "DPI"
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr "Punkter per tomme (eigentleg pikslar per tomme)"
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr "Farge:"
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr "Rammefarge"
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr "<b>Rammestørrelse</b>"
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr "<b>Pikseltettheit</b>"
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr "Sett ramma til laget"
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr "Sett ramma til utstrekninga av det aktive laget"
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr "Sett ramma til dokumentet"
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr "Sett ramma til kombinasjonen av alle lag"
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr "Beskjer laget til ramma"
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr "Beskjer deler av det aktive laget som ligg utanfor ramma"
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr "Slått på"
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr "{width:g}×{height:g} {units}"
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr "tomme"
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr "cm"
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr "mm"
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr "Frihandsteikning"
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr "Mål penselstrok på frihand"
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr "Trykk:"
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr "Feil oppdaga"
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 "<big><b>Ein feil har vorte oppdaga under køyring av programmet .</b></big>"
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1783,35 +2229,35 @@ msgstr ""
 "Ver venleg å fortelje utviklarane om dette ved å nytte "
 "feilrapporteringssystemet dersom ingen andre har rapportert det enno."
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr "Søk i feilrapporteringssystemet …"
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr "Rapporter …"
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr "Ignorer feil"
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr "Avslutt MyPaint"
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr "Detaljar …"
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr "Ei feil oppstod medan feilen vart analysert."
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1835,45 +2281,50 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr "Teikn og deretter juster glatte linjer"
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr "Inneiningstest"
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr "(ikkje noko trykk)"
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr "Trykk:"
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr "(inga helling)"
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr "Helling:"
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr "(inga eining)"
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
 msgstr "Eining:"
 
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+#, fuzzy
+msgid "Barrel Rotation:"
+msgstr "Tilbakestill rotasjon"
+
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr "Flytt laget"
 
@@ -1881,159 +2332,227 @@ msgstr "Flytt laget"
 msgid "Move the current layer"
 msgstr "Flytt det aktive laget"
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
-msgstr "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
+msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+#, fuzzy
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr "Eigenskapar"
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr "Synleg"
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Lag"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+#, fuzzy
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr "Låst"
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+#, fuzzy
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ", "
+
+#: ../gui/layers.py:990
+#, fuzzy, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr "Legg til {layer_default_name}"
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Lag"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr "Arranger lag og tildel effekter"
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr "Lagdekkevne: %d%%"
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr "Flytt laget i stabelen …"
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 "Flytt laget i stabelen (å sleppe det på eit vanleg lag vil lage ei ny gruppe)"
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr "Lag"
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
-msgstr "Modus:"
+#: ../gui/layervis.py:53
+#, fuzzy, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
+msgstr "<b>{brush_name}</b>"
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
-msgstr "Modus: korleis det aktive laget vert kombinert med laga under det."
-
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Dekkevne:"
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
-"Lagdekkevne: kor mykje av det aktive laget som skal brukast. Små verdiar "
-"gjer det meir gjennomsiktig."
 
-#: ../gui/linemode.py:37
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "Roter"
+
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr "Inngangstrykk"
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr "Inngangstrykk for stroket for linjeverktøy"
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr "Midtpunktstrykk"
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr "Midtpunktstrykk for linjeverktøy"
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr "Utgangstrykk"
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr "Utgangstrykk for linjeverktøy"
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr "Hovud"
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 msgid "Stroke lead-in end"
 msgstr "Slutten på byrjinga av stroket"
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr "Hale"
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr "Byrjinga på slutten av stroket"
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr "Trykkvariasjon …"
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr "Linjer og kurver"
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr "Generisk modus for linjer/kurver"
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr "Teikn beine linjer; shift legg til kurver, ctrl innskrenker vinkelen"
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr "Samanhengande linjer"
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 "Teikn ein linjesekvens; shift legg til kurver, ctrl innskrenker vinkelen"
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr "Ellipsar og sirklar"
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
+#, fuzzy
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 "Opphavsrett (C) 2005-2015\n"
 "Martin Renold og MyPaint-utviklarteamet"
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -2045,258 +2564,288 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr "programmering"
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr "portabilitet"
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr "prosjektstyring"
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr "penslar"
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr "mønster"
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr "verktøyikon"
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr "skrivebordsikon"
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr "palettar"
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr "dokumentasjon"
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr "brukarstøtte"
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ", "
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr "Tor Egil Hoftun Kvæstad"
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr "Størrelse:"
 
 # "opaque" -> ikke gjennomsiktig
 # er dette den beste oversettelsen?
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr "Verktøyval"
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr "Spesialiserte innstillingar for det aktive redigeringsverktøyet"
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr "<b>{mode_name}</b>"
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr "<i>Ingen val tilgjengelege</i>"
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr "Forstørring: %.01f%%"
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr "Plukk penselstrokinnstillingar, strokfarge og lag …"
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr "Plukk farge …"
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr "Innstillingar"
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr "Førehandsvisning"
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr "Vis førehandsvisning av heile teikneområdet"
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr "Vis søkar"
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr "Rableblokk"
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr "Bland fargar og lag skisser på separate kladdesider"
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
 msgstr "(Ingenting å vise)"
 
-#: ../gui/symmetry.py:76
+#: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Place axis"
 msgstr "Plasser akse"
 
-#: ../gui/symmetry.py:80
+#: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Move axis"
 msgstr "Flytt akse"
 
-#: ../gui/symmetry.py:84
+#: ../gui/symmetry.py:88
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr "Fjern akse"
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr "Rediger symmetriaksen"
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr "Juster målesymmetriaksen."
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
+#, fuzzy
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr "Posisjon:"
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr "Posisjon:"
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr "Ingen"
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr "%d px"
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr "Alfa:"
 
-#: ../gui/symmetry.py:352
+#: ../gui/symmetry.py:376
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
+msgstr "Symmetri"
+
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+#, fuzzy
 msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+msgid "X axis Position"
 msgstr "Akseposisjon"
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:477
+#, fuzzy
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr "Akseposisjon"
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr "Slått på"
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr "Filbehandling"
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr "Kladdebytar"
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr "Angre og gjer om"
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr "Blandingsmodusar"
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr "Linjemodusar"
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2304,188 +2853,214 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr "<b>MyPaint</b>"
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, fuzzy, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr "%s: lukk fane"
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
-msgstr "%s: rediger eigenskaper"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
+msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr "Ukjend kommando"
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr "Udefinert (kommandoen har ikkje starta enno)"
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr "{seconds:.01f}s måling med {brush_name}"
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr "Fyll"
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr "Beskjer laget"
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "Endre gruppenamn"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr "Tøm laget"
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr "Lim inn lag"
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr "Nytt lag frå synleg"
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr "Flett saman synlege lag"
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr "Flett saman nedover"
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr "Normaliser lagmodus"
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Importert pensel"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr "Legg til {layer_default_name}"
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr "Fjern lag"
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr "Vel lag"
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr "Opprett eit duplikat av laget"
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr "Flytt laget opp"
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr "Flytt laget ned"
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr "Flytt laget i stabelen"
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr "Endre namnet til laget"
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr "Gjer laget synleg"
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr "Gjer laget usynleg"
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr "Lås lag"
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr "Lås opp lag"
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr "Sett lagdekkevna: %0.1f%%"
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr "Ukjend modus"
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr "Sett lagmodus: %s"
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr "Slå på ramme"
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr "Slå av ramme"
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr "Oppdater ramme"
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr "Rediger laget eksternt"
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr "Klarte ikkje å laste «{basename}»."
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr "Loggane kan ha fleire detaljar om denne feilen."
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr "frå no"
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr "sidan"
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2497,13 +3072,13 @@ msgstr ""
 "Køyrer du meir enn ein instans av MyPaint?\n"
 "Lukk programmet og vent {cache_update_interval}s for å prøve igjen."
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr "Uferdig sikkerheitskopi oppdatert {last_modified_time} {ago}"
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2513,11 +3088,11 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 "Sikkerheitskopi oppdatert {last_modified_time} {ago}\n"
-"Størrelse: {autosave.width}×{autosave.height} pikslar, Lag: "
-"{autosave.num_layers}\n"
+"Størrelse: {autosave.width}×{autosave.height} pikslar, Lag: {autosave."
+"num_layers}\n"
 "Inneheld {unsaved_time} måling som ikkje er lagra."
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2525,13 +3100,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2541,7 +3116,7 @@ msgstr ""
 "{error_loading_common}\n"
 "Denne fila eksisterer ikkje."
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2551,7 +3126,7 @@ msgstr ""
 "{error_loading_common}\n"
 "Du har ikkje nødvendige løyve til å opne denne fila."
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2567,7 +3142,7 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2575,7 +3150,13 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+#, fuzzy
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr "Importert pensel"
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2589,7 +3170,7 @@ msgstr ""
 "Prøv å lagre i PNG-formatet i staden, dersom maskina di har lite minne. "
 "MyPaint sin PNG-lagrefunksjon er meir effektiv."
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2605,98 +3186,207 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/helpers.py:402
-#, python-brace-format
+#: ../lib/floodfill.py:131
+#, fuzzy
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr "Fyll"
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr "{days}d{hours}t"
 
-#: ../lib/helpers.py:404
-#, python-brace-format
+#: ../lib/helpers.py:537
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr "{hours}t{minutes}m"
 
-#: ../lib/helpers.py:406
-#, python-brace-format
+#: ../lib/helpers.py:539
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr "{minutes}m{seconds}s"
 
-#: ../lib/helpers.py:408
-#, python-brace-format
+#: ../lib/helpers.py:541
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr "{seconds}s"
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr "Lag"
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
+#, fuzzy
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr "Vektorlag"
+
+#: ../lib/layer/data.py:1158
+#, fuzzy
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr "Vektorlag"
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1244
 msgctxt "layer default names"
-msgid "Unknown Data Layer"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
 msgstr "Ukjend datalag"
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "Nytt målelag"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr "Gruppe"
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "Ny laggruppe"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr "Rot"
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ", "
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+#, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "Visning"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+#, fuzzy
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr "Legg til lag"
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+#, fuzzy
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr "Fjern lag"
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr "Lås lag"
+
+#: ../lib/layervis.py:697
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr "Lås opp lag"
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr "Normal"
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr "Multipliser"
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
@@ -2704,11 +3394,11 @@ msgstr ""
 "Liknar å sette to dias i ein prosjektor og projisere det kombinerte "
 "resultatet."
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr "Skjerm"
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
@@ -2716,146 +3406,146 @@ msgstr ""
 "Som å skine to separate diasprosjektorar på ein skjerm samtidig. Dette er "
 "det motsette av «Multipliser»."
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr "Overlegg"
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr "Mørkare"
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr "Topplaget vert brukt der det er mørkare enn bakgrunnen."
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr "Lysare"
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr "Topplaget vert brukt der det er lysare enn bakgrunnen."
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr "Avskygg"
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr "Etterbelys"
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr "Hardt lys"
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr "Mjukt lys"
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr "Som å skine ein diffus spotlight på bakgrunnen."
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr "Differanse"
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr "Subtraherer den mørkare fargen frå den lysare."
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr "Ekskludering"
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr "Liknar på «Differanse»-modusen, men har lågare kontrast."
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr "Kulør"
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr "Metning"
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr "Legg til"
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr "Dette laget og bakgrunnen vert kun lagt saman."
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr "Mål inn"
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 "Brukar bakgrunnen kun der dette laget dekker den. Alt anna vert ignorert."
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr "Mål ut"
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
@@ -2863,27 +3553,38 @@ msgstr ""
 "Brukar bakgrunnen kun der dette laget ikkje dekker den. Alt anna vert "
 "ignorert."
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr "Kjelde på topp"
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr "Destinasjon på topp"
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
@@ -2892,7 +3593,7 @@ msgstr ""
 "Klarte ikkje å konstruere eit viktig internt objekt. Systemet ditt har "
 "kanskje ikkje nok minne til å utføre denne handlinga."
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2902,7 +3603,30 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+#, fuzzy
+msgid "Vertical"
+msgstr "Spegl loddrett"
+
+#: ../lib/tiledsurface.py:49
+#, fuzzy
+msgid "Horizontal"
+msgstr "Spegl vassrett"
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+#, fuzzy
+msgid "Rotational"
+msgstr "Tilbakestill rotasjon"
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr "PNG-lesar feila: %s"
@@ -2911,57 +3635,92 @@ msgstr "PNG-lesar feila: %s"
 msgid "Recover interrupted work?"
 msgstr "Gjenopprett avbrote arbeid?"
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
-msgstr "Gjenopprett og lagre …"
+msgid "_Look for backups at startup"
+msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr "Slett"
+
+#: ../po/tmp/autorecover.glade.h:9
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr "Slett denne penselen frå disken"
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr "Gjenopprett og lagre …"
+
+#: ../po/tmp/autorecover.glade.h:12
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr "Lagre denne sikkerheitskopien til disken og fortset å arbeide med den."
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 "Begynn å arbeide på eit nytt lerret. Desse sikkerheitskopiane vil verte "
 "behaldne."
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr "Miniatyr"
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr "Beskriving"
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
-msgstr "Kopier til ny"
+msgid "Live update"
+msgstr "Sanntidsoppdatering"
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
-"Kopier desse innstillingane og den aktive penselen sitt ikon til ein ny "
-"pensel"
+"Oppdater det siste stroket på lerretet med innstillingane i dette vindauget, "
+"i sanntid"
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
-msgstr "Gje nytt namn til denne penselen"
+msgid "Save these settings to the brush"
+msgstr "Lagre desse innstillingane til penselen"
 
 #: ../po/tmp/brusheditor.glade.h:5
 msgid "Edit Icon"
@@ -2984,20 +3743,18 @@ msgid "Delete this brush from the disk"
 msgstr "Slett denne penselen frå disken"
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
-msgstr "Sanntidsoppdatering"
+msgid "Copy to New"
+msgstr "Kopier til ny"
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
-"Oppdater det siste stroket på lerretet med innstillingane i dette vindauget, "
-"i sanntid"
+"Kopier desse innstillingane og den aktive penselen sitt ikon til ein ny "
+"pensel"
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
-msgstr "Lagre desse innstillingane til penselen"
+msgid "Rename this brush"
+msgstr "Gje nytt namn til denne penselen"
 
 #: ../po/tmp/brusheditor.glade.h:13
 msgid "Brush Setting"
@@ -3025,12 +3782,7 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr "Notat:"
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr "Innstillingsnamn:"
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
@@ -3038,103 +3790,86 @@ msgstr ""
 "på dette."
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
-msgstr "Grunnverdi:"
+#: ../po/tmp/brusheditor.glade.h:22
+#, fuzzy
+msgid "Value:"
+msgstr "HSV-valør"
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr "Tilbakestill grunnverdien til standardverdien"
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 "Tilbakestill denne innputten til å ikkje ha nokon effekt på innstillinga"
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr "<ymin>"
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr "<ymax>"
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr "Utputt"
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr "Innputt"
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr "Justerer maksimumsverdien"
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr "Justerer minimumsverdien"
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr "<xmin>"
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr "<xmax>"
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr "Penseldynamikk"
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr "Basisdetaljar for denne innstillinga"
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr "Rediger innstilling"
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr "{tooltip}"
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
 msgstr "{dname}:"
+
+#: ../po/tmp/brusheditor.glade.h:42
+#, fuzzy
+msgid "Brush dynamics are not available for this setting."
+msgstr "Basisdetaljar for denne innstillinga"
+
+#: ../po/tmp/brusheditor.glade.h:43
+#, fuzzy
+msgid "<big><b>No Brush Dynamics</b></big>"
+msgstr "<big><b>{accel_label}</b></big>"
 
 #: ../po/tmp/inktool.glade.h:1
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
@@ -3146,7 +3881,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr "Trykk:"
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3191,6 +3926,139 @@ msgstr "Slett punkt"
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
 msgstr "Slett det valde punktet"
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+#, fuzzy
+msgid "Insert Point"
+msgstr "Sett inn rad"
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+#, fuzzy
+msgid "Cull Points"
+msgstr "Slett punkt"
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Namn"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr "Modus"
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Dekkevne"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr "Fjern den aktive bindinga"
+
+#: ../po/tmp/layervis.glade.h:4
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr "Kva synlege lag som skal fyllast"
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
+msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
 msgctxt "footer: color picker button: tooltip"
@@ -3564,13 +4432,34 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr "Skjul peikaren ved måling"
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+#, fuzzy
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr "Slått på"
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr "Visning"
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
@@ -3580,43 +4469,43 @@ msgstr ""
 "sirkelstil.\n"
 "Forskjellige tradisjonar har forskjellige fargeharmoniar."
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr "Primærfargar er:"
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr "Standard digital Raud/Grøn/Blå"
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr "Tradisjonell kunstnars Raud/Gul/Blå"
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3624,12 +4513,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr "Raud-grøn og blå-gul motsette par"
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3638,7 +4527,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3649,28 +4538,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr "<b>Fargehjul</b>"
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr "Farge"
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr "Skjerm (normal)"
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr "Slått av (ingen trykksensitivitet)"
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr "Vindauge (ikkje anbefalt)"
@@ -3731,466 +4620,575 @@ msgid "Reload the file your current work was loaded from."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
+#, fuzzy
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Import Layers…"
+msgstr "Importer penslar …"
+
+#: ../po/tmp/resources.xml.h:13
+msgctxt "Accel Editor (descriptions)"
+msgid "Import layers from one or more files."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save"
 msgstr "Lagre"
 
-#: ../po/tmp/resources.xml.h:13
+#: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file."
 msgstr "Lagre arbeidet ditt til ei fil."
 
-#: ../po/tmp/resources.xml.h:14
+#: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As…"
 msgstr "Lagre som …"
 
-#: ../po/tmp/resources.xml.h:15
+#: ../po/tmp/resources.xml.h:17
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file, assigning it a new name."
 msgstr "Lagre arbeidet ditt til ei fil, og gje den eit nytt namn."
 
-#: ../po/tmp/resources.xml.h:16
+#: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Export…"
 msgstr "Eksporter …"
 
-#: ../po/tmp/resources.xml.h:17
+#: ../po/tmp/resources.xml.h:19
 msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 "Eksporter arbeidet ditt til ei fil, men fortset å arbeide med den same fila."
 
 # "Scrap" -> "kladd"
-#: ../po/tmp/resources.xml.h:18
+#: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As Scrap"
 msgstr "Lagre som kladd"
 
-#: ../po/tmp/resources.xml.h:19
+#: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
 msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 "Lagre til ei ny kladdefil, eller lagre ein ny versjon dersom det allereie er "
 "ein kladd."
 
-#: ../po/tmp/resources.xml.h:20
+#: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Previous Scrap"
 msgstr "Opne førre kladd"
 
-#: ../po/tmp/resources.xml.h:21
+#: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file before the current one."
 msgstr "Opne kladdefila som er før den som er aktiv no."
 
 # "Scrap" -> "kladd"
-#: ../po/tmp/resources.xml.h:22
+#: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Next Scrap"
 msgstr "Opne neste kladd"
 
-#: ../po/tmp/resources.xml.h:23
+#: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file after the current one."
 msgstr "Opne kladdefila som er etter den som er aktiv no."
 
-#: ../po/tmp/resources.xml.h:24
+#: ../po/tmp/resources.xml.h:26
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Recover File from an Automated Backup…"
 msgstr "Gjenopprett fila frå ein automatisk sikkerheitskopi …"
 
-#: ../po/tmp/resources.xml.h:25
+#: ../po/tmp/resources.xml.h:27
 msgctxt "Accel Editor (descriptions)"
 msgid "Try to save and resume interrupted unsaved work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:26
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr "Penselgrupper"
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr "Penslar"
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr "Liste over penselgrupper."
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr "Fargejusterarar"
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr "Fargar"
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr "Tilgjengelege fargejusterarar."
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr "Modus"
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr "Modus"
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
+#: ../po/tmp/resources.xml.h:37
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Pressure"
+msgstr "Inngangstrykk"
+
+#: ../po/tmp/resources.xml.h:38
+msgctxt "Accel Editor (descriptions)"
+msgid "Send harder pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:39
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Pressure"
+msgstr "Inngangstrykk"
+
+#: ../po/tmp/resources.xml.h:40
+msgctxt "Accel Editor (descriptions)"
+msgid "Send softer pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:41
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Rotation"
+msgstr "Auk metning"
+
+#: ../po/tmp/resources.xml.h:42
+msgctxt "Accel Editor (descriptions)"
+msgid "Increase barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:43
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
+msgstr "Minsk metning"
+
+#: ../po/tmp/resources.xml.h:44
+msgctxt "Accel Editor (descriptions)"
+msgid "Decrease barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:45
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Size"
 msgstr "Auk penselstørrelsen"
 
-#: ../po/tmp/resources.xml.h:36
+#: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush bigger."
 msgstr "Gjer den aktive penselen større."
 
-#: ../po/tmp/resources.xml.h:37
+#: ../po/tmp/resources.xml.h:47
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Size"
 msgstr "Minsk penselstørrelsen"
 
-#: ../po/tmp/resources.xml.h:38
+#: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush smaller."
 msgstr "Gjer den aktive penselen mindre."
 
-#: ../po/tmp/resources.xml.h:39
+#: ../po/tmp/resources.xml.h:49
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Opacity"
 msgstr "Auk penselen si dekkevne"
 
-#: ../po/tmp/resources.xml.h:40
+#: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush more opaque."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:41
+#: ../po/tmp/resources.xml.h:51
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Opacity"
 msgstr "Minsk penselen si dekkevne"
 
-#: ../po/tmp/resources.xml.h:42
+#: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush less opaque."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:43
+#: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Lighten Painting Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:44
+#: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase the lightness of the current painting color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:45
+#: ../po/tmp/resources.xml.h:55
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Darken Painting Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:46
+#: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease the lightness of the current painting color."
 msgstr "Minsk valøren til den aktive målefargen."
 
-#: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
-msgstr "Endre kulør mot klokka"
-
-#: ../po/tmp/resources.xml.h:48
-msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
-msgstr "Roter målefargens kulør mot klokka på fargehjulet."
-
-#: ../po/tmp/resources.xml.h:49
+#: ../po/tmp/resources.xml.h:57
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Change Hue Clockwise"
 msgstr "Endre kulør med klokka"
 
-#: ../po/tmp/resources.xml.h:50
+#: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
 msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr "Roter målefargens kulør med klokka på fargehjulet."
 
-#: ../po/tmp/resources.xml.h:51
+#: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr "Endre kulør mot klokka"
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr "Roter målefargens kulør mot klokka på fargehjulet."
+
+#: ../po/tmp/resources.xml.h:61
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Increase Saturation"
 msgstr "Auk metning"
 
-#: ../po/tmp/resources.xml.h:52
+#: ../po/tmp/resources.xml.h:62
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color more saturated (more colorful, purer)."
 msgstr "Gjer målefargen meir metta (meir fargerik, reinare)."
 
-#: ../po/tmp/resources.xml.h:53
+#: ../po/tmp/resources.xml.h:63
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Decrease Saturation"
 msgstr "Minsk metning"
 
-#: ../po/tmp/resources.xml.h:54
+#: ../po/tmp/resources.xml.h:64
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color less saturated (grayer)."
 msgstr "Gjer målefargen mindre metta (gråare)."
 
-#: ../po/tmp/resources.xml.h:55
+#: ../po/tmp/resources.xml.h:65
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Reload Brush Settings"
 msgstr "Last penselinnstillingar på nytt"
 
-#: ../po/tmp/resources.xml.h:56
+#: ../po/tmp/resources.xml.h:66
 msgctxt "Accel Editor (descriptions)"
 msgid "Restore all brush settings to the current brush’s saved values."
 msgstr ""
 "Tilbakestill alle penselinnstillingar til den aktive penselen sine lagra "
 "verdiar."
 
-#: ../po/tmp/resources.xml.h:57
+#: ../po/tmp/resources.xml.h:67
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Pick Stroke and Layer"
 msgstr "Plukk strok og lag"
 
-#: ../po/tmp/resources.xml.h:58
+#: ../po/tmp/resources.xml.h:68
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
-msgstr "Plukk eit penselstrok frå lerretet: gjenoppretter pensel, farge og lag."
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+"Plukk eit penselstrok frå lerretet: gjenoppretter pensel, farge og lag."
 
-#: ../po/tmp/resources.xml.h:59
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr "Penselsnarvegstastar gjenopprettar farge"
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr "Lagre penselen til den sist brukte snarvegstasten"
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr "Lagre penselinnstillingane til den sist brukte snarvegstasten."
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "Tøm laget"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr "Tøm det aktive laget sitt innhald."
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+#, fuzzy
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr "Verktøyval"
+
+#: ../po/tmp/resources.xml.h:76
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr "Beskjer laget til ramma"
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr "Slett deler av det aktive laget som ligg utanfor ramma."
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr "Slett deler av det aktive laget som ligg utanfor ramma."
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "Ny laggruppe under"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "Ny laggruppe under"
+
+#: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr "Kopier laget til utklippstavla"
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr "Kopier innhaldet i det aktive laget til utklippstavla."
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr "Lim inn laget frå utklippstavla"
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr "Byter ut det aktive laget med innhaldet på utklippstavla."
 
-#: ../po/tmp/resources.xml.h:71
+#: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Edit Layer in External App…"
 msgstr "Rediger laget i eksternt program …"
 
-#: ../po/tmp/resources.xml.h:72
+#: ../po/tmp/resources.xml.h:90
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
+msgid "Edit the active layer in an external application."
 msgstr "Begynn å redigere det aktive laget i eit eksternt program."
 
-#: ../po/tmp/resources.xml.h:73
+#: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Update Layer with External Edits"
 msgstr "Oppdater laget med eksterne redigeringar"
 
-#: ../po/tmp/resources.xml.h:74
+#: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
 msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:75
+#: ../po/tmp/resources.xml.h:93
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer at Cursor"
 msgstr "Gå til lag ved peikar"
 
-#: ../po/tmp/resources.xml.h:76
+#: ../po/tmp/resources.xml.h:94
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr "Vel eit lag ved å plukke eit objekt som er på det."
 
-#: ../po/tmp/resources.xml.h:77
+#: ../po/tmp/resources.xml.h:95
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Above"
 msgstr "Gå til laget over"
 
-#: ../po/tmp/resources.xml.h:78
+#: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer up in the layer stack."
 msgstr "Gå eitt lag opp i lagstabelen."
 
-#: ../po/tmp/resources.xml.h:79
+#: ../po/tmp/resources.xml.h:97
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Below"
 msgstr "Gå til laget under"
 
-#: ../po/tmp/resources.xml.h:80
+#: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer down in the layer stack."
 msgstr "Gå eitt lag ned i lagstabelen."
 
-#: ../po/tmp/resources.xml.h:81
+#: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer"
 msgstr "Nytt målelag"
 
-#: ../po/tmp/resources.xml.h:82
+#: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer above the current layer."
 msgstr "Legg til eit nytt målelag over det aktive laget."
 
-#: ../po/tmp/resources.xml.h:83
+#: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer…"
 msgstr "Nytt vektorlag …"
 
-#: ../po/tmp/resources.xml.h:84
+#: ../po/tmp/resources.xml.h:102
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer above the current layer, and begin editing it."
 msgstr ""
 "Legg til eit nytt vektorlag over det aktive laget, og begynn å redigere det."
 
-#: ../po/tmp/resources.xml.h:85
+#: ../po/tmp/resources.xml.h:103
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group"
 msgstr "Ny laggruppe"
 
-#: ../po/tmp/resources.xml.h:86
+#: ../po/tmp/resources.xml.h:104
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group above the current layer."
 msgstr "Legg til ei ny laggruppe over det aktive laget."
 
-#: ../po/tmp/resources.xml.h:87
+#: ../po/tmp/resources.xml.h:105
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer Below"
 msgstr "Nytt målelag under"
 
-#: ../po/tmp/resources.xml.h:88
+#: ../po/tmp/resources.xml.h:106
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer below the current layer."
 msgstr "Legg til eit nytt målelag under det aktive laget."
 
-#: ../po/tmp/resources.xml.h:89
+#: ../po/tmp/resources.xml.h:107
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer Below…"
 msgstr "Nytt vektorlag under …"
 
-#: ../po/tmp/resources.xml.h:90
+#: ../po/tmp/resources.xml.h:108
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer below the current layer, and begin editing it."
 msgstr ""
 "Legg til eit nytt vektorlag under det aktive laget, og begynn å redigere det."
 
-#: ../po/tmp/resources.xml.h:91
+#: ../po/tmp/resources.xml.h:109
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group Below"
 msgstr "Ny laggruppe under"
 
-#: ../po/tmp/resources.xml.h:92
+#: ../po/tmp/resources.xml.h:110
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group below the current layer."
 msgstr "Legg til ei ny laggruppe under det aktive laget."
 
-#: ../po/tmp/resources.xml.h:93
+#: ../po/tmp/resources.xml.h:111
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Layer Down"
 msgstr "Flett saman nedover"
 
-#: ../po/tmp/resources.xml.h:94
+#: ../po/tmp/resources.xml.h:112
 msgctxt "Accel Editor (descriptions)"
 msgid "Merge the current layer with the layer beneath it."
 msgstr "Flett det aktive laget med laget under det."
 
-#: ../po/tmp/resources.xml.h:95
+#: ../po/tmp/resources.xml.h:113
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Visible Layers"
 msgstr "Flett saman synlege lag"
 
-#: ../po/tmp/resources.xml.h:96
+#: ../po/tmp/resources.xml.h:114
 msgctxt "Accel Editor (descriptions)"
 msgid "Consolidate all visible layers, and delete the originals."
 msgstr "Konsolider alle synlege lag og slett dei originale."
 
-#: ../po/tmp/resources.xml.h:97
+#: ../po/tmp/resources.xml.h:115
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer from Visible"
 msgstr "Nytt lag frå synleg"
 
-#: ../po/tmp/resources.xml.h:98
+#: ../po/tmp/resources.xml.h:116
 msgctxt "Accel Editor (descriptions)"
 msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
 msgstr "Som «Flett saman synlege lag», men slettar ikkje originalane."
 
-#: ../po/tmp/resources.xml.h:99
+#: ../po/tmp/resources.xml.h:117
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Delete Layer"
 msgstr "Slett lag"
 
-#: ../po/tmp/resources.xml.h:100
+#: ../po/tmp/resources.xml.h:118
 msgctxt "Accel Editor (descriptions)"
 msgid "Remove the current layer from the layer stack."
 msgstr "Fjern det aktive laget frå lagstabelen."
 
-#: ../po/tmp/resources.xml.h:101
+#: ../po/tmp/resources.xml.h:119
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Convert to Normal Painting Layer"
 msgstr "Konverter til målelag med normalmodus"
 
-#: ../po/tmp/resources.xml.h:102
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
@@ -4199,1288 +5197,1362 @@ msgstr ""
 "Konverter den aktive laget eller gruppa til eit målelag med «Normal»-modus, "
 "samtidig som utsjånaden vert beheldt."
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr "Auk laget si dekkevne"
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr "Gjer laget mindre gjennomsiktig."
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr "Mink laget si dekkevne"
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr "Gjer laget meir gjennomsiktig."
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr "Hev laget"
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr "Hev det aktive laget eitt steg i lagstabelen."
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr "Senk lag"
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr "Senk det aktive laget eitt steg i lagstabelen."
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr "Dupliser lag"
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr "Lag ei eksakt klon av det aktive laget."
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
+#, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
-msgstr "Gje nytt namn til laget …"
+msgid "Layer Properties…"
+msgstr "Eigenskapar"
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
-msgstr "Skriv inn eit nytt namn for det aktive laget."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr "Lag låst"
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr "Lag synleg"
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr "Vis bakgrunn"
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr "Fjern det aktive laget frå lagstabelen."
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr "Tilbakestill og sentrer"
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 "Tilbakestill forstørring, rotering og spegling, samt resentrer dokumentet."
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr "Tilbakestill"
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr "Tilbakestill forstørring"
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
-msgstr ""
+msgid "Reset view zoom level to default."
+msgstr "Tilbakestill grunnverdien til standardverdien"
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr "Tilbakestill rotasjon"
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr "Tilbakestill spegling"
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
-msgstr ""
+msgid "Reset the view's mirroring."
+msgstr "Tilbakestill spegling"
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr "Forstørr"
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr "Auk forstørring."
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Forminsk"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr "Minsk forstørring."
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
-msgstr "Roter mot klokka"
+msgid "Pan Left"
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
-msgstr "Roter mot klokka."
+msgid "Move your view of the canvas to the left."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr "Hardt lys"
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr "Roter med klokka"
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr "Roter mot klokka."
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr "Roter mot klokka"
+
+#: ../po/tmp/resources.xml.h:167
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr "Roter mot klokka."
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr "Spegl vassrett"
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr "Spegl loddrett"
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr "Eittlags-visning"
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr "Bruk symmetrisk måling"
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr "Spegl penselstrok om symmetriaksen"
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr "Bruk ramme"
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr "Slå dokumentramme av/på."
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr "Skriv ut penselen sine innverdiar til konsollen"
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr "Vis penselmaskina sine internt genererte inndata på konsollen."
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr "Visualiser teikning"
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr "Ingen dobbelbufring"
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr "Slå av GTK si dobbelbufring, som vanlegvis er slått på."
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+#, fuzzy
+msgid "Delete Point"
+msgstr "Slett punkt"
+
+#: ../po/tmp/resources.xml.h:187
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr "Slett det valde punktet"
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr "Målemodus"
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr "Målemodus: Normal"
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr "Målemodus: Viskelêr"
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr "Visk med den aktive penselen."
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr "Målemodus: Lås alfa"
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr "Målemodus: Fargelegg"
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Fil"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "Avslutt"
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr "Lukk hovudvindauget og avslutt programmet."
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "Rediger"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr "Aktivt verktøy"
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "Farge"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr "Juster farge"
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr "Fargehistorikk"
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr "Fargedetaljdialog"
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr "Neste palettfarge"
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr "Sett målefargen til den neste fargen i paletten."
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr "Førre palettfarge"
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr "Sett målefargen til den førre fargen i paletten."
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr "Legg fargen til paletten"
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr "Legg den aktive målefargen til i paletten."
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "Lag"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr "Dekkevne"
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr "Gå til lag"
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr "Nytt lag under"
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr "Eigenskapar"
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr "Rableblokk"
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr "Ny rableblokk"
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr "Last standardrableblokka som eit nytt rableblokklerret."
 
 # "Scrap" -> "kladd"
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr "Opne rableblokk …"
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr "Last ei biletfil på disken inn i rableblokka."
 
 # "Scrap" -> "kladd"
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr "Lagre rableblokk"
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr "Lagre rableblokka til si eksisterande fil på disken."
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr "Eksporter rableblokk som …"
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr "Eksporter rableblokka til disken, med eit namn du sjølv kan velje."
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr "Tilbakestill rableblokka"
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr "Lagre rableblokk som standard"
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr "Lagre rableblokka som standarden for «Ny rableblokk»."
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr "Tøm standardrableblokka"
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr "Tøm standardrableblokka slik at den vert eit tomt lerret."
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr "Kopier hovudbakgrunnen til rableblokka"
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "Vindauge"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "Pensel"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr "Snarvegstastar"
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr "Penselsnarvegstasthjelp"
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr "Vis ei forklaring av korleis snarvegstastane fungerer."
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "Endre pensel …"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "Endre farge …"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "Endre farge (rask delmengd) …"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr "Få fleire penslar …"
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr "Last ned penselpakkar frå MyPaint-wikien."
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr "Importer penslar …"
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr "Last ein penselpakke frå disken."
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Hjelp"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr "Onlinehjelp"
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr "Gå til MyPaint sin dokumentasjonswiki."
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "Om MyPaint"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Feilsøk"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr "Skriv minnelekkasjeinformasjon til konsollen (tregt!)"
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr "Feilsøk minnelekkasjar."
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr "Køyr søppeltømaren no"
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr "Frigjer minne brukt for Python-objekt som ikkje lenger er i bruk."
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr "Start/Stopp profilering …"
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr "Start eller stopp pythonprofilering (cProfile)"
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr "Simuler eit kræsj …"
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "Vis"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr "Tilbakemelding"
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
+#, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr "Vis meny"
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "Fullskjerm"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "Rediger innstillingar"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr "Rediger MyPaint sine globale innstillingar."
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr "Test inneiningar"
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr "Vis ein dialog som fangar alle hendingane inneiningane dine sender."
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr "Bakgrunnsveljar"
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr "Endre teksturen på bakgrunnspapiret."
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr "Penselinnstillingsredigerar"
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr "Rediger den aktive penselen sine innstillingar."
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr "Penselikonredigerar"
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr "Rediger penselikon."
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr "Lagpanel"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr "Vis lagpanel"
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr "HCY-hjul"
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "Fargepalett"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr "HSV-hjul"
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr "HSV-triangel"
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr "HSV-kube"
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr "HSV-kvadrat"
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr "Komponentglidebrytarar"
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr "Konsentriske ringar"
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr "Kryssa bolle"
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr "Rableblokkpanel"
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr "Vis rableblokkpanel"
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr "Førehandsvisningspanel"
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "Førehandsvisning"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr "Verktøyvalpanel"
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr "Vis verktøyvalpanelet"
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr "Pensel- og fargehistorikkpanel"
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr "Siste penslar og fargar"
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr "Skjul kontrollar i fullskjerm"
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr "Vis forstørring"
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr "Vis siste måleposisjon"
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr "Visningsfilter"
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr "Vis fargar normalt"
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr "Vis fargar som gråskala"
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr "Vis fargar invertert"
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr "Frihand"
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr "Frihand"
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr "Frihand"
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr "Panorer"
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr "Roter"
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr "Roter"
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr "Roter"
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr "Forstørr"
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr "Forstørring"
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr "Forstørr"
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr "Interaktiv forstørring eller forminsking av lerretet."
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr "Linjer og kurver"
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr "Linjer"
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr "Linjer og kurver: teikn beine eller kurva linjer."
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr "Linjer og kurver"
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr "Teikn beine eller kurva linjer."
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr "Samanhengande linjer"
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr "Samanh. linjer"
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr "Samanhengande linjer: teikn sekvensar av beine eller kurva linjer."
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr "Samanhengande linjer"
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr "Teikn sekvensar av beine eller kurva linjer."
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr "Ellipsar og sirklar"
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr "Ellipse"
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr "Ellipsar og sirklar: teikn runda former."
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr "Ellipsar og sirklar"
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr "Teikn sirklar og ellipsar."
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr "Blekk"
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr "Flytt laget"
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr "Lagpos."
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr "Flytt laget: flytt det aktive laget rundt på lerretet."
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr "Flytt laget"
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr "Flytt det aktive laget interaktivt på lerretet."
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr "Rediger ramma"
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr "Ramme"
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
@@ -5488,12 +6560,12 @@ msgstr ""
 "Rediger ramma: definer ei ramme rundt dokumentet for å gi det ein endeleg "
 "størrelse."
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr "Rediger ramma"
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
@@ -5501,80 +6573,230 @@ msgstr ""
 "Definer ei ramme interaktivt rundt dokumentet for å gi det ein endeleg "
 "størrelse."
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Rediger målesymmetri"
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr "Symmetri"
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr "Rediger målesymmetri: juster aksen brukt til symmetrisk måling."
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Rediger målesymmetri"
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr "Juster aksen brukt til symmetrisk måling interaktivt."
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr "Plukk farge"
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr "Plukk farge"
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr "Plukk farge: sett målingsfargen frå skjermpikslar."
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "Vel farge"
+
+#: ../po/tmp/resources.xml.h:401
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr "Sett målefargen frå skjermpikslar."
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "Vel farge"
+
+#: ../po/tmp/resources.xml.h:403
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr "Sett målefargen frå skjermpikslar."
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "Vel farge"
+
+#: ../po/tmp/resources.xml.h:405
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr "Sett målefargen frå skjermpikslar."
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr "Plukk farge"
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr "Sett målefargen frå skjermpikslar."
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr "Fyll"
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr "Fyll"
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr "Fyll: fyll eit område med farge."
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr "Fyll"
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr "Fyll eit område med farge."
+
+#~ msgctxt "Accelerator map editor: action column markup"
+#~ msgid ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+#~ msgstr ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+
+#~ msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
+#~ msgid "{action_label} {action_desc} {accel_label}"
+#~ msgstr "{action_label} {action_desc} {accel_label}"
+
+#~ msgctxt "brush list context menu"
+#~ msgid "Delete"
+#~ msgstr "Slett"
+
+#~ msgctxt "brush list commands"
+#~ msgid "Really delete brush from disk?"
+#~ msgstr "Er du sikker på at du vil slette penselen frå disken?"
+
+#~ msgid "HSV Triangle"
+#~ msgstr "HSV-triangel"
+
+#~ msgid "The standard GTK color selector"
+#~ msgstr "GTK sin standard fargeveljar"
+
+#~ msgid "Pick a color from the screen"
+#~ msgstr "Plukk ein farge frå skjermen"
+
+#~ msgid "Layer Name"
+#~ msgstr "Lagnamn"
+
+#~ msgid ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+#~ msgstr ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+
+# duplication?
+#~ msgid "Save..."
+#~ msgstr "Lagre …"
+
+#~ msgid "Confirm"
+#~ msgstr "Bekreft"
+
+#~ msgid "Open..."
+#~ msgstr "Opne …"
+
+#~ msgid "Type"
+#~ msgstr "Type"
+
+#~ msgid "Mode:"
+#~ msgstr "Modus:"
+
+#~ msgid ""
+#~ "Blending mode: how the current layer combines with the layers underneath "
+#~ "it."
+#~ msgstr "Modus: korleis det aktive laget vert kombinert med laga under det."
+
+#~ msgid ""
+#~ "Layer opacity: how much of the current layer to use. Smaller values make "
+#~ "it more transparent."
+#~ msgstr ""
+#~ "Lagdekkevne: kor mykje av det aktive laget som skal brukast. Små verdiar "
+#~ "gjer det meir gjennomsiktig."
+
+#~ msgid "%s: edit properties"
+#~ msgstr "%s: rediger eigenskaper"
+
+#~ msgid "Setting name:"
+#~ msgstr "Innstillingsnamn:"
+
+#~ msgid "Base value:"
+#~ msgstr "Grunnverdi:"
+
+#~ msgid "<ymin>"
+#~ msgstr "<ymin>"
+
+#~ msgid "<ymax>"
+#~ msgstr "<ymax>"
+
+#~ msgid "<xmin>"
+#~ msgstr "<xmin>"
+
+#~ msgid "<xmax>"
+#~ msgstr "<xmax>"
+
+#~ msgid "Edit Setting"
+#~ msgstr "Rediger innstilling"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Trim Layer to Frame"
+#~ msgstr "Beskjer laget til ramma"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Rename Layer…"
+#~ msgstr "Gje nytt namn til laget …"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Enter a new name for the current layer."
+#~ msgstr "Skriv inn eit nytt namn for det aktive laget."
+
+#~ msgctxt "Menu→Edit (labels)"
+#~ msgid "Current Tool"
+#~ msgstr "Aktivt verktøy"
+
+#~ msgctxt "Menu→Color (labels), Accel Editor (labels)"
+#~ msgid "HSV Triangle"
+#~ msgstr "HSV-triangel"
 
 #~ msgid "Add As New"
 #~ msgstr "Legg til som ny"
@@ -5679,9 +6901,6 @@ msgstr "Fyll eit område med farge."
 #~ "Forklaringar om penselen sine innstillingar finst som verktøytips.Hald "
 #~ "musa over innstillinga for å sjå dei. \n"
 
-#~ msgid "Open Recent files"
-#~ msgstr "Opne nyleg brukte filer"
-
 #~ msgid "This will discard %d second of unsaved painting."
 #~ msgid_plural "This will discard %d seconds of unsaved painting."
 #~ msgstr[0] "Dette vil kassere %d sekund av måling som ikkje er lagra."
@@ -5771,9 +6990,6 @@ msgstr "Fyll eit område med farge."
 #~ msgid "Brush Blend Mode"
 #~ msgstr "Penselblandingsmodus"
 
-#~ msgid "Add Layer"
-#~ msgstr "Legg til lag"
-
 #, fuzzy
 #~ msgid "Move Layer on Canvas"
 #~ msgstr "Flytt lag"
@@ -5815,9 +7031,6 @@ msgstr "Fyll eit område med farge."
 #~ msgctxt "Menu|File|"
 #~ msgid "Save"
 #~ msgstr "Lagre"
-
-#~ msgid "Export to a file"
-#~ msgstr "Eksporter til ei fil"
 
 #, fuzzy
 #~ msgid ""

--- a/po/nn_NO.po
+++ b/po/nn_NO.po
@@ -531,17 +531,17 @@ msgstr "MyPaint penselpakke (*.zip)"
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr "Ny gruppe …"
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr "Importer penslar …"
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr "Få fleire penslar …"
 
 #: ../gui/brushselectionwindow.py:554
@@ -1223,12 +1223,12 @@ msgstr "Type"
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr "Bruk for …"
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr "Rulling …"
 
 #. Name and preview column: will be indented
@@ -1452,7 +1452,7 @@ msgid "_Quit"
 msgstr "Avslutt"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr "Importer penselpakke …"
 
 #: ../gui/drawwindow.py:698
@@ -1508,7 +1508,7 @@ msgstr ""
 "«{type_name}» ({content_type})?"
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr "Opne med …"
 
 #: ../gui/externalapp.py:123
@@ -1702,13 +1702,13 @@ msgstr "JPEG 90% kvalitet (*.jpg; *.jpeg)"
 
 #: ../gui/filehandling.py:576
 #, fuzzy
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr "Eksporter …"
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Lagre som …"
 
@@ -1781,7 +1781,7 @@ msgstr "Opne nyleg brukte filer"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr "Opne rableblokk …"
 
 #: ../gui/filehandling.py:1099
@@ -2230,12 +2230,12 @@ msgstr ""
 "feilrapporteringssystemet dersom ingen andre har rapportert det enno."
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr "Søk i feilrapporteringssystemet …"
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr "Rapporter …"
 
 #: ../gui/gtkexcepthook.py:180
@@ -2247,7 +2247,7 @@ msgid "Quit MyPaint"
 msgstr "Avslutt MyPaint"
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr "Detaljar …"
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2437,7 +2437,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr "Flytt laget i stabelen …"
 
 #: ../gui/layerswindow.py:110
@@ -2509,7 +2509,7 @@ msgid "Stroke trail-off beginning"
 msgstr "Byrjinga på slutten av stroket"
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr "Trykkvariasjon …"
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/oc.po
+++ b/po/oc.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:19+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Occitan <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -19,27 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -47,39 +27,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -87,214 +67,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "Motiu"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Color"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Personalisat"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -333,142 +323,177 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Enregistrar"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Nòu"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -476,58 +501,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -536,51 +561,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -590,137 +639,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -728,162 +777,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -891,373 +932,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Nom"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Anullar"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Tornar far"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1267,324 +1305,673 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Ecran complet"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Quitar"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Quitar"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
+msgstr ""
+
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
+msgstr ""
+
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Enregistrar"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
 #, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr ""
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Fichièr"
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1427
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1432
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr ""
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1592,130 +1979,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1724,35 +2123,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1776,45 +2175,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1822,153 +2225,217 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr ""
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr ""
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr ""
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1980,256 +2447,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2237,188 +2729,212 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+msgid "Import Layers"
+msgstr ""
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2427,13 +2943,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2443,7 +2959,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2451,13 +2967,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2465,7 +2981,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2473,7 +2989,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2484,7 +3000,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2492,7 +3008,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2502,7 +3023,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2513,285 +3034,394 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr ""
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2801,7 +3431,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2810,52 +3460,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2877,17 +3558,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2916,112 +3595,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3034,7 +3688,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3075,6 +3729,133 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Nom"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3444,56 +4225,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3501,12 +4302,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3515,7 +4316,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3526,28 +4327,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3609,1828 +4410,2018 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Reduire el zoom"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Fichièr"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/oc.po
+++ b/po/oc.po
@@ -513,17 +513,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1184,12 +1184,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1405,7 +1405,7 @@ msgid "_Quit"
 msgstr "Quitar"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1455,7 +1455,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1632,13 +1632,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Enregistrar"
 
@@ -1704,7 +1704,7 @@ msgstr "Fichièr"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -2124,12 +2124,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2141,7 +2141,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2326,7 +2326,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2396,7 +2396,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-23 08:18+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -19,27 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -47,39 +27,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -87,214 +67,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "ਰੰਗ"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "ਕਸਟਮ"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -333,142 +323,177 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "ਸੰਭਾਲੋ"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "ਨਵਾਂ"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -476,58 +501,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -536,51 +561,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -590,137 +639,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -728,162 +777,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -891,373 +932,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "ਨਾਂ"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "ਵਾਪਸ"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "ਪਰਤਾਓ"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1267,324 +1305,679 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "ਖੋਲ੍ਹੋ..."
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "ਪੂਰੀ ਸਕਰੀਨ"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "ਬਾਹਰ"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "ਬਾਹਰ"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "ਖੋਲ੍ਹੋ..."
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "ਸੰਭਾਲੋ"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr ""
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr ""
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "ਫਾਇਲ"
+
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "ਪਰਤਾਂ"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "ਖੋਲ੍ਹੋ..."
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "ਤਾਜ਼ਾ ਖੋਲੇ"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "ਖੋਲ੍ਹੋ..."
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "ਖੋਲ੍ਹੋ..."
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr ""
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1592,130 +1985,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1724,35 +2129,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1776,45 +2181,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1822,153 +2231,218 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "ਪਰਤਾਂ"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "ਪਰਤਾਂ"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr ""
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1980,256 +2454,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2237,188 +2736,213 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "ਪਰਤਾਂ"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2427,13 +2951,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2443,7 +2967,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2451,13 +2975,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2465,7 +2989,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2473,7 +2997,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2484,7 +3008,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2492,7 +3016,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2502,7 +3031,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2513,285 +3042,394 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr ""
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2801,7 +3439,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2810,52 +3468,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2877,17 +3566,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2916,112 +3603,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3034,7 +3696,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3075,6 +3737,133 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "ਨਾਂ"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3444,56 +4233,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3501,12 +4310,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3515,7 +4324,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3526,28 +4335,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3609,1828 +4418,2019 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "ਜ਼ੂਮ ਬਾਹਰ"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "ਫਾਇਲ"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "ਮੱਦਦ"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "ਡੀਬੱਗ"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
-msgstr ""
+msgstr "ਪਰਤਾਂ"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/pa.po
+++ b/po/pa.po
@@ -513,17 +513,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1184,12 +1184,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1372,7 +1372,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Open dragged file confirm dialog: continue button"
 msgid "_Open"
-msgstr "ਖੋਲ੍ਹੋ..."
+msgstr "ਖੋਲ੍ਹੋ…"
 
 #: ../gui/drawwindow.py:486
 msgid "Set current color"
@@ -1406,7 +1406,7 @@ msgid "_Quit"
 msgstr "ਬਾਹਰ"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1456,7 +1456,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1633,13 +1633,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "ਸੰਭਾਲੋ"
 
@@ -1705,7 +1705,7 @@ msgstr "ਫਾਇਲ"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -1723,7 +1723,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "ਖੋਲ੍ਹੋ..."
+msgstr "ਖੋਲ੍ਹੋ…"
 
 #: ../gui/filehandling.py:1427
 #, fuzzy
@@ -1735,7 +1735,7 @@ msgstr "ਤਾਜ਼ਾ ਖੋਲੇ"
 #, fuzzy
 msgctxt "File→Open Most Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "ਖੋਲ੍ਹੋ..."
+msgstr "ਖੋਲ੍ਹੋ…"
 
 #: ../gui/filehandling.py:1446
 msgctxt "File→Open Next/Prev Scrap: error message"
@@ -1756,7 +1756,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
 msgid "_Open"
-msgstr "ਖੋਲ੍ਹੋ..."
+msgstr "ਖੋਲ੍ਹੋ…"
 
 #: ../gui/filehandling.py:1487
 msgctxt "File→Revert: status message: canvas has no filename yet"
@@ -2130,12 +2130,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2147,7 +2147,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2333,7 +2333,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2403,7 +2403,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MyPaint GIT\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2016-08-29 18:17+0000\n"
 "Last-Translator: Mariusz Kryjak <cerb3ruspl@gmail.com>\n"
-"Language-Team: Polish "
-"<https://hosted.weblate.org/projects/mypaint/mypaint/pl/>\n"
+"Language-Team: Polish <https://hosted.weblate.org/projects/mypaint/mypaint/"
+"pl/>\n"
 "Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -23,29 +23,7 @@ msgstr ""
 "X-Poedit-Country: Polski\n"
 "X-Poedit-SourceCharset: utf-8\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr "<big><b>{accel_label}</b></big>"
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr "{action_label} {action_desc} {accel_label}"
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "Akcja"
 
@@ -53,32 +31,32 @@ msgstr "Akcja"
 msgid "Key combination"
 msgstr "Kombinacja klawiszy"
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr "Edytuj Klawisz dla '%s'"
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "Akcja:"
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "Ścieżka:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "Klawisz:"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr "Naciśnij klawisze by zmienić to powiązanie"
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "Nieznana Akcja"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
@@ -87,7 +65,7 @@ msgstr ""
 "<b>{accel} jest już w użyciu dla '{action}'. Istniejące przypisanie zostanie "
 "zmienione.</b>"
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr "Otwórz Folder “{folder_basename}”…"
@@ -95,195 +73,205 @@ msgstr "Otwórz Folder “{folder_basename}”…"
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "OK"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr "Nie znaleziono kopii zapasowych w folderze Cache."
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr "Brak Dostępnych Kopii Zapasowych"
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr "Otwórz Folder Cache…"
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr "Niepowodzenie Przywracania Kopii Zapasowej"
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr "Otwórz Folder Kopii Zapasowych…"
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr "Przywrócono plik z {iso_datetime}.ora"
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "Zapisz jako Domyślne"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "Tło"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "Wzór"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Kolor"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "Dodaj kolor do Wzorów"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr "Nie można załadować jednego lub więcej tła"
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr "Błąd podczas ładowania tła"
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 "Proszę usunąć nieotwieralne pliki, bądź sprawdzić instalację libgdkpixbuf."
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 "Gdk-Pixbuf nie może otworzyć \"{filename}\" i odnotował błąd \"{error}\""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr "{filename} ma rozmiar (w={w}, h={h})"
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr "Edytor Ustawień Pędzla"
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr "O pędzlu"
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "Eksperymentalne"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr "Podstawowe"
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr "Krycie"
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr "Ciapki"
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "Rozmazanie"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr "Szybkość"
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr ""
+
+#: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr "Wygładzanie"
 
-#: ../gui/brusheditor.py:359
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "Pociągnięcie"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr "Kolor"
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Dowolne"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr "Nie wybrano pędzla, użyj \"Dodaj jako Nowy\"."
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr "Nie wybrano żadnego pędzla!"
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "Przemianuj Pędzel"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "Pędzel o tej nazwie już istnieje!"
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr "Nie wybrano pędzla!"
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr "Czy na pewno usunąć pędzel “{brush_name}\" z dysku?"
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr "(Nienazwany pędzel)"
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr "{brush_name} [niezapisany]"
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr "Ikona Pędzla"
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr "Ikona Pędzla (edycja)"
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr "Nie wybrano pędzla"
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -292,7 +280,7 @@ msgstr ""
 "<b>%s</b>\n"
 "<small>Wybierz najpierw poprawny pędzel</small>"
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
@@ -301,7 +289,7 @@ msgstr ""
 "<b>%s</b> <i>(zmodyfikowany)</i>\n"
 "<small>Zmiany nie są jeszcze zapisane</small>"
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
@@ -310,7 +298,7 @@ msgstr ""
 "<b>%s</b> (edycja)\n"
 "<small>Maluj dowolnym pędzlem oraz kolorem</small>"
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -351,98 +339,138 @@ msgstr "Domyślna"
 msgid "Use the default icon"
 msgstr "Użyj domyślnej ikony"
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Zapisz"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr "Zapisz tę ikonę i zakończ edycję"
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr "Znalezione"
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr "Usunięte"
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr "Ulubione"
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr "Tusz"
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr "Klasyczne"
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr "Zestaw#1"
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr "Zestaw#2"
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr "Zestaw#3"
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr "Zestaw#4"
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr "Zestaw#5"
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr "Eksperymentalne"
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Nowy"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr "Nieznany Pędzel"
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr "Dodaj do Ulubionych"
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr "Usuń z Ulubionych"
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr "Klonuj"
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr "Edytuj Ustawienia Pędzla"
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
-msgstr "Usuń"
+#: ../gui/brushselectionwindow.py:250
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
+msgstr "Przemianuj Grupę"
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
-msgstr "Czy na pewno usunąć plik ustawienia pędzla?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, fuzzy, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
+msgstr "Czy na pewno usunąć pędzel “{brush_name}\" z dysku?"
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
@@ -450,44 +478,44 @@ msgstr[0] "%d pędzel"
 msgstr[1] "%d pędzle"
 msgstr[2] "%d pędzle"
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr "Grupa “{group_name}”"
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr "Przemianuj Grupę"
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr "Eksportuj jako Spakowany Zestaw Pędzli"
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr "Usuń Grupę"
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr "Przemianuj Grupę"
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "Istnieje już grupa o tej nazwie!"
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr "Na pewno usunąć grupę “{group_name}”?"
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -497,58 +525,58 @@ msgstr ""
 "Nie można usunąć grupy “{group_name}”.\n"
 "Niektórych specjalnych grup nie można usunąć."
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr "Eksportuj Pędzle"
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr "pakiet pędzli MyPaint (*.zip)"
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "Nowa Grupa..."
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr "Importuj Pędzle..."
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr "Więcej Pędzli..."
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "Stwórz Grupę"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr "Przycisk"
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr "Psk"
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr "Naciśnięcie przycisku"
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr "Dodaj nowe powiązanie"
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr "Usuń obecne powiązanie"
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr "Edytuj powiązanie dla '%s'"
@@ -557,7 +585,7 @@ msgstr "Edytuj powiązanie dla '%s'"
 msgid "Button press:"
 msgstr "Naciśnięcie przycisku:"
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
@@ -565,7 +593,7 @@ msgstr ""
 "Przytrzymaj klawisze modyfikujące i naciśnij przycisk nad tym tekstem by "
 "ustawić nowe powiązanie."
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
@@ -573,40 +601,68 @@ msgstr ""
 "{button} nie może być przypisany bez klawiszy modyfikujących (ma z góry "
 "określone przeznaczenie)"
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr "{button_combination} jest już związane z akcją '{action_name}'"
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr "Pobierz Kolor"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr "Wybierz kolor używany do malowania"
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+#, fuzzy
+msgid "Set the color Hue used for painting"
+msgstr "Wybierz kolor używany do malowania"
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "Pobierz kolor"
+
+#: ../gui/colorpicker.py:296
+#, fuzzy
+msgid "Set the color Chroma used for painting"
+msgstr "Wybierz kolor używany do malowania"
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+#, fuzzy
+msgid "Set the color Luma used for painting"
+msgstr "Wybierz kolor używany do malowania"
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr "Szczegóły koloru"
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr "Obecny kolor pędzla i kolor ostatnio użyty do malowania"
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr "Maskowanie Gamy Aktywne"
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -618,7 +674,7 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr "HCY odcień i nasycenie."
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
@@ -627,12 +683,12 @@ msgstr ""
 "Edytor mask gamy. Kliknij w środku by tworzyć lub manipulować kształtami, "
 "lub obracaj maskę używając krawędzi dysku."
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr "Atmosferyczna Triada"
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
@@ -641,22 +697,22 @@ msgstr ""
 "Nastrojowa i subiektywna, zdefiniowana przez dominująca barwę podstawową i "
 "dwie podstawowe o mniejszym nasyceniu."
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr "Przesunięta Triada"
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr "Przesunięta bardziej w stronę barwy dominującej."
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr "Dopełniające"
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
@@ -665,12 +721,12 @@ msgstr ""
 "Kontrastujące ze sobą odwrotności, równoważone przez centralne obojętne "
 "pomiędzy nimi na kole barw."
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr "Nastrój i Akcent"
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
@@ -679,12 +735,12 @@ msgstr ""
 "Jeden główny zakres kolorów z dopełniającym akcentem dla wyróżnienia i "
 "pasemek."
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr "Sąsiednie Dopełniające"
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
@@ -693,72 +749,72 @@ msgstr ""
 "Dwa analogiczne kolory i uzupełnienie ich bez kolorów podrzędnych między "
 "nimi."
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr "Nowa Gama Maskowania z Szablonu"
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr "Edytor Maski Gamy"
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr "Aktywne"
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr "Pomoc…"
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr "Utwórz maskę z szablonu."
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr "Wczytaj maskę z pliku palety GIMP."
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr "Zapisz maskę do pliku palety GIMP."
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr "Wyczyść maskę."
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr "Otwórz pomoc w sieci dla tego okna w przeglądarce."
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr "Zapisz Maskę jako Paletę GIMP"
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr "Wczytaj Maskę z Palety GIMP"
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr "Ustaw gamę maski."
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr "Koło HCY"
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -768,163 +824,155 @@ msgstr ""
 "jasności . Krążki są tej samej luminancji."
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr "HSV Odcień"
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr "HSV Nasycenie"
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr "HSV Wartość"
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr "HSV Nasycenie i Wartość"
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr "HSV Odcień i Jasność"
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr "HSV Odcień i Nasycenie"
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr "Obróć kostkę (wyświetl inny kąt)"
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr "Kostka HSV"
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 "Kostka HSV z możliwością obracania by wyświetlić na niej inne płaszczyzny."
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr "Kwadrat HSV"
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr "Kwadrat HSV z możliwością obracania by wyświetlić na nim inne barwy."
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr "Trójkąt HSV"
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr "Standardowy selektor kolorów GTK"
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr "Koło HSV"
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr "Zmieniarka Nasycenia i Wartości koloru."
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr "Właściwości palety"
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr "Paleta"
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr "Ustaw kolor z ładowalnej i edytowalnej palety."
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr "Nienazwana Paleta"
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr "Edytor Palety"
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr "Wczytaj z pliku palety GIMP"
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr "Zapisz jako plik palety GIMP"
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr "Dodaj nową pustą próbkę"
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr "Usuń bieżącą próbkę"
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr "Usuń wszystkie próbki"
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr "Nazwa:"
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr "Nazwa lub opis dla tej palety"
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr "Kolumny:"
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr "Ilość kolumn"
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr "Nazwa koloru:"
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr "Nazwa zaznaczonego koloru"
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr "Czyść miejsce w palecie"
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr "Wczytaj paletę"
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr "Zapisz paletę"
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -935,378 +983,375 @@ msgstr ""
 "Upuść tu kolory,\n"
 "przeciągnij je by uporządkować."
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr "Puste miejsce w palecie (przeciągnij tu kolor)"
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr "Dodaj Puste Miejsce"
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr "Wstaw Wiersz"
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr "Wstaw Kolumnę"
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr "Wypełnij Przestrzeń (RGB)"
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr "Wypełnij Przestrzeń (HCY)"
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr "Wypełnij Przestrzeń (HSV)"
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "Plik palety GIMP (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr "Wszystkie pliki (*)"
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "Plik palety GIMP (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr "Wszystkie pliki (*)"
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr "Pobierz kolor z ekranu"
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr "R"
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr "G"
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr "B"
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr "H"
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr "C"
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr "Y"
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr "Suwaki Składowych"
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr "Dostosuj składowe koloru."
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr "RGB Czerwony"
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr "RGB Zielony"
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr "RGB Niebieski"
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr "HSV Odcień"
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr "HSV Nasycenie"
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr "HSV Wartość"
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr "HCY Odcień"
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr "HCY Nasycenie"
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr "HCY Jasność (Y')"
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr "Plama Kolorów"
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr "Zmień kolor za pomocą plamy z sąsiadujących kolorów."
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr "Pierścienie Koncentryczne"
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr "Zmień kolor używając koncentrycznych pierścieni HSV."
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr "Skrzyżowana Misa"
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr "Zmień kolor za pomocą palety HSV na skrzyżowanej misce kolorów."
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr "Kursor/rysik"
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr "Gumka"
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr "Klawiatura"
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr "Myszka"
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr "Pióro"
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr "Touchpad"
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr "Ekran dotykowy"
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr "Ignoruj"
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr "Każdego zadania"
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr "Zadań bez malowana"
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr "Nawigacji"
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr "Powiększanie"
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr "Przesuwanie"
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr "Urządzenie"
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr "Osie"
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr "Typ"
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr "Użyj do..."
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr "Kółko..."
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Nazwa"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr "Nadpisać Pędzel?"
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr "Zastąp"
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr "Przemianuj"
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr "Zastąp wszystkie"
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr "Przemianuj Wszystko"
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr "Zaimportowany pędzel"
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr "Istniejący pędzel"
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 "<b>Pędzel o nazwie `%s' już istnieje.</b>\n"
 "Chcesz go zastąpić, czy zmienić nazwę nowego pędzla?"
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr "Nadpisać Grupę Pędzli?"
 
-#: ../gui/dialogs.py:190
-#, python-brace-format
+#: ../gui/dialogs.py:220
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 "<b>Grupa `{groupname}' już istnieje.</b>\n"
 "Zastąpić ją, czy zmienić nazwę nowej grupy?\n"
 "Gdy ją zastąpisz pędzle mogą być przeniesione do grupy '{deleted_groupname}'."
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr "Zaimportować Paczkę Pędzli?"
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, fuzzy, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr "<b>Czy na pewno chcesz zaimportować paczkę `%s'?</b>"
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr "Wczytaj ustawienia pędzla z miejsca skrótu %d"
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr "Zachowaj ustawienia pędzla w miejscu skrótu %d"
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr "Przywróć Pędzel '%d'"
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr "Zapisz do Pędzla %d"
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr "Cofnij %s"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Cofnij"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr "Ponów %s"
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Ponów"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr "{button_combination} to {resultant_action}"
@@ -1316,104 +1361,147 @@ msgstr "{button_combination} to {resultant_action}"
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ";  "
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr "Z {modifiers} przytrzymaj: {button_actions}."
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
-msgstr "Nazwa Warstwy"
-
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
-#, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
-"<b>{name}</b>\n"
-"{description}"
+
+#: ../gui/document.py:909
+#, python-brace-format
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
+msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr "%s - MyPaint"
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr "MyPaint"
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Otwórz"
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr "Ustaw Bieżący Kolor"
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr "Wyjdź z Trybu Pełnoekranowego"
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr "Wyjdź z Pełnego Ekranu"
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr "Przejdź do Trybu Pełnoekranowego"
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Tryb Pełnoekranowy"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Zakończ"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+#, fuzzy
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr "Czy na pewno chcesz zamknąć program?"
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Zakończ"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr "Zaimportuj Paczkę Pędzli..."
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr "Paczka pędzli MyPaint (*zip)"
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr "Uruchomiono {app_name} do edycji warstwy \"{layer_name}\""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
-"Błąd: niepowodzenie uruchomienia {app_name} do edycji warstwy \"{layer_name}"
-"\""
+"Błąd: niepowodzenie uruchomienia {app_name} do edycji warstwy "
+"\"{layer_name}\""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 "Edytowanie anulowane. Możesz nadal edytować \"{layer_name}\" z menu Warstw."
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr "Zaktualizowano warstwę \"{layer_name}\" przez zewnętrzne zmiany"
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr "Nie udało się wczytać \"{file_basename}\"."
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
@@ -1422,188 +1510,420 @@ msgstr ""
 "MyPaint potrzebuje edytować plik typu \"{type_name}\" ({content_type}). "
 "Jakiej aplikacji powinien użyć?"
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
-"Jakiej aplikacji MyPaint powinien użyć do edycji plików typu \"{type_name}\" "
-"({content_type})?"
+"Jakiej aplikacji MyPaint powinien użyć do edycji plików typu "
+"\"{type_name}\" ({content_type})?"
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr "Otwórz za Pomocą..."
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr "Ikona"
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr "brak opisu"
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
+#: ../gui/filehandling.py:126
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
+msgstr "Ładowanie \"{file_basename}\"…"
+
+#: ../gui/filehandling.py:130
+#, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:134
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
+msgstr "Zapisywanie \"{file_basename}\"…"
+
+#: ../gui/filehandling.py:138
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
+msgstr "Eksportowanie do \"{file_basename}\"…"
+
+#: ../gui/filehandling.py:145
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr "Eksportowanie do \"{file_basename}\" zakończone niepowodzeniem."
+
+#: ../gui/filehandling.py:149
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr "Zapis \"{file_basename}\" zakończone niepowodzeniem."
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr "Nie udało się wczytać \"{file_basename}\"."
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "Zapisz paletę"
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr "Otwórz ostatnie pliki"
+
+#: ../gui/filehandling.py:183
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr "Eksportowanie do \"{file_basename}\" zakończone powodzeniem."
+
+#: ../gui/filehandling.py:187
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr "Zapisano \"{file_basename}\" powodzeniem."
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr "Wczytano \"{file_basename}\"."
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: ../gui/filehandling.py:221
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
+msgstr "Wczytano \"{file_basename}\"."
+
+#: ../gui/filehandling.py:427
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "All Recognized Formats"
 msgstr "Wszystkie obsługiwane formaty plików"
 
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
+#: ../gui/filehandling.py:432
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "OpenRaster (*.ora)"
 msgstr "OpenRaster (*.ora)"
 
-#: ../gui/filehandling.py:95
+#: ../gui/filehandling.py:437
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "PNG (*.png)"
 msgstr "PNG (*.png)"
 
-#: ../gui/filehandling.py:96
+#: ../gui/filehandling.py:442
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "JPEG (*.jpg; *.jpeg)"
 msgstr "JPEG (*.jpg; *.jpeg)"
 
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
+#: ../gui/filehandling.py:490
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "By extension (prefer default format)"
 msgstr "Według rozszerzenia (preferuj domyślny format)"
 
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
+#: ../gui/filehandling.py:494
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:498
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
 msgstr "PNG z tłem (*.png)"
 
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
+#: ../gui/filehandling.py:502
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:506
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
 msgstr "PNG z przeźroczystością (*.png)"
 
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
+#: ../gui/filehandling.py:510
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
 msgstr "Wiele plików PNG z przeźroczystością (*.XXX.png)"
 
-#: ../gui/filehandling.py:113
+#: ../gui/filehandling.py:514
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr "Wiele plików PNG z przeźroczystością (*.XXX.png)"
+
+#: ../gui/filehandling.py:518
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr "JPEG 90% jakości (*.jpg; *.jpeg)"
 
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr "Zapisz..."
+#: ../gui/filehandling.py:576
+#, fuzzy
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr "Eksportuj…"
 
-#: ../gui/filehandling.py:177
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Zapisz Jako…"
+
+#: ../gui/filehandling.py:601
+#, fuzzy
+msgctxt "save dialogs: formats and options: (label)"
 msgid "Format to save as:"
 msgstr "Format do zapisania jako:"
 
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr "Potwierdź"
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
+#: ../gui/filehandling.py:668
+#, fuzzy
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
 msgstr "Czy chcesz kontynuować?"
 
-#: ../gui/filehandling.py:234
-#, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
-msgstr "Spowoduje to odrzucenie {abbreviated_time} niezapisanej pracy"
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
+#: ../gui/filehandling.py:705
+#, fuzzy
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
 msgstr "_Zapisz jako Projekt"
 
-#: ../gui/filehandling.py:282
-#, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
-msgstr "Ładowanie \"{file_basename}\"…"
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
 
-#: ../gui/filehandling.py:296
-#, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
-msgstr "Nie udało się wczytać \"{file_basename}\"."
+#: ../gui/filehandling.py:734
+#, fuzzy, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr "Spowoduje to odrzucenie {abbreviated_time} niezapisanej pracy"
 
-#: ../gui/filehandling.py:321
-#, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
-msgstr "Wczytano \"{file_basename}\"."
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
 
-#: ../gui/filehandling.py:422
-#, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
-msgstr "Eksportowanie do \"{file_basename}\"…"
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
 
-#: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
-msgstr "Zapisywanie \"{file_basename}\"…"
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
-msgstr "Eksportowanie do \"{file_basename}\" zakończone niepowodzeniem."
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr "Otwórz…"
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
-msgstr "Zapis \"{file_basename}\" zakończone niepowodzeniem."
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Otwórz ostatnie pliki"
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
-msgstr "Eksportowanie do \"{file_basename}\" zakończone powodzeniem."
-
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
-msgstr "Zapisano \"{file_basename}\" powodzeniem."
-
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Otwórz..."
-
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr "Otwórz Szkicownik..."
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Zaimportowany pędzel"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Otwórz"
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Otwórz Ostatnio Używany"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Otwórz"
+
+#: ../gui/filehandling.py:1446
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
 msgstr "Nie ma projektów o tej nazwie \"%s\"."
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1455
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr "Otwórz Następny Projekt"
+
+#: ../gui/filehandling.py:1463
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr "Otwórz Poprzedni Projekt"
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Otwórz"
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+#, fuzzy
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr "Odrzuć"
+
+#: ../gui/fill.py:121
+#, fuzzy
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr "Wypełnianie"
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+#, fuzzy
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr "Wypełnij obszary kolorem"
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+#, fuzzy
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr "Tolerancja:"
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+#, fuzzy
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr "Jak dużo kolorów pikseli będzie rozróżnianych podczas wypełniania"
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+#, fuzzy
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr "Źródło:"
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
-msgstr "Które widoczne warstwy powinny zostać wypełnione"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
+msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+#, fuzzy
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr "Tymczasowe Scalanie"
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+#, fuzzy
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
@@ -1613,19 +1933,50 @@ msgstr ""
 "tymczasowego scalenia wszystkich widocznych warstw\n"
 "poniżej bieżącej warstwy"
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+#, fuzzy
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr "Dopasuj Widok"
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+#, fuzzy
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr "Cel:"
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+#, fuzzy
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr "Gdzie wypełnienie powinno być zastosowane"
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr "Nowa Warstwa (tylko raz)"
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+#, fuzzy
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
@@ -1633,21 +1984,108 @@ msgstr ""
 "Tworzy nową warstwę przy wypełnianiu.\n"
 "Automatycznie wyłączany po użyciu."
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Krycie:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr "Przywróć"
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+#, fuzzy
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr "Przywraca domyślne wartości opcji"
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "Wybierz Warstwę"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr "<b>{brush_name}</b>"
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1657,130 +2095,142 @@ msgstr ""
 "<b>{brush_name}</b>\n"
 "{brush_desc}"
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr "Edytor Ramki"
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr "Dopasuj ramkę dokumentu"
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr "Rozmiar Ramki"
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr "px"
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr "Wysokość:"
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr "Szerokość:"
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr "Rozdzielczość:"
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr "DPI"
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr "Punktów na cal (rzeczywiście pikseli na cal)"
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr "Kolor:"
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr "Kolor Ramki"
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr "<b>Wymiary ramki</b>"
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr "<b>Zagęszczenie pikseli</b>"
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr "Umieść Ramkę na Warstwie"
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr "Umieszcza ramkę na całej bieżącej warstwie"
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr "Umieść Ramkę na Dokumencie"
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr "Umieszcza ramkę na wszystkich warstwach"
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr "Przytnij Warstwę do Ramki"
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr "Przycina te części warstwy które są poza ramką"
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr "Włączone"
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr "{width:g}x{height:g}{units}"
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr "cali"
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr "cm"
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr "mm"
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr "Rysowanie Odręczne"
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr "Maluj dowolnie pędzlem"
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr "Płynność:"
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr "Nacisk:"
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr "Wykryto Błąd"
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr "<big><b>Wykryto błąd oprogramowania</b></big>"
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1794,35 +2244,35 @@ msgstr ""
 "Powiadom producentów o tym używając trackera problemów jeśli nikt jeszcze "
 "tego nie zgłosił."
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr "Szukaj na Trackerze..."
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr "Zgłoś Błąd..."
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr "Zignoruj Błąd"
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr "Zakończ MyPaint"
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr "Szczegóły..."
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr "Nie udało się przeanalizować błędu."
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1866,45 +2316,50 @@ msgstr ""
 "            #### Kontakt\n"
 "        "
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr "Stalówka"
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr "Narysuj, a następnie skoryguj linie"
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr "Testuj Urządzenie Wejściowe"
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr "(brak nacisku)"
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr "Nacisk:"
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr "(brak wychylenia)"
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr "Wychylenie:"
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr "(brak urządzenia)"
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
 msgstr "Urządzenie:"
 
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+#, fuzzy
+msgid "Barrel Rotation:"
+msgstr "Resetuj Obrót"
+
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr "Przesuń Warstwę"
 
@@ -1912,159 +2367,227 @@ msgstr "Przesuń Warstwę"
 msgid "Move the current layer"
 msgstr "Przesuń bieżącą warstwę"
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
-msgstr "{default_name} w {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
+msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
-msgstr "Typ"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
+msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+#, fuzzy
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr "Właściwości"
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr "Widoczna"
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Warstwa"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+#, fuzzy
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr "Zablokowana"
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+#, fuzzy
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ", "
+
+#: ../gui/layers.py:990
+#, fuzzy, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr "Dodaj {layer_default_name}"
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Warstwy"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr "Uporządkuj warstwy i zastosuj efekty"
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr "Krycie warstwy: %d%%"
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr "Przestaw warstwę w stosie..."
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 "Przestaw warstwę w stosie (upuszczając na zwykłą warstwę utworzy się grupa "
 "warstw)"
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr "Warstwa"
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
-msgstr "Tryb:"
+#: ../gui/layervis.py:53
+#, fuzzy, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
+msgstr "<b>{brush_name}</b>"
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
-msgstr "Tryb mieszania: jak bieżąca warstwa łączy się z warstwami poniżej."
-
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Krycie:"
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
-"Krycie warstwy: jak bardzo warstwa ma być widoczna. Im mniejsza wartość tym "
-"warstwa staje się bardziej przeźroczysta."
 
-#: ../gui/linemode.py:37
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "Obracanie Widoku"
+
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr "Początkowy nacisk"
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr "Początkowy nacisk kreski dla narzędzi linii"
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr "Środkowy nacisk"
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr "Środkowy nacisk kreski dla narzędzi linii"
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr "Końcowy nacisk"
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr "Końcowy nacisk kreski dla narzędzi linii"
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr "Głowa"
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 msgid "Stroke lead-in end"
 msgstr "Zakończenie początku kreski"
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr "Ogon"
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr "Początek zanikania kreski"
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr "Zmienna nacisku..."
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr "Linie i Krzywe"
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr "Zwykła linia/tryb zakrzywiania"
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr "Rysuj proste linie; Shift dodaje zakrzywienia, Ctrl wymusza kąt"
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr "Linie Połączone"
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr "Rysuj sekwencje linii; Shift dodaje zakrzywienia, Ctrl wymusza kąt"
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr "Elipsy i Koła"
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr "Rysuj elipsy; Shift obraca, Ctrl wymusza proporcję/kąt"
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
+#, fuzzy
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 "Copyright (C) 2005-2015\n"
 "Martin Renold i zespół producentów MyPaint"
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -2083,256 +2606,286 @@ msgstr ""
 "Ten program jest dystrybuowany z nadzieją że okaże się przydatny, lecz nie "
 "dajemy na to gwarancji. Przejrzyj plik COPYING po więcej szczegółów."
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr "programowanie"
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr "przenoszenie na inne systemy"
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr "zarządzanie projektem"
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr "pędzle"
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr "wzory"
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr "ikony narzędzi"
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr "ikona programu"
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr "palety"
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr "dokumentacja"
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr "wsparcie"
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr "kontakt"
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr "społeczność"
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ", "
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr "tłumaczenie"
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr "Rozmiar:"
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr "Krycie:"
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr "Twardość:"
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr "Wzmocnienie:"
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr "Opcje Narzędzia"
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr "Specjalne ustawienia dla bieżącego narzędzia edycyjnego"
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr "<b>{mode_name}</b>"
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr "<i>Brak dostępnych opcji</i>"
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr "Powiększenie: %.01f%%"
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr "Pobierz ustawienia pędzla, kolor kreski i warstwę…"
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr "Pobierz kolor…"
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr "Ustawienia"
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr "Podgląd"
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr "Pokaż podgląd całego obszaru roboczego"
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr "Pokaż Wizjer"
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr "Szkicownik"
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr "Mieszaj kolory i twórz szkice na osobnych kartkach"
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr "Poprzedni element"
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr "Następny element"
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
 msgstr "(Nic tu nie ma)"
 
-#: ../gui/symmetry.py:76
+#: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Place axis"
 msgstr "Umieść oś"
 
-#: ../gui/symmetry.py:80
+#: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Move axis"
 msgstr "Przesuń oś"
 
-#: ../gui/symmetry.py:84
+#: ../gui/symmetry.py:88
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr "Usuń oś"
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr "Edytuj Oś Symetrii"
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr "Dostosuj oś malowania symetrycznego."
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
+#, fuzzy
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr "Pozycja:"
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr "Pozycja:"
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr "Brak"
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr "%d px"
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr "Alfa:"
 
-#: ../gui/symmetry.py:352
+#: ../gui/symmetry.py:376
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
+msgstr "Symetria"
+
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+#, fuzzy
 msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+msgid "X axis Position"
 msgstr "Pozycja Osi"
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:477
+#, fuzzy
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr "Pozycja Osi"
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr "Włączona"
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr "Obsługa pliku"
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr "Przełącznik projektów"
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr "Cofnij i Ponów"
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr "Tryby Malowana"
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr "Tryby Linii"
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr "Widok (Główny)"
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr "Widok (Alternatywny/Drugorzędny)"
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr "Widok (Resetowanie)"
 
@@ -2340,188 +2893,214 @@ msgstr "Widok (Resetowanie)"
 msgid "<b>MyPaint</b>"
 msgstr "<b>MyPaint</b>"
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr "Przesuwanie Widoku"
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr "Przesuwaj widok na płótno"
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr "Powiększanie Widoku"
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr "Powiększaj widok na płótno"
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr "Obracanie Widoku"
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr "Obracaj widok na płótno"
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, fuzzy, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr "%s: zamknij kartę"
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
-msgstr "%s: edytuj właściwości"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
+msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr "Nieznane Polecenie"
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr "Niezdefiniowane (polecenie jeszcze nie uruchomione)"
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr "{seconds:.01f}s malowania z {brush_name}"
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr "Wypełnianie"
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr "Przytnij Warstwę"
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "Przemianuj Grupę"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr "Czyść Warstwę"
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr "Wklej Warstwę"
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr "Nowa Warstwa z Widoku"
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr "Scal Widoczne Warstwy"
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr "Połącz w Dół"
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr "Normalizuj Tryb Warstw"
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Zaimportowany pędzel"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr "Dodaj {layer_default_name}"
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr "Usuń Warstwę"
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr "Wybierz Warstwę"
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr "Duplikuj Warstwę"
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr "Przesuń Warstwę do Góry"
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr "Przesuń Warstwę na Dół"
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr "Przesuń Warstwę w Stosie"
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr "Przemianuj Warstwę"
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr "Ustaw Warstwę na Widoczną"
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr "Ustaw Warstwę na Niewidoczną"
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr "Zablokuj Warstwę"
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr "Odblokuj Warstwę"
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr "Ustaw Krycie Warstwy: %0.1f%%"
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr "Tryb Nieznany"
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr "Ustaw Tryb Warstwy: %s"
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr "Włącz Ramkę"
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr "Wyłącz Ramkę"
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr "Aktualizuj Ramkę"
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr "Edytuj Warstwę Zewnętrznie"
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr "Błąd ładowania: \"{basename}\"."
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr "Logi mogą zawierać więcej szczegółów dotyczących tego błędu."
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr "od teraz"
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr "przed"
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2533,13 +3112,13 @@ msgstr ""
 "Czy masz uruchomione więcej niż jedną instancje MyPaint?\n"
 "Zakończ aplikację i zaczekaj {cache_update_interval}s by ponowić."
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr "Zaktualizowano niekompletną kopie zapasową {last_modified_time} {ago}"
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2549,11 +3128,11 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 "Kopia zapasowa zaktualizowana {last_modified_time} {ago}\n"
-"Wymiary: {autosave.width}x{autosave.height} pikseli, Warstw: "
-"{autosave.num_layers}\n"
+"Wymiary: {autosave.width}x{autosave.height} pikseli, Warstw: {autosave."
+"num_layers}\n"
 "Zawiera {unsaved_time} niezapisanej pracy."
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2563,13 +3142,13 @@ msgstr ""
 "Nie udało się zapisać pliku \"{filename}\":{err}\n"
 "Czy masz wystarczającą ilość wolnego miejsca na dysku?"
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr "Nie udało się zapisać \"{filename}\": {err}"
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2579,7 +3158,7 @@ msgstr ""
 "{error_loading_common}\n"
 "Ten plik nie istnieje."
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2589,7 +3168,7 @@ msgstr ""
 "{error_loading_common}\n"
 "Nie posiadasz wymaganych uprawień do otwarcia tego pliku."
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2605,7 +3184,7 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2615,7 +3194,13 @@ msgstr ""
 "{error_loading_common}\n"
 "Nieznane rozszerzenie pliku: \"{ext}\""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+#, fuzzy
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr "Zaimportowany pędzel"
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2629,7 +3214,7 @@ msgstr ""
 "Jeśli twój sprzęt nie posiada wystarczającej ilości pamięci spróbuj zapisać "
 "w PNG. Funkcja zapisu PNG MyPainta jest bardziej wydajna."
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2645,108 +3230,218 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/helpers.py:402
-#, python-brace-format
+#: ../lib/floodfill.py:131
+#, fuzzy
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr "Wypełnianie"
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr "{days}d{hours}g"
 
-#: ../lib/helpers.py:404
-#, python-brace-format
+#: ../lib/helpers.py:537
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr "{hours}g{minutes}m"
 
-#: ../lib/helpers.py:406
-#, python-brace-format
+#: ../lib/helpers.py:539
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr "{minutes}m{seconds}s"
 
-#: ../lib/helpers.py:408
-#, python-brace-format
+#: ../lib/helpers.py:541
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr "{seconds}s"
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr "Warstwa"
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr "%(name)s%(number)d"
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr "^(.*?)\\s*(\\d+)$"
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
+#, fuzzy
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr "Warstwa Wektorowa"
+
+#: ../lib/layer/data.py:1158
+#, fuzzy
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr "Warstwa Wektorowa"
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
-msgstr "Nieznana Warstwa Bitmapowa"
+msgid "Bitmap"
+msgstr ""
 
-#: ../lib/layer/data.py:1169
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1244
 msgctxt "layer default names"
-msgid "Unknown Data Layer"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
 msgstr "Nieznana Warstwa Danych"
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "Nowa Warstwa Malarska"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr "Grupa"
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "Nowa Grupa Warstw"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr "Zastępcza"
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr "Root"
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ", "
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+#, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "Widok"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+#, fuzzy
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr "Warstwy"
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+#, fuzzy
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr "Usuń Warstwę"
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr "Zablokuj Warstwę"
+
+#: ../lib/layervis.py:697
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr "Odblokuj Warstwę"
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr "Przenikanie"
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr "Zawartość zostaje nałożona na tło grupy"
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr "Zwykły"
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr "Tylko górna warstwa, bez mieszania kolorów."
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr "Mnożenie"
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
-msgstr "Podobne do wyświetlenia obrazu z dwóch slajdów włożonych do projektora."
+msgstr ""
+"Podobne do wyświetlenia obrazu z dwóch slajdów włożonych do projektora."
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr "Przesiewanie"
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
@@ -2754,11 +3449,11 @@ msgstr ""
 "Jak wyświetlanie obrazu z dwóch rzutników na ekran jednocześnie. Odwrotny "
 "efekt \"Mnożenia\"."
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr "Pokrywanie"
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
@@ -2766,161 +3461,173 @@ msgstr ""
 "Pokrywa tło górną warstwą zachowując światło i cień tła. Jest to "
 "odwrotnością \"Twardego Światła\"."
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr "Ciemniejsze"
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr "Górna warstwa jest używana gdy jest ciemniejsza od tła."
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr "Jaśniejsze"
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr "Górna warstwa jest używana gdy jest jaśniejsza od tła."
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr "Rozjaśnianie"
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr "Rozjaśnia tło używając górnej warstwy."
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr "Przyciemnianie"
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr "Przyciemnia tło używając górnej warstwy."
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr "Twarde Światło"
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr "Podobne do świecenia ostrym światłem na zasłonę."
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr "Miękkie Światło"
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr "Podobne do rozproszonego światła padającego na zasłonę."
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr "Różnica"
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr "Odejmuje ciemniejszy kolor z dwóch jaśniejszych."
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr "Wykluczenie"
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr "Podobne do trybu \"Różnica\", ale z mniejszym kontrastem."
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr "Barwa"
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr "Łączy barwę górnej warstwy z nasyceniem i jasnością tła."
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr "Nasycenie"
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr "Łączy nasycenie kolorów górnej warstwy do barwy i jasności tła."
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr "Łączy barwę i nasycenie górnej warstwy do jasności tła."
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr "Jasność"
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr "Łączy jasność górnej warstwy do barwy i nasycenia tła."
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr "Suma"
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr "Warstwa i jej tło zostają połączone."
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr "Cel Wewnątrz"
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr "Tło jest użyte tylko tam gdzie górna warstwa je pokrywa."
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr "Cel na Zewnątrz"
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr "Tło jest użyte tylko tam gdzie górna warstwa nie pokrywa go."
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr "Źródło na Wierzchu"
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
-msgstr "Zostawia tylko te części górnej warstwy które nie pokrywają się z tłem."
+msgstr ""
+"Zostawia tylko te części górnej warstwy które nie pokrywają się z tłem."
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr "Cel na Wierzchu"
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr "Zostawia tylko te części tła które pokrywają się z górną warstwą."
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, fuzzy, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr "%(name)s%(number)d"
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
@@ -2929,7 +3636,7 @@ msgstr ""
 "Nie udało się wygenerować niezbędnego obiektu wewnętrznego. Twój system może "
 "nie mieć wystarczającej ilości pamięci do wykonania tej operacji."
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2943,7 +3650,30 @@ msgstr ""
 "Powód: {err}\n"
 "Folder docelowy : \"{dirname}\"."
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+#, fuzzy
+msgid "Vertical"
+msgstr "Odbij Pionowo"
+
+#: ../lib/tiledsurface.py:49
+#, fuzzy
+msgid "Horizontal"
+msgstr "Odbij Poziomo"
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+#, fuzzy
+msgid "Rotational"
+msgstr "Resetuj Obrót"
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr "Wczytanie PNG powiodło się:%s"
@@ -2952,55 +3682,93 @@ msgstr "Wczytanie PNG powiodło się:%s"
 msgid "Recover interrupted work?"
 msgstr "Przywrócić przerwaną pracę?"
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
-msgstr "_Przywróć i Zapisz..."
+msgid "_Look for backups at startup"
+msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr "Usuń"
+
+#: ../po/tmp/autorecover.glade.h:9
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr "Usuń ten pędzel z dysku"
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr "_Przywróć i Zapisz..."
+
+#: ../po/tmp/autorecover.glade.h:12
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr "Zapisz kopię zapasową na dysku i kontynuuj na niej pracę."
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
-msgstr "_Odłóż na Później"
+msgid "Decide _Later"
+msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr "Zacznij pracę na nowym płótnie. Te kopie zapasowe będą zachowane."
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
+#, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 "MyPaint uległ awarii przy niezapisanej pracy, ale utworzył kopie zapasowe. "
 "Możesz teraz odzyskać plik lub poczekać do ponownego uruchomienia MyPaint."
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr "Miniaturka"
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr "Opis"
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
-msgstr "Kopiuj do Nowego"
+msgid "Live update"
+msgstr "Podgląd na bieżąco"
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
-msgstr "Kopiuj ustawienia i ikonę bieżącego pędzla jako nowy pędzel"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
+msgstr ""
+"Aktualizuj w czasie rzeczywistym ostatnie pociągnięcie pędzla na płótnie "
+"ustawieniami z tego okna"
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
-msgstr "Zmień nazwę tego pędzla"
+msgid "Save these settings to the brush"
+msgstr "Zapisz te ustawienia do pędzla"
 
 #: ../po/tmp/brusheditor.glade.h:5
 msgid "Edit Icon"
@@ -3023,20 +3791,16 @@ msgid "Delete this brush from the disk"
 msgstr "Usuń ten pędzel z dysku"
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
-msgstr "Podgląd na bieżąco"
+msgid "Copy to New"
+msgstr "Kopiuj do Nowego"
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
-msgstr ""
-"Aktualizuj w czasie rzeczywistym ostatnie pociągnięcie pędzla na płótnie "
-"ustawieniami z tego okna"
+msgid "Copy these settings and the current brush's icon to a new brush"
+msgstr "Kopiuj ustawienia i ikonę bieżącego pędzla jako nowy pędzel"
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
-msgstr "Zapisz te ustawienia do pędzla"
+msgid "Rename this brush"
+msgstr "Zmień nazwę tego pędzla"
 
 #: ../po/tmp/brusheditor.glade.h:13
 msgid "Brush Setting"
@@ -3064,12 +3828,7 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr "Notatki:"
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr "Nazwa ustawień:"
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
@@ -3077,19 +3836,16 @@ msgstr ""
 "operuje na niej."
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
-msgstr "Wartość bazowa:"
+#: ../po/tmp/brusheditor.glade.h:22
+#, fuzzy
+msgid "Value:"
+msgstr "HSV Wartość"
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr "Przywróć domyślną wartość bazową"
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr "Przywróć wartość domyślną"
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
@@ -3097,11 +3853,7 @@ msgstr ""
 "Minimalna wartość dla osi wyjściowej.\n"
 "Może być ustawiona za pomocą suwaka {dname}."
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr "<ymin>"
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
@@ -3109,27 +3861,23 @@ msgstr ""
 "Maksymalna wartość dla wyjściowej osi.\n"
 "Może być ustawiona za pomocą suwaka {dname}."
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr "<ymax>"
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr "Wyjście"
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr "Wejście"
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr "Dostosuj maksymalną wartość"
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr "Dostosuj minimalną wartość"
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
@@ -3137,11 +3885,7 @@ msgstr ""
 "Minimalna wartość dla osi wejściowej.\n"
 "Użyj suwaka obok aby dostosować."
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr "<xmin>"
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
@@ -3149,38 +3893,36 @@ msgstr ""
 "Maksymalna wartość dla wejściowej osi.\n"
 "Użyj suwaka obok aby dostosować."
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr "<xmax>"
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr "Modyfikacja wartości bazowej poprzez wejście rysika i inne kryteria"
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr "Dynamika Pędzla"
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr "Podstawowe szczegóły tego ustawienia"
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr "Edytuj Ustawienia"
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr "Szczegółowo dostosuj te ustawienie"
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr "{podpowiedź}"
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
 msgstr "{dname}:"
+
+#: ../po/tmp/brusheditor.glade.h:42
+#, fuzzy
+msgid "Brush dynamics are not available for this setting."
+msgstr "Podstawowe szczegóły tego ustawienia"
+
+#: ../po/tmp/brusheditor.glade.h:43
+#, fuzzy
+msgid "<big><b>No Brush Dynamics</b></big>"
+msgstr "<big><b>{accel_label}</b></big>"
 
 #: ../po/tmp/inktool.glade.h:1
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
@@ -3192,7 +3934,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr "Nacisk:"
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3237,6 +3979,141 @@ msgstr "Usuń Punkt"
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
 msgstr "Usuń zaznaczony punkt"
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+#, fuzzy
+msgid "Insert Point"
+msgstr "Wstaw Wiersz"
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+#, fuzzy
+msgid "Cull Points"
+msgstr "Usuń Punkt"
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Nazwa"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr "Tryb"
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Krycie"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr "Bieżący tryb mieszania warstwy."
+
+#: ../po/tmp/layervis.glade.h:2
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr "Obracaj widok na płótno"
+
+#: ../po/tmp/layervis.glade.h:3
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr "Obracaj widok na płótno"
+
+#: ../po/tmp/layervis.glade.h:4
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr "Które widoczne warstwy powinny zostać wypełnione"
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
+msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
 msgctxt "footer: color picker button: tooltip"
@@ -3643,13 +4520,34 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr "Ukryj kursor podczas malowania"
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+#, fuzzy
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr "Włączone"
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr "Widok"
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
@@ -3658,18 +4556,18 @@ msgstr ""
 "Zestaw kolorów wyświetlany jako podstawowy na kołach kolorów.\n"
 "Różne tradycje mają inne harmonie kolorów."
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr "Głównymi są:"
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr "Standardowe cyfrowe Czerwony/Zielony/Niebieski (RGB)"
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
@@ -3678,7 +4576,7 @@ msgstr ""
 "podstawowe, równomiernie rozmieszczone na okręgu. Zielony jest przeciwnością "
 "magenty."
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
@@ -3687,12 +4585,12 @@ msgstr ""
 "Czerwony, zielony i niebieski 'monitora komputerowego' to kolory podstawowe, "
 "równomiernie rozmieszczone na okręgu. Zielony jest przeciwnością magenty."
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr "Tradycyjne artystyczne Czerwony/Żółty/Niebieski (RYB)"
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
@@ -3702,7 +4600,7 @@ msgstr ""
 "artystów używało od XVIII wieku. Zbliżone do czystych wyświetlanych barw i "
 "rozmieszczone na okręgu. Zielony jest przeciwieństwem czerwonego."
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3713,12 +4611,12 @@ msgstr ""
 "artystów używało od XVIII wieku. Zbliżone do czystych wyświetlanych barw i "
 "rozmieszczone na okręgu. Zielony jest przeciwieństwem czerwonego."
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr "Przeciwne pary Czerwonego-Zielonego i Niebieskiego-Żółtego"
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3733,7 +4631,7 @@ msgstr ""
 "przedstawiają podobny model. Tutaj jest używany czysty czerwony, żółty itd. "
 "jako cztery podstawowe."
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3749,28 +4647,28 @@ msgstr ""
 "Tutaj jest używany czysty czerwony, żółty itd. jako cztery podstawowe."
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr "<b>Koło Kolorów</b>"
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr "Kolor"
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr "Ekran (zwykły)"
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr "Wyłączony (brak czułości nacisku)"
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr "Okno (nie zalecane)"
@@ -3831,249 +4729,306 @@ msgid "Reload the file your current work was loaded from."
 msgstr "Ponownie wczytaj plik bieżącej pracy."
 
 #: ../po/tmp/resources.xml.h:12
+#, fuzzy
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Import Layers…"
+msgstr "Importuj Pędzle…"
+
+#: ../po/tmp/resources.xml.h:13
+msgctxt "Accel Editor (descriptions)"
+msgid "Import layers from one or more files."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save"
 msgstr "Zapisz"
 
-#: ../po/tmp/resources.xml.h:13
+#: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file."
 msgstr "Zapisz pracę do pliku."
 
-#: ../po/tmp/resources.xml.h:14
+#: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As…"
 msgstr "Zapisz Jako…"
 
-#: ../po/tmp/resources.xml.h:15
+#: ../po/tmp/resources.xml.h:17
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file, assigning it a new name."
 msgstr "Zapisz pracę do pliku nadając jej nową nazwę."
 
-#: ../po/tmp/resources.xml.h:16
+#: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Export…"
 msgstr "Eksportuj…"
 
-#: ../po/tmp/resources.xml.h:17
+#: ../po/tmp/resources.xml.h:19
 msgid "Export your work to a file, but keep working on the same file."
 msgstr "Eksportuj do pliku nadal na nim pracując."
 
-#: ../po/tmp/resources.xml.h:18
+#: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As Scrap"
 msgstr "Zapisz jako Projekt"
 
-#: ../po/tmp/resources.xml.h:19
+#: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
 msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 "Zapisz do nowego pliku projektu, lub zapisz nową wersję jeśli już nim jest."
 
-#: ../po/tmp/resources.xml.h:20
+#: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Previous Scrap"
 msgstr "Otwórz Poprzedni Projekt"
 
-#: ../po/tmp/resources.xml.h:21
+#: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file before the current one."
 msgstr "Wczytaj plik projektu przed bieżącym."
 
-#: ../po/tmp/resources.xml.h:22
+#: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Next Scrap"
 msgstr "Otwórz Następny Projekt"
 
-#: ../po/tmp/resources.xml.h:23
+#: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file after the current one."
 msgstr "Wczytaj plik projektu za bieżącym."
 
-#: ../po/tmp/resources.xml.h:24
+#: ../po/tmp/resources.xml.h:26
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Recover File from an Automated Backup…"
 msgstr "Przywróć plik z automatycznej kopii zapasowej…"
 
-#: ../po/tmp/resources.xml.h:25
+#: ../po/tmp/resources.xml.h:27
 msgctxt "Accel Editor (descriptions)"
 msgid "Try to save and resume interrupted unsaved work."
 msgstr "Zapisz i wznów przerwaną, niezapisaną pracę."
 
-#: ../po/tmp/resources.xml.h:26
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr "Grupy Pędzli"
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr "Pędzle"
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr "Lista grup pędzli."
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr "Selektory Kolorów"
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr "Kolory"
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr "Dostępne selektory kolorów."
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr "Tryb"
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr "Tryb"
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr "Bieżący tryb mieszania warstwy."
 
-#: ../po/tmp/resources.xml.h:35
+#: ../po/tmp/resources.xml.h:37
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Pressure"
+msgstr "Początkowy nacisk"
+
+#: ../po/tmp/resources.xml.h:38
+msgctxt "Accel Editor (descriptions)"
+msgid "Send harder pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:39
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Pressure"
+msgstr "Początkowy nacisk"
+
+#: ../po/tmp/resources.xml.h:40
+msgctxt "Accel Editor (descriptions)"
+msgid "Send softer pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:41
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Rotation"
+msgstr "Zwiększ Nasycenie"
+
+#: ../po/tmp/resources.xml.h:42
+msgctxt "Accel Editor (descriptions)"
+msgid "Increase barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:43
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
+msgstr "Zmniejsz Nasycenie"
+
+#: ../po/tmp/resources.xml.h:44
+msgctxt "Accel Editor (descriptions)"
+msgid "Decrease barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:45
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Size"
 msgstr "Zwiększ Rozmiar Pędzla"
 
-#: ../po/tmp/resources.xml.h:36
+#: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush bigger."
 msgstr "Powiększ rozmiar bieżącego pędzla."
 
-#: ../po/tmp/resources.xml.h:37
+#: ../po/tmp/resources.xml.h:47
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Size"
 msgstr "Zmniejsz Rozmiar Pędzla"
 
-#: ../po/tmp/resources.xml.h:38
+#: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush smaller."
 msgstr "Zmniejsz rozmiar bieżącego pędzla."
 
-#: ../po/tmp/resources.xml.h:39
+#: ../po/tmp/resources.xml.h:49
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Opacity"
 msgstr "Zwiększ Krycie Pędzla"
 
-#: ../po/tmp/resources.xml.h:40
+#: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush more opaque."
 msgstr "Zwiększ krycie bieżącego pędzla."
 
-#: ../po/tmp/resources.xml.h:41
+#: ../po/tmp/resources.xml.h:51
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Opacity"
 msgstr "Zmniejsz Krycie Pędzla"
 
-#: ../po/tmp/resources.xml.h:42
+#: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush less opaque."
 msgstr "Zmniejsz krycie bieżącego pędzla."
 
-#: ../po/tmp/resources.xml.h:43
+#: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Lighten Painting Color"
 msgstr "Rozjaśnij Kolor Malowana"
 
-#: ../po/tmp/resources.xml.h:44
+#: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase the lightness of the current painting color."
 msgstr "Zwiększ jasność bieżącego koloru malowania."
 
-#: ../po/tmp/resources.xml.h:45
+#: ../po/tmp/resources.xml.h:55
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Darken Painting Color"
 msgstr "Ściemnij Kolor Malowana"
 
-#: ../po/tmp/resources.xml.h:46
+#: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease the lightness of the current painting color."
 msgstr "Zmniejsz jasność bieżącego koloru malowania."
 
-#: ../po/tmp/resources.xml.h:47
+#: ../po/tmp/resources.xml.h:57
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
+msgstr "Zmień Odcień w Prawo"
+
+#: ../po/tmp/resources.xml.h:58
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgstr "Zmień odcień koloru malowania w kierunku ruchu wskazówek zegara."
+
+#: ../po/tmp/resources.xml.h:59
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Change Hue Anticlockwise"
 msgstr "Zmień Odcień w Lewo"
 
-#: ../po/tmp/resources.xml.h:48
+#: ../po/tmp/resources.xml.h:60
 msgctxt "Accel Editor (descriptions)"
 msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
 msgstr ""
 "Zmień odcień koloru malowania w kierunku przeciwnym do ruchu wskazówek "
 "zegara."
 
-#: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
-msgstr "Zmień Odcień w Prawo"
-
-#: ../po/tmp/resources.xml.h:50
-msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
-msgstr "Zmień odcień koloru malowania w kierunku ruchu wskazówek zegara."
-
-#: ../po/tmp/resources.xml.h:51
+#: ../po/tmp/resources.xml.h:61
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Increase Saturation"
 msgstr "Zwiększ Nasycenie"
 
-#: ../po/tmp/resources.xml.h:52
+#: ../po/tmp/resources.xml.h:62
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color more saturated (more colorful, purer)."
 msgstr "Zwiększ nasycenie koloru malowania (żywszy)."
 
-#: ../po/tmp/resources.xml.h:53
+#: ../po/tmp/resources.xml.h:63
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Decrease Saturation"
 msgstr "Zmniejsz Nasycenie"
 
-#: ../po/tmp/resources.xml.h:54
+#: ../po/tmp/resources.xml.h:64
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color less saturated (grayer)."
 msgstr "Zmniejsz nasycenie koloru malowania (bladszy)."
 
-#: ../po/tmp/resources.xml.h:55
+#: ../po/tmp/resources.xml.h:65
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Reload Brush Settings"
 msgstr "Odśwież Ustawienia Pędzla"
 
-#: ../po/tmp/resources.xml.h:56
+#: ../po/tmp/resources.xml.h:66
 msgctxt "Accel Editor (descriptions)"
 msgid "Restore all brush settings to the current brush’s saved values."
 msgstr "Przywróć ustawienia pędzla do zapisanych wartości bieżącego pędzla."
 
-#: ../po/tmp/resources.xml.h:57
+#: ../po/tmp/resources.xml.h:67
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Pick Stroke and Layer"
 msgstr "Pobierz Kreskę i Warstwę"
 
-#: ../po/tmp/resources.xml.h:58
+#: ../po/tmp/resources.xml.h:68
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
 msgstr ""
 "Pobierz pociągnięcie pędzla z płótna: przywraca pędzel, kolor i warstwę."
 
-#: ../po/tmp/resources.xml.h:59
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr "Skróty Klawiszowe Przywracają Kolor Pędzla"
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
@@ -4082,213 +5037,264 @@ msgstr ""
 "Włącz/Wyłącz kiedy przywracanie pędzla ze skrótu również przywraca jego "
 "kolor."
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr "Zapisz Pędzel do Ostatnio Użytego Skrótu Klawiszowego"
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr "Zapisz ustawienia pędzla do ostatnio używanego skrótu klawiaturowego."
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "Czyść Warstwę"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr "Czyść bieżącą warstwę z zawartości."
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+#, fuzzy
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr "Opcje Narzędzia"
+
+#: ../po/tmp/resources.xml.h:76
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr "Przytnij Warstwę do Ramki"
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr "Wymaż części bieżącej warstwy będące za ramką."
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr "Wymaż części bieżącej warstwy będące za ramką."
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "Nowa Grupa Warstw Poniżej"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "Nowa Grupa Warstw Poniżej"
+
+#: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr "Kopiuj Warstwę do Schowka"
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr "Kopiuj zawartość bieżącej warstwy do schowka."
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr "Wklej Warstwę ze Schowka"
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr "Podmienia bieżącą warstwę na zawartość schowka."
 
-#: ../po/tmp/resources.xml.h:71
+#: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Edit Layer in External App…"
 msgstr "Edytuj Warstwę w Zewnętrznej Aplikacji…"
 
-#: ../po/tmp/resources.xml.h:72
+#: ../po/tmp/resources.xml.h:90
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
+msgid "Edit the active layer in an external application."
 msgstr "Rozpocznij edycje bieżącej warstwy w zewnętrznej aplikacji."
 
-#: ../po/tmp/resources.xml.h:73
+#: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Update Layer with External Edits"
 msgstr "Aktualizuj Warstwę Przez Zewnętrzne Edycje"
 
-#: ../po/tmp/resources.xml.h:74
+#: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
 msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 "Zatwierdź zmiany zapisane z aplikacji zewnętrznej (zwykle automatycznie)."
 
-#: ../po/tmp/resources.xml.h:75
+#: ../po/tmp/resources.xml.h:93
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer at Cursor"
 msgstr "Przejdź do Warstwy pod Kursorem"
 
-#: ../po/tmp/resources.xml.h:76
+#: ../po/tmp/resources.xml.h:94
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr "Wybierz warstwę zaznaczając obiekt na niej."
 
-#: ../po/tmp/resources.xml.h:77
+#: ../po/tmp/resources.xml.h:95
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Above"
 msgstr "Przejdź do Wyższej Warstwy"
 
-#: ../po/tmp/resources.xml.h:78
+#: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer up in the layer stack."
 msgstr "Przejdź do warstwy wyżej w stosie."
 
-#: ../po/tmp/resources.xml.h:79
+#: ../po/tmp/resources.xml.h:97
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Below"
 msgstr "Przejdź do Niższej Warstwy"
 
-#: ../po/tmp/resources.xml.h:80
+#: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer down in the layer stack."
 msgstr "Przejdź do warstwy niżej w stosie."
 
-#: ../po/tmp/resources.xml.h:81
+#: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer"
 msgstr "Nowa Warstwa Malarska"
 
-#: ../po/tmp/resources.xml.h:82
+#: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer above the current layer."
 msgstr "Dodaj nową warstwę malarską powyżej bieżącej."
 
-#: ../po/tmp/resources.xml.h:83
+#: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer…"
 msgstr "Nowa Warstwa Wektorowa…"
 
-#: ../po/tmp/resources.xml.h:84
+#: ../po/tmp/resources.xml.h:102
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer above the current layer, and begin editing it."
 msgstr "Dodaj nową warstwę wektorową powyżej bieżącej."
 
-#: ../po/tmp/resources.xml.h:85
+#: ../po/tmp/resources.xml.h:103
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group"
 msgstr "Nowa Grupa Warstw"
 
-#: ../po/tmp/resources.xml.h:86
+#: ../po/tmp/resources.xml.h:104
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group above the current layer."
 msgstr "Dodaj nową grupę warstw powyżej bieżącej warstwy."
 
-#: ../po/tmp/resources.xml.h:87
+#: ../po/tmp/resources.xml.h:105
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer Below"
 msgstr "Nowa Warstwa Malarska Poniżej"
 
-#: ../po/tmp/resources.xml.h:88
+#: ../po/tmp/resources.xml.h:106
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer below the current layer."
 msgstr "Dodaj nową warstwę malarską poniżej bieżącej."
 
-#: ../po/tmp/resources.xml.h:89
+#: ../po/tmp/resources.xml.h:107
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer Below…"
 msgstr "Nowa Warstwa Wektorowa Poniżej…"
 
-#: ../po/tmp/resources.xml.h:90
+#: ../po/tmp/resources.xml.h:108
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer below the current layer, and begin editing it."
 msgstr "Dodaj nową warstwę wektorową poniżej bieżącej."
 
-#: ../po/tmp/resources.xml.h:91
+#: ../po/tmp/resources.xml.h:109
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group Below"
 msgstr "Nowa Grupa Warstw Poniżej"
 
-#: ../po/tmp/resources.xml.h:92
+#: ../po/tmp/resources.xml.h:110
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group below the current layer."
 msgstr "Dodaj nową grupę warstw poniżej bieżącej warstwy."
 
-#: ../po/tmp/resources.xml.h:93
+#: ../po/tmp/resources.xml.h:111
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Layer Down"
 msgstr "Połącz Warstwę z Dolną"
 
-#: ../po/tmp/resources.xml.h:94
+#: ../po/tmp/resources.xml.h:112
 msgctxt "Accel Editor (descriptions)"
 msgid "Merge the current layer with the layer beneath it."
 msgstr "Połącz bieżącą warstwę z warstwą poniżej."
 
-#: ../po/tmp/resources.xml.h:95
+#: ../po/tmp/resources.xml.h:113
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Visible Layers"
 msgstr "Scal Widoczne Warstwy"
 
-#: ../po/tmp/resources.xml.h:96
+#: ../po/tmp/resources.xml.h:114
 msgctxt "Accel Editor (descriptions)"
 msgid "Consolidate all visible layers, and delete the originals."
 msgstr "Scal widoczne warstwy i usuń ich pierwowzory."
 
-#: ../po/tmp/resources.xml.h:97
+#: ../po/tmp/resources.xml.h:115
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer from Visible"
 msgstr "Nowa Warstwa z Widocznych"
 
-#: ../po/tmp/resources.xml.h:98
+#: ../po/tmp/resources.xml.h:116
 msgctxt "Accel Editor (descriptions)"
 msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
 msgstr "Jak 'Scal Widoczne Warstwy', ale nie usuwa pierwowzorów."
 
-#: ../po/tmp/resources.xml.h:99
+#: ../po/tmp/resources.xml.h:117
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Delete Layer"
 msgstr "Usuń Warstwę"
 
-#: ../po/tmp/resources.xml.h:100
+#: ../po/tmp/resources.xml.h:118
 msgctxt "Accel Editor (descriptions)"
 msgid "Remove the current layer from the layer stack."
 msgstr "Usuń bieżącą warstwę ze stosu."
 
-#: ../po/tmp/resources.xml.h:101
+#: ../po/tmp/resources.xml.h:119
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Convert to Normal Painting Layer"
 msgstr "Konwertuj do Zwykłej Warstwy Malarskiej"
 
-#: ../po/tmp/resources.xml.h:102
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
@@ -4297,72 +5303,74 @@ msgstr ""
 "Konwertuj bieżącą warstwę lub grupę do warstwy malarskiej w 'Zwykłym\" "
 "trybie zachowując jej wygląd."
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr "Zwiększ Krycie Warstwy"
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr "Zmniejsz przeźroczystość warstwy."
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr "Zmniejsz Krycie Warstwy"
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr "Zwiększ przeźroczystość warstwy."
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr "Podnieś Warstwę"
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr "Podnosi bieżącą warstwę w stosie."
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr "Obniż Warstwę"
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr "Obniża bieżącą warstwę w stosie."
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr "Duplikuj Warstwę"
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr "Utwórz dokładną kopię bieżącej warstwy."
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
+#, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
-msgstr "Przemianuj Warstwę…"
+msgid "Layer Properties…"
+msgstr "Właściwości"
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
-msgstr "Wprowadź nową nazwę dla bieżącej warstwy."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr "Zablokowana Warstwa"
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
@@ -4370,496 +5378,584 @@ msgstr ""
 "Zmień stan blokady bieżącej warstwy. Zablokowane warstwy nie mogą być "
 "modyfikowane."
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr "Widoczna Warstwa"
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr "Zmień stan widoczności bieżącej warstwy."
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr "Pokaż Tło"
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr "Zmień widoczność tła warstwy."
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr "Usuń bieżącą warstwę ze stosu."
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr "Resetuj i Wyśrodkuj Widok"
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr "Resetuj Powiększenie, Obrót i Odbicie, i wyśrodkuj dokument."
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr "Dopasuj Widok"
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr "Przełącz między widokiem dopasowanym, a widokiem roboczym."
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr "Resetowanie"
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr "Resetuj Powiększenie"
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr "Przywróć domyślne wartości powiększenia."
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr "Resetuj Obrót"
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr "Przywróć obrót widoku do 0°"
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr "Resetuj Odbicie"
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
-msgstr "Wyłącz odbicie widoku."
+msgid "Reset the view's mirroring."
+msgstr "Resetuj Odbicie"
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr "Przybliż"
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr "Zwiększ powiększenie."
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Oddal"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr "Zmniejsz powiększenie."
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
+#, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
-msgstr "Obróć w Lewo"
+msgid "Pan Left"
+msgstr "Przesuwanie Widoku"
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
-msgstr "Obróć widok w lewo."
+msgid "Move your view of the canvas to the left."
+msgstr "Obracanie Widoku: obróć widok na płótno."
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr "Twarde Światło"
+
+#: ../po/tmp/resources.xml.h:159
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr "Przesuwanie Widoku: przesuń widok na płótno w dowolnym kierunku."
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr "Obracanie Widoku: obróć widok na płótno."
+
+#: ../po/tmp/resources.xml.h:162
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr "Przesuwanie Widoku"
+
+#: ../po/tmp/resources.xml.h:163
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr "Obracanie Widoku: obróć widok na płótno."
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr "Obróć w Prawo"
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr "Obróć widok w prawo."
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr "Obróć w Lewo"
+
+#: ../po/tmp/resources.xml.h:167
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr "Obróć widok w lewo."
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr "Odbij Poziomo"
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr "Przewróć widok z lewa do prawa."
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr "Odbij Pionowo"
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr "Przewróć widok do góry nogami."
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr "Tryb Jednej Warstwy"
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr "Przełącz kiedy tylko bieżąca warstwa ma być pokazana."
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr "Malowanie Symetryczne Aktywne"
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr "Odbij pociągnięcia pędzla wzdłuż osi symetrii"
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr "Ramka Włączona"
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr "Przełącz widoczność ramki dokumentu."
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr "Wyświetl na Konsoli Wejściowe Wartości Pędzla"
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr "Wyświetl na konsoli wygenerowane informacje silnika pędzla."
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr "Renderowanie"
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr "Pokaż na ekranie aktualizacje renderowania dla debugowania."
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr "Bez Podwójnego Buforowania"
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr "Wyłącz podwójne buforowanie GTK, Zwykle włączone."
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+#, fuzzy
+msgid "Delete Point"
+msgstr "Usuń Punkt"
+
+#: ../po/tmp/resources.xml.h:187
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr "Usuń zaznaczony punkt"
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr "Tryb Malowania"
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr "Tryb Malowania: Zwykły"
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr "Zastosuj kolor podczas malowania."
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr "Tryb Malowania: Gumka"
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr "Wymaż używając bieżącego pędzla."
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr "Tryb Malowania: Zablokuj Kanał Alfa"
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr "Użycie pędzla nie wpłynie na krycie warstwy."
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr "Tryb Malowania: Koloryzacja"
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
-msgstr "Zastosuj kolor na bieżącej warstwie bez zmiany jej jasności czy krycia."
+msgstr ""
+"Zastosuj kolor na bieżącej warstwie bez zmiany jej jasności czy krycia."
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Plik"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "Zakończ"
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr "Zamknij główne okno i wyjdź z programu."
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "Edycja"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr "Bieżące Narzędzie"
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "Kolor"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr "Dostosuj Kolor"
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr "Okienko Historii Kolorów"
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr "Wyświetl pod kursorem okienko ostatnio użytych kolorów."
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr "Okno Szczegółów Koloru"
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr "Pokaż okno szczegółów koloru z wprowadzaniem tekstu."
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr "Następny Kolor Palety"
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr "Ustaw następny kolor w palecie jako kolor malowania."
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr "Poprzedni Kolor Palety"
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr "Ustaw poprzedni kolor w palecie jako kolor malowania."
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr "Dodaj Kolor do Palety"
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr "Dodaj bieżący kolor malowania do palety."
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "Warstwa"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr "Krycie"
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr "Przejdź do Warstwy"
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr "Nowa Warstwa Poniżej"
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr "Właściwości"
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr "Szkicownik"
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr "Nowy Szkicownik"
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr "Wczytaj domyślny szkicownik jako płótno nowego szkicownika."
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr "Otwórz Szkicownik…"
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr "Wczytaj plik obrazu z dysku do szkicownika."
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr "Zapisz Szkicownik"
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr "Zapisz szkicownik do istniejącego pliku na dysku."
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr "Eksportuj Szkicownik Jako…"
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr "Eksportuj szkicownik na dysk pod wybraną nazwą pliku."
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr "Resetuj Szkicownik"
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr "Odrzuć zmiany w szkicowniku od momentu ostatniego zapisu."
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr "Zapisz Szkicownik jako Domyślny"
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr "Zapisz szkicownik jako domyślny dla 'Nowy szkicownik'."
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr "Czyść Domyślny Szkicownik"
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr "Czyść do zera domyślny szkicownik."
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr "Kopiuj Główne Tło do Szkicownika"
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr "Kopiuj obraz tła z bieżącego dokumentu do szkicownika."
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "Okno"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "Pędzel"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr "Skróty Klawiszowe"
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr "Pomoc do Skrótów Klawiszowych"
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr "Pokaż wyjaśnienie jak działają skróty klawiaturowe."
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "Zmień Pędzel…"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr "Wyświetl pod kursorem okienko z pędzlami."
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "Zmień Kolor…"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 "Wyświetl pod kursorem okienko wyboru koloru z listą wszystkich selektorów."
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "Zmień Kolor (szybszy podzbiór)…"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
@@ -4868,209 +5964,213 @@ msgstr ""
 "Wyświetl pod kursorem okienko wyboru kolorów z listą jedno-klikowych "
 "selektorów."
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr "Więcej Pędzli…"
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr "Pobierz paczki pędzli z MyPaint wiki."
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr "Importuj Pędzle…"
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr "Wczytaj paczkę pędzli z dysku."
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Pomoc"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr "Pomoc w Sieci"
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr "Przejdź do dokumentacji wiki MyPaint."
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "O MyPaint"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr "Pokaż zasługi, licencję i numer wersji MyPainta."
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Debugowanie"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr "Wyświetl na Konsoli Informacje o Wyciekach Pamięci (Powolne!)"
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr "Debuguj wycieki pamięci."
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr "Uruchom Czyszczenie Pamięci (Garbage Collector)"
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr "Zwolnij pamięć nie używaną dla obiektów Python."
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr "Rozpocznij/Zatrzymaj Profilowanie…"
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr "Rozpocznij lub Zakończ Profilowanie Python (cProfile)"
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr "Symuluj Awarię…"
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr "Wywołaj wyjątek Pythona, by przetestować okno awarii."
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "Widok"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr "Informacje Zwrotne"
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr "Dostosuj Widok"
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
+#, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr "Menu Podręczne"
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr "Pokaż główne menu jako wyskakujące okienko."
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "Tryb Pełnoekranowy"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr "Przełącz między trybem pełnoekranowym i trybem okna."
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "Ustawienia"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr "Edytuj globalne ustawienia MyPainta."
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr "Testuj Urządzenia Wejściowe"
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 "Pokaż okno wyświetlające nadesłane zdarzenia z twoich urządzeń wejściowych."
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr "Zmiana Tła"
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr "Zmień teksturę tła."
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr "Edytor Ustawień Pędzla"
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr "Edytuj ustawienia aktywnego pędzla."
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr "Edytor Ikon Pędzli"
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr "Edytuj ikony pędzla."
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr "Panel Warstw"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
-"Pokaż/Ukryj dokowalny panel warstw (uporządkuj warstwy i/lub zastosuj tryby)."
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr "Pokaż Panel Warstw"
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
-msgstr "Pokaż dokowalny panel warstw (uporządkuj warstwy i/lub zastosuj tryby)."
+msgstr ""
+"Pokaż dokowalny panel warstw (uporządkuj warstwy i/lub zastosuj tryby)."
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr "Koło HCY"
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
@@ -5079,42 +6179,32 @@ msgstr ""
 "Dokowalny cylindryczny selektor kolorów (HCL) odcienia/nasycenia/jasności. "
 "Krążki są tej samej luminancji."
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "Paleta Kolorów"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr "Dokowalna paleta kolorów."
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr "Koło HSV"
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr "Dokowalna zmieniarka koloru nasycenia i jasności."
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr "Trójkąt HSV"
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr "Dokowalny selektor kolorów: stary trójkąt kolorów GTK."
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr "Kostka HSV"
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
@@ -5123,571 +6213,775 @@ msgstr ""
 "Dokowalny selektor koloru: Kostka HSV z możliwością obrotu by wyświetlić "
 "inne jej płaszczyzny."
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr "Kwadrat HSV"
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
-msgstr ""
-"Dokowalny selektor kolorów: Kwadrat HSV z możliwością obracania by "
-"wyświetlić inne odcienie."
+msgid "Dockable color selector: HSV square with Hue ring."
+msgstr "Dokowalny selektor kolorów z pierścieniami koncentrycznymi HSV."
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr "Suwaki Składowych"
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr "Dokowalny selektor koloru przedstawiający składowe koloru."
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr "Plama Kolorów"
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 "Dokowalny selektor kolorów przedstawiający plamę z sąsiadujących kolorów."
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr "Pierścienie Koncentryczne"
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr "Dokowalny selektor kolorów z pierścieniami koncentrycznymi HSV."
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr "Skrzyżowana Misa"
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 "Dokowalny selektor kolorów HSV krzyżujących się na promienistej misce "
 "kolorów."
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr "Panel Szkicownika"
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
-"Pokaż/Ukryj dokowalny panel Szkicownika (mieszaj kolory i twórz szkice)."
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr "Pokaż Panel Szkicownika"
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr "Pokaż dokowalny panel Szkicownika (mieszaj kolory i twórz szkice)."
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr "Panel Podglądu"
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
-msgstr "Pokaż/Ukryj dokowalny panel Podglądu (podgląd na cały obszar roboczy)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "Podgląd"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr "Pokaż dokowalny panel Podglądu (podgląd na cały obszar roboczy)."
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr "Panel Opcji Narzędzia"
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
-"Pokaż/Ukryj dokowalny panel Opcji Narzędzia (opcje bieżącego narzędzia)."
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr "Pokaż Panel Opcji Narzędzia"
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr "Pokaż dokowalny panel Opcji Narzędzia (opcje dla bieżącego narzędzia)."
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr "Panel Historii Koloru i Pędzla"
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
-msgstr "Pokaż/Ukryj panel Historii (ostatnio użyte pędzle i kolory)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr "Ostatnio Użyte Pędzle i Kolory"
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr "Pokaż panel Historii (ostatnio użyte pędzle i kolory)."
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr "Ukryj Panel Sterowania na Pełnym Ekranie"
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr "Włącz/Wyłącz autoukrywanie interfejsu na pełnym ekranie."
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr "Pokaż Poziom Powiększenia"
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr "Pokaz/Ukryj informację zwrotną o poziomie powiększenia."
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr "Pokaż Ostatnią Pozycję Malowania"
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 "Pokaż/Ukryj znaczek w miejscu zakończenia ostatniego pociągnięcia kreski."
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr "Filtry Wyświetlania"
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr "Pokaż Normalnie Kolory"
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr "Filtr kolorów: pokazuje niezmienione kolory."
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr "Pokaż Kolory w Skali Szarości"
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr "Filtr kolorów: pokazuje jedynie jasność (HCY/YCbCr Luma)"
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr "Pokaż Odwrócone Kolory"
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr "Filtr kolorów: inwersja. Czerń jest bielą, a czerwień jest cyjanem."
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr "Wyświetl Kolory z Symulowaną Obniżoną Percepcją na Czerwony"
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 "Filtruje kolory by symulowały deuteranopię, częstą odmianę ślepoty barw."
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr "Wyświetl Kolory z Symulowaną Obniżoną Percepcją na Zielony"
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr "Filtruje kolory by symulowały protanopię, częstą formę ślepoty barw."
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr "Wyświetl Kolory z Symulowaną Obniżoną Percepcją na Niebieski"
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr "Filtruje kolory by symulowały tritanopię, rzadką odmianę ślepoty barw."
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr "Tryb Odręczny"
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr "Odręczny"
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr "Odręcznie: rysuj i maluj swobodnie bez ograniczeń geometrycznych."
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr "Tryb Odręczny"
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr "Rysuj i maluj swobodnie bez ograniczeń geometrycznych."
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr "Przesuwanie Widoku"
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr "Przesuwaj"
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr "Przesuwanie Widoku: przesuń widok na płótno w dowolnym kierunku."
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr "Przesuwanie Widoku"
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr "Przesuwaj swobodnie widok na płótno."
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr "Obracanie Widoku"
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr "Obróć"
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr "Obracanie Widoku: obróć widok na płótno."
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr "Obracanie Widoku"
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr "Swobodnie obracaj widok na płótno."
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr "Powiększanie Widoku"
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr "Powiększaj"
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr "Powiększanie Widoku: przybliż lub oddal widok płótno."
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr "Powiększanie Widoku"
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr "Swobodnie przybliżaj lub oddalaj płótno."
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr "Linie i Krzywe"
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr "Linie"
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr "Linie i Krzywe: rysuj proste lub zakrzywione linie."
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr "Linie i Krzywe"
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr "Rysuj proste lub zakrzywione linie."
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr "Połączone Linie"
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr "Poł. Linie"
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr "Połączone Linie: rysuj sekwencję prostych lub zakrzywionych linii."
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr "Połączone Linie"
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr "Rysuj sekwencje prostych lub zakrzywionych linii."
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr "Elipsy i Koła"
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr "Elipsa"
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr "Elipsy i Koła: rysuj zaokrąglone kształty."
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr "Elipsy i Koła"
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr "Rysuj koła i elipsy."
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr "Stalówka"
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr "Stalówka"
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr "Stalówka: rysuj kontrolowalne wygładzone linie."
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr "Stalówka"
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr "Rysuj kontrolowalne wygładzone linie."
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr "Przemieszczenie Warstwy"
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr "Poł. Warstwy"
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr "Przemieszczenie Warstwy: przesuń bieżącą warstwę na płótnie."
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr "Przemieszczanie Warstwy"
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr "Swobodnie przesuń bieżącą warstwę na płótnie."
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr "Edycja Ramki"
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr "Ramka"
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
-msgstr "Edycja Ramki: określ ramkę wokół dokumentu by nadać mu końcowy rozmiar."
+msgstr ""
+"Edycja Ramki: określ ramkę wokół dokumentu by nadać mu końcowy rozmiar."
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr "Edytor Ramki"
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr "Swobodnie określ ramkę wokół dokumentu by nadać mu końcowy rozmiar."
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Edycja Malowania Symetrycznego"
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr "Symetria"
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 "Edycja Malowania Symetrycznego: dostosuj oś używaną do malowania "
 "symetrycznego."
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Edytor Malowana Symetrycznego"
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr "Swobodnie dostosuj oś używaną do malowania symetrycznego."
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr "Pobierz Kolor"
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr "Pobierz kolor"
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr "Pobierz Kolor: wybierz kolor malowania z pikseli ekranu."
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "Pobierz Kolor"
+
+#: ../po/tmp/resources.xml.h:401
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr "Ustaw kolor malowania z pikseli ekranu."
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "Pobierz Kolor"
+
+#: ../po/tmp/resources.xml.h:403
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr "Ustaw kolor malowania z pikseli ekranu."
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "Pobierz Kolor"
+
+#: ../po/tmp/resources.xml.h:405
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr "Ustaw kolor malowania z pikseli ekranu."
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr "Pobierz Kolor"
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr "Ustaw kolor malowania z pikseli ekranu."
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr "Wypełnianie"
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr "Wypełnianie"
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr "Wypełnianie: wypełnij obszar kolorem."
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr "Wypełnianie"
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr "Wypełnij obszar kolorem."
+
+#~ msgctxt "Accelerator map editor: action column markup"
+#~ msgid ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+#~ msgstr ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+
+#~ msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
+#~ msgid "{action_label} {action_desc} {accel_label}"
+#~ msgstr "{action_label} {action_desc} {accel_label}"
+
+#~ msgctxt "brush list context menu"
+#~ msgid "Delete"
+#~ msgstr "Usuń"
+
+#~ msgctxt "brush list commands"
+#~ msgid "Really delete brush from disk?"
+#~ msgstr "Czy na pewno usunąć plik ustawienia pędzla?"
+
+#~ msgid "HSV Triangle"
+#~ msgstr "Trójkąt HSV"
+
+#~ msgid "The standard GTK color selector"
+#~ msgstr "Standardowy selektor kolorów GTK"
+
+#~ msgid "Pick a color from the screen"
+#~ msgstr "Pobierz kolor z ekranu"
+
+#~ msgid "Layer Name"
+#~ msgstr "Nazwa Warstwy"
+
+#~ msgid ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+#~ msgstr ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+
+#~ msgid "Save..."
+#~ msgstr "Zapisz..."
+
+#~ msgid "Confirm"
+#~ msgstr "Potwierdź"
+
+#~ msgid "Open..."
+#~ msgstr "Otwórz..."
+
+#~ msgid "{default_name} at {path}"
+#~ msgstr "{default_name} w {path}"
+
+#~ msgid "Type"
+#~ msgstr "Typ"
+
+#~ msgid "Mode:"
+#~ msgstr "Tryb:"
+
+#~ msgid ""
+#~ "Blending mode: how the current layer combines with the layers underneath "
+#~ "it."
+#~ msgstr "Tryb mieszania: jak bieżąca warstwa łączy się z warstwami poniżej."
+
+#~ msgid ""
+#~ "Layer opacity: how much of the current layer to use. Smaller values make "
+#~ "it more transparent."
+#~ msgstr ""
+#~ "Krycie warstwy: jak bardzo warstwa ma być widoczna. Im mniejsza wartość "
+#~ "tym warstwa staje się bardziej przeźroczysta."
+
+#~ msgid "%s: edit properties"
+#~ msgstr "%s: edytuj właściwości"
+
+#~ msgctxt "layer unique names: match regex (leave untranslated if unsure)"
+#~ msgid "^(.*?)\\s*(\\d+)$"
+#~ msgstr "^(.*?)\\s*(\\d+)$"
+
+#~ msgctxt "layer default names"
+#~ msgid "Unknown Bitmap Layer"
+#~ msgstr "Nieznana Warstwa Bitmapowa"
+
+#~ msgctxt "Autosave Recovery dialog|"
+#~ msgid "_Ignore for Now"
+#~ msgstr "_Odłóż na Później"
+
+#~ msgid "Setting name:"
+#~ msgstr "Nazwa ustawień:"
+
+#~ msgid "Base value:"
+#~ msgstr "Wartość bazowa:"
+
+#~ msgid "Reset the base value to its default"
+#~ msgstr "Przywróć domyślną wartość bazową"
+
+#~ msgid "<ymin>"
+#~ msgstr "<ymin>"
+
+#~ msgid "<ymax>"
+#~ msgstr "<ymax>"
+
+#~ msgid "<xmin>"
+#~ msgstr "<xmin>"
+
+#~ msgid "<xmax>"
+#~ msgstr "<xmax>"
+
+#~ msgid "Edit Setting"
+#~ msgstr "Edytuj Ustawienia"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Trim Layer to Frame"
+#~ msgstr "Przytnij Warstwę do Ramki"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Rename Layer…"
+#~ msgstr "Przemianuj Warstwę…"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Enter a new name for the current layer."
+#~ msgstr "Wprowadź nową nazwę dla bieżącej warstwy."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Turn off mirroring of the view."
+#~ msgstr "Wyłącz odbicie widoku."
+
+#~ msgctxt "Menu→Edit (labels)"
+#~ msgid "Current Tool"
+#~ msgstr "Bieżące Narzędzie"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+#~ msgstr ""
+#~ "Pokaż/Ukryj dokowalny panel warstw (uporządkuj warstwy i/lub zastosuj "
+#~ "tryby)."
+
+#~ msgctxt "Menu→Color (labels), Accel Editor (labels)"
+#~ msgid "HSV Triangle"
+#~ msgstr "Trójkąt HSV"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Dockable color selector: the old GTK color triangle."
+#~ msgstr "Dokowalny selektor kolorów: stary trójkąt kolorów GTK."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid ""
+#~ "Dockable color selector: HSV square which can be rotated to show "
+#~ "different hues."
+#~ msgstr ""
+#~ "Dokowalny selektor kolorów: Kwadrat HSV z możliwością obracania by "
+#~ "wyświetlić inne odcienie."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+#~ msgstr ""
+#~ "Pokaż/Ukryj dokowalny panel Szkicownika (mieszaj kolory i twórz szkice)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+#~ msgstr ""
+#~ "Pokaż/Ukryj dokowalny panel Podglądu (podgląd na cały obszar roboczy)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+#~ msgstr ""
+#~ "Pokaż/Ukryj dokowalny panel Opcji Narzędzia (opcje bieżącego narzędzia)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the History panel (recently used brushes and colors)."
+#~ msgstr "Pokaż/Ukryj panel Historii (ostatnio użyte pędzle i kolory)."
 
 #~ msgid "Add As New"
 #~ msgstr "Dodaj jako nowy"
@@ -5787,9 +7081,6 @@ msgstr "Wypełnij obszar kolorem."
 #~ "urządzenia (nacisk, prędkość, itp.) są dostępne jako chmurki. Najedź "
 #~ "kursorem na tekst opcji i poczekaj sekundę by wyskoczyły.\n"
 
-#~ msgid "Open Recent files"
-#~ msgstr "Otwórz ostatnie pliki"
-
 #, fuzzy
 #~ msgid "This will discard %d second of unsaved painting."
 #~ msgid_plural "This will discard %d seconds of unsaved painting."
@@ -5841,10 +7132,6 @@ msgstr "Wypełnij obszar kolorem."
 #, fuzzy
 #~ msgid "Restore Saved Settings"
 #~ msgstr "Zapisz ustawienia"
-
-#, fuzzy
-#~ msgid "Add Layer"
-#~ msgstr "Warstwy"
 
 #, fuzzy
 #~ msgid "Change Layer Visibility"

--- a/po/pl.po
+++ b/po/pl.po
@@ -537,18 +537,18 @@ msgstr "pakiet pędzli MyPaint (*.zip)"
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
-msgstr "Nowa Grupa..."
+msgid "New Group…"
+msgstr "Nowa Grupa…"
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
-msgstr "Importuj Pędzle..."
+msgid "Import Brushes…"
+msgstr "Importuj Pędzle…"
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
-msgstr "Więcej Pędzli..."
+msgid "Get More Brushes…"
+msgstr "Więcej Pędzli…"
 
 #: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
@@ -1235,13 +1235,13 @@ msgstr "Typ"
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
-msgstr "Użyj do..."
+msgid "Use for…"
+msgstr "Użyj do…"
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
-msgstr "Kółko..."
+msgid "Scroll…"
+msgstr "Kółko…"
 
 #. Name and preview column: will be indented
 #: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
@@ -1463,8 +1463,8 @@ msgid "_Quit"
 msgstr "Zakończ"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
-msgstr "Zaimportuj Paczkę Pędzli..."
+msgid "Import brush package…"
+msgstr "Zaimportuj Paczkę Pędzli…"
 
 #: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
@@ -1520,8 +1520,8 @@ msgstr ""
 "\"{type_name}\" ({content_type})?"
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
-msgstr "Otwórz za Pomocą..."
+msgid "Open With…"
+msgstr "Otwórz za Pomocą…"
 
 #: ../gui/externalapp.py:123
 msgid "Icon"
@@ -1713,13 +1713,13 @@ msgstr "JPEG 90% jakości (*.jpg; *.jpeg)"
 
 #: ../gui/filehandling.py:576
 #, fuzzy
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr "Eksportuj…"
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Zapisz Jako…"
 
@@ -1790,8 +1790,8 @@ msgstr "Otwórz ostatnie pliki"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
-msgstr "Otwórz Szkicownik..."
+msgid "Open Scratchpad…"
+msgstr "Otwórz Szkicownik…"
 
 #: ../gui/filehandling.py:1099
 #, fuzzy
@@ -2245,13 +2245,13 @@ msgstr ""
 "tego nie zgłosił."
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
-msgstr "Szukaj na Trackerze..."
+msgid "Search Tracker…"
+msgstr "Szukaj na Trackerze…"
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
-msgstr "Zgłoś Błąd..."
+msgid "Report…"
+msgstr "Zgłoś Błąd…"
 
 #: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
@@ -2262,8 +2262,8 @@ msgid "Quit MyPaint"
 msgstr "Zakończ MyPaint"
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
-msgstr "Szczegóły..."
+msgid "Details…"
+msgstr "Szczegóły…"
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
@@ -2472,8 +2472,8 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
-msgstr "Przestaw warstwę w stosie..."
+msgid "Move layer in stack…"
+msgstr "Przestaw warstwę w stosie…"
 
 #: ../gui/layerswindow.py:110
 msgid ""
@@ -2545,8 +2545,8 @@ msgid "Stroke trail-off beginning"
 msgstr "Początek zanikania kreski"
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
-msgstr "Zmienna nacisku..."
+msgid "Pressure variation…"
+msgstr "Zmienna nacisku…"
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
@@ -3716,7 +3716,7 @@ msgstr "Usuń ten pędzel z dysku"
 #, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid "_Recover & Save…"
-msgstr "_Przywróć i Zapisz..."
+msgstr "_Przywróć i Zapisz…"
 
 #: ../po/tmp/autorecover.glade.h:12
 #, fuzzy

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-05-03 16:49+0000\n"
 "Last-Translator: Rui Mendes <xz9@protonmail.com>\n"
 "Language-Team: Portuguese <https://hosted.weblate.org/projects/mypaint/"
@@ -19,29 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.7-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr "<big><b>{accel_label}</b></big>"
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr "{action_label} {action_desc} {accel_label}"
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "Ação"
 
@@ -49,32 +27,32 @@ msgstr "Ação"
 msgid "Key combination"
 msgstr "Combinação de teclas"
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr "Editar tecla para '%s'"
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "Ação:"
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "Caminho:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "Tecla:"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr "Pressione as teclas para alterar esta atribuição"
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "Ação desconhecida"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
@@ -83,7 +61,7 @@ msgstr ""
 "<b>{accel} já está a ser utilizada em '{action}'. A atribuição existente "
 "será substituída.</b>"
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr "Abrir pasta “{folder_basename}”…"
@@ -91,197 +69,207 @@ msgstr "Abrir pasta “{folder_basename}”…"
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "OK"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr "Não foram encontradas cópias de segurança na cache."
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr "Sem cópias de segurança disponíveis"
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr "Abrir a pasta da cache…"
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr "Falha na recuperação da cópia de segurança"
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr "Abrir a pasta de cópia de segurança…"
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr "Ficheiro recuperado de {iso_datetime}.ora"
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "Guardar como padrão"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "Fundo"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "Textura"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Cor"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "Adicionar cor às texturas"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr "Não foi possível carregar uma ou mais imagens de fundo"
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr "Erro ao carregar as imagens de fundo"
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 "Remova os ficheiros que não puderam ser carregados ou verifique a sua "
 "instalação de libgdkpixbuf."
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
-"Gdk-pixbuf não conseguiu carregar \"{filename}\" e reportou o erro \"{error}"
-"\""
+"Gdk-pixbuf não conseguiu carregar \"{filename}\" e reportou o erro "
+"\"{error}\""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr "{filename} tem tamanho zero (w={w}, h={h})"
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr "Editor de configuração do pincel"
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr "Sobre"
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "Experimental"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr "Básico"
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr "Opacidade"
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr "Pincelada"
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "Borrar"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr "Velocidade"
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr ""
+
+#: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr "Acompanhamento"
 
-#: ../gui/brusheditor.py:359
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "Traço"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr "Cor"
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Personalizado"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr "Nenhum pincel selecionado, favor usar \"Adicionar como novo\"."
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr "Nenhum pincel selecionado!"
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "Alterar nome do pincel"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "Já existe um pincel com este nome!"
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr "Nenhum pincel selecionado!"
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr "Quer mesmo eliminar o pincel “{brush_name}”?"
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr "(pincel sem nome)"
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr "{brush_name} [não guardado]"
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr "Ícone do pincel"
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr "Ícone do pincel (a editar)"
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr "Nenhum pincel selecionado"
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -290,7 +278,7 @@ msgstr ""
 "<b>%s</b>\n"
 "<small>Selecione primeiro um pincel válido</small>"
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
@@ -299,7 +287,7 @@ msgstr ""
 "<b>%s</b> <i>(alterado)</i>\n"
 "<small>As alterações ainda não foram guardadas</small>"
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
@@ -308,7 +296,7 @@ msgstr ""
 "<b>%s</b> (a editar)\n"
 "<small>Pinte com qualquer pincel ou cor</small>"
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -349,142 +337,182 @@ msgstr "Automático"
 msgid "Use the default icon"
 msgstr "Utilizar o ícone padrão"
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Guardar"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr "guardar este ícone de pré-visualização e terminar a edição"
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr "Perdidos e achados"
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr "Eliminado"
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr "Favoritos"
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr "Tinta"
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr "Clássico"
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr "Conjunto nº 1"
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr "Conjunto nº 2"
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr "Conjunto nº 3"
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr "Conjunto nº 4"
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr "Conjunto nº 5"
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr "Experimental"
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Novo"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr "Pincel desconhecido"
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr "Adicionar aos favoritos"
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr "Remover dos favoritos"
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr "Clonar"
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr "Editar as configurações do pincel"
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
-msgstr "Eliminar"
+#: ../gui/brushselectionwindow.py:250
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
+msgstr "Alterar nome do grupo"
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
-msgstr "Quer mesmo eliminar o pincel?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, fuzzy, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
+msgstr "Quer mesmo eliminar o pincel “{brush_name}”?"
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] "%d pincel"
 msgstr[1] "%d pincéis"
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr "Grupo “{group_name}”"
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr "Alterar nome do grupo"
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr "Exportar como pacote de pincéis zipado"
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr "Eliminar grupo"
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr "Alterar nome do grupo"
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "Já existe um grupo com este nome!"
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr "Quer mesmo eliminar o grupo “{group_name}”?"
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -494,58 +522,58 @@ msgstr ""
 "Não foi possível eliminar o grupo “{group_name}”.\n"
 "Alguns grupos especiais não podem ser eliminados."
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr "Exportar pincéis"
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr "Pacote de pincéis do MyPaint (*.zip)"
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "Novo grupo..."
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr "Importar pincéis..."
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr "Obter mais pincéis..."
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "Criar grupo"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr "Botão"
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr "Btn"
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr "Botão pressionado"
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr "Adicionar um novo atalho"
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr "Remover o atalho atual"
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr "Editar atalho para '%s'"
@@ -554,7 +582,7 @@ msgstr "Editar atalho para '%s'"
 msgid "Button press:"
 msgstr "Botão pressionado:"
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
@@ -562,46 +590,74 @@ msgstr ""
 "Mantenha as teclas modificadoras pressionadas e pressione um botão sobre "
 "este texto para definir um novo atalho."
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr "{button} não pode ser associado sem teclas modificadoras (é fixo)"
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr "{button_combination} já está associado à ação '{action_name}'"
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr "Recolher cor"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr "Selecionar a cor usada para pintar"
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+#, fuzzy
+msgid "Set the color Hue used for painting"
+msgstr "Selecionar a cor usada para pintar"
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "Pegar cor"
+
+#: ../gui/colorpicker.py:296
+#, fuzzy
+msgid "Set the color Chroma used for painting"
+msgstr "Selecionar a cor usada para pintar"
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+#, fuzzy
+msgid "Set the color Luma used for painting"
+msgstr "Selecionar a cor usada para pintar"
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr "Detalhes da cor"
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr "Cor do pincel atual e a cor usada mais recentemente para a pintura"
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr "Máscara de gama ativa"
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr "Limite a sua paleta a tons específicos usando uma máscara de gama."
@@ -611,7 +667,7 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr "Matiz HCY e intensidade."
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
@@ -620,12 +676,12 @@ msgstr ""
 "Editor de máscara de gama. Clique no meio para criar ou manipular formas ou "
 "rode a máscara usando as bordas do disco."
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr "Tríade atmosférica"
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
@@ -634,22 +690,22 @@ msgstr ""
 "Subjetiva e com tom forte, definida por uma cor primária dominante e duas "
 "primárias que são menos intensas."
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr "Tríade deslocada"
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr "Com mais peso em direção à cor dominante."
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr "Complementar"
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
@@ -658,12 +714,12 @@ msgstr ""
 "Opostos contrastantes, balanceados por cores neutras centrais entre eles na "
 "roda de cores."
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr "Tom e destaque"
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
@@ -672,12 +728,12 @@ msgstr ""
 "Uma faixa principal de cores, com um destaque complementar para variação e "
 "altas luzes."
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr "Complementares divididas"
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
@@ -686,72 +742,72 @@ msgstr ""
 "Duas cores análogas e um complemento para elas, sem cores secundárias entre "
 "elas."
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr "Nova máscara de gama a partir do modelo"
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr "Editor de máscaras de gama"
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr "Ativo"
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr "Ajuda…"
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr "Criar máscara a partir de um modelo."
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr "Carregar máscara a partir de um ficheiro de paleta do GIMP."
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr "Guardar máscara para um ficheiro de paleta do GIMP."
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr "Apagar a máscara."
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr "Abre a ajuda na Internet para este diálogo num navegador."
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr "Guardar a máscara como uma paleta do GIMP"
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr "Carregar a máscara a partir de um ficheiro de paleta do GIMP"
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr "Definir máscara de gama."
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr "Roda HCY"
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -761,163 +817,155 @@ msgstr ""
 "fatias circulares são de mesma luminosidade."
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr "Matiz HSV"
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr "Saturação HSV"
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr "Valor HSV"
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr "Saturação e valor HSV"
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr "Matiz e valor HSV"
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr "Matiz e saturação HSV"
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr "Rodar cubo (mostrar eixos diferentes)"
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr "Cubo HSV"
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 "Um cubo HSV que pode ser rodado para mostrar diferentes fatias planares."
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr "Quadrado HSV"
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr "Um quadrado HSV que pode ser rodado para mostrar diferentes matizes."
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr "Triângulo HSV"
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr "Seletor de cores padrão do GTK"
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr "Roda HSV"
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr "Seletor de cores por saturação e valor."
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr "Propriedades da paleta"
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr "Paleta"
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr "Selecionar a cor de uma paleta que seja carregável e editável."
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr "Camada sem título"
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr "Editor de paleta"
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr "Carregar a partir de um ficheiro de paleta do GIMP"
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr "Guardar para um ficheiro de paleta do GIMP"
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr "Adicionar uma nova amostra de cor vazia"
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr "Remover a amostra de cor atual"
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr "Remover todas as amostras de cores"
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr "Título:"
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr "Nome ou descrição para esta paleta"
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr "Colunas:"
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr "Número de colunas"
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr "Nome da cor:"
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr "Nome da cor atual"
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr "Ranhura de paleta vazia"
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr "Carregar paleta"
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr "Guardar paleta"
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -928,379 +976,376 @@ msgstr ""
 "Largue cores aqui e \n"
 "arraste-as para organizá-las."
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr "Ranhura de paleta vazia (arraste uma cor para aqui)"
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr "Adicionar ranhura vazia"
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr "Inserir linha"
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr "Inserir coluna"
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr "Preencher lacuna (RGB)"
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr "Preencher lacuna (HCY)"
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr "Preencher lacuna (HSV)"
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "Ficheiro de paleta do GIMP (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr "Todos os ficheiros (*)"
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "Ficheiro de paleta do GIMP (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr "Todos os ficheiros (*)"
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr "Recolher uma cor da tela"
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr "R"
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr "G"
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr "B"
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr "H"
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr "C"
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr "Y"
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr "Controles deslizantes de componentes"
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr "Ajustar componentes individuais da cor."
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr "Vermelho RGB"
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr "Verde RGB"
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr "Azul RGB"
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr "Matiz HSV"
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr "Saturação HSV"
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr "Valor HSV"
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr "Matiz HCY"
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr "Pureza HCY"
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr "Luminosidade HCY (Y')"
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr "Paleta líquida"
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr "Mude a cor usando uma paleta líquida de cores próximas."
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr "Anéis concêntricos"
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr "Seletor de cor usando anéis concêntricos HSV."
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr "Paleta cruzada"
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr "Mude a cor HSV usando uma paleta radial atravessada pela cor."
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr "Cursor"
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr "Borracha"
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr "Teclado"
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr "Rato"
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr "Caneta"
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr "Touchpad"
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr "Ecrã tátil"
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr "Ignorar"
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr "Qualquer tarefa"
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr "Tarefas não-pintura"
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr "Apenas navegação"
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr "Aplicação"
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr "Deslocar"
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr "Dispositivo"
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr "Eixos"
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr "Tipo"
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr "Usar para..."
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr "Deslocar..."
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Nome"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr "Substituir pincel?"
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr "Substituir"
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr "Alterar nome"
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr "Substituir tudo"
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr "Alterar nome de tudo"
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr "Pincel importado"
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr "Pincel existente"
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 "<b>Já existe um pincel com o nome `%s'</b>\n"
 "Quer substituí-lo ou quer alterar o nome do novo pincel?"
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr "Substituir grupo de pincéis?"
 
-#: ../gui/dialogs.py:190
-#, python-brace-format
+#: ../gui/dialogs.py:220
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 "<b>Já existe um grupo com o nome `{groupname}'</b>\n"
 "Quer substituí-lo ou quer alterar o nome do novo grupo?\n"
 "Se o substituir, os pincéis podem ser movidos para um grupo com o nome "
 "`{deleted_groupname}'."
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr "Importar pacote de pincéis?"
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, fuzzy, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr "<b>Quer mesmo importar o pacote `%s'?</b>"
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr "Carregar configurações do pincel pelo atalho %d"
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr "Guardar as configurações do pincel no atalho %d"
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr "Restaurar pincel %d"
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr "Guardar para o pincel %d"
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr "Desfazer %s"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Desfazer"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr "Refazer %s"
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Refazer"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr "{button_combination} é {resultant_action}"
@@ -1310,101 +1355,144 @@ msgstr "{button_combination} é {resultant_action}"
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ";  "
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr "Com {modifiers} pressionados:  {button_actions}."
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
-msgstr "Nome da camada"
-
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
-#, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
-"<b>{name}</b>\n"
-"{description}"
+
+#: ../gui/document.py:909
+#, python-brace-format
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
+msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr "%s - MyPaint"
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr "MyPaint"
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Abrir"
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr "Selecionar cor atual"
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr "Sair do modo de ecrã inteiro"
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr "Sair do modo de ecrã inteiro"
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr "Entrar no modo de ecrã inteiro"
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Ecrã inteiro"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Sair"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+#, fuzzy
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr "Quer mesmo sair?"
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Sair"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr "Importar pacote de pincéis..."
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr "Pacote de pincéis do MyPaint (*.zip)"
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr "{app_name} aberto para editar a camada “{layer_name}”"
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr "Erro: falha ao abrir {app_name} para editar a camada “{layer_name}”"
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr "Edição cancelada. Ainda pode editar “{layer_name}” no menu Camadas."
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr "Camada “{layer_name}” atualizada com edições externas"
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr "Não foi possível carregar “{file_basename}”."
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
@@ -1413,7 +1501,7 @@ msgstr ""
 "O MyPaint tem de editar um ficheiro do tipo “{type_name}” ({content_type}). "
 "Que programa deve ser usado?"
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
@@ -1422,161 +1510,374 @@ msgstr ""
 "Qual o programa que o MyPaint deve utilizar para edição de ficheiros do tipo "
 "“{type_name}” ({content_type})?"
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr "Abrir com..."
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr "Ícone"
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr "sem descrição"
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
+#: ../gui/filehandling.py:126
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
+msgstr "A carregar “{file_basename}”…"
+
+#: ../gui/filehandling.py:130
+#, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:134
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
+msgstr "A guardar “{file_basename}”…"
+
+#: ../gui/filehandling.py:138
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
+msgstr "A exportar para “{file_basename}”…"
+
+#: ../gui/filehandling.py:145
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr "Falha ao exportar para “{file_basename}”."
+
+#: ../gui/filehandling.py:149
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr "Falha ao guardar “{file_basename}”."
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr "Não foi possível carregar “{file_basename}”."
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "Guardar paleta"
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr "“{file_basename}” exportado com sucesso."
+
+#: ../gui/filehandling.py:187
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr "“{file_basename}” guardado com sucesso."
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr "“{file_basename}” carregado."
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
+msgstr "“{file_basename}” carregado."
+
+#: ../gui/filehandling.py:427
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "All Recognized Formats"
 msgstr "Todos os formatos conhecidos"
 
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
+#: ../gui/filehandling.py:432
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "OpenRaster (*.ora)"
 msgstr "OpenRaster (*.ora)"
 
-#: ../gui/filehandling.py:95
+#: ../gui/filehandling.py:437
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "PNG (*.png)"
 msgstr "PNG (*.png)"
 
-#: ../gui/filehandling.py:96
+#: ../gui/filehandling.py:442
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "JPEG (*.jpg; *.jpeg)"
 msgstr "JPEG (*.jpg; *.jpeg)"
 
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
+#: ../gui/filehandling.py:490
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "By extension (prefer default format)"
 msgstr "Por extensão (preferir formato padrão)"
 
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
+#: ../gui/filehandling.py:494
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:498
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
 msgstr "PNG sólido com fundo (*.png)"
 
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
+#: ../gui/filehandling.py:502
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:506
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
 msgstr "PNG transparente (*.png)"
 
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
+#: ../gui/filehandling.py:510
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
 msgstr "Múltiplos PNG transparentes (*.XXX.png)"
 
-#: ../gui/filehandling.py:113
+#: ../gui/filehandling.py:514
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr "Múltiplos PNG transparentes (*.XXX.png)"
+
+#: ../gui/filehandling.py:518
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr "JPEG com qualidade de 90% (*.jpg; *.jpeg)"
 
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr "Guardar..."
+#: ../gui/filehandling.py:576
+#, fuzzy
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr "Exportar…"
 
-#: ../gui/filehandling.py:177
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Guardar como…"
+
+#: ../gui/filehandling.py:601
+#, fuzzy
+msgctxt "save dialogs: formats and options: (label)"
 msgid "Format to save as:"
 msgstr "Formato a guardar como:"
 
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr "Confirmar"
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
+#: ../gui/filehandling.py:668
+#, fuzzy
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
 msgstr "Quer mesmo continuar?"
 
-#: ../gui/filehandling.py:234
-#, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
-msgstr "Isto irá descartar {abbreviated_time} de pintura não guardada"
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
+#: ../gui/filehandling.py:705
+#, fuzzy
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
 msgstr "_Guardar como rascunho"
 
-#: ../gui/filehandling.py:282
-#, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
-msgstr "A carregar “{file_basename}”…"
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
 
-#: ../gui/filehandling.py:296
-#, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
-msgstr "Não foi possível carregar “{file_basename}”."
+#: ../gui/filehandling.py:734
+#, fuzzy, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr "Isto irá descartar {abbreviated_time} de pintura não guardada"
 
-#: ../gui/filehandling.py:321
-#, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
-msgstr "“{file_basename}” carregado."
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
 
-#: ../gui/filehandling.py:422
-#, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
-msgstr "A exportar para “{file_basename}”…"
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
 
-#: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
-msgstr "A guardar “{file_basename}”…"
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
-msgstr "Falha ao exportar para “{file_basename}”."
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr "Abrir…"
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
-msgstr "Falha ao guardar “{file_basename}”."
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Abrir"
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
-msgstr "“{file_basename}” exportado com sucesso."
-
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
-msgstr "“{file_basename}” guardado com sucesso."
-
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Abrir..."
-
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr "Abrir painel de rascunho..."
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Pincel importado"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Abrir"
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Abrir o mais recente"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Abrir"
+
+#: ../gui/filehandling.py:1446
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
 msgstr "Ainda não há ficheiros de rascunho com o nome \"%s\"."
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1455
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr "Abrir próximo rascunho"
+
+#: ../gui/filehandling.py:1463
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr "Abrir rascunho anterior"
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Abrir"
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+#, fuzzy
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr "Reverter"
+
+#: ../gui/fill.py:121
+#, fuzzy
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr "Preenchimento"
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+#, fuzzy
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr "Preencher áreas com cor"
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+#, fuzzy
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr "Tolerância:"
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+#, fuzzy
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
@@ -1584,19 +1885,36 @@ msgstr ""
 "O quanto as cores dos píxeis podem variar do ponto de partida\n"
 "antes do Preenchimento se recusar a preenchê-los"
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+#, fuzzy
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr "Origem:"
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
-msgstr "Que camadas visíveis devem ser preenchidas"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
+msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+#, fuzzy
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr "Amostra combinada"
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+#, fuzzy
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
@@ -1606,19 +1924,50 @@ msgstr ""
 "utilizar uma combinação temporária de todas \n"
 "as camadas visíveis abaixo da camada atual"
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+#, fuzzy
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr "Ajustar à visualização"
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+#, fuzzy
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr "Alvo:"
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+#, fuzzy
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr "Onde a saída deve ir"
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr "Nova camada (uma)"
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+#, fuzzy
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
@@ -1626,21 +1975,108 @@ msgstr ""
 "Crie uma nova camada com os resultados do preenchimento.\n"
 "Esta é desligada automaticamente após o uso."
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Opacidade:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr "Restaurar"
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+#, fuzzy
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr "Restaurar opções para os valores originais"
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "Selecionar camada"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr "<b>{brush_name}</b>"
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1650,130 +2086,142 @@ msgstr ""
 "<b>{brush_name}</b>\n"
 "{brush_desc}"
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr "Editar moldura"
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr "Ajustar a moldura do documento"
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr "Tamanho da moldura"
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr "px"
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr "Altura:"
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr "Largura:"
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr "Resolução:"
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr "DPI"
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr "Pontos por polegada (píxeis por polegada)"
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr "Cor:"
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr "Cor da moldura"
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr "<b>Dimensões da moldura</b>"
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr "<b>Densidade de píxeis</b>"
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr "Definir moldura da camada"
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr "Definir moldura para o tamanho da camada atual"
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr "Definir moldura para o tamanho do documento"
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr "Definir moldura para a combinação de todas as camadas"
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr "Cortar camada para moldura"
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr "Cortar partes da camada atual que estão fora da moldura"
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr "Ativado"
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr "{width:g}×{height:g} {units}"
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr "polegada"
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr "cm"
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr "mm"
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr "Desenho à mão livre"
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr "Pintar pinceladas de forma livre"
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr "Suavização:"
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr "Pressão:"
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr "Erro detetado"
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr "<big><b>Foi detetado um erro de programação.</b></big>"
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1787,35 +2235,35 @@ msgstr ""
 "Por favor reporte o problema aos programadores usando o rastreador de erros, "
 "se ainda ninguém reportou o mesmo problema."
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr "Pesquisar no rastreador..."
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr "Reportar..."
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr "Ignorar erro"
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr "Sair do MyPaint"
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr "Detalhes..."
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr "Exceção ao analisar a exceção."
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1858,45 +2306,50 @@ msgstr ""
 "            #### Traceback\n"
 "        "
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr "Finalização"
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr "Desenhe e depois suavize as linhas ajustando-as"
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr "Teste de dispositivo de entrada"
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr "(sem pressão)"
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr "Pressão:"
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr "(sem inclinação)"
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr "Inclinação:"
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr "(sem dispositivo)"
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
 msgstr "Dispositivo:"
 
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+#, fuzzy
+msgid "Barrel Rotation:"
+msgstr "Restaurar rotação"
+
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr "Mover camada"
 
@@ -1904,162 +2357,229 @@ msgstr "Mover camada"
 msgid "Move the current layer"
 msgstr "Mover a camada atual"
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
-msgstr "{default_name} em {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
+msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
-msgstr "Tipo"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
+msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+#, fuzzy
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr "Propriedades"
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr "Visível"
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Camada"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+#, fuzzy
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr "Bloqueado"
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+#, fuzzy
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ", "
+
+#: ../gui/layers.py:990
+#, fuzzy, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr "Adicionar {layer_default_name}"
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Camadas"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr "Organizar camadas e aplicar efeitos"
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr "Opacidade da camada: %d%%"
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr "Reordenar camada na pilha..."
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 "Mover camada na pilha (deixando-a numa camada retangular, criará um novo "
 "grupo)"
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr "Camada"
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
-msgstr "Modo:"
+#: ../gui/layervis.py:53
+#, fuzzy, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
+msgstr "<b>{brush_name}</b>"
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
-"Modo de mistura: como a camada atual se combina com as camadas abaixo dela."
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Opacidade:"
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "Rodar visualização"
 
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-"Opacidade da camada: que quantidade da camada atual usar. Valores mais "
-"baixos tornam a camada mais transparente."
-
-#: ../gui/linemode.py:37
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr "Pressão no início"
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr "Pressão no início do traço para as ferramentas de linha"
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr "Pressão no centro"
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr "Pressão no meio do traço para as ferramentas de linha"
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr "Pressão no fim"
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr "Pressão no fim do traço para as ferramentas de linha"
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr "Cabeça"
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 msgid "Stroke lead-in end"
 msgstr "Traçado indo para o final"
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr "Cauda"
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr "Traçado saindo do começo"
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr "Variação de pressão..."
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr "Linhas e curvas"
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr "Linha genérica / movo curva"
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr "Desenhar linhas retas; Shift adiciona curvas, Ctrl restringe o ângulo"
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr "Linhas conectadas"
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 "Desenha uma sequência de linhas; Shift adiciona curvas, Ctrl restringe o "
 "ângulo"
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr "Elipses e círculos"
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr "Desenha elipses; Shift roda, Ctrl restringe a proporção / ângulo"
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
+#, fuzzy
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 "Direitos de autor (C) 2005-2015\n"
 "Martin Renold e a equipa de desenvolvimento do MyPaint"
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -2078,256 +2598,286 @@ msgstr ""
 "Este programa é distribuído na esperança de que será útil, mas SEM NENHUMA "
 "GARANTIA. Veja o ficheiro COPYING para mais detalhes."
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr "programação"
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr "portabilidade"
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr "gestão de projetos"
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr "pincéis"
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr "texturas"
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr "ícones de ferramentas"
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr "ícone da área de trabalho"
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr "paletas"
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr "documentação"
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr "suporte"
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr "divulgar"
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr "comunidade"
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ", "
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr "Créditos da tradução"
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr "Tamanho:"
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr "Opacidade:"
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr "Duro:"
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr "Ganho:"
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr "Opções de ferramentas"
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr "Configurações específicas para a ferramenta de edição atual"
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr "<b>{mode_name}</b>"
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr "<i>Não há opções disponíveis</i>"
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr "Ampliação: %.01f%%"
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr "Escolha as configurações de pincelada, cor do traço e camada…"
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr "Recolher cor…"
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr "Preferências"
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr "Pré-visualização"
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr "Mostrar pré-visualização de toda a área de desenho"
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr "Mostrar área visível"
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr "Painel de rascunhos"
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr "Misturar cores e fazer esboços em páginas separadas para o rascunho"
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr "Item anterior"
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr "Próximo item"
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
 msgstr "(Nada a mostrar)"
 
-#: ../gui/symmetry.py:76
+#: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Place axis"
 msgstr "Posicionar eixo"
 
-#: ../gui/symmetry.py:80
+#: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Move axis"
 msgstr "Mover eixo"
 
-#: ../gui/symmetry.py:84
+#: ../gui/symmetry.py:88
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr "Remover eixo"
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr "Editar o eixo de simetria"
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr "Ajustar o eixo de simetria da pintura."
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
+#, fuzzy
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr "Posição:"
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr "Posição:"
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr "Nenhum"
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr "%d px"
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr "Alfa:"
 
-#: ../gui/symmetry.py:352
+#: ../gui/symmetry.py:376
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
+msgstr "Simetria"
+
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+#, fuzzy
 msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+msgid "X axis Position"
 msgstr "Posição do eixo"
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:477
+#, fuzzy
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr "Posição do eixo"
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr "Ativada"
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr "Manipulação de ficheiros"
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr "Mudança de rascunho"
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr "Desfazer e refazer"
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr "Modos de mistura"
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr "Modo de linha"
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr "Visualização (principal)"
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr "Visualização (alternativa / secundária)"
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr "Visualização (reiniciar)"
 
@@ -2335,188 +2885,214 @@ msgstr "Visualização (reiniciar)"
 msgid "<b>MyPaint</b>"
 msgstr "<b>MyPaint</b>"
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr "Mover visualização"
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr "Arrastar a visualização da tela"
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr "Ampliação da visualização"
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr "Ampliar a visualização da tela"
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr "Rodar visualização"
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr "Rodar a visualização da tela"
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, fuzzy, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr "%s: fechar separador"
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
-msgstr "%s: editar propriedades"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
+msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr "Comando desconhecido"
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr "Não definido (comando não foi iniciado)"
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr "{seconds:.01f}s de pintura com {brush_name}"
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr "Preenchimento"
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr "Cortar camada"
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "Alterar nome do grupo"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr "Limpar camada"
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr "Colar camada"
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr "Nova camada a partir do visível"
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr "Combinar camadas visíveis"
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr "Combinar abaixo"
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr "Normalizar modo da camada"
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Pincel importado"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr "Adicionar {layer_default_name}"
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr "Remover camada"
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr "Selecionar camada"
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr "Duplicar camada"
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr "Mover camada para cima"
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr "Mover camada para baixo"
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr "Reordenar camada na pilha"
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr "Alterar nome da camada"
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr "Tornar camada visível"
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr "Tornar camada invisível"
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr "Bloquear camada"
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr "Desbloquear camada"
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr "Opacidade da camada: %0.1f%%"
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr "Modo desconhecido"
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr "Modo da camada: %s"
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr "Ativar moldura"
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr "Desativar moldura"
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr "Atualizar moldura"
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr "Editar camada externamente"
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr "Erro ao carregar “{basename}”."
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr "Os registos podem conter mais detalhes sobre este erro."
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr "a partir de agora"
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr "atrás"
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2528,13 +3104,13 @@ msgstr ""
 "Está a executar mais do uma instância do MyPaint?\n"
 "Feche a aplicação e aguarde {cache_update_interval}s para tentar novamente."
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr "Cópia de segurança incompleta atualizada há {last_modified_time} {ago}"
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2544,11 +3120,11 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 "Cópia de segurança atualizada há {last_modified_time} {ago}\n"
-"Tamanho: {autosave.width}×{autosave.height} pixels, Camadas: "
-"{autosave.num_layers}\n"
+"Tamanho: {autosave.width}×{autosave.height} pixels, Camadas: {autosave."
+"num_layers}\n"
 "Contém  {unsaved_time} de pintura ainda não guardada."
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2558,13 +3134,13 @@ msgstr ""
 "Não foi possível guardar “{filename}”: {err}\n"
 "Tem espaço livre suficiente no dispositivo?"
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr "Não foi possível gravar \"{filename}\": {err}"
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2574,7 +3150,7 @@ msgstr ""
 "{error_loading_common}\n"
 "O ficheiro não existe."
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2584,7 +3160,7 @@ msgstr ""
 "{error_loading_common}\n"
 "Não tem as permissões necessárias para abrir o ficheiro."
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2600,7 +3176,7 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2610,7 +3186,13 @@ msgstr ""
 "{error_loading_common}\n"
 "Extensão de formato de ficheiro desconhecida: “{ext}”"
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+#, fuzzy
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr "Pincel importado"
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2624,7 +3206,7 @@ msgstr ""
 "Em vez disso, tente guardar no formato PNG se o seu computador não tiver "
 "muita memória RAM. A função de guardar como PNG do MyPaint é mais eficiente."
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2634,105 +3216,214 @@ msgid ""
 "\n"
 "{see_logs}"
 msgstr ""
-"Erro ao recuperar o documento a partir de uma cópia de segurança automática."
-"\n"
+"Erro ao recuperar o documento a partir de uma cópia de segurança "
+"automática.\n"
 "\n"
 "Razão: {reason}\n"
 "\n"
 "{see_logs}"
 
-#: ../lib/helpers.py:402
-#, python-brace-format
+#: ../lib/floodfill.py:131
+#, fuzzy
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr "Preencher"
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr "{days}d{hours}h"
 
-#: ../lib/helpers.py:404
-#, python-brace-format
+#: ../lib/helpers.py:537
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr "{hours}h{minutes}m"
 
-#: ../lib/helpers.py:406
-#, python-brace-format
+#: ../lib/helpers.py:539
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr "{minutes}m{seconds}s"
 
-#: ../lib/helpers.py:408
-#, python-brace-format
+#: ../lib/helpers.py:541
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr "{seconds}s"
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr "Camada"
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr "%(name)s %(number)d"
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr "^(.*?)\\s*(\\d+)$"
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
+#, fuzzy
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr "Camada vetorial"
+
+#: ../lib/layer/data.py:1158
+#, fuzzy
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr "Camada vetorial"
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
-msgstr "Camada bitmap desconhecida"
+msgid "Bitmap"
+msgstr ""
 
-#: ../lib/layer/data.py:1169
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1244
 msgctxt "layer default names"
-msgid "Unknown Data Layer"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
 msgstr "Camada de dados desconhecida"
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "Nova camada de pintura"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr "Grupo"
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "Novo grupo de camadas"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr "Marcador de posição"
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr "Raiz"
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ", "
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+#, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "Visualização"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+#, fuzzy
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr "Camada visível"
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+#, fuzzy
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr "Remover camada"
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr "Bloquear camada"
+
+#: ../lib/layervis.py:697
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr "Desbloquear camada"
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr "Através"
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr "O conteúdo do grupo é aplicado diretamente ao fundo do grupo"
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr "Normal"
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr "Apenas a camada de cima, sem misturar as cores."
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr "Multiplicar"
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
@@ -2740,11 +3431,11 @@ msgstr ""
 "Similar a colocar dois slides num único projetor e projetar o resultado "
 "combinado."
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr "Esconder"
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
@@ -2752,11 +3443,11 @@ msgstr ""
 "É como projetar dois projetores de slides diferentes numa tela "
 "simultaneamente. Isto é o inverso de 'Multiplicar'."
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr "Sobrepor"
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
@@ -2764,30 +3455,30 @@ msgstr ""
 "Sobrepõe a imagem de baixo com a camada de cima, preservando as regiões de "
 "altas luzes e sombras da imagem abaixo. É o inverso de 'Luz forte'."
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr "Escurecer"
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 "A camada de cima é usada apenas onde é mais escura do que a imagem de baixo."
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr "Clarear"
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 "A camada de cima é usada apenas onde ela é mais clara do que a imagem de "
 "baixo."
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr "Sub-expor"
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
@@ -2797,11 +3488,11 @@ msgstr ""
 "técnica fotográfica com o mesmo nome que é usada para melhorar o contraste "
 "em sombras."
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr "Sobre-expor"
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
@@ -2811,43 +3502,43 @@ msgstr ""
 "técnica fotográfica com o mesmo nome que é usada para reduzir o brilho de "
 "áreas muito claras."
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr "Luz forte"
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr "Similar a apontar uma luz forte de um foco na imagem de baixo."
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr "Luz suave"
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr "Similar a apontar uma luz difusa de um foco na imagem de baixo."
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr "Diferença"
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr "Subtrai a cor mais escura da cor mais clara das duas."
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr "Exclusão"
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr "Similar ao modo 'Diferença', mas com menos contraste."
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr "Matiz"
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
@@ -2855,11 +3546,11 @@ msgstr ""
 "Combina a matiz da camada de cima com a saturação e luminosidade da imagem "
 "de baixo."
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr "Saturação"
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
@@ -2867,7 +3558,7 @@ msgstr ""
 "Aplica a saturação das cores da camada de cima à matiz e luminosidade da "
 "imagem de baixo."
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
@@ -2875,11 +3566,11 @@ msgstr ""
 "Aplica a matiz e a saturação da camada de cima à luminosidade da imagem de "
 "baixo."
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr "Luminosidade"
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
@@ -2887,58 +3578,69 @@ msgstr ""
 "Aplica a luminosidade da camada de cima à matiz e a saturação da imagem de "
 "baixo."
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr "Mais"
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr "Esta camada e as camadas de baixo são simplesmente somadas."
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr "Destino interno"
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr "Usa o fundo apenas onde esta camada o cobre. Tudo o resto é ignorado."
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr "Destino externo"
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 "Usa o fundo apenas onde esta camada não o cobre. Tudo o resto é ignorado."
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr "Origem sobre"
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 "Origem sobre o destino, substituindo-o. O destino é movido para outro local."
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr "Destino sobre"
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 "Destino sobre a origem, substituindo-a. A origem é movida para outro local."
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, fuzzy, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr "%(name)s %(number)d"
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
@@ -2947,7 +3649,7 @@ msgstr ""
 "Não foi possível construir um objeto interno vital. Talvez o seu sistema não "
 "tenha a memória RAM suficiente para esta operação."
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2961,7 +3663,30 @@ msgstr ""
 "Causa: {err}\n"
 "Pasta de destino: “{dirname}”."
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+#, fuzzy
+msgid "Vertical"
+msgstr "Espelhar verticalmente"
+
+#: ../lib/tiledsurface.py:49
+#, fuzzy
+msgid "Horizontal"
+msgstr "Espelhar horizontalmente"
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+#, fuzzy
+msgid "Rotational"
+msgstr "Restaurar rotação"
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr "A leitura do PNG falhou: %s"
@@ -2970,57 +3695,95 @@ msgstr "A leitura do PNG falhou: %s"
 msgid "Recover interrupted work?"
 msgstr "Recuperar trabalho interrompido?"
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
-msgstr "_Recuperar e guardar..."
+msgid "_Look for backups at startup"
+msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr "Eliminar"
+
+#: ../po/tmp/autorecover.glade.h:9
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr "Eliminar este pincel do disco"
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr "_Recuperar e guardar..."
+
+#: ../po/tmp/autorecover.glade.h:12
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 "Guardar esta cópia de segurança no disco, depois continuar a trabalhar nela."
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
-msgstr "_Ignorar por enquanto"
+msgid "Decide _Later"
+msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 "Começar a trabalhar numa nova tela. Estas cópias de segurança serão mantidas."
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
+#, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 "O MyPaint bloqueou com trabalho por guardar, mas fez cópias de segurança. "
 "Pode recuperar um ficheiro agora ou deixar que o MyPaint reinicie novamente."
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr "Miniatura"
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr "Descrição"
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
-msgstr "Copiar para novo"
+msgid "Live update"
+msgstr "Atualização instantânea"
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
-msgstr "Copiar estas configurações e ícone do pincel atual para um novo pincel"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
+msgstr ""
+"Atualizar o último traço na tela com as configurações desta janela, em tempo "
+"real"
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
-msgstr "Alterar nome deste pincel"
+msgid "Save these settings to the brush"
+msgstr "Guardar estas configurações no pincel"
 
 #: ../po/tmp/brusheditor.glade.h:5
 msgid "Edit Icon"
@@ -3043,20 +3806,16 @@ msgid "Delete this brush from the disk"
 msgstr "Eliminar este pincel do disco"
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
-msgstr "Atualização instantânea"
+msgid "Copy to New"
+msgstr "Copiar para novo"
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
-msgstr ""
-"Atualizar o último traço na tela com as configurações desta janela, em tempo "
-"real"
+msgid "Copy these settings and the current brush's icon to a new brush"
+msgstr "Copiar estas configurações e ícone do pincel atual para um novo pincel"
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
-msgstr "Guardar estas configurações no pincel"
+msgid "Rename this brush"
+msgstr "Alterar nome deste pincel"
 
 #: ../po/tmp/brusheditor.glade.h:13
 msgid "Brush Setting"
@@ -3084,12 +3843,7 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr "Notas:"
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr "Nome da configuração:"
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
@@ -3097,19 +3851,16 @@ msgstr ""
 "age neste aqui."
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
-msgstr "Valor base:"
+#: ../po/tmp/brusheditor.glade.h:22
+#, fuzzy
+msgid "Value:"
+msgstr "Valor HSV"
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr "Reconfigura o valor base para o valor padrão"
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr "Reconfigura esta entrada para não ter efeito na configuração"
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
@@ -3117,11 +3868,7 @@ msgstr ""
 "Valor mínimo para o eixo de saída.\n"
 "Pode ser ajustado utilizando a barra de deslizar principal para {dname}."
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr "<ymin>"
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
@@ -3129,27 +3876,23 @@ msgstr ""
 "Valor máximo do eixo de resultado.\n"
 "Isto pode ser definido usando a barra de deslizar principal para {dname}."
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr "<ymax>"
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr "Resultado"
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr "Entrada"
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr "Ajusta o valor máximo"
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr "Ajusta o valor mínimo"
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
@@ -3157,11 +3900,7 @@ msgstr ""
 "Valor mínimo para o eixo de entrada.\n"
 "Use a escala que surge para ajustar isto."
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr "<xmin>"
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
@@ -3169,39 +3908,37 @@ msgstr ""
 "Valor máximo para o eixo de entrada.\n"
 "Use a escala que surge para ajustar isto."
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr "<xmax>"
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 "Variação do valor de base pela entrada por caneta digital e outros critérios"
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr "Dinâmica de pincel"
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr "Detalhes básicos para esta configuração"
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr "Editar configuração"
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr "Ajustar este mapeamento de entrada em detalhe"
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr "{tooltip}"
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
 msgstr "{dname}:"
+
+#: ../po/tmp/brusheditor.glade.h:42
+#, fuzzy
+msgid "Brush dynamics are not available for this setting."
+msgstr "Detalhes básicos para esta configuração"
+
+#: ../po/tmp/brusheditor.glade.h:43
+#, fuzzy
+msgid "<big><b>No Brush Dynamics</b></big>"
+msgstr "<big><b>{accel_label}</b></big>"
 
 #: ../po/tmp/inktool.glade.h:1
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
@@ -3213,7 +3950,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr "Pressão:"
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3258,6 +3995,141 @@ msgstr "Eliminar ponto"
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
 msgstr "Eliminar o ponto selecionado"
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+#, fuzzy
+msgid "Insert Point"
+msgstr "Inserir linha"
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+#, fuzzy
+msgid "Cull Points"
+msgstr "Eliminar ponto"
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Nome"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr "Modo"
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Opacidade"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr "O modo de composição da camada atual."
+
+#: ../po/tmp/layervis.glade.h:2
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr "Rodar a visualização da tela"
+
+#: ../po/tmp/layervis.glade.h:3
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr "Rodar a visualização da tela"
+
+#: ../po/tmp/layervis.glade.h:4
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr "Que camadas visíveis devem ser preenchidas"
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
+msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
 msgctxt "footer: color picker button: tooltip"
@@ -3617,8 +4489,8 @@ msgid ""
 "Draw a real checkerboard pattern to show transparency.\n"
 "This slows down the display, but can be less confusing."
 msgstr ""
-"Desenhar um padrão de tabuleiro de xadrez real para mostrar a transparência."
-"\n"
+"Desenhar um padrão de tabuleiro de xadrez real para mostrar a "
+"transparência.\n"
 "Isto atrasa a visualização, mas pode ser menos confuso."
 
 #: ../po/tmp/preferenceswindow.glade.h:73
@@ -3667,13 +4539,34 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr "Ocultar cursor ao pintar"
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+#, fuzzy
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr "Ativado"
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr "Visualização"
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
@@ -3682,18 +4575,18 @@ msgstr ""
 "O conjunto de cores a mostrar como primárias no estilo de rodas de cor.\n"
 "As diferentes tradições têm diferentes harmonias de cores."
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr "As primárias são:"
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr "Digital padrão vermelho / verde / azul"
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
@@ -3701,7 +4594,7 @@ msgstr ""
 "O vermelho, verde e azul primários do monitor, dispostos de forma uniforme "
 "ao redor do círculo. O verde é o oposto ao magenta."
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
@@ -3710,12 +4603,12 @@ msgstr ""
 "O vermelho, verde e azul primários do monitor, dispostos de forma uniforme "
 "ao redor do círculo. O verde é o oposto ao magenta."
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr "Vermelho/Amarelo/Azul tradicionais de artistas"
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
@@ -3726,7 +4619,7 @@ msgstr ""
 "de visualização de forma uniforme à volta do círculo. O verde é o oposto ao "
 "vermelho."
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3738,12 +4631,12 @@ msgstr ""
 "de visualização de forma uniforme à volta do círculo. O verde é o oposto ao "
 "vermelho."
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr "Pares opositores Vermelho-Verde e Azul-Amarelo"
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3757,7 +4650,7 @@ msgstr ""
 "oposto ao azul. O CIECAM02 e o NCS apresentam um modelo similar. Aqui usamos "
 "o vermelho de ecrã puro, amarelo, etc. como as quatro primárias."
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3773,28 +4666,28 @@ msgstr ""
 "o vermelho de ecrã puro, amarelo, etc. como as quatro primárias."
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr "<b>Roda de cores</b>"
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr "Cor"
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr "Ecrã (normal)"
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr "Desativado (sem sensibilidade à pressão)"
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr "Janela (não recomendado)"
@@ -3855,252 +4748,309 @@ msgid "Reload the file your current work was loaded from."
 msgstr "Recarregar o ficheiro do trabalho atual de onde foi carregado."
 
 #: ../po/tmp/resources.xml.h:12
+#, fuzzy
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Import Layers…"
+msgstr "Importar pincéis…"
+
+#: ../po/tmp/resources.xml.h:13
+msgctxt "Accel Editor (descriptions)"
+msgid "Import layers from one or more files."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save"
 msgstr "Guardar"
 
-#: ../po/tmp/resources.xml.h:13
+#: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file."
 msgstr "Guardar o seu trabalho num ficheiro."
 
-#: ../po/tmp/resources.xml.h:14
+#: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As…"
 msgstr "Guardar como…"
 
-#: ../po/tmp/resources.xml.h:15
+#: ../po/tmp/resources.xml.h:17
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file, assigning it a new name."
 msgstr "Guardar o seu trabalho num ficheiro com um novo nome."
 
-#: ../po/tmp/resources.xml.h:16
+#: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Export…"
 msgstr "Exportar…"
 
-#: ../po/tmp/resources.xml.h:17
+#: ../po/tmp/resources.xml.h:19
 msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 "Exportar o seu trabalho para um ficheiro, mas manter-se a trabalhar no mesmo "
 "ficheiro."
 
-#: ../po/tmp/resources.xml.h:18
+#: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As Scrap"
 msgstr "Guardar como rascunho"
 
-#: ../po/tmp/resources.xml.h:19
+#: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
 msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 "Guardar num novo ficheiro de rascunho ou guardar uma nova revisão já num "
 "rascunho."
 
-#: ../po/tmp/resources.xml.h:20
+#: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Previous Scrap"
 msgstr "Abrir rascunho anterior"
 
-#: ../po/tmp/resources.xml.h:21
+#: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file before the current one."
 msgstr "Carregar o ficheiro de rascunho antes do atual."
 
-#: ../po/tmp/resources.xml.h:22
+#: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Next Scrap"
 msgstr "Abrir próximo rascunho"
 
-#: ../po/tmp/resources.xml.h:23
+#: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file after the current one."
 msgstr "Carregar o ficheiro de rascunho após o atual."
 
-#: ../po/tmp/resources.xml.h:24
+#: ../po/tmp/resources.xml.h:26
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Recover File from an Automated Backup…"
 msgstr "Recuperar ficheiro de uma cópia de segurança automática…"
 
-#: ../po/tmp/resources.xml.h:25
+#: ../po/tmp/resources.xml.h:27
 msgctxt "Accel Editor (descriptions)"
 msgid "Try to save and resume interrupted unsaved work."
 msgstr "Tentar guardar e continuar o trabalho por guardar interrompido."
 
-#: ../po/tmp/resources.xml.h:26
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr "Grupos de pincéis"
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr "Pincéis"
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr "Lista de grupos de pincéis."
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr "Ajustes da cor"
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr "Cores"
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr "Ajustes de cor disponíveis."
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr "Modo"
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr "Modo"
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr "O modo de composição da camada atual."
 
-#: ../po/tmp/resources.xml.h:35
+#: ../po/tmp/resources.xml.h:37
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Pressure"
+msgstr "Pressão no início"
+
+#: ../po/tmp/resources.xml.h:38
+msgctxt "Accel Editor (descriptions)"
+msgid "Send harder pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:39
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Pressure"
+msgstr "Pressão no início"
+
+#: ../po/tmp/resources.xml.h:40
+msgctxt "Accel Editor (descriptions)"
+msgid "Send softer pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:41
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Rotation"
+msgstr "Aumentar saturação"
+
+#: ../po/tmp/resources.xml.h:42
+msgctxt "Accel Editor (descriptions)"
+msgid "Increase barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:43
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
+msgstr "Diminuir saturação"
+
+#: ../po/tmp/resources.xml.h:44
+msgctxt "Accel Editor (descriptions)"
+msgid "Decrease barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:45
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Size"
 msgstr "Aumentar tamanho do pincel"
 
-#: ../po/tmp/resources.xml.h:36
+#: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush bigger."
 msgstr "Torna maior o pincel atual."
 
-#: ../po/tmp/resources.xml.h:37
+#: ../po/tmp/resources.xml.h:47
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Size"
 msgstr "Diminuir tamanho do pincel"
 
-#: ../po/tmp/resources.xml.h:38
+#: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush smaller."
 msgstr "Torna menor o pincel atual."
 
-#: ../po/tmp/resources.xml.h:39
+#: ../po/tmp/resources.xml.h:49
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Opacity"
 msgstr "Aumentar opacidade do pincel"
 
-#: ../po/tmp/resources.xml.h:40
+#: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush more opaque."
 msgstr "Tornar o pincel atual mais opaco."
 
-#: ../po/tmp/resources.xml.h:41
+#: ../po/tmp/resources.xml.h:51
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Opacity"
 msgstr "Diminuir a opacidade do pincel"
 
-#: ../po/tmp/resources.xml.h:42
+#: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush less opaque."
 msgstr "Tornar o pincel atual menos opaco."
 
-#: ../po/tmp/resources.xml.h:43
+#: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Lighten Painting Color"
 msgstr "Clarear a cor de pintura"
 
-#: ../po/tmp/resources.xml.h:44
+#: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase the lightness of the current painting color."
 msgstr "Aumenta a luminosidade da cor de pintura selecionada."
 
-#: ../po/tmp/resources.xml.h:45
+#: ../po/tmp/resources.xml.h:55
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Darken Painting Color"
 msgstr "Escurecer a cor de pintura"
 
-#: ../po/tmp/resources.xml.h:46
+#: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease the lightness of the current painting color."
 msgstr "Diminui a luminosidade da cor de pintura selecionada."
 
-#: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
-msgstr "Mudar matiz (sentido anti-horário)"
-
-#: ../po/tmp/resources.xml.h:48
-msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
-msgstr "Rodar a matiz da cor no sentido anti-horário na roda de cores."
-
-#: ../po/tmp/resources.xml.h:49
+#: ../po/tmp/resources.xml.h:57
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Change Hue Clockwise"
 msgstr "Mudar a matiz da cor (sentido horário)"
 
-#: ../po/tmp/resources.xml.h:50
+#: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
 msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr "Rodar a matiz da cor no sentido horário na roda de cores."
 
-#: ../po/tmp/resources.xml.h:51
+#: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr "Mudar matiz (sentido anti-horário)"
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr "Rodar a matiz da cor no sentido anti-horário na roda de cores."
+
+#: ../po/tmp/resources.xml.h:61
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Increase Saturation"
 msgstr "Aumentar saturação"
 
-#: ../po/tmp/resources.xml.h:52
+#: ../po/tmp/resources.xml.h:62
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color more saturated (more colorful, purer)."
 msgstr "Torna a cor de pintura mais saturada (mais colorida, mais pura)."
 
-#: ../po/tmp/resources.xml.h:53
+#: ../po/tmp/resources.xml.h:63
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Decrease Saturation"
 msgstr "Diminuir saturação"
 
-#: ../po/tmp/resources.xml.h:54
+#: ../po/tmp/resources.xml.h:64
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color less saturated (grayer)."
 msgstr "Torna a cor de pintura menos saturada (cinzenta)."
 
-#: ../po/tmp/resources.xml.h:55
+#: ../po/tmp/resources.xml.h:65
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Reload Brush Settings"
 msgstr "Recarregar configurações de pincel"
 
-#: ../po/tmp/resources.xml.h:56
+#: ../po/tmp/resources.xml.h:66
 msgctxt "Accel Editor (descriptions)"
 msgid "Restore all brush settings to the current brush’s saved values."
 msgstr ""
 "Restaura todos os parâmetros do pincel para os valores guardados do pincel "
 "atual."
 
-#: ../po/tmp/resources.xml.h:57
+#: ../po/tmp/resources.xml.h:67
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Pick Stroke and Layer"
 msgstr "Pegar traço e camada"
 
-#: ../po/tmp/resources.xml.h:58
+#: ../po/tmp/resources.xml.h:68
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
 msgstr ""
 "Selecione uma pincelada na tela de pintura: restaura o pincel, cor e camada."
 
-#: ../po/tmp/resources.xml.h:59
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr "Atalho para restaurar cor do pincel"
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
@@ -4109,217 +5059,269 @@ msgstr ""
 "Ativa / desativa se ao restaurar um pincel com uma tecla atalho também "
 "restaura a cor guardada."
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr "Guardar pincel para a tecla de atalho mais recente"
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
-msgstr "Guardar as configurações de pincel para a tecla de atalho mais recente."
+msgstr ""
+"Guardar as configurações de pincel para a tecla de atalho mais recente."
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "Limpar camada"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr "Limpa o conteúdo da camada ativa."
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Trim Layer to Frame"
-msgstr "Cortar camada pelos limites da moldura"
+#: ../po/tmp/resources.xml.h:75
+#, fuzzy
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr "Opções de ferramentas"
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:76
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Trim Layer to Frame"
+msgstr "Cortar camada para moldura"
+
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr "Elimina partes da camada ativa que estejam fora da moldura."
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr "Elimina partes da camada ativa que estejam fora da moldura."
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "Novo grupo de camadas abaixo"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "Novo grupo de camadas abaixo"
+
+#: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr "Copiar camada para a área de transferência"
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr "Copia o conteúdo da camada ativa para a área de transferência."
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr "Colar camada da área de transferência"
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr "Substitui a camada ativa pelo conteúdo na área de transferência."
 
-#: ../po/tmp/resources.xml.h:71
+#: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Edit Layer in External App…"
 msgstr "Editar camada numa aplicação externa…"
 
-#: ../po/tmp/resources.xml.h:72
+#: ../po/tmp/resources.xml.h:90
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
+msgid "Edit the active layer in an external application."
 msgstr "Inicia a edição da camada ativa numa aplicação externa."
 
-#: ../po/tmp/resources.xml.h:73
+#: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Update Layer with External Edits"
 msgstr "Atualizar camada com edições externas"
 
-#: ../po/tmp/resources.xml.h:74
+#: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
 msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 "Aplicar alterações guardadas numa aplicação externa (normalmente automático)."
 
-#: ../po/tmp/resources.xml.h:75
+#: ../po/tmp/resources.xml.h:93
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer at Cursor"
 msgstr "Ir para a camada no cursor"
 
-#: ../po/tmp/resources.xml.h:76
+#: ../po/tmp/resources.xml.h:94
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr "Selecionar uma camada clicando numa pincelada nela."
 
-#: ../po/tmp/resources.xml.h:77
+#: ../po/tmp/resources.xml.h:95
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Above"
 msgstr "Ir para camada superior"
 
-#: ../po/tmp/resources.xml.h:78
+#: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer up in the layer stack."
 msgstr "Ir para uma camada acima na pilha de camadas."
 
-#: ../po/tmp/resources.xml.h:79
+#: ../po/tmp/resources.xml.h:97
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Below"
 msgstr "Ir para camada inferior"
 
-#: ../po/tmp/resources.xml.h:80
+#: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer down in the layer stack."
 msgstr "Ir para uma camada abaixo na pilha de camadas."
 
-#: ../po/tmp/resources.xml.h:81
+#: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer"
 msgstr "Nova camada de pintura"
 
-#: ../po/tmp/resources.xml.h:82
+#: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer above the current layer."
 msgstr "Adicionar uma nova camada acima da camada atual."
 
-#: ../po/tmp/resources.xml.h:83
+#: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer…"
 msgstr "Nova camada vetorial…"
 
-#: ../po/tmp/resources.xml.h:84
+#: ../po/tmp/resources.xml.h:102
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer above the current layer, and begin editing it."
 msgstr ""
 "Adicionar uma nova camada vetorial acima da camada atual e começar a editar "
 "nela."
 
-#: ../po/tmp/resources.xml.h:85
+#: ../po/tmp/resources.xml.h:103
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group"
 msgstr "Novo grupo de camadas"
 
-#: ../po/tmp/resources.xml.h:86
+#: ../po/tmp/resources.xml.h:104
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group above the current layer."
 msgstr "Adicionar um novo grupo de camadas acima da camada atual."
 
-#: ../po/tmp/resources.xml.h:87
+#: ../po/tmp/resources.xml.h:105
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer Below"
 msgstr "Nova camada de pintura abaixo"
 
-#: ../po/tmp/resources.xml.h:88
+#: ../po/tmp/resources.xml.h:106
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer below the current layer."
 msgstr "Adicionar uma nova camada de pintura abaixo da camada atual."
 
-#: ../po/tmp/resources.xml.h:89
+#: ../po/tmp/resources.xml.h:107
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer Below…"
 msgstr "Nova camada de pintura abaixo…"
 
-#: ../po/tmp/resources.xml.h:90
+#: ../po/tmp/resources.xml.h:108
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer below the current layer, and begin editing it."
 msgstr ""
 "Adicionar uma nova camada vetorial abaixo da camada atual e começar a editar "
 "nela."
 
-#: ../po/tmp/resources.xml.h:91
+#: ../po/tmp/resources.xml.h:109
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group Below"
 msgstr "Novo grupo de camadas abaixo"
 
-#: ../po/tmp/resources.xml.h:92
+#: ../po/tmp/resources.xml.h:110
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group below the current layer."
 msgstr "Adicionar um novo grupo de camadas abaixo da camada atual."
 
-#: ../po/tmp/resources.xml.h:93
+#: ../po/tmp/resources.xml.h:111
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Layer Down"
 msgstr "Combinar camadas abaixo"
 
-#: ../po/tmp/resources.xml.h:94
+#: ../po/tmp/resources.xml.h:112
 msgctxt "Accel Editor (descriptions)"
 msgid "Merge the current layer with the layer beneath it."
 msgstr "Juntar a camada atual com as camadas abaixo dela."
 
-#: ../po/tmp/resources.xml.h:95
+#: ../po/tmp/resources.xml.h:113
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Visible Layers"
 msgstr "Combinar camadas visíveis"
 
-#: ../po/tmp/resources.xml.h:96
+#: ../po/tmp/resources.xml.h:114
 msgctxt "Accel Editor (descriptions)"
 msgid "Consolidate all visible layers, and delete the originals."
 msgstr "Juntar todas as camadas visíveis e eliminar todas as originais."
 
-#: ../po/tmp/resources.xml.h:97
+#: ../po/tmp/resources.xml.h:115
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer from Visible"
 msgstr "Nova camada da camada visível"
 
-#: ../po/tmp/resources.xml.h:98
+#: ../po/tmp/resources.xml.h:116
 msgctxt "Accel Editor (descriptions)"
 msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
 msgstr "Tal como ‘Combinar camadas visíveis’, mas não elimina as originais."
 
-#: ../po/tmp/resources.xml.h:99
+#: ../po/tmp/resources.xml.h:117
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Delete Layer"
 msgstr "Eliminar camada"
 
-#: ../po/tmp/resources.xml.h:100
+#: ../po/tmp/resources.xml.h:118
 msgctxt "Accel Editor (descriptions)"
 msgid "Remove the current layer from the layer stack."
 msgstr "Remover a camada atual da pilha de camadas."
 
-#: ../po/tmp/resources.xml.h:101
+#: ../po/tmp/resources.xml.h:119
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Convert to Normal Painting Layer"
 msgstr "Converter em camada de pintura normal"
 
-#: ../po/tmp/resources.xml.h:102
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
@@ -4328,565 +5330,657 @@ msgstr ""
 "Converter a camada atual ou grupo de camadas numa camada de pintura no modo "
 "‘Normal’, preservando a sua aparência."
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr "Aumentar opacidade da camada"
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr "Tornar a camada menos transparente."
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr "Diminuir opacidade da camada"
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr "Tornar a camada mais transparente."
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr "Subir camada"
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr "Subir a camada atual um nível na pilha de camadas."
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr "Descer camada"
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr "Descer a camada atual um nível na pilha de camadas."
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr "Duplicar camada"
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr "Fazer uma cópia exata da camada atual."
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
+#, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
-msgstr "Alterar nome da camada…"
+msgid "Layer Properties…"
+msgstr "Propriedades"
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
-msgstr "Escreva um novo nome para a camada atual."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr "Camada bloqueada"
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr "A camada atual está bloqueada: não se pode alterar camadas bloqueadas."
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr "Camada visível"
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr "Ocultar ou mostrar a camada atual."
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr "Mostrar fundo"
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr "Ocultar ou mostrar o fundo da camada."
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr "Remover a camada atual da pilha de camadas."
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr "Restaurar e centralizar vista"
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 "Restaurar ampliação, rotação e espelhamento e centralizar o documento "
 "novamente."
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr "Ajustar à visualização"
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 "Mudar entre uma visualização ajustada, o seu local de trabalho e a ampliação."
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr "Restaurar"
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr "Restaurar ampliação"
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr "Restaura a ampliação da visualização no valor original."
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr "Restaurar rotação"
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr "Restaura a rotação da visualização para o valor 0°"
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr "Restaurar espelhamento"
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
-msgstr "Desativa o espelhamento da visualização."
+msgid "Reset the view's mirroring."
+msgstr "Restaurar espelhamento"
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr "Ampliar"
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr "Aumentar a ampliação."
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Reduzir"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr "Diminuir a ampliação."
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
+#, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
-msgstr "Rodar no sentido anti-horário"
+msgid "Pan Left"
+msgstr "Deslocar visualização"
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
-msgstr "Rodar a visualização no sentido anti-horário."
+msgid "Move your view of the canvas to the left."
+msgstr "Rodar visualização: inclina a visualização da tela."
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr "Luz forte"
+
+#: ../po/tmp/resources.xml.h:159
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+"Deslocamento da visualização: mova a visualização da tela horizontalmente ou "
+"verticalmente."
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr "Rodar visualização: inclina a visualização da tela."
+
+#: ../po/tmp/resources.xml.h:162
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr "Deslocar visualização"
+
+#: ../po/tmp/resources.xml.h:163
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr "Rodar visualização: inclina a visualização da tela."
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr "Rodar no sentido horário"
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr "Rodar a visualização no sentido horário."
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr "Rodar no sentido anti-horário"
+
+#: ../po/tmp/resources.xml.h:167
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr "Rodar a visualização no sentido anti-horário."
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr "Espelhar horizontalmente"
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr "Espelhar a visualização do lado esquerdo no lado direito."
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr "Espelhar verticalmente"
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr "Espelhar a visualização do lado de cima no lado de baixo."
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr "Apenas a camada atual"
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr "Ativa ou desativa a visualização de apenas a camada atual."
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr "Pintura simétrica ativa"
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr "Espelha as pinceladas ao longo do eixo de simetria"
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr "Moldura ativada"
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr "Oculta / mostra a moldura do documento."
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr "Imprimir valores de entrada do pincel na linha de comandos"
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 "Mostrar as entradas na linha de comandos.do pincel geradas internamente pelo "
 "motor."
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr "Visualizar renderização"
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr "Mostrar atualizações de renderização na tela, para depuração de erros."
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr "Desativar buffering duplo do GTK"
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr "Desativar buffering duplo do GTK, normalmente ativado."
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+#, fuzzy
+msgid "Delete Point"
+msgstr "Eliminar ponto"
+
+#: ../po/tmp/resources.xml.h:187
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr "Eliminar o ponto selecionado"
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr "Modo de pintura"
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr "Modo de pintura: normal"
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr "Aplicar cor normalmente ao pintar."
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr "Modo de pintura: borracha"
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr "Remover traços usando o pincel atual."
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr "Modo de pintura: bloquear alfa"
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr "Aplicar o pincel não altera a opacidade da camada."
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr "Modo de pintura: colorear"
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr "Aplicar cor na camada atual sem afetar o brilhou ou opacidade."
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Ficheiro"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "Sair"
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr "Fechar a janela principal e sair da aplicação."
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "Editar"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr "Ferramenta atual"
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "Cor"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr "Ajustar cor"
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr "Histórico de cores"
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr "Mostrar uma linha de tempo das cores recentes por baixo do cursor."
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr "Detalhes da cor"
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr "Mostra um diálogo com detalhes da cor com entrada de texto."
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr "Próxima cor da paleta"
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr "Define a cor como a próxima cor na paleta."
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr "Cor anterior da paleta"
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr "Define a cor como a cor anterior na paleta."
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr "Adicionar cor à paleta"
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr "Adiciona a cor de pintura atual à paleta."
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "Camada"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr "Opacidade"
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr "Ir para camada"
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr "Nova camada por baixo"
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr "Propriedades"
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr "Painel de rascunho"
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr "Novo painel de rascunhos"
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 "Carregar o painel de rascunhos padrão como uma nova tela de painel de "
 "rascunhos."
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr "Abrir painel de rascunhos…"
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr "Carregar um ficheiro de imagem do disco para o painel rascunhos."
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr "Guardar painel de rascunhos"
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr "Guarda o painel rascunhos para um ficheiro."
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr "Exportar painel de rascunhos como…"
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
-msgstr "Exportar o painel de rascunhos para o disco, com um nome à sua escolha."
+msgstr ""
+"Exportar o painel de rascunhos para o disco, com um nome à sua escolha."
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr "Reverter painel de rascunhos"
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr "Reverter o painel de rascunhos para o último estado guardado."
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr "Guardar painel de rascunhos como padrão"
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 "Guardar o painel de rascunhos como padrão a usar em ‘Novo painel de "
 "rascunhos’."
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr "Limpar painel de rascunhos padrão"
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr "Limpa o painel de rascunhos padrão tornando-o vazio."
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr "Copiar fundo para painel de rascunhos"
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 "Copiar a imagem de fundo do documento de trabalho para o painel de rascunhos."
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "Janela"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "Pincel"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr "Teclas de atalhos"
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr "Ajuda das teclas de atalhos de pincéis"
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr "Mostra uma explicação de como as teclas de atalho funcionam."
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "Mudar pincel…"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr "Mostra um alterador do pincel por baixo do cursor."
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "Mudar cor…"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
@@ -4894,12 +5988,12 @@ msgstr ""
 "Mostra um alterador da cor por baixo do cursor, com todos os seletores de "
 "cor listados."
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "Mudar cor (paleta simples)…"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
@@ -4908,213 +6002,216 @@ msgstr ""
 "Mostra um alterador da cor por baixo do cursor, com apenas os seletores de "
 "cor listados de um só clique."
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr "Obter mais pincéis…"
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr "Descarregar pacotes de pincéis na wiki do MyPaint."
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr "Importar pincéis…"
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr "Carregar um pacote de pincéis do disco."
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Ajuda"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr "Ajuda na Internet"
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr "Ir para a wiki de documentação do MyPaint."
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "Sobre o MyPaint"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr "Mostrar a licença do MyPaint, número da versão e os créditos."
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Depurar"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 "Imprimir informação de fuga de memória para a linha de comandos (lento!)"
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr "Depuração de fugas de memória."
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr "Executar o coletor de lixo agora"
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 "Libertar memória usada para os objetos Python que já não estejam a ser "
 "usados."
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr "Iniciar / parar perfilador…"
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr "Iniciar / parar o perfilador do Python (cProfile)"
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr "Simular um erro…"
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr "Provocar uma exceção do Python, para testar a janela de bloqueio."
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "Visualização"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr "Comentários"
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr "Ajustar visualização"
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
+#, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr "Menu destacável"
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr "Mostrar o menu principal como um menu destacável."
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "Ecrã total"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr "Alterar entre os modos ecrã inteiro e em janela."
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "Preferências"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr "Editar as configurações globais do MyPaint."
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr "Testar dispositivos de entrada"
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 "Mostrar uma janela que captura todos os eventos que os seus dispositivos "
 "enviam."
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr "Seletor de fundo"
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr "Alterar a textura do do papel de fundo."
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr "Editor de configurações do pincel"
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr "Editar as configurações do pincel ativo."
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr "Editor de ícone de pincel"
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr "Editar ícones de pincéis."
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr "Painel de camadas"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
-"Oculta/mostra o painel das camadas (organizar as camadas ou atribuir modos)."
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr "Mostrar painel de camadas"
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr "Revela o painel das camadas (organizar as camadas ou atribuir modos)."
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr "Roda HCY"
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
@@ -5123,42 +6220,32 @@ msgstr ""
 "Seletor de cores cilíndrico aclopável de matiz / pureza / luminosidade. As "
 "fatias circulares são da mesma luminosidade."
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "Paleta de cores"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr "Seletor de paleta de cor acplopável."
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr "Roda HSV"
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr "Seletor de cores por saturação e valor aclopável."
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr "Triângulo HSV"
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr "Seletor de cor aclopável: o antigo triângulo de cores GTK."
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr "Cubo HSV"
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
@@ -5167,487 +6254,481 @@ msgstr ""
 "Um cubo HSV aclopável que pode ser rodado para mostrar diferentes fatias "
 "planares."
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr "Quadrado HSV"
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
-msgstr ""
-"Um cubo HSV aclopável que pode ser rodado para mostrar diferentes matizes."
+msgid "Dockable color selector: HSV square with Hue ring."
+msgstr "Seletor de cores alocável com anéis HSV concêntricos."
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr "Controles deslizantes de componentes"
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr "Seletor de cor aclopável mostrando componentes de cores individuais."
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr "Paleta líquida"
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 "Seletor de cor aclopável mostrando uma paleta líquida de cores vizinhas."
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr "Anéis concêntricos"
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr "Seletor de cores alocável com anéis HSV concêntricos."
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr "Taça cruzada"
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 "Seletor de cor alocável com rampas HSV que cruzam uma taça de cores radial."
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr "Painel de rascunhos"
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
-msgstr "Oculta/mostra o painel de rascunhos (misturar cores e fazer esboços)."
+msgid "Dockable Panel for mixing colors and testing brushes."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr "Mostrar painel de rascunho"
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr "Revela o painel de rascunhos (misturar cores e fazer rascunhos)."
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr "Painel de previsão"
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
-"Oculta/mostra o painel de pré-visualização (vista geral de toda a área de "
-"desenho)."
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "Prever"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 "Revela o painel de pré-visualização (vista geral de toda a área de desenho)."
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr "Painel de opções da ferramenta"
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
-"Oculta/mostra o painel de opções de ferramenta (opções para a ferramenta "
-"atual)."
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr "Mostrar o painel de opções da ferramenta"
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 "Revela o painel de opções de ferramenta (opções para a ferramenta atual)."
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr "Painel de histórico de cores e pincéis"
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
-"Oculta/mostra o painel de histórico (pincéis e cores usadas recentemente)."
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr "Cores e pincéis recentes"
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr "Revela o painel de histórico (pincéis e cores usadas recentemente)."
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr "Ocultar controlos em ecrã inteiro"
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr "Ativa/desativa a ocultação automática da interface em ecrã inteiro."
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr "Mostrar nível de ampliação"
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr "Ocultar/mostrar informação do nível de ampliação."
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr "Mostrar última posição pintada"
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr "Ativar/desativar visualização onde a última pincelada terminou."
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr "Filtro de visualização"
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr "Mostrar as cores normalmente"
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr "Filtrar cores: mostrar cores inalteradas."
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr "Mostrar cores em escala de cinzas"
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr "Filtrar cores: mostrar apenas claridade (luminância HCY/YCbCr)"
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr "Mostrar cores invertidas"
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr "Filtrar cores: inverter vídeo. O preto é branco e o vermelho é ciano."
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr "Mostrar cores com simulação de insensibilidade ao vermelho"
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 "Filtrar cores para simular a deuteranopia, uma forma comum de daltonismo."
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr "Mostrar cores com simulação de insensibilidade ao verde"
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
-msgstr "Filtrar cores para simular a protanopia, uma forma comum de daltonismo."
+msgstr ""
+"Filtrar cores para simular a protanopia, uma forma comum de daltonismo."
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr "Mostrar cores com simulação de insensibilidade ao azul"
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr "Filtrar cores para simular a tritanopia, uma forma rara de daltonismo."
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr "Mão livre"
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr "Mão livre"
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 "Desenho à mão livre: desenhar e pintar livremente, sem restrições de "
 "geometria."
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr "Mão livre"
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr "Desenhar e pintar livremente, sem restrições de geometria."
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr "Deslocar visualização"
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr "Deslocar"
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 "Deslocamento da visualização: mova a visualização da tela horizontalmente ou "
 "verticalmente."
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr "Deslocar visualização"
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 "Mova a visualização da tela horizontalmente ou verticalmente de forma "
 "interativa."
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr "Rodar visualização"
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr "Rodar"
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr "Rodar visualização: inclina a visualização da tela."
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr "Rodar visualização"
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr "Roda a visualização da tela de forma interativa."
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr "Ampliar visualização"
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr "Ampliação"
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr "Ampliação da visualização: aproximar e afastar a visualização da tela."
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr "Ampliar visualização"
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr "Aproximar e afastar a visualização da tela de forma interativa."
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr "Linhas e curvas"
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr "Linhas"
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr "Linhas e curvas: desenhar linhas retas ou curvas."
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr "Linhas e curvas"
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr "Desenhar linhas retas ou curvas."
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr "Linhas conectadas"
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr "Linhas conectadas"
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr "Linhas conectadas: desenhar sequências de linhas retas ou curvas."
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr "Linhas conectadas"
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr "Desenhar sequências de linhas retas ou curvas."
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr "Elipses e círculos"
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr "Elipse"
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr "Elipses e círculos: desenhar formas arredondadas."
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr "Elipses e círculos"
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr "Desenhar círculos e elipses."
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr "Arte-finalizar"
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr "Tinta"
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr "Arte-finalizar: desenhar linhas com suavização controlada."
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr "Arte-finalizar"
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr "Desenhar linhas com suavização controlada."
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr "Reposicionar camada"
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr "Pos. camadas"
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr "Mover camada: mover a camada atual na tela."
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr "Reposicionar camada"
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr "Mover a camada atual na tela de forma interativa."
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr "Editar moldura"
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr "Moldura"
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
@@ -5655,12 +6736,12 @@ msgstr ""
 "Editar moldura: definir uma moldura à volta do documento para lhe dar um "
 "tamanho finito."
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr "Editar moldura"
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
@@ -5668,79 +6749,291 @@ msgstr ""
 "Definir uma moldura à volta do documento para lhe dar um tamanho finito de "
 "forma interativa."
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Editar simetria da pintura"
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr "Simetria"
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 "Editar simetria da pintura: ajustar o eixo utilizado para a pintura "
 "simétrica."
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Editar simetria de pintura"
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr "Ajustar o eixo utilizado para a pintura simétrica de forma interativa."
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr "Recolher cor"
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr "Pegar cor"
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr "Recolher cor: definir a cor de pintura a partir dos píxeis no ecrã."
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "Recolher cor"
+
+#: ../po/tmp/resources.xml.h:401
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr "Definir a cor de pintura a partir dos píxeis no ecrã."
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "Recolher cor"
+
+#: ../po/tmp/resources.xml.h:403
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr "Definir a cor de pintura a partir dos píxeis no ecrã."
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "Recolher cor"
+
+#: ../po/tmp/resources.xml.h:405
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr "Definir a cor de pintura a partir dos píxeis no ecrã."
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr "Recolher cor"
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr "Definir a cor de pintura a partir dos píxeis no ecrã."
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr "Preenchimento"
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr "Preencher"
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr "Preenchimento: preencher uma área com uma cor."
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr "Preenchimento"
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr "Preencher uma área com uma cor."
+
+#~ msgctxt "Accelerator map editor: action column markup"
+#~ msgid ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+#~ msgstr ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+
+#~ msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
+#~ msgid "{action_label} {action_desc} {accel_label}"
+#~ msgstr "{action_label} {action_desc} {accel_label}"
+
+#~ msgctxt "brush list context menu"
+#~ msgid "Delete"
+#~ msgstr "Eliminar"
+
+#~ msgctxt "brush list commands"
+#~ msgid "Really delete brush from disk?"
+#~ msgstr "Quer mesmo eliminar o pincel?"
+
+#~ msgid "HSV Triangle"
+#~ msgstr "Triângulo HSV"
+
+#~ msgid "The standard GTK color selector"
+#~ msgstr "Seletor de cores padrão do GTK"
+
+#~ msgid "Pick a color from the screen"
+#~ msgstr "Recolher uma cor da tela"
+
+#~ msgid "Layer Name"
+#~ msgstr "Nome da camada"
+
+#~ msgid ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+#~ msgstr ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+
+#~ msgid "Save..."
+#~ msgstr "Guardar..."
+
+#~ msgid "Confirm"
+#~ msgstr "Confirmar"
+
+#~ msgid "Open..."
+#~ msgstr "Abrir..."
+
+#~ msgid "{default_name} at {path}"
+#~ msgstr "{default_name} em {path}"
+
+#~ msgid "Type"
+#~ msgstr "Tipo"
+
+#~ msgid "Mode:"
+#~ msgstr "Modo:"
+
+#~ msgid ""
+#~ "Blending mode: how the current layer combines with the layers underneath "
+#~ "it."
+#~ msgstr ""
+#~ "Modo de mistura: como a camada atual se combina com as camadas abaixo "
+#~ "dela."
+
+#~ msgid ""
+#~ "Layer opacity: how much of the current layer to use. Smaller values make "
+#~ "it more transparent."
+#~ msgstr ""
+#~ "Opacidade da camada: que quantidade da camada atual usar. Valores mais "
+#~ "baixos tornam a camada mais transparente."
+
+#~ msgid "%s: edit properties"
+#~ msgstr "%s: editar propriedades"
+
+#~ msgctxt "layer unique names: match regex (leave untranslated if unsure)"
+#~ msgid "^(.*?)\\s*(\\d+)$"
+#~ msgstr "^(.*?)\\s*(\\d+)$"
+
+#~ msgctxt "layer default names"
+#~ msgid "Unknown Bitmap Layer"
+#~ msgstr "Camada bitmap desconhecida"
+
+#~ msgctxt "Autosave Recovery dialog|"
+#~ msgid "_Ignore for Now"
+#~ msgstr "_Ignorar por enquanto"
+
+#~ msgid "Setting name:"
+#~ msgstr "Nome da configuração:"
+
+#~ msgid "Base value:"
+#~ msgstr "Valor base:"
+
+#~ msgid "Reset the base value to its default"
+#~ msgstr "Reconfigura o valor base para o valor padrão"
+
+#~ msgid "<ymin>"
+#~ msgstr "<ymin>"
+
+#~ msgid "<ymax>"
+#~ msgstr "<ymax>"
+
+#~ msgid "<xmin>"
+#~ msgstr "<xmin>"
+
+#~ msgid "<xmax>"
+#~ msgstr "<xmax>"
+
+#~ msgid "Edit Setting"
+#~ msgstr "Editar configuração"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Trim Layer to Frame"
+#~ msgstr "Cortar camada pelos limites da moldura"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Rename Layer…"
+#~ msgstr "Alterar nome da camada…"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Enter a new name for the current layer."
+#~ msgstr "Escreva um novo nome para a camada atual."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Turn off mirroring of the view."
+#~ msgstr "Desativa o espelhamento da visualização."
+
+#~ msgctxt "Menu→Edit (labels)"
+#~ msgid "Current Tool"
+#~ msgstr "Ferramenta atual"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+#~ msgstr ""
+#~ "Oculta/mostra o painel das camadas (organizar as camadas ou atribuir "
+#~ "modos)."
+
+#~ msgctxt "Menu→Color (labels), Accel Editor (labels)"
+#~ msgid "HSV Triangle"
+#~ msgstr "Triângulo HSV"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Dockable color selector: the old GTK color triangle."
+#~ msgstr "Seletor de cor aclopável: o antigo triângulo de cores GTK."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid ""
+#~ "Dockable color selector: HSV square which can be rotated to show "
+#~ "different hues."
+#~ msgstr ""
+#~ "Um cubo HSV aclopável que pode ser rodado para mostrar diferentes matizes."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+#~ msgstr ""
+#~ "Oculta/mostra o painel de rascunhos (misturar cores e fazer esboços)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+#~ msgstr ""
+#~ "Oculta/mostra o painel de pré-visualização (vista geral de toda a área de "
+#~ "desenho)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+#~ msgstr ""
+#~ "Oculta/mostra o painel de opções de ferramenta (opções para a ferramenta "
+#~ "atual)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the History panel (recently used brushes and colors)."
+#~ msgstr ""
+#~ "Oculta/mostra o painel de histórico (pincéis e cores usadas recentemente)."

--- a/po/pt.po
+++ b/po/pt.po
@@ -534,18 +534,18 @@ msgstr "Pacote de pincéis do MyPaint (*.zip)"
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
-msgstr "Novo grupo..."
+msgid "New Group…"
+msgstr "Novo grupo…"
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
-msgstr "Importar pincéis..."
+msgid "Import Brushes…"
+msgstr "Importar pincéis…"
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
-msgstr "Obter mais pincéis..."
+msgid "Get More Brushes…"
+msgstr "Obter mais pincéis…"
 
 #: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
@@ -1228,13 +1228,13 @@ msgstr "Tipo"
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
-msgstr "Usar para..."
+msgid "Use for…"
+msgstr "Usar para…"
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
-msgstr "Deslocar..."
+msgid "Scroll…"
+msgstr "Deslocar…"
 
 #. Name and preview column: will be indented
 #: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
@@ -1457,8 +1457,8 @@ msgid "_Quit"
 msgstr "Sair"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
-msgstr "Importar pacote de pincéis..."
+msgid "Import brush package…"
+msgstr "Importar pacote de pincéis…"
 
 #: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
@@ -1511,8 +1511,8 @@ msgstr ""
 "“{type_name}” ({content_type})?"
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
-msgstr "Abrir com..."
+msgid "Open With…"
+msgstr "Abrir com…"
 
 #: ../gui/externalapp.py:123
 msgid "Icon"
@@ -1702,13 +1702,13 @@ msgstr "JPEG com qualidade de 90% (*.jpg; *.jpeg)"
 
 #: ../gui/filehandling.py:576
 #, fuzzy
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr "Exportar…"
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Guardar como…"
 
@@ -1779,8 +1779,8 @@ msgstr "Abrir"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
-msgstr "Abrir painel de rascunho..."
+msgid "Open Scratchpad…"
+msgstr "Abrir painel de rascunho…"
 
 #: ../gui/filehandling.py:1099
 #, fuzzy
@@ -2236,13 +2236,13 @@ msgstr ""
 "se ainda ninguém reportou o mesmo problema."
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
-msgstr "Pesquisar no rastreador..."
+msgid "Search Tracker…"
+msgstr "Pesquisar no rastreador…"
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
-msgstr "Reportar..."
+msgid "Report…"
+msgstr "Reportar…"
 
 #: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
@@ -2253,8 +2253,8 @@ msgid "Quit MyPaint"
 msgstr "Sair do MyPaint"
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
-msgstr "Detalhes..."
+msgid "Details…"
+msgstr "Detalhes…"
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
@@ -2462,8 +2462,8 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
-msgstr "Reordenar camada na pilha..."
+msgid "Move layer in stack…"
+msgstr "Reordenar camada na pilha…"
 
 #: ../gui/layerswindow.py:110
 msgid ""
@@ -2535,8 +2535,8 @@ msgid "Stroke trail-off beginning"
 msgstr "Traçado saindo do começo"
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
-msgstr "Variação de pressão..."
+msgid "Pressure variation…"
+msgstr "Variação de pressão…"
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
@@ -3729,7 +3729,7 @@ msgstr "Eliminar este pincel do disco"
 #, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid "_Recover & Save…"
-msgstr "_Recuperar e guardar..."
+msgstr "_Recuperar e guardar…"
 
 #: ../po/tmp/autorecover.glade.h:12
 #, fuzzy

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.9.0-git\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-08-01 05:10+0000\n"
 "Last-Translator: Neymar Junior <wizureye@nextmail.in>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -22,29 +22,7 @@ msgstr ""
 "X-Poedit-Country: BRAZIL\n"
 "X-Poedit-SourceCharset: utf-8\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr "<big><b>{accel_label}</b></big>"
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr "{action_label} {action_desc} {accel_label}"
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "Ação"
 
@@ -52,32 +30,32 @@ msgstr "Ação"
 msgid "Key combination"
 msgstr "Combinação de teclas"
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr "Editar Tecla para '%s'"
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "Ação:"
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "Caminho:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "Tecla:"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr "Pressione as teclas para modificar esta atribuição"
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "Ação Desconhecida"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
@@ -86,7 +64,7 @@ msgstr ""
 "<b>{accel} já está em uso por '{action}'. A atribuição existente será "
 "substituída.</b>"
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr "Abrir Pasta “{folder_basename}”…"
@@ -94,196 +72,206 @@ msgstr "Abrir Pasta “{folder_basename}”…"
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "OK"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr "Não foram encontrados backups no cache."
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr "Sem Backups Disponíveis"
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr "Abrir a Pasta de Cache…"
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr "Falha na Recuperação do Backup"
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr "Abrir a Pasta de Backup…"
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr "Arquivo recuperado de {iso_datetime}.ora"
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "Salvar como Padrão"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "Fundo"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "Textura"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Cor"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "Adicionar cor às Texturas"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr "Uma ou mais imagens de fundo não puderam ser carregadas"
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr "Erro ao carregar imagens de fundo"
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 "Favor remover os arquivos que não puderam ser carregados, ou verifique a sua "
 "instalação de libgdkpixbuf."
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 "Gdk-pixbuf não pôde carregar \"{filename}\", e deu a mensagem \"{error}\""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr "{filename} tem tamanho zero (w={w}, h={h})"
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr "Editor de Configurações de Pincel"
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr "Sobre"
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "Experimental"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr "Básico"
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr "Opacidade"
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr "Pincelada"
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "Borrar"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr "Velocidade"
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr ""
+
+#: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr "Acompanhamento"
 
-#: ../gui/brusheditor.py:359
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "Traço"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr "Cor"
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Personalizado"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr "Nenhum pincel selecionado, favor usar \"Adicionar Como Novo\"."
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr "Nenhum pincel selecionado!"
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "Renomear Pincel"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "Um pincel com este nome já existe!"
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr "Nenhum pincel selecionado!"
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr "Realmente excluir o pincel “{brush_name}” do disco?"
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr "(Pincel sem nome)"
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr "{brush_name} [não salvo]"
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr "Ícone do Pincel"
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr "Ícone do Pincel (edição)"
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr "Nenhum pincel selecionado"
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -292,7 +280,7 @@ msgstr ""
 "<b>%s</b>\n"
 "<small>Selecione um pincel válido primeiro</small>"
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
@@ -301,7 +289,7 @@ msgstr ""
 "<b>%s</b> <i>(modificado)</i>\n"
 "<small>Mudanças ainda não salvas</small>"
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
@@ -310,7 +298,7 @@ msgstr ""
 "<b>%s</b> (edição)\n"
 "<small>Pinte com qualquer pincel ou cor</small>"
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -351,142 +339,182 @@ msgstr "Automático"
 msgid "Use the default icon"
 msgstr "Utilizar o ícone padrão"
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Salvar"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr "Salvar este ícone de pré-visualização, e terminar a edição"
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr "Achados e Perdidos"
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr "Excluído"
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr "Favoritos"
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr "Tinta"
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr "Clássico"
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr "Conjunto Nº1"
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr "Conjunto Nº2"
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr "Conjunto Nº3"
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr "Conjunto Nº4"
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr "Conjunto Nº5"
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr "Experimental"
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Novo"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr "Pincel Desconhecido"
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr "Adicionar aos Favoritos"
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr "Remover dos Favoritos"
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr "Clonar"
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr "Editar as Configurações do Pincel"
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
-msgstr "Excluir"
+#: ../gui/brushselectionwindow.py:250
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
+msgstr "Renomear Grupo"
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
-msgstr "Realmente apagar o pincel do disco?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, fuzzy, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
+msgstr "Realmente excluir o pincel “{brush_name}” do disco?"
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] "%d pincel"
 msgstr[1] "%d pincéis"
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr "Grupo “{group_name}”"
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr "Renomear Grupo"
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr "Exportar como Pacote de Pincéis Zipado"
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr "Excluir Grupo"
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr "Renomear Grupo"
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "Um grupo com este nome já existe!"
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr "Realmente excluir grupo “{group_name}”?"
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -496,58 +524,58 @@ msgstr ""
 "Não foi possível excluir o grupo “{group_name}”.\n"
 "Alguns grupos especiais não podem ser excluídos."
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr "Exportar Pincéis"
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr "Pacote de pincéis do MyPaint (*.zip)"
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "Novo Grupo..."
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr "Importar Pincéis..."
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr "Obter Mais Pincéis..."
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "Criar Grupo"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr "Botão"
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr "Botão"
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr "Botão pressionado"
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr "Adicionar uma nova associação"
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr "Remover a associação atual"
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr "Editar associação para '%s'"
@@ -556,7 +584,7 @@ msgstr "Editar associação para '%s'"
 msgid "Button press:"
 msgstr "Botão pressionado:"
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
@@ -564,47 +592,75 @@ msgstr ""
 "Mantenha as teclas modificadoras pressionadas, e pressione um botão sobre "
 "este texto para definir uma nova associação."
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 "{button} não pode ser vinculado sem teclas modificadoras (é fixo, desculpe)"
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr "{button_combination} já está associado à ação '{action_name}'"
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr "Selecionar Cor"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr "Selecionar a cor usada para pintura"
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+#, fuzzy
+msgid "Set the color Hue used for painting"
+msgstr "Selecionar a cor usada para pintura"
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "Pegar Cor"
+
+#: ../gui/colorpicker.py:296
+#, fuzzy
+msgid "Set the color Chroma used for painting"
+msgstr "Selecionar a cor usada para pintura"
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+#, fuzzy
+msgid "Set the color Luma used for painting"
+msgstr "Selecionar a cor usada para pintura"
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr "Detalhes da cor"
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr "Cor do pincel atual, e a cor usada mais recentemente para a pintura"
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr "Máscara de Gama Ativa"
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr "Limite sua paleta à tons específicos usando uma máscara de gama."
@@ -614,7 +670,7 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr "Matiz HCY e intensidade."
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
@@ -623,12 +679,12 @@ msgstr ""
 "Editor de máscara de gama. Clique no meio para criar ou manipular formas, ou "
 "gire a máscara usando as bordas do disco."
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr "Tríade Atmosférica"
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
@@ -637,22 +693,22 @@ msgstr ""
 "Subjetiva e com forte tom, definida por uma cor primária dominante e duas "
 "primárias que são menos intensas."
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr "Tríade Deslocada"
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr "Com mais peso em direção à cor dominante."
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr "Complementar"
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
@@ -661,12 +717,12 @@ msgstr ""
 "Opostos contrastantes, balanceados por neutras centrais entre eles na roda "
 "de cores."
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr "Tom e Destaque"
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
@@ -675,12 +731,12 @@ msgstr ""
 "Uma faixa principal de cores, com um destaque complementar para variação e "
 "realces."
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr "Complementares Divididas"
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
@@ -689,72 +745,72 @@ msgstr ""
 "Duas cores análogas e um complemento para elas, sem cores secundárias entre "
 "elas."
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr "Nova máscara de gama a partir do modelo"
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr "Editor de Máscaras de Gama"
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr "Ativo"
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr "Ajuda…"
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr "Criar máscara a partir de modelo."
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr "Carregar máscara a partir de um arquivo de paleta do GIMP."
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr "Salvar máscara para um arquivo de paleta do GIMP."
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr "Apagar a máscara."
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr "Abre a ajuda on-line para este diálogo em um navegador web."
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr "Salvar Máscara como uma Paleta do GIMP"
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr "Carregar Máscara a partir de um arquivo de Paleta do GIMP"
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr "Definir máscara de gama."
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr "Roda HCY"
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -764,162 +820,155 @@ msgstr ""
 "fatias circulares são de mesma luminosidade."
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr "Matiz HSV"
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr "Saturação HSV"
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr "Valor HSV"
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr "Saturação e Valor HSV"
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr "Matiz e Valor HSV"
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr "Matiz e Saturação HSV"
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr "Rodar cubo (exibir eixos diferentes)"
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr "Cubo HSV"
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
-msgstr "Um cubo HSV que pode ser rodado para exibir diferentes fatias planares."
+msgstr ""
+"Um cubo HSV que pode ser rodado para exibir diferentes fatias planares."
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr "Quadrado HSV"
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr "Um quadrado HSV que pode ser rodado para exibir diferentes matizes."
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr "Triângulo HSV"
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr "Seletor de cores padrão do GTK"
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr "Roda HSV"
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr "Seletor de cores por Saturação e Valor."
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr "Propriedades da paleta"
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr "Paleta"
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr "Selecionar a cor de uma paleta que seja carregável e editável."
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr "Camada Sem Título"
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr "Editor de Paleta"
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr "Carregar a partir de um arquivo de paleta do GIMP"
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr "Salvar para um arquivo de paleta do GIMP"
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr "Adicionar uma nova amostra de cor vazia"
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr "Remover a amostra de cor atual"
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr "Remover todas as amostras de cores"
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr "Título:"
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr "Nome ou descrição para esta paleta"
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr "Colunas:"
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr "Número de colunas"
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr "Nome da cor:"
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr "Nome da cor atual"
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr "Entrada de paleta vazia"
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr "Carregar paleta"
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr "Salvar paleta"
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -930,379 +979,376 @@ msgstr ""
 "Solte cores aqui e \n"
 "arraste-as para organizá-las."
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr "Entrada de paleta vazia (arraste uma cor para cá)"
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr "Adicionar Entrada Vazia"
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr "Inserir Linha"
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr "Inserir Coluna"
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr "Preencher Lacuna (RGB)"
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr "Preencher Lacuna (HCY)"
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr "Preencher Lacuna (HSV)"
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "Arquivo de paleta do GIMP (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr "Todos os arquivos (*)"
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "Arquivo de paleta do GIMP (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr "Todos os arquivos (*)"
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr "Pegar uma cor da tela"
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr "R"
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr "G"
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr "B"
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr "H"
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr "C"
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr "Y"
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr "Controles deslizantes de componentes"
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr "Ajustar componentes individuais da cor."
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr "Vermelho RGB"
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr "Verde RGB"
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr "Azul RGB"
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr "Matiz HSV"
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr "Saturação HSV"
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr "Valor HSV"
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr "Matiz HCY"
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr "Pureza HCY"
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr "Luminosidade HCY (Y')"
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr "Paleta Líquida"
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr "Mude a cor usando uma paleta líquida de cores próximas."
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr "Anéis Concêntricos"
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr "Seletor de cor usando anéis concêntricos HSV."
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr "Paleta Cruzada"
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr "Mude a cor HSV usando uma paleta radial atravessada pela cor."
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr "Cursor"
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr "Borracha"
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr "Teclado"
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr "Mouse"
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr "Caneta"
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr "Touchpad"
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr "Tela Sensível Ao Toque"
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr "Ignore"
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr "Tarefas"
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr "Funções não-pintura"
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr "Apenas navegação"
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr "Zoom"
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr "Deslocar"
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr "Dispositivo"
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr "Eixos"
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr "Tipo"
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr "Use para..."
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr "Move..."
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Nome"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr "Sobrescrever pincel?"
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr "Substituir"
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr "Renomear"
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr "Substituir Todos"
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr "Renomear Todos"
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr "Pincel importado"
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr "Pincel existente"
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 "<b>Um pincel chamado `%s' já existe</b>\n"
 "Você deseja substituí-lo, ou o novo pincel deve ser renomeado?"
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr "Sobrescrever grupo de pincéis?"
 
-#: ../gui/dialogs.py:190
-#, python-brace-format
+#: ../gui/dialogs.py:220
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 "<b>Um grupo chamado `{groupname}' já existe</b>\n"
 "Você deseja substituí-lo, ou o novo grupo deve ser renomeado?\n"
 "Se você substituí-lo, os pincéis podem ser movidos para um grupo chamado "
 "`{deleted_groupname}'."
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr "Importar pacote de pincéis?"
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, fuzzy, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr "<b>Você realmente quer importar o pacote `%s'?</b>"
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr "Carregar configurações do pincel pelo atalho %d"
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr "Guardar as configurações do pincel no atalho %d"
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr "Restaurar Pincel %d"
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr "Salvar para Pincel %d"
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr "Desfazer %s"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Desfazer"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr "Refazer %s"
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Refazer"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr "{button_combination} é {resultant_action}"
@@ -1312,102 +1358,145 @@ msgstr "{button_combination} é {resultant_action}"
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ";  "
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr "Com {modifiers} pressionados:  {button_actions}."
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
-msgstr "Nome da Camada"
-
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
-#, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
-"<b>{name}</b>\n"
-"{description}"
+
+#: ../gui/document.py:909
+#, python-brace-format
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
+msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr "%s - MyPaint"
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr "MyPaint"
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Abrir"
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr "Selecionar cor atual"
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr "Sair do Modo Tela Cheia"
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr "Sair do Modo Tela Cheia"
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr "Entrar no Modo Tela Cheia"
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Ir para Tela Cheia"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Sair"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+#, fuzzy
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr "Realmente Sair?"
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Sair"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr "Importar pacote de pincéis..."
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr "Pacote de pincéis do MyPaint (*.zip)"
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr "{app_name} aberto para editar a camada “{layer_name}”"
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr "Erro: falha ao abrir {app_name} para editar a camada “{layer_name}”"
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 "Edição cancelada. Você ainda pode editar “{layer_name}” no menu Camadas."
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr "Camada “{layer_name}” atualizada com edições externas"
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr "Não foi possível carregar “{file_basename}”."
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
@@ -1416,7 +1505,7 @@ msgstr ""
 "O MyPaint precisa editar um arquivo do tipo “{type_name}” ({content_type}). "
 "Que programa ele deve usar?"
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
@@ -1425,161 +1514,377 @@ msgstr ""
 "Qual programa o MyPaint deve utilizar para edição de arquivos do tipo "
 "“{type_name}” ({content_type})?"
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr "Abrir Com..."
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr "Ícone"
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr "sem descrição"
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
+#: ../gui/filehandling.py:126
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
+msgstr "Carregando “{file_basename}”…"
+
+#: ../gui/filehandling.py:130
+#, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:134
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
+msgstr "Salvando “{file_basename}”…"
+
+#: ../gui/filehandling.py:138
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
+msgstr "Exportando para “{file_basename}”…"
+
+#: ../gui/filehandling.py:145
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr "Falha ao exportar para “{file_basename}”."
+
+#: ../gui/filehandling.py:149
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr "Falha ao salvar “{file_basename}”."
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr "Não foi possível carregar “{file_basename}”."
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "Salvar paleta"
+
+#: ../gui/filehandling.py:168
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr "Exportar para um arquivo"
+
+#: ../gui/filehandling.py:172
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr "Exportar para um arquivo"
+
+#: ../gui/filehandling.py:176
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr "Abrir Arquivos Recentes"
+
+#: ../gui/filehandling.py:183
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr "“{file_basename}” exportado com sucesso."
+
+#: ../gui/filehandling.py:187
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr "“{file_basename}” salvo com sucesso."
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr "“{file_basename}” carregado."
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
+msgstr "“{file_basename}” carregado."
+
+#: ../gui/filehandling.py:427
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "All Recognized Formats"
 msgstr "Todos os Formatos Conhecidos"
 
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
+#: ../gui/filehandling.py:432
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "OpenRaster (*.ora)"
 msgstr "OpenRaster (*.ora)"
 
-#: ../gui/filehandling.py:95
+#: ../gui/filehandling.py:437
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "PNG (*.png)"
 msgstr "PNG (*.png)"
 
-#: ../gui/filehandling.py:96
+#: ../gui/filehandling.py:442
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "JPEG (*.jpg; *.jpeg)"
 msgstr "JPEG (*.jpg; *.jpeg)"
 
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
+#: ../gui/filehandling.py:490
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "By extension (prefer default format)"
 msgstr "Por extensão (preferir formato padrão)"
 
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
+#: ../gui/filehandling.py:494
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:498
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
 msgstr "PNG sólido com fundo (*.png)"
 
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
+#: ../gui/filehandling.py:502
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:506
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
 msgstr "PNG transparente (*.png)"
 
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
+#: ../gui/filehandling.py:510
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
 msgstr "Múltiplos PNG transparentes (*.XXX.png)"
 
-#: ../gui/filehandling.py:113
+#: ../gui/filehandling.py:514
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr "Múltiplos PNG transparentes (*.XXX.png)"
+
+#: ../gui/filehandling.py:518
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr "JPEG com qualidade de 90% (*.jpg; *.jpeg)"
 
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr "Salvar..."
+#: ../gui/filehandling.py:576
+#, fuzzy
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr "Exportar…"
 
-#: ../gui/filehandling.py:177
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Salvar Como…"
+
+#: ../gui/filehandling.py:601
+#, fuzzy
+msgctxt "save dialogs: formats and options: (label)"
 msgid "Format to save as:"
 msgstr "Formato a salvar como:"
 
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr "Confirmar"
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
+#: ../gui/filehandling.py:668
+#, fuzzy
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
 msgstr "Realmente continuar?"
 
-#: ../gui/filehandling.py:234
-#, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
-msgstr "Isto irá descartar {abbreviated_time} de pintura não salva"
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
+#: ../gui/filehandling.py:705
+#, fuzzy
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
 msgstr "_Salvar como Rascunho"
 
-#: ../gui/filehandling.py:282
-#, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
-msgstr "Carregando “{file_basename}”…"
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
 
-#: ../gui/filehandling.py:296
-#, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
-msgstr "Não foi possível carregar “{file_basename}”."
+#: ../gui/filehandling.py:734
+#, fuzzy, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr "Isto irá descartar {abbreviated_time} de pintura não salva"
 
-#: ../gui/filehandling.py:321
-#, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
-msgstr "“{file_basename}” carregado."
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
 
-#: ../gui/filehandling.py:422
-#, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
-msgstr "Exportando para “{file_basename}”…"
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
 
-#: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
-msgstr "Salvando “{file_basename}”…"
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
-msgstr "Falha ao exportar para “{file_basename}”."
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr "Abrir…"
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
-msgstr "Falha ao salvar “{file_basename}”."
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Abrir Arquivos Recentes"
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
-msgstr "“{file_basename}” exportado com sucesso."
-
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
-msgstr "“{file_basename}” salvo com sucesso."
-
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Abrir..."
-
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr "Abrir Painel de Rascunho"
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Pincel importado"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Abrir"
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Abrir o Mais Recente"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Abrir"
+
+#: ../gui/filehandling.py:1446
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
 msgstr "Não há arquivos de rascunho chamados \"%s\" ainda."
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1455
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr "Abrir Próximo Rascunho"
+
+#: ../gui/filehandling.py:1463
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr "Abrir Rascunho Anterior"
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Abrir"
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+#, fuzzy
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr "Reverter"
+
+#: ../gui/fill.py:121
+#, fuzzy
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr "Preenchimento"
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+#, fuzzy
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr "Preencher áreas com cor"
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+#, fuzzy
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr "Tolerância:"
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+#, fuzzy
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
@@ -1587,19 +1892,36 @@ msgstr ""
 "Quanto as cores dos pixels podem variar do ponto de partida\n"
 "antes do Preenchimento se recusar a preenchê-los"
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+#, fuzzy
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr "Origem:"
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
-msgstr "Quais camadas visíveis devem ser preenchidas"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
+msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+#, fuzzy
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr "Amostra Mesclada"
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+#, fuzzy
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
@@ -1609,19 +1931,50 @@ msgstr ""
 "utilize uma mesclagem temporária de todas \n"
 "as camadas visíveis abaixo da camada atual"
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+#, fuzzy
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr "Ajustar à Tela"
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+#, fuzzy
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr "Alvo:"
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+#, fuzzy
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr "Onde a saída deve ir"
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr "Nova Camada (uma)"
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+#, fuzzy
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
@@ -1629,21 +1982,108 @@ msgstr ""
 "Crie uma nova camada com os resultados do preenchimento.\n"
 "Esta é desligada automaticamente após o uso."
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Opacidade:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr "Restaurar"
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+#, fuzzy
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr "Restaurar opções para seus padrões"
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "Selecionar Camada"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr "<b>{brush_name}</b>"
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1653,130 +2093,142 @@ msgstr ""
 "<b>{brush_name}</b>\n"
 "{brush_desc}"
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr "Editar Moldura"
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr "Ajustar a moldura do documento"
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr "Tamanho da Moldura"
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr "px"
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr "Altura:"
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr "Largura:"
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr "Resolução:"
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr "PPP"
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr "Pontos Por Polegada (realmente Pixels Por Polegada)"
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr "Cor:"
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr "Cor da Moldura"
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr "<b>Dimensões da moldura</b>"
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr "<b>Densidade do pixel</b>"
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr "Definir Moldura para Camada"
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr "Definir moldura para o tamanho da camada atual"
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr "Definir Moldura para o tamanho do Documento"
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr "Definir moldura para a combinação de todas as camadas"
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr "Cortar Camada para Moldura"
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr "Cortar partes da camada atual que estão fora da moldura"
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr "Ativada"
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr "{width:g}×{height:g} {units}"
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr "polegada"
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr "cm"
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr "mm"
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr "Desenho à Mão Livre"
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr "Pintar pinceladas de forma livre"
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr "Suavização:"
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr "Pressão:"
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr "Bug Detectado"
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr "<big><b>Um erro de programação foi detectado.</b></big>"
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1790,35 +2242,35 @@ msgstr ""
 "Por favor, informe os desenvolvedores sobre isso usando o rastreador de "
 "problemas, se mais ninguém relatou ainda."
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr "Pesquisar Rastreador..."
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr "Reportar..."
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr "Ignorar Erro"
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr "Sair do MyPaint"
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr "Detalhes..."
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr "Exceção ao analisar a exceção."
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1862,45 +2314,50 @@ msgstr ""
 "            #### Traceback\n"
 "        "
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr "Finalização"
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr "Desenhe, e depois suavize as linhas ajustando-as"
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr "Teste de Dispositivo de Entrada"
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr "(sem pressão)"
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr "Pressão:"
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr "(sem inclinação)"
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr "Inclinação:"
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr "(sem dispositivo)"
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
 msgstr "Dispositivo:"
 
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+#, fuzzy
+msgid "Barrel Rotation:"
+msgstr "Rotação"
+
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr "Mover Camada"
 
@@ -1908,162 +2365,229 @@ msgstr "Mover Camada"
 msgid "Move the current layer"
 msgstr "Mover a camada atual"
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
-msgstr "{default_name} em {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
+msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
-msgstr "Tipo"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
+msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+#, fuzzy
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr "Propriedades da paleta"
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr "Visível"
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Camada"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+#, fuzzy
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr "Travada"
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+#, fuzzy
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ", "
+
+#: ../gui/layers.py:990
+#, fuzzy, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr "Adicionar {layer_default_name}"
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Camadas"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr "Organizar camadas e aplicar efeitos"
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr "Opacidade da camada: %d%%"
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr "Reordenar Camada na Pilha..."
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 "Mover camada na pilha (deixando-a em uma camada retangular criará um novo "
 "grupo)"
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr "Camada"
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
-msgstr "Modo:"
+#: ../gui/layervis.py:53
+#, fuzzy, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
+msgstr "<b>{brush_name}</b>"
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
-"Modo de mistura: como a camada atual se combina com as camadas abaixo dela."
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Opacidade:"
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "Girar Visualização"
 
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-"Opacidade da camada: quanto da camada atual usar. Valores menores tornam a "
-"camada mais transparente."
-
-#: ../gui/linemode.py:37
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr "Pressão à Entrada"
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr "Pressão à entrada do traço para ferramentas de linha"
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr "Pressão ao Meio"
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr "Pressão ao meio do traço para ferramentas de linha"
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr "Pressão à Saída"
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr "Pressão à saída do traço para ferramentas de linha"
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr "Cabeça"
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 msgid "Stroke lead-in end"
 msgstr "Traçado indo para o final"
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr "Cauda"
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr "Traçado saindo do começo"
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr "Variação de pressão..."
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr "Linhas e Curvas"
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr "Linha genérica/movo curvo"
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr "Desenhar linhas retas; Shift adiciona curvas, Ctrl trava o ângulo"
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr "Linhas Conectadas"
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 "Desenha uma sequência de linhas; Shift adiciona curvas, Ctrl restringe o "
 "ângulo"
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr "Elipses e Círculos"
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr "Desenha elipses; Shift rotaciona, Ctrl restringe a proporção/ângulo"
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
+#, fuzzy
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 "Copyright (C) 2005-2015\n"
 "Martin Renold e o Time de Desenvolvimento do MyPaint"
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -2082,256 +2606,286 @@ msgstr ""
 "Este programa é distribuído na esperança de que será útil, mas SEM NENHUMA "
 "GARANTIA. Veja o arquivo COPYING para mais detalhes."
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr "programação"
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr "portabilidade"
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr "gerenciamento de projetos"
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr "pincéis"
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr "texturas"
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr "ícones de ferramentas"
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr "ícone da área de trabalho"
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr "paletas"
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr "documentação"
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr "suporte"
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr "divulgar"
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr "comunidade"
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ", "
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr "Créditos da tradução"
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr "Tamanho:"
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr "Opacidade:"
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr "Duro:"
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr "Ganho:"
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr "Opções de Ferramentas"
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr "Configurações específicas para a ferramenta de edição atual"
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr "<b>{mode_name}</b>"
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr "<i>Não há opções disponíveis</i>"
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr "Ampliação: %.01f%%"
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr "Escolha as configurações pincelada, cor do traço, e camada…"
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr "Escolha a cor…"
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr "Preferências"
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr "Pré-visualização"
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr "Exibir pré-visualização de toda a área de desenho"
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr "Mostrar Área Visível"
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr "Painel de Rascunho"
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr "Misturar cores e fazer rabiscos em páginas separadas para rascunho"
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr "Item anterior"
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr "Próximo item"
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
 msgstr "(Nada a mostrar)"
 
-#: ../gui/symmetry.py:76
+#: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Place axis"
 msgstr "Posicionar eixo"
 
-#: ../gui/symmetry.py:80
+#: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Move axis"
 msgstr "Mover Eixo"
 
-#: ../gui/symmetry.py:84
+#: ../gui/symmetry.py:88
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr "Remover eixo"
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr "Editar o Eixo de Simetria"
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr "Ajustar o Eixo de Simetria da pintura."
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
+#, fuzzy
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr "Posição:"
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr "Posição:"
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr "Nenhum"
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr "%d px"
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr "Alfa:"
 
-#: ../gui/symmetry.py:352
+#: ../gui/symmetry.py:376
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
+msgstr "Eixo de Simetria"
+
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+#, fuzzy
 msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+msgid "X axis Position"
 msgstr "Posição do eixo"
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:477
+#, fuzzy
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr "Posição do eixo"
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr "Ativada"
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr "Gerenciamento de arquivos"
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr "Escolhedor de rascunhos"
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr "Desfazer e Refazer"
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr "Modos de Mistura"
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr "Modo de Linha"
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr "Visualização (Principal)"
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr "Visualização (Alternativa/Secundária)"
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr "Visualização (Reiniciar)"
 
@@ -2339,188 +2893,214 @@ msgstr "Visualização (Reiniciar)"
 msgid "<b>MyPaint</b>"
 msgstr "<b>MyPaint</b>"
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr "Mover Visualização"
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr "Arrastar a visualização da tela"
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr "Zoom da Visualização"
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr "Dar zoom na visualização da tela"
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr "Girar Visualização"
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr "Girar a visualização do canvas"
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, fuzzy, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr "%s: fechar aba"
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
-msgstr "%s: editar propriedades"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
+msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr "Comando Desconhecido"
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr "Não definido (comando não foi iniciado)"
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr "{seconds:.01f}s de pintura com {brush_name}"
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr "Preenchimento"
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr "Cortar Camada"
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "Renomear Grupo"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr "Limpar Camada"
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr "Colar Camada"
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr "Nova Camada a partir do Visível"
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr "Mesclar Camadas Visíveis"
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr "Combinar Abaixo"
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr "Normalizar Modo da Camada"
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Pincel importado"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr "Adicionar {layer_default_name}"
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr "Remover Camada"
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr "Selecionar Camada"
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr "Duplicar Camada"
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr "Mover Camada para Cima"
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr "Mover Camada para Baixo"
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr "Reordenar Camada na Pilha"
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr "Renomear Camada"
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr "Tornar Camada Visível"
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr "Tornar Camada Invisível"
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr "Travar Camada"
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr "Destravar Camada"
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr "Opacidade da camada: %0.1f%%"
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr "Modo Desconhecido"
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr "Modo da Camada: %s"
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr "Ativar Moldura"
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr "Desativar Moldura"
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr "Atualizar Moldura"
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr "Editar camada externamente"
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr "Erro ao carregar “{basename}”."
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr "Os registros podem conter mais detalhes sobre este erro."
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr "a partir de agora"
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr "atrás"
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2532,13 +3112,13 @@ msgstr ""
 "Você está executando mais de uma instância do MyPaint?\n"
 "Feche o aplicativo e aguarde  {cache_update_interval}s para tentar novamente."
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr "Backup incompleto atualizado {last_modified_time} {ago}"
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2548,11 +3128,11 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 "Backup atualizado {last_modified_time} {ago}\n"
-"Tamanho: {autosave.width}×{autosave.height} pixels, Camadas: "
-"{autosave.num_layers}\n"
+"Tamanho: {autosave.width}×{autosave.height} pixels, Camadas: {autosave."
+"num_layers}\n"
 "Contém  {unsaved_time} de pintura ainda não salvos."
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2562,13 +3142,13 @@ msgstr ""
 "Não foi possível salvar “{filename}”: {err}\n"
 "Você tem espaço suficiente no dispositivo?"
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr "Não foi possível escrever \"{filename}\": {err}"
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2578,7 +3158,7 @@ msgstr ""
 "{error_loading_common}\n"
 "O arquivo não existe."
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2588,7 +3168,7 @@ msgstr ""
 "{error_loading_common}\n"
 "Você não possui as permissões necessárias para abrir o arquivo."
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2604,7 +3184,7 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2614,7 +3194,13 @@ msgstr ""
 "{error_loading_common}\n"
 "Extensão de formato de arquivo desconhecida: “{ext}”"
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+#, fuzzy
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr "Pincel importado"
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2628,7 +3214,7 @@ msgstr ""
 "Em vez disso, tente salvar no formato PNG se o seu computador não tem "
 "bastante memória. A função de salvar como PNG do MyPaint é mais eficiente."
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2644,98 +3230,207 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/helpers.py:402
-#, python-brace-format
+#: ../lib/floodfill.py:131
+#, fuzzy
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr "Preencher"
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr "{days}d{hours}h"
 
-#: ../lib/helpers.py:404
-#, python-brace-format
+#: ../lib/helpers.py:537
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr "{hours}h{minutes}m"
 
-#: ../lib/helpers.py:406
-#, python-brace-format
+#: ../lib/helpers.py:539
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr "{minutes}m{seconds}s"
 
-#: ../lib/helpers.py:408
-#, python-brace-format
+#: ../lib/helpers.py:541
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr "{seconds}s"
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr "Camada"
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr "%(name)s %(number)d"
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr "^(.*?)\\s*(\\d+)$"
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
+#, fuzzy
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr "Camada Vetorial"
+
+#: ../lib/layer/data.py:1158
+#, fuzzy
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr "Camada Vetorial"
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
-msgstr "Camada bitmap desconhecida"
+msgid "Bitmap"
+msgstr ""
 
-#: ../lib/layer/data.py:1169
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1244
 msgctxt "layer default names"
-msgid "Unknown Data Layer"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
 msgstr "Camada de dados desconhecida"
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "Nova camada de pintura"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr "Grupo"
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "Novo Grupo de Camada"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr "Marcador de posição"
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr "Raiz"
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ", "
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+#, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "Visualização"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+#, fuzzy
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr "Adicionar Camada"
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+#, fuzzy
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr "Remover Camada"
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr "Travar Camada"
+
+#: ../lib/layervis.py:697
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr "Destravar Camada"
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr "Através"
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr "O conteúdo do grupo é aplicado diretamente ao fundo do grupo"
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr "Normal"
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr "Apenas a camada de cima, sem misturar as cores."
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr "Multiplicar"
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
@@ -2743,11 +3438,11 @@ msgstr ""
 "Similar a colocar múltiplos slides em um único projetor e projetar o "
 "resultado combinado."
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr "Esconder"
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
@@ -2755,11 +3450,11 @@ msgstr ""
 "É como projetar dois projetores de slides diferentes em uma tela "
 "simultaneamente. Este é o inverso de 'Multiplicar'."
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr "Sobrepor"
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
@@ -2767,29 +3462,29 @@ msgstr ""
 "Sobrepõe a imagem abaixo com a camada de cima, preservando as regiões de "
 "alto brilho e sombras da imagem abaixo. É o inverso de 'Luz forte'."
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr "Escurecer"
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 "A camada de cima é usada somente onde ela é mais escura que a imagem abaixo."
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr "Clarear"
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 "A camada de cima é usada somente onde ela é mais clara que a imagem abaixo."
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr "Sub-expor"
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
@@ -2799,11 +3494,11 @@ msgstr ""
 "técnica fotográfica de mesmo nome que é usada para melhorar o contraste em "
 "sombras."
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr "Super-expor"
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
@@ -2813,43 +3508,43 @@ msgstr ""
 "técnica fotográfica de mesmo nome que é usada para reduzir o brilho de áreas "
 "muito claras."
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr "Luz Forte"
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr "Similar a fazer brilhar uma luz de spot na imagem abaixo."
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr "Luz Suave"
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr "Como fazer brilhar um holofote na imagem abaixo."
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr "Diferença"
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr "Subtrai a cor mais escura da cor mais clara das duas."
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr "Exclusão"
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr "Similar ao modo 'Diferença', mas com menos contraste."
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr "Matiz"
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
@@ -2857,11 +3552,11 @@ msgstr ""
 "Combina a matiz da camada de cima com a saturação e luminosidade da imagem "
 "abaixo."
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr "Saturação"
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
@@ -2869,7 +3564,7 @@ msgstr ""
 "Aplica a saturação das cores da camada de cima à matiz e luminosidade da "
 "imagem abaixo."
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
@@ -2877,11 +3572,11 @@ msgstr ""
 "Aplica a matiz e a saturação da camada de cima à luminosidade da imagem "
 "abaixo."
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr "Luminosidade"
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
@@ -2889,19 +3584,19 @@ msgstr ""
 "Aplica a luminosidade da camada de cima à matiz e a saturação da imagem "
 "abaixo."
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr "Mais"
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr "Essa camada e seu pano de fundo são simplesmente somados."
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr "Destino Interno"
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
@@ -2909,11 +3604,11 @@ msgstr ""
 "Usa o pano de fundo somente onde esta camada o cobre. Todo o restante é "
 "ignorado."
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr "Destino Externo"
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
@@ -2921,29 +3616,40 @@ msgstr ""
 "Usa o pano de fundo somente onde esta camada não o cobre. Todo o restante é "
 "ignorado."
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr "Origem Sobre"
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 "Origem sobre o destino, substituindo-o. O Destino é movido para outro local."
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr "Destino Sobre"
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 "Destino sobre a origem, substituindo-a. A origem é movida para outro local."
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, fuzzy, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr "%(name)s %(number)d"
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
@@ -2952,7 +3658,7 @@ msgstr ""
 "Não consigo construir um objeto interno vital. Talvez seu sistema não tenha "
 "a memória suficiente para esta operação."
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2966,7 +3672,30 @@ msgstr ""
 "Causa: {err}\n"
 "Pasta de destino: “{dirname}”."
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+#, fuzzy
+msgid "Vertical"
+msgstr "Espelhar Verticalmente"
+
+#: ../lib/tiledsurface.py:49
+#, fuzzy
+msgid "Horizontal"
+msgstr "Espelhar Horizontalmente"
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+#, fuzzy
+msgid "Rotational"
+msgstr "Rotação"
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr "Leitura de PNG falhou: %s"
@@ -2975,59 +3704,97 @@ msgstr "Leitura de PNG falhou: %s"
 msgid "Recover interrupted work?"
 msgstr "Recuperar trabalho interrompido?"
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
-msgstr "_Recuperar e Salvar..."
+msgid "_Look for backups at startup"
+msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr "Excluir"
+
+#: ../po/tmp/autorecover.glade.h:9
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr "Apagar este pincel do disco"
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr "_Recuperar e Salvar..."
+
+#: ../po/tmp/autorecover.glade.h:12
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 "Salvar esta cópia de segurança no disco, depois continuar trabalhando nela."
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
-msgstr "_Ignorar por enquanto"
+msgid "Decide _Later"
+msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 "Começar a trabalhar em uma nova tela. Estas cópias de segurança serão "
 "mantidas."
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
+#, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 "MyPaint travou com trabalho sem salvar, mas fez cópias de segurança. Você "
 "pode recuperar um arquivo agora ou deixar até que o MyPaint reinicie "
 "novamente."
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr "Miniatura"
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr "Descrição"
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
-msgstr "Copiar para Novo"
+msgid "Live update"
+msgstr "Atualização instantânea"
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
-msgstr "Copiar estas configurações e ícone do pincel atual para um novo pincel"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
+msgstr ""
+"Atualizar o último traço na tela com as configurações desta janela, em tempo "
+"real"
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
-msgstr "Renomear este Pincel"
+msgid "Save these settings to the brush"
+msgstr "Salve estas configurações no pincel"
 
 #: ../po/tmp/brusheditor.glade.h:5
 msgid "Edit Icon"
@@ -3050,20 +3817,16 @@ msgid "Delete this brush from the disk"
 msgstr "Apagar este pincel do disco"
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
-msgstr "Atualização instantânea"
+msgid "Copy to New"
+msgstr "Copiar para Novo"
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
-msgstr ""
-"Atualizar o último traço na tela com as configurações desta janela, em tempo "
-"real"
+msgid "Copy these settings and the current brush's icon to a new brush"
+msgstr "Copiar estas configurações e ícone do pincel atual para um novo pincel"
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
-msgstr "Salve estas configurações no pincel"
+msgid "Rename this brush"
+msgstr "Renomear este Pincel"
 
 #: ../po/tmp/brusheditor.glade.h:13
 msgid "Brush Setting"
@@ -3091,12 +3854,7 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr "Notas:"
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr "Nome da configuração:"
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
@@ -3104,19 +3862,16 @@ msgstr ""
 "age neste aqui."
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
-msgstr "Valor base:"
+#: ../po/tmp/brusheditor.glade.h:22
+#, fuzzy
+msgid "Value:"
+msgstr "Valor HSV"
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr "Reconfigura o valor base para seu padrão"
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr "Reconfigura esta entrada para não ter efeito na configuração"
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
@@ -3124,11 +3879,7 @@ msgstr ""
 "Valor mínimo para o eixo de saída.\n"
 "Pode ser ajustado utilizando a barra de rolagem principal para {dname}."
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr "<ymin>"
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
@@ -3136,27 +3887,23 @@ msgstr ""
 "Valor máximo do eixo de resultado.\n"
 "Isto pode ser definido usando a barra de rolagem principal para {dname}."
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr "<ymax>"
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr "Resultado"
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr "Entrada"
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr "Ajusta o valor máximo"
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr "Ajusta o valor mínimo"
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
@@ -3164,11 +3911,7 @@ msgstr ""
 "Valor mínimo para o eixo de entrada.\n"
 "Use a escala que surge para ajustar isto."
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr "<xmin>"
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
@@ -3176,39 +3919,37 @@ msgstr ""
 "Valor máximo para o eixo de entrada.\n"
 "Use a escala que surge para ajustar isto."
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr "<xmax>"
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 "Variação do valor de base pela entrada por caneta digital e outros critérios"
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr "Dinâmica de Pincel"
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr "Detalhes básicos para essa configuração"
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr "Editar Configuração"
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr "Ajustar este mapeamento de entrada em detalhes"
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr "{dica de ferramenta}"
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
 msgstr "{dname}:"
+
+#: ../po/tmp/brusheditor.glade.h:42
+#, fuzzy
+msgid "Brush dynamics are not available for this setting."
+msgstr "Detalhes básicos para essa configuração"
+
+#: ../po/tmp/brusheditor.glade.h:43
+#, fuzzy
+msgid "<big><b>No Brush Dynamics</b></big>"
+msgstr "<big><b>{accel_label}</b></big>"
 
 #: ../po/tmp/inktool.glade.h:1
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
@@ -3220,7 +3961,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr "Pressão:"
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 #, fuzzy
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
@@ -3266,6 +4007,141 @@ msgstr "Excluir Ponto"
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
 msgstr "Excluir o ponto selecionado"
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+#, fuzzy
+msgid "Insert Point"
+msgstr "Inserir Linha"
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+#, fuzzy
+msgid "Cull Points"
+msgstr "Excluir Ponto"
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Nome"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr "Modo"
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Opacidade"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr "Moldura de corte para a camada atualmente ativa"
+
+#: ../po/tmp/layervis.glade.h:2
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr "Girar a visualização do canvas"
+
+#: ../po/tmp/layervis.glade.h:3
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr "Girar a visualização do canvas"
+
+#: ../po/tmp/layervis.glade.h:4
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr "Quais camadas visíveis devem ser preenchidas"
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
+msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
 msgctxt "footer: color picker button: tooltip"
@@ -3655,56 +4531,77 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr "Ocultar cursor quando estiver pintando"
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+#, fuzzy
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr "Ativada"
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr "Visualização"
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3712,12 +4609,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr "Pares opositores Vermelho-Verde e Azul-Amarelo"
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3726,7 +4623,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3737,28 +4634,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr "<b>Roda de Cores</b>"
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr "Cor"
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr "Tela (normal)"
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr "Desabilitado (sem sensibilidade à pressão)"
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr "Janela (não recomendado)"
@@ -3819,227 +4716,282 @@ msgid "Reload the file your current work was loaded from."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
+#, fuzzy
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Import Layers…"
+msgstr "Importar Pincéis..."
+
+#: ../po/tmp/resources.xml.h:13
+msgctxt "Accel Editor (descriptions)"
+msgid "Import layers from one or more files."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save"
 msgstr "Salvar"
 
-#: ../po/tmp/resources.xml.h:13
+#: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file."
 msgstr "Salvar seu trabalho para um arquivo."
 
-#: ../po/tmp/resources.xml.h:14
+#: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As…"
 msgstr "Salvar Como…"
 
-#: ../po/tmp/resources.xml.h:15
+#: ../po/tmp/resources.xml.h:17
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file, assigning it a new name."
 msgstr "Salvar seu trabalho para um arquivo com um novo nome."
 
-#: ../po/tmp/resources.xml.h:16
+#: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Export…"
 msgstr "Exportar…"
 
-#: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:18
-msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
-msgstr "Salvar Como Rascunho"
-
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Save As Scrap"
+msgstr "Salvar Como Rascunho"
+
+#: ../po/tmp/resources.xml.h:21
+msgctxt "Accel Editor (descriptions)"
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:22
+msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Previous Scrap"
 msgstr "Abrir Rascunho Anterior"
 
-#: ../po/tmp/resources.xml.h:21
+#: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file before the current one."
 msgstr "Carregar o arquivo de rascunho antes do atual."
 
-#: ../po/tmp/resources.xml.h:22
+#: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Next Scrap"
 msgstr "Abrir Próximo Rascunho"
 
-#: ../po/tmp/resources.xml.h:23
+#: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file after the current one."
 msgstr "Carregar o arquivo de rascunho após o atual."
 
-#: ../po/tmp/resources.xml.h:24
+#: ../po/tmp/resources.xml.h:26
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Recover File from an Automated Backup…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:25
+#: ../po/tmp/resources.xml.h:27
 msgctxt "Accel Editor (descriptions)"
 msgid "Try to save and resume interrupted unsaved work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:26
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr "Grupos de Pincéis"
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr "Pincéis"
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr "Lista de grupos de pincel."
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr "Ajustes da cor"
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr "Cores"
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr "Modo"
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr "Modo"
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr "O modo de composição da camada atual."
 
-#: ../po/tmp/resources.xml.h:35
+#: ../po/tmp/resources.xml.h:37
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Pressure"
+msgstr "Pressão à Entrada"
+
+#: ../po/tmp/resources.xml.h:38
+msgctxt "Accel Editor (descriptions)"
+msgid "Send harder pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:39
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Pressure"
+msgstr "Pressão à Entrada"
+
+#: ../po/tmp/resources.xml.h:40
+msgctxt "Accel Editor (descriptions)"
+msgid "Send softer pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:41
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Rotation"
+msgstr "Aumentar Saturação"
+
+#: ../po/tmp/resources.xml.h:42
+msgctxt "Accel Editor (descriptions)"
+msgid "Increase barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:43
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
+msgstr "Diminuir Saturação"
+
+#: ../po/tmp/resources.xml.h:44
+msgctxt "Accel Editor (descriptions)"
+msgid "Decrease barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:45
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Size"
 msgstr "Aumentar Tamanho do Pincel"
 
-#: ../po/tmp/resources.xml.h:36
+#: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush bigger."
 msgstr "Faz o pincel atual ficar maior."
 
-#: ../po/tmp/resources.xml.h:37
+#: ../po/tmp/resources.xml.h:47
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Size"
 msgstr "Diminuir Tamanho do Pincel"
 
-#: ../po/tmp/resources.xml.h:38
+#: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush smaller."
 msgstr "Faz o pincel atual ficar menor."
 
-#: ../po/tmp/resources.xml.h:39
+#: ../po/tmp/resources.xml.h:49
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Opacity"
 msgstr "Aumentar a Opacidade do Pincel"
 
-#: ../po/tmp/resources.xml.h:40
+#: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush more opaque."
 msgstr "Tornar o pincel atual mais opaco."
 
-#: ../po/tmp/resources.xml.h:41
+#: ../po/tmp/resources.xml.h:51
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Opacity"
 msgstr "Diminuir a Opacidade do Pincel"
 
-#: ../po/tmp/resources.xml.h:42
+#: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush less opaque."
 msgstr "Tornar o pincel atual menos opaco."
 
-#: ../po/tmp/resources.xml.h:43
+#: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Lighten Painting Color"
 msgstr "Clarear a Cor de Pintura"
 
-#: ../po/tmp/resources.xml.h:44
+#: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase the lightness of the current painting color."
 msgstr "Aumenta a luminosidade da cor de pintura selecionada."
 
-#: ../po/tmp/resources.xml.h:45
+#: ../po/tmp/resources.xml.h:55
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Darken Painting Color"
 msgstr "Escurecer Cor de Pintura"
 
-#: ../po/tmp/resources.xml.h:46
+#: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease the lightness of the current painting color."
 msgstr "Diminui a luminosidade da cor de pintura selecionada."
 
-#: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
-msgstr "Mudar Matiz (sentido anti-horário)"
-
-#: ../po/tmp/resources.xml.h:48
-#, fuzzy
-msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
-msgstr "Girar a matiz da cor no sentido anti-horário"
-
-#: ../po/tmp/resources.xml.h:49
+#: ../po/tmp/resources.xml.h:57
 #, fuzzy
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Change Hue Clockwise"
 msgstr "Mudar a matiz da cor (sentido horário)"
 
-#: ../po/tmp/resources.xml.h:50
+#: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
 msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr "Girar a matiz da cor no sentido horário."
 
-#: ../po/tmp/resources.xml.h:51
+#: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr "Mudar Matiz (sentido anti-horário)"
+
+#: ../po/tmp/resources.xml.h:60
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr "Girar a matiz da cor no sentido anti-horário"
+
+#: ../po/tmp/resources.xml.h:61
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Increase Saturation"
 msgstr "Aumentar Saturação"
 
-#: ../po/tmp/resources.xml.h:52
+#: ../po/tmp/resources.xml.h:62
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color more saturated (more colorful, purer)."
 msgstr "Torna a cor de pintura mais saturada (mais colorida, mais pura)."
 
-#: ../po/tmp/resources.xml.h:53
+#: ../po/tmp/resources.xml.h:63
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Decrease Saturation"
 msgstr "Diminuir Saturação"
 
-#: ../po/tmp/resources.xml.h:54
+#: ../po/tmp/resources.xml.h:64
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color less saturated (grayer)."
 msgstr "Torna a cor de pintura menos saturada (cinzenta)."
 
-#: ../po/tmp/resources.xml.h:55
+#: ../po/tmp/resources.xml.h:65
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Reload Brush Settings"
 msgstr "Recarregar Configurações de Pincel"
 
-#: ../po/tmp/resources.xml.h:56
+#: ../po/tmp/resources.xml.h:66
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Restore all brush settings to the current brush’s saved values."
@@ -4047,23 +4999,26 @@ msgstr ""
 "Restaurar todos os parâmetros do pincel para os valores salvos do pincel "
 "atual"
 
-#: ../po/tmp/resources.xml.h:57
+#: ../po/tmp/resources.xml.h:67
 #, fuzzy
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Pick Stroke and Layer"
 msgstr "Pegar Traço e Camada"
 
-#: ../po/tmp/resources.xml.h:58
+#: ../po/tmp/resources.xml.h:68
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
-msgstr "Selecione um traçado da tela de pintura: restaura pincel, cor e camada."
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+"Selecione um traçado da tela de pintura: restaura pincel, cor e camada."
 
-#: ../po/tmp/resources.xml.h:59
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr "Atalho para Restauração de Cor do Pincel"
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
@@ -4072,351 +5027,412 @@ msgstr ""
 "Chaveia se ao restaurar um pincel por meio de atalho também restaura a cor "
 "salva."
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr "Salvar Pincel para o Atalho Mais Recente"
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr "Salva as configurações de pincel para o atalho mais recente."
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "Limpar Camada"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr "Limpa o conteúdo da camada ativa."
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Trim Layer to Frame"
-msgstr "Cortar Camada para Limites da Moldura"
+#: ../po/tmp/resources.xml.h:75
+#, fuzzy
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr "Opções de Ferramentas"
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:76
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Trim Layer to Frame"
+msgstr "Cortar Camada para Moldura"
+
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr "Apaga partes da camada ativa que estejam externas à moldura."
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr "Apaga partes da camada ativa que estejam externas à moldura."
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "Novo Grupo de Camada"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "Novo Grupo de Camada"
+
+#: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr "Copiar Camada para a Área de Transferência"
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr "Copia o conteúdo da camada ativa para a área de transferência."
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr "Colar Camada da Área de Transferência"
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr "Substitui a camada ativa pelo conteúdo na área de transferência."
 
-#: ../po/tmp/resources.xml.h:71
+#: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Edit Layer in External App…"
 msgstr "Editar Camada em uma Aplicação Externa…"
 
-#: ../po/tmp/resources.xml.h:72
+#: ../po/tmp/resources.xml.h:90
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
+msgid "Edit the active layer in an external application."
 msgstr "Inicia a edição da camada ativa em uma aplicação externa."
 
-#: ../po/tmp/resources.xml.h:73
+#: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Update Layer with External Edits"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:74
+#: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
 msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:75
+#: ../po/tmp/resources.xml.h:93
 #, fuzzy
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer at Cursor"
 msgstr "Seleciona a camada no cursor"
 
-#: ../po/tmp/resources.xml.h:76
+#: ../po/tmp/resources.xml.h:94
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr "Escolher uma camada clicando em uma pincelada nela"
 
-#: ../po/tmp/resources.xml.h:77
+#: ../po/tmp/resources.xml.h:95
 #, fuzzy
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Above"
 msgstr "Ir para Camada"
 
-#: ../po/tmp/resources.xml.h:78
+#: ../po/tmp/resources.xml.h:96
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer up in the layer stack."
 msgstr "Subir uma camada na pilha de camadas"
 
-#: ../po/tmp/resources.xml.h:79
+#: ../po/tmp/resources.xml.h:97
 #, fuzzy
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Below"
 msgstr "Ir para Camada"
 
-#: ../po/tmp/resources.xml.h:80
+#: ../po/tmp/resources.xml.h:98
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer down in the layer stack."
 msgstr "Descer uma camada na pilha de camadas"
 
-#: ../po/tmp/resources.xml.h:81
+#: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer"
 msgstr "Nova camada de pintura"
 
-#: ../po/tmp/resources.xml.h:82
+#: ../po/tmp/resources.xml.h:100
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer above the current layer."
 msgstr "Adicionar uma nova camada acima da camada atual"
 
-#: ../po/tmp/resources.xml.h:83
+#: ../po/tmp/resources.xml.h:101
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer…"
 msgstr "Selecionar Camada"
 
-#: ../po/tmp/resources.xml.h:84
+#: ../po/tmp/resources.xml.h:102
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer above the current layer, and begin editing it."
 msgstr "Adicionar uma nova camada acima da camada atual"
 
-#: ../po/tmp/resources.xml.h:85
+#: ../po/tmp/resources.xml.h:103
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group"
 msgstr "Novo Grupo de Camada"
 
-#: ../po/tmp/resources.xml.h:86
+#: ../po/tmp/resources.xml.h:104
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group above the current layer."
 msgstr "Adicionar uma nova camada acima da camada atual"
 
-#: ../po/tmp/resources.xml.h:87
+#: ../po/tmp/resources.xml.h:105
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:88
+#: ../po/tmp/resources.xml.h:106
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer below the current layer."
 msgstr "Adicionar uma nova camada abaixo da camada atual"
 
-#: ../po/tmp/resources.xml.h:89
+#: ../po/tmp/resources.xml.h:107
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer Below…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:90
+#: ../po/tmp/resources.xml.h:108
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer below the current layer, and begin editing it."
 msgstr "Adicionar uma nova camada abaixo da camada atual"
 
-#: ../po/tmp/resources.xml.h:91
+#: ../po/tmp/resources.xml.h:109
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:92
+#: ../po/tmp/resources.xml.h:110
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group below the current layer."
 msgstr "Adicionar uma nova camada abaixo da camada atual"
 
-#: ../po/tmp/resources.xml.h:93
+#: ../po/tmp/resources.xml.h:111
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Layer Down"
 msgstr "Mesclar Camadas"
 
-#: ../po/tmp/resources.xml.h:94
+#: ../po/tmp/resources.xml.h:112
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Merge the current layer with the layer beneath it."
 msgstr "Juntar camada com a camada abaixo dela"
 
-#: ../po/tmp/resources.xml.h:95
+#: ../po/tmp/resources.xml.h:113
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Visible Layers"
 msgstr "Mesclar Camadas"
 
-#: ../po/tmp/resources.xml.h:96
+#: ../po/tmp/resources.xml.h:114
 msgctxt "Accel Editor (descriptions)"
 msgid "Consolidate all visible layers, and delete the originals."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:97
+#: ../po/tmp/resources.xml.h:115
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer from Visible"
 msgstr "Tornar Camada Visível"
 
-#: ../po/tmp/resources.xml.h:98
+#: ../po/tmp/resources.xml.h:116
 msgctxt "Accel Editor (descriptions)"
 msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:99
+#: ../po/tmp/resources.xml.h:117
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Delete Layer"
 msgstr "Excluir Camada"
 
-#: ../po/tmp/resources.xml.h:100
+#: ../po/tmp/resources.xml.h:118
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Remove the current layer from the layer stack."
 msgstr "Subir a camada atual um passo na pilha de camadas"
 
-#: ../po/tmp/resources.xml.h:101
+#: ../po/tmp/resources.xml.h:119
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Convert to Normal Painting Layer"
 msgstr "Converter para modo Normal"
 
-#: ../po/tmp/resources.xml.h:102
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 #, fuzzy
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr "Aumentar Opacidade"
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 #, fuzzy
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr "Diminuir Opacidade"
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr "Renomear Camada"
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr "Subir a camada atual um passo na pilha de camadas"
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr "Carregar Camada"
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr "Descer a camada atual um passo na pilha de camadas"
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr "Duplicar Camada"
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr "Fazer uma cópia exata da camada atual"
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
-msgstr "Renomear Camada"
+msgid "Layer Properties…"
+msgstr "Propriedades da paleta"
 
-#: ../po/tmp/resources.xml.h:114
-#, fuzzy
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
-msgstr "Escreva um novo nome para a camada atual"
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr "Travada"
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr "A camada atual está travada: não se pode desenhar em camadas travadas"
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr "Tornar Camada Visível"
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr "O estado de visibilidade da camada atual"
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 #, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr "Escolher Fundo"
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr "O estado de visibilidade da camada atual"
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr "Subir a camada atual um passo na pilha de camadas"
+
+#: ../po/tmp/resources.xml.h:141
 #, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr "Restaurar e Centralizar"
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
@@ -4424,734 +5440,805 @@ msgstr ""
 "Restaurar Ampliação, Rotação e Espelhamento, e centralizar o documento "
 "novamente"
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr "Ajustar à Tela"
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 #, fuzzy
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr "Restaurar"
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 #, fuzzy
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr "Restaurar"
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
-msgstr ""
+msgid "Reset view zoom level to default."
+msgstr "Reconfigura o valor base para seu padrão"
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 #, fuzzy
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr "Rotação"
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 #, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr "Ampliar"
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr "Aumentar a ampliação"
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Reduzir"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr "Diminuir a ampliação"
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 #, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
-msgstr "Girar no Sentido Anti-horário"
+msgid "Pan Left"
+msgstr "Visualizar"
 
-#: ../po/tmp/resources.xml.h:137
-#, fuzzy
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
-msgstr "Girar a visualização no sentido anti-horário"
+msgid "Move your view of the canvas to the left."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr "Luz Forte"
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr "Visualizar"
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 #, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr "Girar no sentido horário"
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr "Girar a visualização no sentido horário"
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr "Girar no Sentido Anti-horário"
+
+#: ../po/tmp/resources.xml.h:167
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr "Girar a visualização no sentido anti-horário"
+
+#: ../po/tmp/resources.xml.h:168
 #, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr "Espelhar Horizontalmente"
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr "Fazer da esquerda da visualização a direita"
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 #, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr "Espelhar Verticalmente"
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr "Fazer da parte de cima da visualização a parte de baixo"
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 #, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr "Camada Solo"
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr "Excluir a camada atual"
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 #, fuzzy
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr "Pintura Simétrica"
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 #, fuzzy
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr "Moldura Ativada"
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr "Liga/desl. moldura do documento"
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 #, fuzzy
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr "Imprimir Valores de Entrada do Pincel para o Terminal"
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 #, fuzzy
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr "Visualizar Renderização"
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr "Mostrar atualizações de renderização na tela, para depuração"
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr "Desabilitar Double Buffering da GTK"
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr "Desabilitar buffering duplo da GTK, normalmente habilitado."
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+#, fuzzy
+msgid "Delete Point"
+msgstr "Excluir Ponto"
+
+#: ../po/tmp/resources.xml.h:187
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr "Excluir o ponto selecionado"
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 #, fuzzy
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr "Modo de Linha"
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr "Modo de pintura: Normal"
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr "Aplicar cor normalmente ao pintar."
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr "Modo de pintura: Borracha"
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr "Remover traços usando o pincel atual."
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr "Modo de pintura: Trancar alfa"
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr "Aplicar pincel não altera opacidade da camada."
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Arquivo"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "Sair"
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr "Feche a janela principal e saia da aplicação."
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "Editar"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr "Ferramenta Atual"
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "Cor"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 #, fuzzy
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr "Ajustar Cor"
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 #, fuzzy
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr "Histórico de Cores"
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 #, fuzzy
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr "Detalhes da Cor"
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr "Diálogo com detalhes da cor com entrada de texto"
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 #, fuzzy
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr "Próxima Cor da Paleta"
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr "Próxima cor na paleta"
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 #, fuzzy
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr "Cor Anterior da Paleta"
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr "Cor anterior na paleta"
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 #, fuzzy
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr "Adicionar cor à Paleta"
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "Camada"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 #, fuzzy
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr "Opacidade"
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 #, fuzzy
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr "Ir para Camada"
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 #, fuzzy
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr "Camada Solo"
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 #, fuzzy
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr "Propriedades da paleta"
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr "Painel de Rascunho"
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 #, fuzzy
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr "Novo Painel de Rascunho"
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 #, fuzzy
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr "Abrir Painel de Rascunho..."
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr "Carregar um arquivo de imagem do disco para o painel rascunho."
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 #, fuzzy
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr "Salvar painel de rascunho agora"
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr "Salvar o painel rascunho para seu arquivo existente no disco."
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 #, fuzzy
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr "Reverter Painel de Rascunho"
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 #, fuzzy
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr "Reverter Painel de Rascunho"
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 #, fuzzy
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr "Salvar painel de rascunho como padrão"
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 #, fuzzy
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr "Limpar o painel de rascunho padrão"
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr "Limpar o painel de rascunho padrão"
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 #, fuzzy
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr "Copiar fundo para painel de rascunho"
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "Janela"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "Pincel"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 #, fuzzy
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr "Teclas de Atalho"
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 #, fuzzy
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr "Teclas de Atalho"
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "Mudar Pincel…"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "Mudar a Cor…"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "Mudar Cor (paleta simples)…"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr "Obter Mais Pincéis…"
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 #, fuzzy
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr "Importar Pincéis..."
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr "Realmente apagar o pincel do disco?"
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Ajuda"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr "Ajuda Online"
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "Sobre MyPaint"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Depurar"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 #, fuzzy
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr "Imprimir Informação de Vazamento de Memória para o Terminal (Lento!)"
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 #, fuzzy
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr "Executar Coletor de Lixo Agora"
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 #, fuzzy
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr "Iniciar/Parar o Profiler de Python (cProfile)"
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr "Iniciar/Parar o Profiler de Python (cProfile)"
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "Visualizar"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 #, fuzzy
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr "Contato"
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 #, fuzzy
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr "Ajustar Visualização"
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 #, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr "Menu Destacável"
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "Tela Cheia"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "Preferências"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 #, fuzzy
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr "Testar Dispositivos de Entrada"
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr "Fundo"
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr "Preferências de Pincel"
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr "Editar as configurações do pincel ativo"
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 #, fuzzy
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr "Editor de listas de pinceis"
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr "Editar Ícone do Pincel"
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr "Painel de Camadas"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr "Mostrar o painel Camadas"
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 #, fuzzy
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr "Roda HCY"
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid ""
@@ -5161,46 +6248,35 @@ msgstr ""
 "Selecionar a cor usando o espaço cilíndrico matiz/pureza/luminosidade. As "
 "fatias circulares são de mesma luminosidade."
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "Paleta de Cores"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 #, fuzzy
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr "Roda HSV"
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr "Seletor de cores por Saturação e Valor."
 
-#: ../po/tmp/resources.xml.h:260
-#, fuzzy
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr "Triângulo HSV"
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 #, fuzzy
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr "Cubo HSV"
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid ""
@@ -5209,254 +6285,252 @@ msgid ""
 msgstr ""
 "Um cubo HSV que pode ser rodado para exibir diferentes fatias planares."
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 #, fuzzy
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr "Quadrado"
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 "Um cubo HSV que pode ser rodado para exibir diferentes fatias planares."
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 #, fuzzy
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr "Controles deslizantes de componentes"
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr "Ajustar componentes individuais da cor."
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 #, fuzzy
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr "Painel de Rascunho"
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr "Mostrar Painel de Rascunho"
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr "Painel de pré-visualização"
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "Pré-visualizar"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr "Painel de Opções de Ferramentas"
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr "Mostrar o Painel de Opções de Ferramentas"
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr "Painel de Histórico de Cores e Pincéis"
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr "Cores e Pincéis Recentes"
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 #, fuzzy
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr "Nível de Ampliação"
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 #, fuzzy
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr "Última Posição de Pintura"
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr "Mão Livre"
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr "Mão-livre"
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 #, fuzzy
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
@@ -5464,12 +6538,12 @@ msgstr ""
 "Desenho à Mão Livre: desenhar e pintar livremente, sem restrições de "
 "geometria"
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr "Mão Livre"
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
@@ -5477,103 +6551,103 @@ msgstr ""
 "Desenho à Mão Livre: desenhar e pintar livremente, sem restrições de "
 "geometria"
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 #, fuzzy
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr "Visualizar"
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr "Deslocar"
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 #, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr "Visualizar"
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 #, fuzzy
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr "Girar Visualização"
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr "Girar"
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 #, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr "Girar Visualização"
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 #, fuzzy
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr "Ampliar Visualização"
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr "Ampliação"
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 #, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr "Ampliar Visualização"
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 #, fuzzy
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr "Linhas e Curvas"
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr "Linhas"
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 #, fuzzy
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
@@ -5582,30 +6656,30 @@ msgstr ""
 "Ctrl: restringir ângulo.\n"
 "Shift: adicionar curvas à última linha."
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr "Linhas e Curvas"
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr "Linha reta"
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 #, fuzzy
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr "Linhas Conectadas"
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr "Linhas Conectadas"
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 #, fuzzy
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
@@ -5614,109 +6688,109 @@ msgstr ""
 "Ctrl: restringir ângulo.\n"
 "Shift: adicionar curvas à última linha."
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr "Linhas Sequenciais"
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr "Desenhar sequências de linhas retas ou curvas."
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 #, fuzzy
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr "Elipses e Círculos"
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr "Elipse"
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr "Elipses e Círculos: desenhar formas arredondadas."
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr "Elipses e Círculos"
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr "Desenhar círculos e elipses."
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr "Arte-finalizar"
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr "Tinta"
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr "Arte-finalizar: desenhar linhas com suavização controlada."
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr "Arte-finalizar"
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr "Desenhar linhas com suavização controlada."
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr "Reposicionar Camada"
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr "Camadas"
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 #, fuzzy
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr "Mover Camada: reposicionar a camada atual na tela"
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr "Reposicionar Camada"
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 #, fuzzy
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr "Mover Camada: reposicionar a camada atual na tela"
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 #, fuzzy
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr "Editar Moldura"
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr "Moldura"
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 #, fuzzy
 msgctxt "Toolbar (tooltips)"
 msgid ""
@@ -5725,12 +6799,12 @@ msgstr ""
 "Editar Moldura: definir uma moldura em volta do documento para lhe dar um "
 "tamanho finito. A moldura é usada ao exportar."
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr "Editar Moldura"
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid ""
@@ -5739,83 +6813,249 @@ msgstr ""
 "Editar Moldura: definir uma moldura em volta do documento para lhe dar um "
 "tamanho finito. A moldura é usada ao exportar."
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr "Eixo de Simetria"
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Editar Simetria de Pintura"
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 #, fuzzy
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr "Pegar Cor"
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr "Pegar Cor"
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "Selecionar Cor"
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "Selecionar Cor"
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "Selecionar Cor"
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr "Selecionar Cor"
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr "Preencher"
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr "Preenchimento"
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""
+
+#~ msgctxt "Accelerator map editor: action column markup"
+#~ msgid ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+#~ msgstr ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+
+#~ msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
+#~ msgid "{action_label} {action_desc} {accel_label}"
+#~ msgstr "{action_label} {action_desc} {accel_label}"
+
+#~ msgctxt "brush list context menu"
+#~ msgid "Delete"
+#~ msgstr "Excluir"
+
+#~ msgctxt "brush list commands"
+#~ msgid "Really delete brush from disk?"
+#~ msgstr "Realmente apagar o pincel do disco?"
+
+#~ msgid "HSV Triangle"
+#~ msgstr "Triângulo HSV"
+
+#~ msgid "The standard GTK color selector"
+#~ msgstr "Seletor de cores padrão do GTK"
+
+#~ msgid "Pick a color from the screen"
+#~ msgstr "Pegar uma cor da tela"
+
+#~ msgid "Layer Name"
+#~ msgstr "Nome da Camada"
+
+#~ msgid ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+#~ msgstr ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+
+#~ msgid "Save..."
+#~ msgstr "Salvar..."
+
+#~ msgid "Confirm"
+#~ msgstr "Confirmar"
+
+#~ msgid "Open..."
+#~ msgstr "Abrir..."
+
+#~ msgid "{default_name} at {path}"
+#~ msgstr "{default_name} em {path}"
+
+#~ msgid "Type"
+#~ msgstr "Tipo"
+
+#~ msgid "Mode:"
+#~ msgstr "Modo:"
+
+#~ msgid ""
+#~ "Blending mode: how the current layer combines with the layers underneath "
+#~ "it."
+#~ msgstr ""
+#~ "Modo de mistura: como a camada atual se combina com as camadas abaixo "
+#~ "dela."
+
+#~ msgid ""
+#~ "Layer opacity: how much of the current layer to use. Smaller values make "
+#~ "it more transparent."
+#~ msgstr ""
+#~ "Opacidade da camada: quanto da camada atual usar. Valores menores tornam "
+#~ "a camada mais transparente."
+
+#~ msgid "%s: edit properties"
+#~ msgstr "%s: editar propriedades"
+
+#~ msgctxt "layer unique names: match regex (leave untranslated if unsure)"
+#~ msgid "^(.*?)\\s*(\\d+)$"
+#~ msgstr "^(.*?)\\s*(\\d+)$"
+
+#~ msgctxt "layer default names"
+#~ msgid "Unknown Bitmap Layer"
+#~ msgstr "Camada bitmap desconhecida"
+
+#~ msgctxt "Autosave Recovery dialog|"
+#~ msgid "_Ignore for Now"
+#~ msgstr "_Ignorar por enquanto"
+
+#~ msgid "Setting name:"
+#~ msgstr "Nome da configuração:"
+
+#~ msgid "Base value:"
+#~ msgstr "Valor base:"
+
+#~ msgid "<ymin>"
+#~ msgstr "<ymin>"
+
+#~ msgid "<ymax>"
+#~ msgstr "<ymax>"
+
+#~ msgid "<xmin>"
+#~ msgstr "<xmin>"
+
+#~ msgid "<xmax>"
+#~ msgstr "<xmax>"
+
+#~ msgid "Edit Setting"
+#~ msgstr "Editar Configuração"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Trim Layer to Frame"
+#~ msgstr "Cortar Camada para Limites da Moldura"
+
+#, fuzzy
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Rename Layer…"
+#~ msgstr "Renomear Camada"
+
+#, fuzzy
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Enter a new name for the current layer."
+#~ msgstr "Escreva um novo nome para a camada atual"
+
+#~ msgctxt "Menu→Edit (labels)"
+#~ msgid "Current Tool"
+#~ msgstr "Ferramenta Atual"
+
+#, fuzzy
+#~ msgctxt "Menu→Color (labels), Accel Editor (labels)"
+#~ msgid "HSV Triangle"
+#~ msgstr "Triângulo HSV"
 
 #~ msgid ""
 #~ "\"%s\" has an alpha channel. Background images with transparency are not "
@@ -6027,9 +7267,6 @@ msgstr ""
 #~ "entradas (pressão, velocidade, etc.) estão disponíveis como dicas de "
 #~ "ferramenta. Mantenha o mouse sobre uma ferramente para vê-las. \n"
 
-#~ msgid "Open Recent files"
-#~ msgstr "Abrir Arquivos Recentes"
-
 #~ msgid "This will discard %d second of unsaved painting."
 #~ msgid_plural "This will discard %d seconds of unsaved painting."
 #~ msgstr[0] "Isto irá descartar %d segundo de pintura não salva."
@@ -6037,9 +7274,6 @@ msgstr ""
 
 #~ msgid "Crop to Current Layer"
 #~ msgstr "Cortar a Camada Atual"
-
-#~ msgid "Crop frame to the currently active layer"
-#~ msgstr "Moldura de corte para a camada atualmente ativa"
 
 #~ msgid ""
 #~ "While the frame is enabled, it \n"
@@ -6148,9 +7382,6 @@ msgstr ""
 #~ msgid "Brush Blend Mode"
 #~ msgstr "Modo de Mistura do Pincel"
 
-#~ msgid "Add Layer"
-#~ msgstr "Adicionar Camada"
-
 #~ msgid "Move Layer on Canvas"
 #~ msgstr "Mover Camada na Tela"
 
@@ -6188,9 +7419,6 @@ msgstr ""
 #~ msgctxt "Menu|File|"
 #~ msgid "Save"
 #~ msgstr "Salvar"
-
-#~ msgid "Export to a file"
-#~ msgstr "Exportar para um arquivo"
 
 #~ msgid ""
 #~ "Saves to a new scrap file. If the drawing is currently saved as a scrap, "

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -536,18 +536,18 @@ msgstr "Pacote de pincéis do MyPaint (*.zip)"
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
-msgstr "Novo Grupo..."
+msgid "New Group…"
+msgstr "Novo Grupo…"
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
-msgstr "Importar Pincéis..."
+msgid "Import Brushes…"
+msgstr "Importar Pincéis…"
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
-msgstr "Obter Mais Pincéis..."
+msgid "Get More Brushes…"
+msgstr "Obter Mais Pincéis…"
 
 #: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
@@ -1231,13 +1231,13 @@ msgstr "Tipo"
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
-msgstr "Use para..."
+msgid "Use for…"
+msgstr "Use para…"
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
-msgstr "Move..."
+msgid "Scroll…"
+msgstr "Move…"
 
 #. Name and preview column: will be indented
 #: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
@@ -1460,8 +1460,8 @@ msgid "_Quit"
 msgstr "Sair"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
-msgstr "Importar pacote de pincéis..."
+msgid "Import brush package…"
+msgstr "Importar pacote de pincéis…"
 
 #: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
@@ -1515,8 +1515,8 @@ msgstr ""
 "“{type_name}” ({content_type})?"
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
-msgstr "Abrir Com..."
+msgid "Open With…"
+msgstr "Abrir Com…"
 
 #: ../gui/externalapp.py:123
 msgid "Icon"
@@ -1709,13 +1709,13 @@ msgstr "JPEG com qualidade de 90% (*.jpg; *.jpeg)"
 
 #: ../gui/filehandling.py:576
 #, fuzzy
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr "Exportar…"
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Salvar Como…"
 
@@ -1786,7 +1786,7 @@ msgstr "Abrir Arquivos Recentes"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr "Abrir Painel de Rascunho"
 
 #: ../gui/filehandling.py:1099
@@ -2243,13 +2243,13 @@ msgstr ""
 "problemas, se mais ninguém relatou ainda."
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
-msgstr "Pesquisar Rastreador..."
+msgid "Search Tracker…"
+msgstr "Pesquisar Rastreador…"
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
-msgstr "Reportar..."
+msgid "Report…"
+msgstr "Reportar…"
 
 #: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
@@ -2260,8 +2260,8 @@ msgid "Quit MyPaint"
 msgstr "Sair do MyPaint"
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
-msgstr "Detalhes..."
+msgid "Details…"
+msgstr "Detalhes…"
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
@@ -2470,8 +2470,8 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
-msgstr "Reordenar Camada na Pilha..."
+msgid "Move layer in stack…"
+msgstr "Reordenar Camada na Pilha…"
 
 #: ../gui/layerswindow.py:110
 msgid ""
@@ -2543,8 +2543,8 @@ msgid "Stroke trail-off beginning"
 msgstr "Traçado saindo do começo"
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
-msgstr "Variação de pressão..."
+msgid "Pressure variation…"
+msgstr "Variação de pressão…"
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
@@ -3738,7 +3738,7 @@ msgstr "Apagar este pincel do disco"
 #, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid "_Recover & Save…"
-msgstr "_Recuperar e Salvar..."
+msgstr "_Recuperar e Salvar…"
 
 #: ../po/tmp/autorecover.glade.h:12
 #, fuzzy
@@ -4719,7 +4719,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Import Layers…"
-msgstr "Importar Pincéis..."
+msgstr "Importar Pincéis…"
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
@@ -5885,7 +5885,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
-msgstr "Abrir Painel de Rascunho..."
+msgstr "Abrir Painel de Rascunho…"
 
 #: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
@@ -6034,7 +6034,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
-msgstr "Importar Pincéis..."
+msgstr "Importar Pincéis…"
 
 #: ../po/tmp/resources.xml.h:253
 #, fuzzy

--- a/po/ro.po
+++ b/po/ro.po
@@ -554,20 +554,20 @@ msgstr "Pachetul de pensule Mypaint(*.zip)"
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
-msgstr "Grup nou..."
+msgid "New Group…"
+msgstr "Grup nou…"
 
 #: ../gui/brushselectionwindow.py:537
 #, fuzzy
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
-msgstr "Importă pensule..."
+msgid "Import Brushes…"
+msgstr "Importă pensule…"
 
 #: ../gui/brushselectionwindow.py:540
 #, fuzzy
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
-msgstr "Obține mai multe pensule..."
+msgid "Get More Brushes…"
+msgstr "Obține mai multe pensule…"
 
 #: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
@@ -1322,13 +1322,13 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 #, fuzzy
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr "Defilare"
 
 #. Name and preview column: will be indented
@@ -1517,7 +1517,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Open dragged file confirm dialog: continue button"
 msgid "_Open"
-msgstr "Deschide..."
+msgstr "Deschide…"
 
 #: ../gui/drawwindow.py:486
 msgid "Set current color"
@@ -1553,8 +1553,8 @@ msgid "_Quit"
 msgstr "Ieșire"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
-msgstr "Importă pachet de pensule..."
+msgid "Import brush package…"
+msgstr "Importă pachet de pensule…"
 
 #: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
@@ -1604,8 +1604,8 @@ msgstr ""
 
 #: ../gui/externalapp.py:71
 #, fuzzy
-msgid "Open With..."
-msgstr "Deschide..."
+msgid "Open With…"
+msgstr "Deschide…"
 
 #: ../gui/externalapp.py:123
 msgid "Icon"
@@ -1795,13 +1795,13 @@ msgstr "JPEG calitate 90% (*.jpg; *.jpeg)"
 
 #: ../gui/filehandling.py:576
 #, fuzzy
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
-msgstr "Exportă..."
+msgstr "Exportă…"
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Salvează ca…"
 
@@ -1872,8 +1872,8 @@ msgstr "Deschide fișierele recente"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
-msgstr "Deschide caiet de ciorne..."
+msgid "Open Scratchpad…"
+msgstr "Deschide caiet de ciorne…"
 
 #: ../gui/filehandling.py:1099
 #, fuzzy
@@ -1890,7 +1890,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Deschide..."
+msgstr "Deschide…"
 
 #: ../gui/filehandling.py:1427
 #, fuzzy
@@ -1902,7 +1902,7 @@ msgstr "Deschide cel mai recent"
 #, fuzzy
 msgctxt "File→Open Most Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Deschide..."
+msgstr "Deschide…"
 
 #: ../gui/filehandling.py:1446
 #, fuzzy
@@ -1926,7 +1926,7 @@ msgstr "Deschide rebutul anterior"
 #, fuzzy
 msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
 msgid "_Open"
-msgstr "Deschide..."
+msgstr "Deschide…"
 
 #: ../gui/filehandling.py:1487
 msgctxt "File→Revert: status message: canvas has no filename yet"
@@ -2318,14 +2318,14 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
 #, fuzzy
-msgid "Report..."
-msgstr "Exportă..."
+msgid "Report…"
+msgstr "Exportă…"
 
 #: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
@@ -2337,8 +2337,8 @@ msgid "Quit MyPaint"
 msgstr "Despre MyPaint"
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
-msgstr "Detalii..."
+msgid "Details…"
+msgstr "Detalii…"
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
@@ -2529,7 +2529,7 @@ msgstr ""
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
 #, fuzzy
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr "Reordonează stratul pe stivă"
 
 #: ../gui/layerswindow.py:110
@@ -2601,7 +2601,7 @@ msgid "Stroke trail-off beginning"
 msgstr "Începutul dârei de tușă"
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777
@@ -4748,7 +4748,7 @@ msgstr "Deschide…"
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Open"
-msgstr "Deschide..."
+msgstr "Deschide…"
 
 #: ../po/tmp/resources.xml.h:6
 msgctxt "Toolbar (tooltips), Accel Editor (descriptions)"
@@ -4786,7 +4786,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Import Layers…"
-msgstr "Importă pensule..."
+msgstr "Importă pensule…"
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
@@ -4819,7 +4819,7 @@ msgstr "Salvează într-un fișier cu un nou nume"
 #, fuzzy
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Export…"
-msgstr "Exportă..."
+msgstr "Exportă…"
 
 #: ../po/tmp/resources.xml.h:19
 msgid "Export your work to a file, but keep working on the same file."
@@ -5989,7 +5989,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
-msgstr "Deschide caiet de ciorne..."
+msgstr "Deschide caiet de ciorne…"
 
 #: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
@@ -6141,7 +6141,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
-msgstr "Importă pensule..."
+msgstr "Importă pensule…"
 
 #: ../po/tmp/resources.xml.h:253
 #, fuzzy

--- a/po/ro.po
+++ b/po/ro.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.7.1-git\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:19+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Romanian <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -22,27 +22,7 @@ msgstr ""
 "X-Language: ro\n"
 "X-Source-Language: C\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "Acțiune"
 
@@ -50,39 +30,39 @@ msgstr "Acțiune"
 msgid "Key combination"
 msgstr "Combinaţii taste"
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, fuzzy, python-format
 msgid "Edit Key for '%s'"
 msgstr "Editează legătura pentru '%s'"
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "Acțiune:"
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "Cale:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "Tastă:"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "Acțiune necunoscută"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -90,240 +70,250 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "Gata"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr "Copii de rezervă nu sunt."
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr "Copii de rezervă lipsesc"
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 #, fuzzy
 msgid "Open the Cache Folder…"
 msgstr "Deschide dosarul Cache…"
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 #, fuzzy
 msgid "Backup Recovery Failed"
 msgstr "Restabilirea din copia de rezervă a eşuat"
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 #, fuzzy
 msgid "Open the Backup’s Folder…"
 msgstr "Deschide dosarul Copii de rezervă…"
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "Salvează ca Implicit"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "Fundal"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "Tipar"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Culoare"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "Adaugă culoare la Modele"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr "Una sau mai multe imagini de fundal nu au putut fi încărcate"
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr "Eroare la încărcarea imaginilor de fundal"
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 "Eliminați fișierele care nu pot fi încărcate, sau verificați instalarea "
 "libgdkpixbuf."
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 "Gdk-Pixbuf nu a putut încărca \"{filename}\", și a raportat \"{error}\""
 
-#: ../gui/backgroundwindow.py:369
-#, fuzzy, python-brace-format
+#: ../gui/backgroundwindow.py:387
+#, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 #, fuzzy
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr "Editor de setări pentru pensule"
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 #, fuzzy
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr "Despre"
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 #, fuzzy
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "Experimentale"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 #, fuzzy
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr "Simplu"
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 #, fuzzy
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr "Opacitate"
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 #, fuzzy
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr "Tamponări"
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 #, fuzzy
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "Murdărire"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 #, fuzzy
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr "Viteză"
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr ""
+
+#: ../gui/brusheditor.py:370
 #, fuzzy
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr "Urmărire"
 
-#: ../gui/brusheditor.py:359
+#: ../gui/brusheditor.py:381
 #, fuzzy
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "Tușă"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 #, fuzzy
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr "Culoare"
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Personalizat"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 #, fuzzy
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr "Nicio pensulă nu este selectată, folosiți în schimb \"Adaugă ca nou\"."
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 #, fuzzy
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr "Nicio pensula selectată!"
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 #, fuzzy
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "Redenumește pensula"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 #, fuzzy
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "O pensulă cu acest nume există deja!"
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 #, fuzzy
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr "Nicio pensula selectată!"
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, fuzzy, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr "Stergeți efectiv pensula de pe disc?"
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 #, fuzzy
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr "(pensulă nedenumită)"
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 #, fuzzy
 msgid "Brush Icon"
 msgstr "Editează icoana pensulei"
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 #, fuzzy
 msgid "Brush Icon (editing)"
 msgstr "Opțiuni pensulă"
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 #, fuzzy
 msgid "No brush selected"
 msgstr "Nicio pensula selectată!"
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -364,151 +354,185 @@ msgstr ""
 msgid "Use the default icon"
 msgstr "Resetează la valoarea implicită"
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Salvează"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr "Recuperate"
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr "Șterse"
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr "Favorite"
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr "Cerneală"
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr "Clasic"
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr "Set nr. 1"
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr "Set nr. 2"
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr "Set nr. 3"
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr "Set nr. 4"
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr "Set nr. 5"
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr "Experimentale"
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Nou"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr "Pensulă necunoscută"
 
-#: ../gui/brushselectionwindow.py:183
+#: ../gui/brushselectionwindow.py:220
 #, fuzzy
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr "Favorite"
 
-#: ../gui/brushselectionwindow.py:187
+#: ../gui/brushselectionwindow.py:227
 #, fuzzy
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr "Elimină toate specimenele"
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
+#: ../gui/brushselectionwindow.py:242
 #, fuzzy
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr "Editează setările pensulei active"
 
-#: ../gui/brushselectionwindow.py:201
+#: ../gui/brushselectionwindow.py:250
 #, fuzzy
-msgctxt "brush list context menu"
-msgid "Delete"
-msgstr "Șterge"
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
+msgstr "Redenumește grup"
 
-#: ../gui/brushselectionwindow.py:241
-#, fuzzy
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, fuzzy, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr "Stergeți efectiv pensula de pe disc?"
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, fuzzy, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] "pensule"
 msgstr[1] "pensule"
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 #, fuzzy
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr "Redenumește grup"
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 #, fuzzy
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr "Exportă pensule"
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 #, fuzzy
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr "Șterge grup"
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 #, fuzzy
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr "Redenumește grup"
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "Deja există un grup cu această denumire!"
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, fuzzy, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr "Ștergeți efectiv grupul %s?"
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -516,64 +540,64 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 #, fuzzy
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr "Exportă pensule"
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 #, fuzzy
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr "Pachetul de pensule Mypaint(*.zip)"
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "Grup nou..."
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 #, fuzzy
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr "Importă pensule..."
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 #, fuzzy
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr "Obține mai multe pensule..."
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "Creare grup"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 #, fuzzy
 msgid "Button"
 msgstr "Butoane"
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 #, fuzzy
 msgid "Btn"
 msgstr "Butoane"
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr "Apăsare buton"
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr "Adaugă o nouă legătură"
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr "Reîncarcă legătura curentă"
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr "Editează legătura pentru '%s'"
@@ -582,7 +606,7 @@ msgstr "Editează legătura pentru '%s'"
 msgid "Button press:"
 msgstr "Apăsare de buton:"
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
@@ -590,49 +614,77 @@ msgstr ""
 "Țineți apăsate tastele modificator, apoi apăsați un buton deasupra acestui "
 "text pentru a seta o nouă legătură."
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, fuzzy, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr "%s este deja legat cu acțiunea '%s'"
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 #, fuzzy
 msgid "Pick Color"
 msgstr "Alege culoare"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr "Setează culoarea folosită pentru desen"
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+#, fuzzy
+msgid "Set the color Hue used for painting"
+msgstr "Setează culoarea folosită pentru desen"
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "Alege culoare"
+
+#: ../gui/colorpicker.py:296
+#, fuzzy
+msgid "Set the color Chroma used for painting"
+msgstr "Setează culoarea folosită pentru desen"
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+#, fuzzy
+msgid "Set the color Luma used for painting"
+msgstr "Setează culoarea folosită pentru desen"
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr "Detalii culoare"
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 #, fuzzy
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 "Culoarea nou selectată, și culoarea cel mai recent utilizată pentru pictat"
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 #, fuzzy
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr "Masca gamut activă"
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 #, fuzzy
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
@@ -644,7 +696,7 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr "HCY Hue și Chroma"
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 #, fuzzy
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
@@ -654,13 +706,13 @@ msgstr ""
 "Editor de mască gamut. Faceți clic în mijloc pentru a crea sau manipula "
 "forme, saupentru a roti masca folosind marginile discului."
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 #, fuzzy
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr "Triada atmosferică"
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 #, fuzzy
 msgctxt "HCY Gamut Mask template description"
 msgid ""
@@ -670,25 +722,25 @@ msgstr ""
 "În funcție de dispoziție si subiectivă, definită de o primară dominantă și "
 "două primaremai puțin intense."
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 #, fuzzy
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr "Triadă deplasată"
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 #, fuzzy
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr "Înclinat mai puternic către culoarea dominantă."
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 #, fuzzy
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr "Complementar"
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 #, fuzzy
 msgctxt "HCY Gamut Mask template description"
 msgid ""
@@ -698,13 +750,13 @@ msgstr ""
 "Opuse contrastante, echilibrate având neutre centrale între ele pe roata de "
 "culoare."
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 #, fuzzy
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr "Dispoziție și accent"
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 #, fuzzy
 msgctxt "HCY Gamut Mask template description"
 msgid ""
@@ -714,13 +766,13 @@ msgstr ""
 "O gamă principală de culori, cu un accent complementar pentru variație și "
 "accente."
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 #, fuzzy
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr "Separă complementar"
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 #, fuzzy
 msgctxt "HCY Gamut Mask template description"
 msgid ""
@@ -730,84 +782,84 @@ msgstr ""
 "Două culori analoage și un complement al lor, fără culori secundare între "
 "ele."
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 #, fuzzy
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr "Nouă mască gamut după șablon"
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 #, fuzzy
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr "Editor de mască gamut"
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 #, fuzzy
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr "Acțiune"
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 #, fuzzy
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr "Ajutor"
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 #, fuzzy
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr "Creează mască după șablon"
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 #, fuzzy
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr "Încarcă mască dintr-un fișier paletă GIMP"
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 #, fuzzy
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr "Salvează mască într-un fișier paletă GIMP"
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 #, fuzzy
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr "Șterge masca"
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 #, fuzzy
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr "Salvează mască ca o paletă GIMP"
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 #, fuzzy
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr "Încarcă mască dintr-un fișier paletă GIMP"
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 #, fuzzy
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr "Setează mască gamut"
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 #, fuzzy
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr "Roată HCY"
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 #, fuzzy
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
@@ -818,183 +870,175 @@ msgstr ""
 "circulare sunt echivalente din punct de vedere al luminozității."
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr "Nuanță HSV"
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr "Saturație HSV"
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr "Valoare HSV"
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr "Saturație și valoare HSV"
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr "Nuanță și valoare HSV"
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr "Nuanță și saturație HSV"
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr "Rotește cub (arată axe diferite)"
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr "Cub HSV"
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr "Un cub HSV care poate fi rotit pentru a arăta diferite felii planare."
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 #, fuzzy
 msgid "HSV Square"
 msgstr "Pătrat"
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 #, fuzzy
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr "Un cub HSV care poate fi rotit pentru a arăta diferite felii planare."
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr "Triunghi HSV"
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr "Selector de culoare standard GTK"
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 #, fuzzy
 msgid "HSV Wheel"
 msgstr "Roată HSV"
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr "Schimbă saturație și valoare."
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 #, fuzzy
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr "Proprietăți paletă"
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 #, fuzzy
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr "Paletă"
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 #, fuzzy
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr "Setează culoare plecând de la o paletă încărcabilă și editabilă."
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 #, fuzzy
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr "Strat #%d fără titlu"
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 #, fuzzy
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr "Editor paletă"
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 #, fuzzy
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr "Încarcă dintr-un fișier paletă GIMP"
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 #, fuzzy
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr "Salvează într-un fișier paletă GIMP"
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 #, fuzzy
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr "Adaugă un nou specimen vid"
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 #, fuzzy
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr "Elimină specimenul curent"
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 #, fuzzy
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr "Elimină toate specimenele"
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 #, fuzzy
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr "Nume sau descriere pentru această paletă"
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 #, fuzzy
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr "Coloane:"
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 #, fuzzy
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr "Număr de coloane"
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 #, fuzzy
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr "Nume culoare:"
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 #, fuzzy
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr "Numele culorii curente"
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 #, fuzzy
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr "Slot de paletă gol"
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 #, fuzzy
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr "Încarcă paletă"
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 #, fuzzy
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr "Salvează paletă"
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 #, fuzzy
 msgctxt "palette view"
 msgid ""
@@ -1005,401 +1049,398 @@ msgstr ""
 "Paletă specimene de culoate. Puneți culori aici și deplasați-le pentru a le "
 "organiza."
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 #, fuzzy
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr "Golește slot paletă (deplasați o culoare aici)"
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 #, fuzzy
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "Fișier paletă GIMP (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 #, fuzzy
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr "Toate fișierele (*)"
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 #, fuzzy
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "Fișier paletă GIMP (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 #, fuzzy
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr "Toate fișierele (*)"
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr "Alege o culoare de pe ecran"
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 #, fuzzy
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr "Glisoare component"
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 #, fuzzy
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr "Ajustează componente individuale ale culorii."
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 #, fuzzy
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr "Roșu RGB"
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 #, fuzzy
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr "Verde RGB"
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 #, fuzzy
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr "Albastru RGB"
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 #, fuzzy
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr "Nuanță HSV"
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 #, fuzzy
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr "Saturație HSV"
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 #, fuzzy
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr "Valoare HSV"
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 #, fuzzy
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr "Nuanță HCY"
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 #, fuzzy
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr "HCY Hue și Chroma"
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 #, fuzzy
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr "Selector culoare (inele concentrice)"
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr "radieră"
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 #, fuzzy
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr "Mută"
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 #, fuzzy
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr "Ecran complet"
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 #, fuzzy
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr "Mărire"
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 #, fuzzy
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr "Mută"
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 #, fuzzy
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr "Dispozitiv:"
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 #, fuzzy
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr "Defilare"
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Nume"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr "Suprascrie pensulă?"
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr "Înlocuiește"
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr "Redenumește"
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr "Înlocuiește tot"
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr "Redenumește tot"
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr "Pensula importată"
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr "Pensulă existentă"
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 "<b>O pensulă numită `%s' există deja.</b>\n"
 "Doriți să o înlocuiți, sau redenumiți noua pensulă?"
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr "Suprascrie grup de pensule?"
 
-#: ../gui/dialogs.py:190
-#, python-brace-format
+#: ../gui/dialogs.py:220
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 "<b>Un grup numit `{groupname}' deja există.</b>\n"
 "Doriți să-l înlocuiți, sau să redenumiți noul grup?\n"
 "Dacă-l înlocuiți, pensulele ar putea fi mutate intr-un grup numit "
 "`{deleted_groupname}'."
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr "Importă pachetul de pensule?"
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, fuzzy, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr "<b>Doriți să importați pachetul `%s' cu siguranță?</b>"
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr "Restaurează pensula %d"
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr "Salvează ca pensulă %d"
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr "Anulează %s"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Anulează"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr "Refă %s"
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Refă"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1409,328 +1450,712 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
-msgstr "Nume strat"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
+msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, fuzzy, python-format
 msgid "%s - MyPaint"
 msgstr "Despre MyPaint"
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Deschide..."
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr "Setează culoare curentă"
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr "Părăsește modul ecran întreg"
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 #, fuzzy
 msgid "Leave Fullscreen"
 msgstr "Părăsește modul ecran întreg"
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr "Intră mod ecran complet"
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Ecran complet"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Ieșire"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+#, fuzzy
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr "Sigur ieșiți?"
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Ieșire"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr "Importă pachet de pensule..."
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr "Pachetul de pensule Mypaint(*.zip)"
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 #, fuzzy
 msgid "Open With..."
 msgstr "Deschide..."
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
+#: ../gui/filehandling.py:126
+#, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:130
+#, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:134
+#, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:138
+#, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:145
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "Salvează paletă"
+
+#: ../gui/filehandling.py:168
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr "Exportă într-un fișier"
+
+#: ../gui/filehandling.py:172
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr "Exportă într-un fișier"
+
+#: ../gui/filehandling.py:176
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr "Deschide fișierele recente"
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: ../gui/filehandling.py:221
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
+msgstr "Eroare la încărcarea imaginilor de fundal"
+
+#: ../gui/filehandling.py:427
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "All Recognized Formats"
 msgstr "Toate formatele recunoscute"
 
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
 msgid "OpenRaster (*.ora)"
 msgstr ""
 
-#: ../gui/filehandling.py:95
+#: ../gui/filehandling.py:437
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "PNG (*.png)"
 msgstr "PNG (*.png)"
 
-#: ../gui/filehandling.py:96
+#: ../gui/filehandling.py:442
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "JPEG (*.jpg; *.jpeg)"
 msgstr "JPEG (*.jpg; *.jpeg)"
 
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
+#: ../gui/filehandling.py:490
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "By extension (prefer default format)"
 msgstr "După extensie (preferă formatul implicit)"
 
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr "PNG solid cu fundal (*.png)"
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr "PNG transparent (*.png)"
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
 msgstr ""
 
-#: ../gui/filehandling.py:113
+#: ../gui/filehandling.py:498
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr "PNG solid cu fundal (*.png)"
+
+#: ../gui/filehandling.py:502
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:506
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr "PNG transparent (*.png)"
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr "JPEG calitate 90% (*.jpg; *.jpeg)"
 
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr "Salvează..."
+#: ../gui/filehandling.py:576
+#, fuzzy
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr "Exportă..."
 
-#: ../gui/filehandling.py:177
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Salvează ca…"
+
+#: ../gui/filehandling.py:601
+#, fuzzy
+msgctxt "save dialogs: formats and options: (label)"
 msgid "Format to save as:"
 msgstr "Formatul pentru salvare:"
 
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
+#: ../gui/filehandling.py:668
+#, fuzzy
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
 msgstr "Confirmă continuare?"
 
-#: ../gui/filehandling.py:234
-#, fuzzy, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
-msgstr "Aceasta va anula %d minut de desen nesalvat."
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
+#: ../gui/filehandling.py:705
+#, fuzzy
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
 msgstr "_Salvează ca rebut"
 
-#: ../gui/filehandling.py:282
-#, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
 msgstr ""
 
-#: ../gui/filehandling.py:296
-#, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+#: ../gui/filehandling.py:734
+#, fuzzy, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr "Aceasta va anula %d minut de desen nesalvat."
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
 msgstr ""
 
-#: ../gui/filehandling.py:321
-#, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
 msgstr ""
 
-#: ../gui/filehandling.py:422
-#, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
-msgstr ""
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr "Deschide…"
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
-msgstr ""
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Deschide fișierele recente"
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
-msgstr ""
-
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
-msgstr ""
-
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
-msgstr ""
-
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Deschide..."
-
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr "Deschide caiet de ciorne..."
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Pensula importată"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Deschide..."
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Deschide cel mai recent"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Deschide..."
+
+#: ../gui/filehandling.py:1446
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
 msgstr "Nu există încă fișiere rebut numite \"%s\"."
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1455
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr "Deschide următorul rebut"
+
+#: ../gui/filehandling.py:1463
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr "Deschide rebutul anterior"
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Deschide..."
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+#, fuzzy
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr "Revino"
+
+#: ../gui/fill.py:121
+#, fuzzy
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
-msgstr ""
+msgstr "Umplere culoare"
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+#, fuzzy
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
-msgstr ""
+msgstr "Umple o zona cu culoare."
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+#, fuzzy
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr "Adapteaza la câmpul vizual"
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
-msgstr ""
+msgstr "Grup nou de straturi"
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Opacitate:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 #, fuzzy
 msgid "Reset"
 msgstr "Resetează"
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
 #, fuzzy
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr "Resetează la valoarea implicită"
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "Selectează strat"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1738,140 +2163,152 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 #, fuzzy
 msgid "Edit Frame"
 msgstr "Editează cadru"
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 #, fuzzy
 msgid "Adjust the document frame"
 msgstr "Comută ramă document"
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 #, fuzzy
 msgid "Frame Size"
 msgstr "Cadru"
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr "Înălțime:"
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr "Lățime:"
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr "Rezoluție:"
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr "Culoare:"
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr "Culoare ramă"
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 #, fuzzy
 msgid "<b>Frame dimensions</b>"
 msgstr "<b>Ecran complet</b>"
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 #, fuzzy
 msgid "Set Frame to Layer"
 msgstr "Elimină strat"
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 #, fuzzy
 msgid "Set frame to the extents of the current layer"
 msgstr "Creează o replică exactă a stratului curent"
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 #, fuzzy
 msgid "Set Frame to Document"
 msgstr "Decupează documentul"
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 #, fuzzy
 msgid "Set frame to the combination of all layers"
 msgstr "Decupează toate straturile după cadru"
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 #, fuzzy
 msgid "Trim Layer to Frame"
 msgstr "Nume strat"
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr "Activat"
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 #, fuzzy
 msgid "Freehand Drawing"
 msgstr "Desen liber"
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr "Presiune:"
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr "Defect detectat"
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr "<big><b>O eroare de programare a fost detectată.</b></big>"
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1880,37 +2317,37 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 #, fuzzy
 msgid "Report..."
 msgstr "Exportă..."
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 #, fuzzy
 msgid "Quit MyPaint"
 msgstr "Despre MyPaint"
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr "Detalii..."
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr "S-a produs o excepție în timp ce se analiza excepția."
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1934,45 +2371,50 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr "Test dispozitiv de intrare"
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr "(fără presiune)"
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr "Presiune:"
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr "(fără înclinare)"
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr "Înclinare:"
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr "(niciun dispozitiv)"
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
 msgstr "Dispozitiv:"
 
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+#, fuzzy
+msgid "Barrel Rotation:"
+msgstr "Rotație"
+
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 #, fuzzy
 msgid "Move Layer"
 msgstr "Deplasează strat"
@@ -1982,165 +2424,229 @@ msgstr "Deplasează strat"
 msgid "Move the current layer"
 msgstr "Curăță stratul curent"
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+#, fuzzy
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr "Proprietăți paletă"
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr "Vizibil"
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Strat"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+#, fuzzy
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr "Blocat"
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, fuzzy, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr "Nume strat"
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Straturi"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr "Opacitate strat: %d%%"
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 #, fuzzy
 msgid "Move layer in stack..."
 msgstr "Reordonează stratul pe stivă"
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 #, fuzzy
 msgid "Layer"
 msgstr "Strat"
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
-msgstr "Mod:"
-
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
-"Mod amestecare: modul în care stratul curent se combină cu straturile de sub "
-"acesta."
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Opacitate:"
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
-"Opacitate strat: procentajul din stratul curent care este folosit. Valori "
-"mai mici îl fac mai transparent."
 
-#: ../gui/linemode.py:37
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "Rotește viziune"
+
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr "Presiune intrare"
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr "Presiunea de intrare a tușei pentru unelte de linii"
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr "Presiune la punctul de mijloc"
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr "Presiune la mijlocul tușei pentru unelte de linii"
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr "Presiune de ieșire"
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr "Presiunea de ieșire a tușei pentru unelte de linii"
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr "Cap"
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 msgid "Stroke lead-in end"
 msgstr "Capătul de intrare al tușei"
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr "Coadă"
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr "Începutul dârei de tușă"
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 #, fuzzy
 msgid "Lines and Curves"
 msgstr "Linii și curbe"
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 #, fuzzy
 msgid "Connected Lines"
 msgstr "Linii conectate"
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 #, fuzzy
 msgid "Ellipses and Circles"
 msgstr "Elipse și cercuri"
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 #, fuzzy
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 "Drepturi de autor (C) 2005-2010\n"
 "Martin Renold și echipa de dezvoltare MyPaint"
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 #, fuzzy
 msgctxt "About dialog: license summary"
 msgid ""
@@ -2160,277 +2666,306 @@ msgstr ""
 "Acest program este distribuit în speranța că va fi folositor, dar FĂRĂ NICIO "
 "GARANȚIE. Consultați fișierul COPYING pentru mai multe detalii."
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr "programare"
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr "portabilitate"
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 #, fuzzy
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr "pensule"
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 #, fuzzy
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr "modele"
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 #, fuzzy
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr "iconițe unelte"
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 #, fuzzy
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr "iconiță desktop"
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 #, fuzzy
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr "Paletă"
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 #, fuzzy
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr "Rotație"
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 #, fuzzy
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr "Andrei Brănescu"
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 #, fuzzy
 msgid "Opaque:"
 msgstr "Mai opac"
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 #, fuzzy
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr "iconițe unelte"
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 #, fuzzy
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr "Deschide un fișier, înlocuind desenul curent"
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr "Mărire: %.01f%%"
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 #, fuzzy
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr "Alege tușă: setări și strat"
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 #, fuzzy
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr "Alege culoare"
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr "Preferințe"
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 #, fuzzy
 msgid "Preview"
 msgstr "Elementul precedent"
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 #, fuzzy
 msgid "Show Viewfinder"
 msgstr "Arată subferestre"
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr "Caiet de ciorne"
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr "Amestecă culori și schițează pe ciorne diferite"
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr "Elementul precedent"
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr "Elementul urmator"
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
 msgstr "(Nimic de afișat)"
 
-#: ../gui/symmetry.py:76
+#: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Place axis"
 msgstr ""
 
-#: ../gui/symmetry.py:80
+#: ../gui/symmetry.py:84
 #, fuzzy
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Move axis"
 msgstr "Deplasează strat"
 
-#: ../gui/symmetry.py:84
+#: ../gui/symmetry.py:88
 #, fuzzy
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr "Elimină"
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 #, fuzzy
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr "Arată axa de simetrie"
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 #, fuzzy
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr "Arată axa de simetrie"
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 #, fuzzy
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr "Acțiune:"
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr "Acțiune:"
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
+msgstr "Axă de simetrie"
+
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:446
+#, fuzzy
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr "Acțiune:"
+
+#: ../gui/symmetry.py:477
+#, fuzzy
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr "Acțiune:"
+
+#: ../gui/symmetry.py:605
 #, fuzzy
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr "Activat"
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr "Manipulare fișier"
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr "Comutator rebuturi"
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr "Anulează și refă"
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr "Moduri amestecare"
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 #, fuzzy
 msgid "Line Modes"
 msgstr "Mod amestecare"
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr "Vizualizare (Principal)"
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr "Vizualizare (Alternativ/Secundar)"
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr "Vizualizare (Restabilire)"
 
@@ -2439,206 +2974,232 @@ msgstr "Vizualizare (Restabilire)"
 msgid "<b>MyPaint</b>"
 msgstr "<b>Salvare</b>"
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 #, fuzzy
 msgid "Scroll View"
 msgstr "Defilează viziunea"
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 #, fuzzy
 msgid "Zoom View"
 msgstr "Mărește viziune"
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 #, fuzzy
 msgid "Rotate View"
 msgstr "Rotește viziune"
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 #, fuzzy
 msgid "Rotate the canvas view"
 msgstr "Rotește imaginea spre dreapta"
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, fuzzy, python-format
-msgid "%s: edit properties"
-msgstr "Proprietăți paletă"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
+msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 #, fuzzy
 msgid "Unknown Command"
 msgstr "Acțiune necunoscută"
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 #, fuzzy
 msgid "Trim Layer"
 msgstr "Curață strat"
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "Redenumește grup"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr "Curață strat"
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 #, fuzzy
 msgid "Paste Layer"
 msgstr "Elimină strat"
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 #, fuzzy
 msgid "New Layer from Visible"
 msgstr "Fă stratul vizibil"
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 #, fuzzy
 msgid "Merge Visible Layers"
 msgstr "Contopește straturi"
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 #, fuzzy
 msgid "Merge Down"
 msgstr "Contopește în jos"
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 #, fuzzy
 msgid "Normalize Layer Mode"
 msgstr "Strat in mod convertire"
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Pensula importată"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr "Elimină strat"
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr "Selectează strat"
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr "Duplichează stratul"
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 #, fuzzy
 msgid "Move Layer Up"
 msgstr "Deplasează strat"
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 #, fuzzy
 msgid "Move Layer Down"
 msgstr "Deplasează strat"
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 #, fuzzy
 msgid "Move Layer in Stack"
 msgstr "Reordonează stratul pe stivă"
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr "Elimină strat"
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr "Fă stratul vizibil"
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr "Fă stratul invizibil"
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr "Blochează stratul"
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr "Deblochează stratul"
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, fuzzy, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr "Opacitate strat: %d%%"
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 #, fuzzy
 msgid "Unknown Mode"
 msgstr "Acțiune necunoscută"
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, fuzzy, python-format
 msgid "Set Layer Mode: %s"
 msgstr "Strat in mod convertire"
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 #, fuzzy
 msgid "Enable Frame"
 msgstr "Editează cadru"
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 #, fuzzy
 msgid "Disable Frame"
 msgstr "Editează cadru"
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 #, fuzzy
 msgid "Update Frame"
 msgstr "Editează cadru"
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, fuzzy, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr "Eroare la încărcarea imaginilor de fundal"
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2647,13 +3208,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2663,7 +3224,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, fuzzy, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2673,13 +3234,13 @@ msgstr ""
 "Nu se poate salva: %s\n"
 "Aveți suficient spațiu rămas pe disc?"
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2687,7 +3248,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, fuzzy, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2695,7 +3256,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr "Nu aveți pemisiunea să deschideți fișierul %s"
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2706,7 +3267,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, fuzzy, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2714,7 +3275,13 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr "Format fișier necunoscut: %s"
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+#, fuzzy
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr "Pensula importată"
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2724,7 +3291,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2735,102 +3302,208 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+#, fuzzy
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr "Manipulare fișier"
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 #, fuzzy
 msgctxt "layer default names"
 msgid "Layer"
 msgstr "Strat"
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
-#, fuzzy
-msgctxt "layer default names"
-msgid "Vector Layer"
-msgstr "Selectează strat"
-
 #: ../lib/layer/data.py:1153
 #, fuzzy
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
-msgstr "Pensulă necunoscută"
+msgid "Vectors"
+msgstr "Selectează strat"
 
-#: ../lib/layer/data.py:1169
+#: ../lib/layer/data.py:1158
 #, fuzzy
+msgctxt "layer type descriptions"
+msgid "Vector Layer"
+msgstr "Selectează strat"
+
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Data Layer"
+msgid "Bitmap"
+msgstr ""
+
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
 msgstr "Du-te la strat"
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "Un nou strat"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "Grup nou de straturi"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+#, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "Vizualizare"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+#, fuzzy
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr "Adaugă strat"
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+#, fuzzy
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr "Elimină strat"
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr "Blochează stratul"
+
+#: ../lib/layervis.py:697
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr "Deblochează stratul"
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr "Numai stratul din vârf, fără culori amestecate."
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr "Multiplică"
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 #, fuzzy
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
@@ -2839,11 +3512,11 @@ msgstr ""
 "Similar cu încărcarea mai multor diapozitive intr-un singur locaș de "
 "proiector și proiectând rezultatul combinat."
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr "Barieră"
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
@@ -2851,11 +3524,11 @@ msgstr ""
 "Ca și luminând cu două proiectoare pe un ecran în același timp. Acesta este "
 "inversul lui 'Multiplică'."
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr "Acoperire"
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
@@ -2863,33 +3536,33 @@ msgstr ""
 "Acoperă fundalul cu stratul din vârf, păstrând părțile luminoase și umbrele "
 "fundalului. Acesta este inversul lui 'Lumină dură'."
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr "Întunecă"
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 #, fuzzy
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 "Stratul din vârf este folosit numai unde acesta este mai întunecat decât "
 "fundalul."
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr "Luminează"
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 #, fuzzy
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 "Stratul din vârf este folosit numai unde acesta este mai luminos decat "
 "fundalul."
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr "Evită"
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
@@ -2899,11 +3572,11 @@ msgstr ""
 "tehnica fotografică cu același nume folosită în camera obscură pentru "
 "îmbunătățirea contrastului în umbre."
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr "Arde"
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
@@ -2913,54 +3586,54 @@ msgstr ""
 "fotografică cu același nume folosită în camera obscură pentru reducerea "
 "părților luminoase supra accentuate."
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr "Lumină puternică"
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr "Similar cu iluminarea fundalului cu o sursă de lumină puternică."
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr "Lumină slabă"
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr "Similar cu iluminarea fundalului cu o sursă de lumină difuză."
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr "Diferență"
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr "Excludere"
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr "Similar cu modul 'Diferență', dar mai slab în contrast."
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr "Nuanță"
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 "Combină nuanța stratului superior cu saturația și luminozitatea fundalului."
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr "Saurație"
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
@@ -2968,7 +3641,7 @@ msgstr ""
 "Aplică saturația culorilor stratului superior asupra nuanței și "
 "luminozității fundalului."
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
@@ -2976,11 +3649,11 @@ msgstr ""
 "Aplică nuanța și saturația stratului superior asupra luminozității "
 "fundalului."
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr "Luminozitate"
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
@@ -2988,62 +3661,73 @@ msgstr ""
 "Aplică luminozitatea stratului superior asupra nuanței și luminozității "
 "fundalului."
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -3053,7 +3737,30 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+#, fuzzy
+msgid "Vertical"
+msgstr "Oglindește vertical"
+
+#: ../lib/tiledsurface.py:49
+#, fuzzy
+msgid "Horizontal"
+msgstr "Oglindește orizontal"
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+#, fuzzy
+msgid "Rotational"
+msgstr "Rotație"
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -3062,57 +3769,87 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr "Șterge"
+
+#: ../po/tmp/autorecover.glade.h:9
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr "Stergeți efectiv pensula de pe disc?"
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-#, fuzzy
-msgid "Copy to New"
-msgstr "Copie a %s"
+msgid "Live update"
+msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
 #, fuzzy
-msgid "Copy these settings and the current brush's icon to a new brush"
-msgstr ""
-"Resetează toate opțiunile de pensulă la valorile salvate ale pensulei curente"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
+msgstr "Actualizează ultima tușa pe pânză în timp real"
 
 #: ../po/tmp/brusheditor.glade.h:4
-#, fuzzy
-msgid "Rename this brush"
-msgstr "Redenumește pensula"
+msgid "Save these settings to the brush"
+msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
 #, fuzzy
@@ -3136,19 +3873,20 @@ msgid "Delete this brush from the disk"
 msgstr "Stergeți efectiv pensula de pe disc?"
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
-msgstr ""
+#, fuzzy
+msgid "Copy to New"
+msgstr "Copie a %s"
 
 #: ../po/tmp/brusheditor.glade.h:10
 #, fuzzy
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
-msgstr "Actualizează ultima tușa pe pânză în timp real"
+msgid "Copy these settings and the current brush's icon to a new brush"
+msgstr ""
+"Resetează toate opțiunile de pensulă la valorile salvate ale pensulei curente"
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
-msgstr ""
+#, fuzzy
+msgid "Rename this brush"
+msgstr "Redenumește pensula"
 
 #: ../po/tmp/brusheditor.glade.h:13
 #, fuzzy
@@ -3179,117 +3917,90 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-#, fuzzy
-msgid "Setting name:"
-msgstr "Fereastră setări"
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
+#: ../po/tmp/brusheditor.glade.h:22
 #, fuzzy
-msgid "Base value:"
-msgstr "Valoare de bază"
+msgid "Value:"
+msgstr "Valoare HSV"
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr "<ymin>"
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr "<ymax>"
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 #, fuzzy
 msgid "Input"
 msgstr "Intrare stilou"
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr "<xmin>"
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr "<xmax>"
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-#, fuzzy
-msgid "Basic details for this setting"
-msgstr "Înapoi la setări"
-
-#: ../po/tmp/brusheditor.glade.h:46
-#, fuzzy
-msgid "Edit Setting"
-msgstr "Salvează preferințe"
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+#, fuzzy
+msgid "Brush dynamics are not available for this setting."
+msgstr "Înapoi la setări"
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3304,7 +4015,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr "Presiune:"
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3350,6 +4061,140 @@ msgstr "Șterge grup"
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
 msgstr "Reîncarcă stratul curent"
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+#, fuzzy
+msgid "Insert Point"
+msgstr "Șterge grup"
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+#, fuzzy
+msgid "Cull Points"
+msgstr "Șterge grup"
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Nume"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr "Mod:"
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Opacitate"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr "Decupează stratul curent după cadru"
+
+#: ../po/tmp/layervis.glade.h:2
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr "Rotește imaginea spre dreapta"
+
+#: ../po/tmp/layervis.glade.h:3
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr "Rotește imaginea spre dreapta"
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
+msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
 #, fuzzy
@@ -3741,57 +4586,78 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+#, fuzzy
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr "Activat"
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 #, fuzzy
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr "Vizualizare"
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3799,13 +4665,13 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 #, fuzzy
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr "Schimbă componentele roșu, verde și albastru"
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3814,7 +4680,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3825,32 +4691,32 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 #, fuzzy
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr "<b>Ecran complet</b>"
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 #, fuzzy
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr "Culoare"
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 #, fuzzy
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr "Ecran (normal)"
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 #, fuzzy
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr "Dezactivat (fără sensibilitate la presiune)"
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 #, fuzzy
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
@@ -3917,602 +4783,708 @@ msgid "Reload the file your current work was loaded from."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
+#, fuzzy
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Import Layers…"
+msgstr "Importă pensule..."
+
+#: ../po/tmp/resources.xml.h:13
+msgctxt "Accel Editor (descriptions)"
+msgid "Import layers from one or more files."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save"
 msgstr "Salvează"
 
-#: ../po/tmp/resources.xml.h:13
+#: ../po/tmp/resources.xml.h:15
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file."
 msgstr "Salvează în fișier"
 
-#: ../po/tmp/resources.xml.h:14
+#: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As…"
 msgstr "Salvează ca…"
 
-#: ../po/tmp/resources.xml.h:15
+#: ../po/tmp/resources.xml.h:17
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file, assigning it a new name."
 msgstr "Salvează într-un fișier cu un nou nume"
 
-#: ../po/tmp/resources.xml.h:16
+#: ../po/tmp/resources.xml.h:18
 #, fuzzy
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Export…"
 msgstr "Exportă..."
 
-#: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:18
-#, fuzzy
-msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
-msgstr "Salvează ca rebut"
-
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 #, fuzzy
 msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Save As Scrap"
+msgstr "Salvează ca rebut"
+
+#: ../po/tmp/resources.xml.h:21
+msgctxt "Accel Editor (descriptions)"
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:22
+#, fuzzy
+msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Previous Scrap"
 msgstr "Deschide rebutul anterior"
 
-#: ../po/tmp/resources.xml.h:21
+#: ../po/tmp/resources.xml.h:23
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file before the current one."
 msgstr "Încarcă urmatorul fișier rebut, înlocuind desenul curent"
 
-#: ../po/tmp/resources.xml.h:22
+#: ../po/tmp/resources.xml.h:24
 #, fuzzy
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Next Scrap"
 msgstr "Deschide următorul rebut"
 
-#: ../po/tmp/resources.xml.h:23
+#: ../po/tmp/resources.xml.h:25
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file after the current one."
 msgstr "Încarcă urmatorul fișier rebut, înlocuind desenul curent"
 
-#: ../po/tmp/resources.xml.h:24
+#: ../po/tmp/resources.xml.h:26
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Recover File from an Automated Backup…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:25
+#: ../po/tmp/resources.xml.h:27
 msgctxt "Accel Editor (descriptions)"
 msgid "Try to save and resume interrupted unsaved work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:26
+#: ../po/tmp/resources.xml.h:28
 #, fuzzy
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr "Pensule"
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr "Pensule"
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 #, fuzzy
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr "Suprascrie grup de pensule?"
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 #, fuzzy
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr "Detalii culoare"
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr "Culori"
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 #, fuzzy
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr "Mod:"
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr "Mod:"
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 #, fuzzy
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr "Starea de vizibilitate a stratului curent"
 
-#: ../po/tmp/resources.xml.h:35
-#, fuzzy
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr "Crește opacitate strat"
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 #, fuzzy
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
-msgstr "Scade opacitate pensulă"
+msgid "Increase Fake Pressure"
+msgstr "Presiune intrare"
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 #, fuzzy
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
-msgstr "Crește opacitate pensulă"
+msgid "Decrease Fake Pressure"
+msgstr "Presiune intrare"
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 #, fuzzy
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
-msgstr "Scade opacitate pensulă"
+msgid "Increase Fake Rotation"
+msgstr "Crește saturație culoare"
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
 #, fuzzy
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
-msgstr "Ulrima poziție de desenare"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
+msgstr "Scade saturația culorii"
 
 #: ../po/tmp/resources.xml.h:44
-#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
-msgstr "Deschide un fișier, înlocuind desenul curent"
+msgid "Decrease barrel rotation for devices that don't support rotation input."
+msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
 #, fuzzy
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
-msgstr "Ulrima poziție de desenare"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
+msgstr "Crește opacitate strat"
 
 #: ../po/tmp/resources.xml.h:46
-#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
-msgstr "Deschide un fișier, înlocuind desenul curent"
+msgid "Make the working brush bigger."
+msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
 #, fuzzy
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
-msgstr "Nuanță în sens trigonometric"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
+msgstr "Scade opacitate pensulă"
 
 #: ../po/tmp/resources.xml.h:48
-#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
-msgstr "Rotește nuanța în sens trigonometric"
+msgid "Make the working brush smaller."
+msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
 #, fuzzy
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
-msgstr "Schimbă nuanța culorii (în sensul acelor de ceasornic)"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
+msgstr "Crește opacitate pensulă"
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
 #, fuzzy
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
-msgstr "Crește saturație culoare"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
+msgstr "Scade opacitate pensulă"
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 #, fuzzy
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Lighten Painting Color"
+msgstr "Ulrima poziție de desenare"
+
+#: ../po/tmp/resources.xml.h:54
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Increase the lightness of the current painting color."
+msgstr "Deschide un fișier, înlocuind desenul curent"
+
+#: ../po/tmp/resources.xml.h:55
+#, fuzzy
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
+msgstr "Ulrima poziție de desenare"
+
+#: ../po/tmp/resources.xml.h:56
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Decrease the lightness of the current painting color."
+msgstr "Deschide un fișier, înlocuind desenul curent"
+
+#: ../po/tmp/resources.xml.h:57
+#, fuzzy
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
+msgstr "Schimbă nuanța culorii (în sensul acelor de ceasornic)"
+
+#: ../po/tmp/resources.xml.h:58
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:59
+#, fuzzy
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr "Nuanță în sens trigonometric"
+
+#: ../po/tmp/resources.xml.h:60
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr "Rotește nuanța în sens trigonometric"
+
+#: ../po/tmp/resources.xml.h:61
+#, fuzzy
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr "Crește saturație culoare"
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+#, fuzzy
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Decrease Saturation"
 msgstr "Scade saturația culorii"
 
-#: ../po/tmp/resources.xml.h:54
+#: ../po/tmp/resources.xml.h:64
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color less saturated (grayer)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:55
+#: ../po/tmp/resources.xml.h:65
 #, fuzzy
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Reload Brush Settings"
 msgstr "Opțiuni pensulă detaliate"
 
-#: ../po/tmp/resources.xml.h:56
+#: ../po/tmp/resources.xml.h:66
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Restore all brush settings to the current brush’s saved values."
 msgstr ""
 "Resetează toate opțiunile de pensulă la valorile salvate ale pensulei curente"
 
-#: ../po/tmp/resources.xml.h:57
+#: ../po/tmp/resources.xml.h:67
 #, fuzzy
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Pick Stroke and Layer"
 msgstr "Alege tușă și strat"
 
-#: ../po/tmp/resources.xml.h:58
+#: ../po/tmp/resources.xml.h:68
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
-msgstr ""
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr "Alege tușă: setări și strat"
 
-#: ../po/tmp/resources.xml.h:59
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 #, fuzzy
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr "Salvează pensulă la recent restaurate"
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr "Salvează pensulă la recent restaurate"
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "Curață strat"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr "Curăță stratul curent"
 
-#: ../po/tmp/resources.xml.h:65
+#: ../po/tmp/resources.xml.h:75
 #, fuzzy
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr "iconițe unelte"
+
+#: ../po/tmp/resources.xml.h:76
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr "Nume strat"
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr ""
+"Aplică saturația culorilor stratului superior asupra nuanței și "
+"luminozității fundalului."
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "Grup nou de straturi"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "Grup nou de straturi"
+
+#: ../po/tmp/resources.xml.h:85
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr "Copiaza în clipboard"
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr "Copiază stratul curent în clipboard"
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr "Copiaza în clipboard"
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr "Înlocuiește stratul curent cu conținutul clipboardului"
 
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-#, fuzzy
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr "Deplasează strat: repoziționează stratul curent pe pânză"
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-#, fuzzy
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr "Selectează stratul de la cursor"
-
-#: ../po/tmp/resources.xml.h:76
-#, fuzzy
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr "Alege un strat selectând o tușă de pe acesta"
-
-#: ../po/tmp/resources.xml.h:77
-#, fuzzy
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr "Du-te la strat"
-
-#: ../po/tmp/resources.xml.h:78
-#, fuzzy
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
-msgstr "Mergi cu un strat mai sus pe stiva de straturi"
-
-#: ../po/tmp/resources.xml.h:79
-#, fuzzy
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
-msgstr "Du-te la strat"
-
-#: ../po/tmp/resources.xml.h:80
-#, fuzzy
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
-msgstr "Mergi cu un strat mai jos pe stiva de straturi"
-
-#: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
-msgstr "Un nou strat"
-
-#: ../po/tmp/resources.xml.h:82
-#, fuzzy
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
-msgstr "Adaugă un nou strat, deasupra celui curent"
-
-#: ../po/tmp/resources.xml.h:83
-#, fuzzy
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
-msgstr "Selectează strat"
-
-#: ../po/tmp/resources.xml.h:84
-#, fuzzy
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
-msgstr "Adaugă un nou strat, deasupra celui curent"
-
-#: ../po/tmp/resources.xml.h:85
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
-msgstr "Grup nou de straturi"
-
-#: ../po/tmp/resources.xml.h:86
-#, fuzzy
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
-msgstr "Adaugă un nou strat, deasupra celui curent"
-
-#: ../po/tmp/resources.xml.h:87
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:88
-#, fuzzy
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
-msgstr "Adaugă un nou strat sub cel curent"
-
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
+msgid "Edit the active layer in an external application."
+msgstr "Deplasează strat: repoziționează stratul curent pe pânză"
+
+#: ../po/tmp/resources.xml.h:91
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Update Layer with External Edits"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:92
+msgctxt "Accel Editor (descriptions)"
+msgid "Commit changes saved from the external app (normally automatic)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:93
+#, fuzzy
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
+msgstr "Selectează stratul de la cursor"
+
+#: ../po/tmp/resources.xml.h:94
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Select a layer by picking something [drawn] on it."
+msgstr "Alege un strat selectând o tușă de pe acesta"
+
+#: ../po/tmp/resources.xml.h:95
+#, fuzzy
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
+msgstr "Du-te la strat"
+
+#: ../po/tmp/resources.xml.h:96
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Go one layer up in the layer stack."
+msgstr "Mergi cu un strat mai sus pe stiva de straturi"
+
+#: ../po/tmp/resources.xml.h:97
+#, fuzzy
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
+msgstr "Du-te la strat"
+
+#: ../po/tmp/resources.xml.h:98
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Go one layer down in the layer stack."
+msgstr "Mergi cu un strat mai jos pe stiva de straturi"
+
+#: ../po/tmp/resources.xml.h:99
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer"
+msgstr "Un nou strat"
+
+#: ../po/tmp/resources.xml.h:100
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer above the current layer."
+msgstr "Adaugă un nou strat, deasupra celui curent"
+
+#: ../po/tmp/resources.xml.h:101
+#, fuzzy
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer…"
+msgstr "Selectează strat"
+
+#: ../po/tmp/resources.xml.h:102
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr "Adaugă un nou strat, deasupra celui curent"
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr "Grup nou de straturi"
+
+#: ../po/tmp/resources.xml.h:104
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr "Adaugă un nou strat, deasupra celui curent"
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr "Adaugă un nou strat sub cel curent"
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer below the current layer, and begin editing it."
 msgstr "Adaugă un nou strat sub cel curent"
 
-#: ../po/tmp/resources.xml.h:91
+#: ../po/tmp/resources.xml.h:109
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:92
+#: ../po/tmp/resources.xml.h:110
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group below the current layer."
 msgstr "Adaugă un nou strat sub cel curent"
 
-#: ../po/tmp/resources.xml.h:93
+#: ../po/tmp/resources.xml.h:111
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Layer Down"
 msgstr "Contopește straturi"
 
-#: ../po/tmp/resources.xml.h:94
+#: ../po/tmp/resources.xml.h:112
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Merge the current layer with the layer beneath it."
 msgstr "Contopește strat cu cel de sub el"
 
-#: ../po/tmp/resources.xml.h:95
+#: ../po/tmp/resources.xml.h:113
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Visible Layers"
 msgstr "Contopește straturi"
 
-#: ../po/tmp/resources.xml.h:96
+#: ../po/tmp/resources.xml.h:114
 msgctxt "Accel Editor (descriptions)"
 msgid "Consolidate all visible layers, and delete the originals."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:97
+#: ../po/tmp/resources.xml.h:115
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer from Visible"
 msgstr "Fă stratul vizibil"
 
-#: ../po/tmp/resources.xml.h:98
+#: ../po/tmp/resources.xml.h:116
 msgctxt "Accel Editor (descriptions)"
 msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:99
+#: ../po/tmp/resources.xml.h:117
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Delete Layer"
 msgstr "Șterge strat"
 
-#: ../po/tmp/resources.xml.h:100
+#: ../po/tmp/resources.xml.h:118
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Remove the current layer from the layer stack."
 msgstr "Ridică stratul curent cu o poziție pe stiva de straturi"
 
-#: ../po/tmp/resources.xml.h:101
+#: ../po/tmp/resources.xml.h:119
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Convert to Normal Painting Layer"
 msgstr "Convertește în modul normal"
 
-#: ../po/tmp/resources.xml.h:102
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 #, fuzzy
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr "Crește opacitate"
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 #, fuzzy
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr "Scade opacitate"
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr "Elimină strat"
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr "Ridică stratul curent cu o poziție pe stiva de straturi"
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr "Încarcă strat"
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr "Coboară stratul curent cu o poziție pe stiva de straturi"
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr "Duplichează stratul"
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr "Creează o replică exactă a stratului curent"
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
-msgstr "Elimină strat"
+msgid "Layer Properties…"
+msgstr "Proprietăți paletă"
 
-#: ../po/tmp/resources.xml.h:114
-#, fuzzy
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
-msgstr "Introdu un nou nume pentru stratul curent"
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr "Blocat"
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid ""
@@ -4521,779 +5493,859 @@ msgstr ""
 "Starea de blocare a stratului curent: straturile blocate nu pot fi desenate "
 "pe"
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr "Fă stratul vizibil"
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr "Starea de vizibilitate a stratului curent"
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 #, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr "Alege fundal"
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr "Starea de vizibilitate a stratului curent"
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr "Ridică stratul curent cu o poziție pe stiva de straturi"
+
+#: ../po/tmp/resources.xml.h:141
 #, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr "Resetează și centrează"
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr "Resetează zoom, rotație și oglindire, și recentrează documentul"
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr "Adapteaza la câmpul vizual"
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 #, fuzzy
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr "Resetează"
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 #, fuzzy
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr "Resetează"
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 #, fuzzy
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr "Rotație"
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 #, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr "Mărește"
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr "Crește mărirea"
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Micșorează"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr "Scade mărirea"
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 #, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
-msgstr "Rotește în sens trigonometric"
+msgid "Pan Left"
+msgstr "Vizualizare"
 
-#: ../po/tmp/resources.xml.h:137
-#, fuzzy
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
-msgstr "Rotește viziunea în sens trigonometric"
+msgid "Move your view of the canvas to the left."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr "Lumină puternică"
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr "Vizualizare"
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 #, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr "Rotește în sens orar"
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr "Rotește viziunea imaginea spre stânga"
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr "Rotește în sens trigonometric"
+
+#: ../po/tmp/resources.xml.h:167
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr "Rotește viziunea în sens trigonometric"
+
+#: ../po/tmp/resources.xml.h:168
 #, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr "Oglindește orizontal"
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr "Întoarce imaginea de la stânga la dreapta"
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 #, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr "Oglindește vertical"
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr "Intoarce imaginea de sus în jos"
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 #, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr "Strat singur"
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr "Reîncarcă stratul curent"
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 #, fuzzy
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr "Desenează simetric"
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 #, fuzzy
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr "Cadru activat"
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr "Comută ramă document"
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 #, fuzzy
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr "Afișează la consolă valorile de intrare ale pensulei"
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 #, fuzzy
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr "Vizualizează randarea"
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr "Afișează actualizarea randării pe ecran, pentru depanare"
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 #, fuzzy
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr "Dezactivează GTK Double Buffering"
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+#, fuzzy
+msgid "Delete Point"
+msgstr "Șterge grup"
+
+#: ../po/tmp/resources.xml.h:187
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr "Reîncarcă stratul curent"
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 #, fuzzy
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr "Mod amestecare"
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 #, fuzzy
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr "Pictează normal"
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr "Mod radieră: îndepărtează tușe folosind pensula actuală"
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Fișier"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 #, fuzzy
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "Ieșire"
 
-#: ../po/tmp/resources.xml.h:167
-msgctxt "Accel Editor (descriptions)"
-msgid "Close main window and exit the app."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:168
-#, fuzzy
-msgctxt "Menu (labels)"
-msgid "Edit"
-msgstr "Editează"
-
-#: ../po/tmp/resources.xml.h:169
-#, fuzzy
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr "Culoare curentă"
-
-#: ../po/tmp/resources.xml.h:170
-msgctxt "Menu (labels)"
-msgid "Color"
-msgstr "Culoare"
-
-#: ../po/tmp/resources.xml.h:171
-#, fuzzy
-msgctxt "Menu→Color (labels)"
-msgid "Adjust Color"
-msgstr "Ajustează culoare"
-
-#: ../po/tmp/resources.xml.h:172
-#, fuzzy
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "Color History Popup"
-msgstr "Istoric culoare"
-
-#: ../po/tmp/resources.xml.h:173
-msgctxt "Accel Editor (descriptions)"
-msgid "Pop up a timeline of recent colors under the cursor."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:174
-#, fuzzy
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "Color Details Dialog"
-msgstr "Detalii culoare"
-
-#: ../po/tmp/resources.xml.h:175
-#, fuzzy
-msgctxt "Accel Editor (descriptions)"
-msgid "Show a color details dialog with text entry."
-msgstr "Dialog pentru detalii de culoare cu intrare text"
-
-#: ../po/tmp/resources.xml.h:176
-#, fuzzy
-msgctxt "Menu→Color"
-msgid "Next Palette Color"
-msgstr "Următoarea paletă de culoare"
-
-#: ../po/tmp/resources.xml.h:177
-#, fuzzy
-msgctxt "Accel Editor (descriptions)"
-msgid "Set painting color to the next color in the palette."
-msgstr "Următoarea culoare în paletă"
-
-#: ../po/tmp/resources.xml.h:178
-#, fuzzy
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "Previous Palette Color"
-msgstr "Culoarea precedentă în paletă"
-
-#: ../po/tmp/resources.xml.h:179
-#, fuzzy
-msgctxt "Accel Editor (descriptions)"
-msgid "Set painting color to the previous color in the palette."
-msgstr "Culoarea precedentă în paletă"
-
-#: ../po/tmp/resources.xml.h:180
-#, fuzzy
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "Add Color to Palette"
-msgstr "Adaugă culoare la modele"
-
-#: ../po/tmp/resources.xml.h:181
-msgctxt "Accel Editor (descriptions)"
-msgid "Append the current painting color to the palette."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:182
-msgctxt "Menu (labels)"
-msgid "Layer"
-msgstr "Strat"
-
-#: ../po/tmp/resources.xml.h:183
-#, fuzzy
-msgctxt "Menu→Layer→Properties (labels)"
-msgid "Opacity"
-msgstr "Opacitate"
-
-#: ../po/tmp/resources.xml.h:184
-#, fuzzy
-msgctxt "Menu→Layer (labels)"
-msgid "Go to Layer"
-msgstr "Du-te la strat"
-
-#: ../po/tmp/resources.xml.h:185
-#, fuzzy
-msgctxt "Menu→Layer (labels)"
-msgid "New Layer Below"
-msgstr "Strat singur"
-
-#: ../po/tmp/resources.xml.h:186
-#, fuzzy
-msgctxt "Menu→Layer (labels)"
-msgid "Properties"
-msgstr "Proprietăți paletă"
-
-#: ../po/tmp/resources.xml.h:187
-msgctxt "Menu (labels)"
-msgid "Scratchpad"
-msgstr "Caiet de ciorne"
-
-#: ../po/tmp/resources.xml.h:188
-#, fuzzy
-msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
-msgid "New Scratchpad"
-msgstr "Caiet de ciorne nou"
-
-#: ../po/tmp/resources.xml.h:189
-msgctxt "Accel Editor (descriptions)"
-msgid "Load the default scratchpad as a new scratchpad canvas."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:190
-#, fuzzy
-msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
-msgid "Open Scratchpad…"
-msgstr "Deschide caiet de ciorne..."
-
-#: ../po/tmp/resources.xml.h:191
-msgctxt "Accel Editor (descriptions)"
-msgid "Load an image file on disk into the scratchpad."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:192
-#, fuzzy
-msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
-msgid "Save Scratchpad"
-msgstr "Salvează scratchpadul acum"
-
-#: ../po/tmp/resources.xml.h:193
-msgctxt "Accel Editor (descriptions)"
-msgid "Save the scratchpad to its existing file on disk."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:194
-#, fuzzy
-msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
-msgid "Export Scratchpad As…"
-msgstr "Refă caiet de ciorne"
-
-#: ../po/tmp/resources.xml.h:195
-msgctxt "Accel Editor (descriptions)"
-msgid "Export the scratchpad to disk, under a file name of your choice."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:196
-#, fuzzy
-msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
-msgid "Revert Scratchpad"
-msgstr "Refă caiet de ciorne"
-
-#: ../po/tmp/resources.xml.h:197
-msgctxt "Accel Editor (descriptions)"
-msgid "Revert the scratchpad to its last saved state."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:198
-#, fuzzy
-msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
-msgid "Save Scratchpad as Default"
-msgstr "Salvează scratchpadul ca implicit"
-
-#: ../po/tmp/resources.xml.h:199
-msgctxt "Accel Editor (descriptions)"
-msgid "Save the scratchpad as the default for ‘New Scratchpad’."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:200
-#, fuzzy
-msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
-msgid "Clear Default Scratchpad"
-msgstr "Curăță scratchpadul implicit"
-
-#: ../po/tmp/resources.xml.h:201
-#, fuzzy
-msgctxt "Accel Editor (descriptions)"
-msgid "Clear the default scratchpad to a blank canvas."
-msgstr "Curăță scratchpadul implicit"
-
-#: ../po/tmp/resources.xml.h:202
-#, fuzzy
-msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
-msgid "Copy Main Background to Scratchpad"
-msgstr "Copiază fundal în scratchpad"
-
 #: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Copy the background image from the working document into the Scratchpad."
+msgid "Close main window and exit the app."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:204
 #, fuzzy
 msgctxt "Menu (labels)"
+msgid "Edit"
+msgstr "Editează"
+
+#: ../po/tmp/resources.xml.h:205
+msgctxt "Menu (labels)"
+msgid "Color"
+msgstr "Culoare"
+
+#: ../po/tmp/resources.xml.h:206
+#, fuzzy
+msgctxt "Menu→Color (labels)"
+msgid "Adjust Color"
+msgstr "Ajustează culoare"
+
+#: ../po/tmp/resources.xml.h:207
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Color History Popup"
+msgstr "Istoric culoare"
+
+#: ../po/tmp/resources.xml.h:208
+msgctxt "Accel Editor (descriptions)"
+msgid "Pop up a timeline of recent colors under the cursor."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:209
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Color Details Dialog"
+msgstr "Detalii culoare"
+
+#: ../po/tmp/resources.xml.h:210
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Show a color details dialog with text entry."
+msgstr "Dialog pentru detalii de culoare cu intrare text"
+
+#: ../po/tmp/resources.xml.h:211
+#, fuzzy
+msgctxt "Menu→Color"
+msgid "Next Palette Color"
+msgstr "Următoarea paletă de culoare"
+
+#: ../po/tmp/resources.xml.h:212
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Set painting color to the next color in the palette."
+msgstr "Următoarea culoare în paletă"
+
+#: ../po/tmp/resources.xml.h:213
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Previous Palette Color"
+msgstr "Culoarea precedentă în paletă"
+
+#: ../po/tmp/resources.xml.h:214
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Set painting color to the previous color in the palette."
+msgstr "Culoarea precedentă în paletă"
+
+#: ../po/tmp/resources.xml.h:215
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Add Color to Palette"
+msgstr "Adaugă culoare la modele"
+
+#: ../po/tmp/resources.xml.h:216
+msgctxt "Accel Editor (descriptions)"
+msgid "Append the current painting color to the palette."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:217
+msgctxt "Menu (labels)"
+msgid "Layer"
+msgstr "Strat"
+
+#: ../po/tmp/resources.xml.h:218
+#, fuzzy
+msgctxt "Menu→Layer→Properties (labels)"
+msgid "Opacity"
+msgstr "Opacitate"
+
+#: ../po/tmp/resources.xml.h:219
+#, fuzzy
+msgctxt "Menu→Layer (labels)"
+msgid "Go to Layer"
+msgstr "Du-te la strat"
+
+#: ../po/tmp/resources.xml.h:220
+#, fuzzy
+msgctxt "Menu→Layer (labels)"
+msgid "New Layer Below"
+msgstr "Strat singur"
+
+#: ../po/tmp/resources.xml.h:221
+#, fuzzy
+msgctxt "Menu→Layer (labels)"
+msgid "Properties"
+msgstr "Proprietăți paletă"
+
+#: ../po/tmp/resources.xml.h:222
+msgctxt "Menu (labels)"
+msgid "Scratchpad"
+msgstr "Caiet de ciorne"
+
+#: ../po/tmp/resources.xml.h:223
+#, fuzzy
+msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
+msgid "New Scratchpad"
+msgstr "Caiet de ciorne nou"
+
+#: ../po/tmp/resources.xml.h:224
+msgctxt "Accel Editor (descriptions)"
+msgid "Load the default scratchpad as a new scratchpad canvas."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:225
+#, fuzzy
+msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
+msgid "Open Scratchpad…"
+msgstr "Deschide caiet de ciorne..."
+
+#: ../po/tmp/resources.xml.h:226
+msgctxt "Accel Editor (descriptions)"
+msgid "Load an image file on disk into the scratchpad."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:227
+#, fuzzy
+msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
+msgid "Save Scratchpad"
+msgstr "Salvează scratchpadul acum"
+
+#: ../po/tmp/resources.xml.h:228
+msgctxt "Accel Editor (descriptions)"
+msgid "Save the scratchpad to its existing file on disk."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:229
+#, fuzzy
+msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
+msgid "Export Scratchpad As…"
+msgstr "Refă caiet de ciorne"
+
+#: ../po/tmp/resources.xml.h:230
+msgctxt "Accel Editor (descriptions)"
+msgid "Export the scratchpad to disk, under a file name of your choice."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:231
+#, fuzzy
+msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
+msgid "Revert Scratchpad"
+msgstr "Refă caiet de ciorne"
+
+#: ../po/tmp/resources.xml.h:232
+msgctxt "Accel Editor (descriptions)"
+msgid "Revert the scratchpad to its last saved state."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:233
+#, fuzzy
+msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
+msgid "Save Scratchpad as Default"
+msgstr "Salvează scratchpadul ca implicit"
+
+#: ../po/tmp/resources.xml.h:234
+msgctxt "Accel Editor (descriptions)"
+msgid "Save the scratchpad as the default for ‘New Scratchpad’."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:235
+#, fuzzy
+msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
+msgid "Clear Default Scratchpad"
+msgstr "Curăță scratchpadul implicit"
+
+#: ../po/tmp/resources.xml.h:236
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Clear the default scratchpad to a blank canvas."
+msgstr "Curăță scratchpadul implicit"
+
+#: ../po/tmp/resources.xml.h:237
+#, fuzzy
+msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
+msgid "Copy Main Background to Scratchpad"
+msgstr "Copiază fundal în scratchpad"
+
+#: ../po/tmp/resources.xml.h:238
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Copy the background image from the working document into the Scratchpad."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:239
+#, fuzzy
+msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "Fereastră culoare"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 #, fuzzy
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "Pensulă"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 #, fuzzy
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr "Taste scurtături"
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 #, fuzzy
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr "Taste scurtături"
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "Schimbă pensulă…"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "Schimbă culoare…"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 #, fuzzy
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "Schimbă culoare (rapid)"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr "Obține mai multe pensule…"
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 #, fuzzy
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr "Importă pensule..."
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr "Stergeți efectiv pensula de pe disc?"
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Ajutor"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr "Ajutor"
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "Despre MyPaint"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Depanare"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 #, fuzzy
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr "Afișează informații despre scurgeri de memorie la consola (lent!)"
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 #, fuzzy
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr "Pornește Garbage Collector acum"
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 #, fuzzy
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr "Pornește/Oprește Python Profiling (cProfile)"
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr "Pornește/Oprește Python Profiling (cProfile)"
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "Vizualizare"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 #, fuzzy
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr "Răspuns"
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 #, fuzzy
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr "Ajustează vizualizare"
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 #, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr "Meniu context"
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "Ecran complet"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "Preferințe"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 #, fuzzy
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr "Testează dispozitive intrare"
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr "Fundal"
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr "Editor de setări pentru pensule"
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr "Editează setările pensulei active"
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 #, fuzzy
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr "Editor listă pensule"
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr "Editează icoana pensulei"
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr "Panou straturi"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr "Arată panoul straturilor"
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 #, fuzzy
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr "Roată HCY"
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid ""
@@ -5303,47 +6355,36 @@ msgstr ""
 "Setează culoarea folosind spațiul cilindric hue/croma/luma. Feliile "
 "circulare sunt echivalente din punct de vedere al luminozității."
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 #, fuzzy
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "Paleta de culori"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 #, fuzzy
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr "Roată HSV"
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr "Schimbă saturație și valoare"
 
-#: ../po/tmp/resources.xml.h:260
-#, fuzzy
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr "Triunghi HSV"
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 #, fuzzy
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr "Cub HSV"
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid ""
@@ -5351,510 +6392,508 @@ msgid ""
 "planar slices."
 msgstr "Un cub HSV care poate fi rotit pentru a arăta diferite felii planare."
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 #, fuzzy
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr "Pătrat"
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr "Un cub HSV care poate fi rotit pentru a arăta diferite felii planare."
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 #, fuzzy
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr "Glisoare component"
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr "Ajustează componente individuale ale culorii."
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 #, fuzzy
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr "Caiet de ciorne"
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr "Arată carnet de schiţe"
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr "Fereastră de previzualizare"
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "Previzualizare"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 #, fuzzy
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr "Opţiuni instrumente"
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 #, fuzzy
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr "Arată Opţiuni instrumente"
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr "Istoric culoare"
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 #, fuzzy
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr "Culori folosite recent"
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 #, fuzzy
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr "Nivel mărire"
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 #, fuzzy
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr "Ulrima poziție de desenare"
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr "Liber"
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr "Liber"
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 #, fuzzy
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr "Desen liber: desenează și pictează liber, fără limitări geometrice"
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 #, fuzzy
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr "Liber"
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr "Desen liber: desenează și pictează liber, fără limitări geometrice"
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 #, fuzzy
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr "Vizualizare"
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr "Mută"
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 #, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr "Vizualizare"
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 #, fuzzy
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr "Rotește viziune"
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr "Rotește"
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 #, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr "Rotește viziune"
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 #, fuzzy
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr "Mărește viziune"
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr "Mărire"
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 #, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr "Mărește viziune"
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 #, fuzzy
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr "Linii și curbe"
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr "Linii"
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr "Linii și curbe"
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr "Linie dreaptă"
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 #, fuzzy
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr "Linii conectate"
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr "Linii conectate"
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr "Linii conectate"
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 #, fuzzy
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr "Elipse și cercuri"
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr "Elipsă"
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 #, fuzzy
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr "Elipse și cercuri"
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr "Elipse și cercuri"
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr "Cerneală"
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 #, fuzzy
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr "Contur"
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 #, fuzzy
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr "Du-te la strat"
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr "Straturi"
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 #, fuzzy
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr "Deplasează strat: repoziționează stratul curent pe pânză"
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr "Du-te la strat"
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 #, fuzzy
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr "Deplasează strat: repoziționează stratul curent pe pânză"
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 #, fuzzy
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr "Editează cadru"
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr "Cadru"
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 #, fuzzy
 msgctxt "Toolbar (tooltips)"
 msgid ""
@@ -5863,12 +6902,12 @@ msgstr ""
 "Editează cadru: definește un cadru în jurul documentului pentru a-i da o "
 "dimensiune finită. Cadrul este folosit la exportare."
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr "Editează cadru"
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid ""
@@ -5877,83 +6916,219 @@ msgstr ""
 "Editează cadru: definește un cadru în jurul documentului pentru a-i da o "
 "dimensiune finită. Cadrul este folosit la exportare."
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr "Axă de simetrie"
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Desen simetric"
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 #, fuzzy
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr "Alege culoare"
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr "Alege culoare"
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "Alege culoare"
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "Alege culoare"
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "Alege culoare"
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr "Alege culoare"
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr "Umplere culoare"
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr "Umple o zona cu culoare."
+
+#, fuzzy
+#~ msgctxt "brush list context menu"
+#~ msgid "Delete"
+#~ msgstr "Șterge"
+
+#, fuzzy
+#~ msgctxt "brush list commands"
+#~ msgid "Really delete brush from disk?"
+#~ msgstr "Stergeți efectiv pensula de pe disc?"
+
+#~ msgid "HSV Triangle"
+#~ msgstr "Triunghi HSV"
+
+#~ msgid "The standard GTK color selector"
+#~ msgstr "Selector de culoare standard GTK"
+
+#~ msgid "Pick a color from the screen"
+#~ msgstr "Alege o culoare de pe ecran"
+
+#~ msgid "Save..."
+#~ msgstr "Salvează..."
+
+#~ msgid "Open..."
+#~ msgstr "Deschide..."
+
+#~ msgid "Mode:"
+#~ msgstr "Mod:"
+
+#~ msgid ""
+#~ "Blending mode: how the current layer combines with the layers underneath "
+#~ "it."
+#~ msgstr ""
+#~ "Mod amestecare: modul în care stratul curent se combină cu straturile de "
+#~ "sub acesta."
+
+#~ msgid ""
+#~ "Layer opacity: how much of the current layer to use. Smaller values make "
+#~ "it more transparent."
+#~ msgstr ""
+#~ "Opacitate strat: procentajul din stratul curent care este folosit. Valori "
+#~ "mai mici îl fac mai transparent."
+
+#, fuzzy
+#~ msgid "%s: edit properties"
+#~ msgstr "Proprietăți paletă"
+
+#, fuzzy
+#~ msgctxt "layer default names"
+#~ msgid "Unknown Bitmap Layer"
+#~ msgstr "Pensulă necunoscută"
+
+#, fuzzy
+#~ msgid "Setting name:"
+#~ msgstr "Fereastră setări"
+
+#, fuzzy
+#~ msgid "Base value:"
+#~ msgstr "Valoare de bază"
+
+#~ msgid "<ymin>"
+#~ msgstr "<ymin>"
+
+#~ msgid "<ymax>"
+#~ msgstr "<ymax>"
+
+#~ msgid "<xmin>"
+#~ msgstr "<xmin>"
+
+#~ msgid "<xmax>"
+#~ msgstr "<xmax>"
+
+#, fuzzy
+#~ msgid "Edit Setting"
+#~ msgstr "Salvează preferințe"
+
+#, fuzzy
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Trim Layer to Frame"
+#~ msgstr "Nume strat"
+
+#, fuzzy
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Rename Layer…"
+#~ msgstr "Elimină strat"
+
+#, fuzzy
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Enter a new name for the current layer."
+#~ msgstr "Introdu un nou nume pentru stratul curent"
+
+#, fuzzy
+#~ msgctxt "Menu→Edit (labels)"
+#~ msgid "Current Tool"
+#~ msgstr "Culoare curentă"
+
+#, fuzzy
+#~ msgctxt "Menu→Color (labels), Accel Editor (labels)"
+#~ msgid "HSV Triangle"
+#~ msgstr "Triunghi HSV"
 
 #~ msgid ""
 #~ "\"%s\" has an alpha channel. Background images with transparency are not "
@@ -6089,9 +7264,6 @@ msgstr "Umple o zona cu culoare."
 #~ "etc.) și intrări (presiune, viteză, etc.) sunt disponibile ca sfaturi "
 #~ "(tooltips). Așezati mausul deasupra etichetei pentru a le vedea. \n"
 
-#~ msgid "Open Recent files"
-#~ msgstr "Deschide fișierele recente"
-
 #~ msgid "This will discard %d second of unsaved painting."
 #~ msgid_plural "This will discard %d seconds of unsaved painting."
 #~ msgstr[0] "Aceasta va anula %d secundă de desen nesalvat."
@@ -6099,9 +7271,6 @@ msgstr "Umple o zona cu culoare."
 
 #~ msgid "Crop to Current Layer"
 #~ msgstr "Decupează stratul curent"
-
-#~ msgid "Crop frame to the currently active layer"
-#~ msgstr "Decupează stratul curent după cadru"
 
 #~ msgid ""
 #~ "While the frame is enabled, it \n"
@@ -6206,9 +7375,6 @@ msgstr "Umple o zona cu culoare."
 #~ msgid "Brush Blend Mode"
 #~ msgstr "Mod pensulă amestecare"
 
-#~ msgid "Add Layer"
-#~ msgstr "Adaugă strat"
-
 #~ msgid "Move Layer on Canvas"
 #~ msgstr "Deplasează strat pe pânză"
 
@@ -6246,9 +7412,6 @@ msgstr "Umple o zona cu culoare."
 #~ msgctxt "Menu|File|"
 #~ msgid "Save"
 #~ msgstr "Salvează"
-
-#~ msgid "Export to a file"
-#~ msgstr "Exportă într-un fișier"
 
 #~ msgid ""
 #~ "Saves to a new scrap file. If the drawing is currently saved as a scrap, "

--- a/po/ru.po
+++ b/po/ru.po
@@ -542,17 +542,17 @@ msgstr "Пакет кистей MyPaint (*.zip)"
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr "Новая группа…"
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr "Импортировать кисти…"
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr "Найти больше кистей…"
 
 #: ../gui/brushselectionwindow.py:554
@@ -1238,12 +1238,12 @@ msgstr "Тип"
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr "Использовать для…"
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr "Прокрутка…"
 
 #. Name and preview column: will be indented
@@ -1467,7 +1467,7 @@ msgid "_Quit"
 msgstr "Выход"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr "Импортировать пакет кистей…"
 
 #: ../gui/drawwindow.py:698
@@ -1524,7 +1524,7 @@ msgstr ""
 "“{type_name}” ({content_type})?"
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr "Открыть с помощью…"
 
 #: ../gui/externalapp.py:123
@@ -1719,13 +1719,13 @@ msgstr "JPEG с качеством 90% (*.jpg; *.jpeg)"
 
 #: ../gui/filehandling.py:576
 #, fuzzy
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr "Экспортировать…"
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Сохранить как…"
 
@@ -1796,7 +1796,7 @@ msgstr "Открыть недавние рисунки"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr "Открыть блокнот…"
 
 #: ../gui/filehandling.py:1099
@@ -2251,12 +2251,12 @@ msgstr ""
 "этого не сделал."
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr "Искать по трекеру…"
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr "Сообщить о баге…"
 
 #: ../gui/gtkexcepthook.py:180
@@ -2268,7 +2268,7 @@ msgid "Quit MyPaint"
 msgstr "Выйти из MyPaint"
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr "Подробнее…"
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2480,7 +2480,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr "Переместить слой в стопке…"
 
 #: ../gui/layerswindow.py:110
@@ -2551,7 +2551,7 @@ msgid "Stroke trail-off beginning"
 msgstr "Конец штриха"
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr "Вариация силы нажатия…"
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/ru.po
+++ b/po/ru.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MyPaint 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-05-14 16:49+0000\n"
 "Last-Translator: Tolstovka <tolstovka@tuta.io>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -20,33 +20,11 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<="
-"4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 3.7-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr "<big><b>{accel_label}</b></big>"
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr "{action_label} {action_desc} {accel_label}"
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "Действие"
 
@@ -54,32 +32,32 @@ msgstr "Действие"
 msgid "Key combination"
 msgstr "Сочетание клавиш"
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr "Изменить привязку для '%s'"
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "Действие:"
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "Путь:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "Клавиша:"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr "Нажмите на кнопки, чтобы обновить задание"
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "Неизвестное действие"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
@@ -88,7 +66,7 @@ msgstr ""
 "<b>{accel} уже используется для '{action}'. Существующая привязка будет "
 "замещена.</b>"
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr "Открыть папку “{folder_basename}”…"
@@ -96,199 +74,209 @@ msgstr "Открыть папку “{folder_basename}”…"
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "OK"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr "Резервные копии в кэше не обнаружены."
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr "Нет доступных резервных файлов"
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr "Открыть папку с кэшем…"
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr "Восстановление из резервной копии не удалось"
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr "Открыть папку с резервными копиями…"
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr "Recovered file from {iso_datetime}.ora"
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "Сохранить по умолчанию"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "Фон"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "Текстура"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Цвет"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "Добавить цвет в список текстур"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr "Не удалось загрузить одно или несколько фоновых изображений"
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr "Ошибка при загрузке фоновых изображений"
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 "Пожалуйста, удалите файлы, которые не удалось загрузить, или проверьте вашу "
 "установку libgdkpixbuf."
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 "Gdk-pixbuf не может загрузить \"{filename}\", сообщение об ошибке: "
 "\"{error}\""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr "У {filename} нулевой размер (w={w}, h={h})"
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr "Редактор параметров кисти"
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr "О кисти"
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "Экспериментальные"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr "Основные"
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr "Непрозрачность"
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr "Мазки"
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "Размазывание"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr "Скорость"
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr ""
+
+#: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr "Отслеживание указателя"
 
-#: ../gui/brusheditor.py:359
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "Штрих"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr "Цвет"
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Пользовательский"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
-"Кисть не выбрана. Пожалуйста, используйте вместо этого \"Добавить как новую\""
-"."
+"Кисть не выбрана. Пожалуйста, используйте вместо этого \"Добавить как новую"
+"\"."
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr "Кисть не выбрана!"
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "Переименовать кисть"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "Кисть с таким именем уже существует!"
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr "Кисть не выбрана!"
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr "Действительно удалить кисть “{brush_name}”?"
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr "(Безымянная кисть)"
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr "{brush_name} [не сохранена]"
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr "Значок кисти"
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr "Значок кисти (редактирование)"
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr "Кисть не выбрана"
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -297,7 +285,7 @@ msgstr ""
 "<b>%s</b>\n"
 "<small>Для начала выберите корректную кисть</small>"
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
@@ -306,7 +294,7 @@ msgstr ""
 "<b>%s</b> <i>(изменена)</i>\n"
 "<small>Изменения не сохранены</small>"
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
@@ -315,7 +303,7 @@ msgstr ""
 "<b>%s</b> (редактирование)\n"
 "<small>Рисуйте любой кистью или цветом</small>"
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -356,98 +344,138 @@ msgstr "Авто"
 msgid "Use the default icon"
 msgstr "Использовать значок по умолчанию"
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Сохранить"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr "Сохранить и закончить редактирование"
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr "Потерянные"
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr "Удалённые"
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr "Избранное"
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr "Чернила"
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr "Классические"
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr "Набор 1"
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr "Набор 2"
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr "Набор 3"
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr "Набор 4"
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr "Набор 5"
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr "Экспериментальные"
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Создать"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr "Неизвестная кисть"
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr "Добавить в избранное"
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr "Удалить из избранного"
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr "Дублировать"
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr "Редактировать параметры кисти"
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
-msgstr "Удалить"
+#: ../gui/brushselectionwindow.py:250
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
+msgstr "Переименовать группу"
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
-msgstr "Действительно удалить кисть?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, fuzzy, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
+msgstr "Действительно удалить кисть “{brush_name}”?"
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
@@ -455,44 +483,44 @@ msgstr[0] "%d кисть"
 msgstr[1] "%d кисти"
 msgstr[2] "%d кистей"
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr "Группа “{group_name}”"
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr "Переименовать группу"
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr "Экспортировать набор кистей"
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr "Удалить группу"
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr "Переименовать группу"
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "Группа с таким именем уже существует!"
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr "Действительно удалить группу “{group_name}”?"
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -502,58 +530,58 @@ msgstr ""
 "Удаление группы “{group_name}” не удалось.\n"
 "Особые группы не могут быть удалены."
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr "Экспортировать кисти"
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr "Пакет кистей MyPaint (*.zip)"
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "Новая группа…"
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr "Импортировать кисти…"
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr "Найти больше кистей…"
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "Создать группу"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr "Кнопка"
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr "Кнопка"
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr "Нажатие кнопки"
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr "Добавить новую привязку"
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr "Удалить текущую привязку"
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr "Изменить привязку для '%s'"
@@ -562,7 +590,7 @@ msgstr "Изменить привязку для '%s'"
 msgid "Button press:"
 msgstr "Нажатие кнопки:"
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
@@ -570,46 +598,74 @@ msgstr ""
 "Чтобы создать привязку, зажмите клавиши-модификаторы и нажмите кнопку над "
 "этим текстом."
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr "{button} не может быть привязана без модификаторов"
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr "{button_combination} уже привязано к действию '{action_name}'"
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr "Выбрать цвет"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr "Выбрать цвет, используемый для рисования"
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+#, fuzzy
+msgid "Set the color Hue used for painting"
+msgstr "Выбрать цвет, используемый для рисования"
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "Пипетка"
+
+#: ../gui/colorpicker.py:296
+#, fuzzy
+msgid "Set the color Chroma used for painting"
+msgstr "Выбрать цвет, используемый для рисования"
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+#, fuzzy
+msgid "Set the color Luma used for painting"
+msgstr "Выбрать цвет, используемый для рисования"
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr "Подробнее"
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr "Текущий цвет и цвет, использованный последним"
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr "Маска цветового охвата включена"
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -620,7 +676,7 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr "Тон и насыщенность HCY."
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
@@ -629,12 +685,12 @@ msgstr ""
 "Редактор маски цветового охвата. Щелкните в середине, чтобы создать или "
 "изменить фигуры, или поворачивайте маску с использованием краев диска."
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr "Атмосферная триада"
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
@@ -643,22 +699,22 @@ msgstr ""
 "Мрачная и субъективная, ограниченная одним доминирующим первичным цветом и "
 "ещё двумя менее интенсивными первичными цветами."
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr "Сдвинутая триада"
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr "Смещена к доминантному цвету."
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr "Противоположный цвет"
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
@@ -667,12 +723,12 @@ msgstr ""
 "Контрастные противоположности, уравновешенные нейтральными цветами в "
 "середине цветового круга."
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr "Настроение и акцент"
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
@@ -680,12 +736,12 @@ msgid ""
 msgstr ""
 "Один главный диапазон цветов, и дополнительный цвет для вариаций и акцентов."
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr "Разделённые противоположные"
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
@@ -693,72 +749,72 @@ msgid ""
 msgstr ""
 "Два похожих цвета и дополнительный цвет, без вторичных цветов между ними."
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr "Создать маску цветового охвата из шаблона"
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr "Редактор маски цветового охвата"
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr "Активно"
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr "Справка…"
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr "Создать маску из шаблона."
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr "Загрузить маску из файла палитры GIMP."
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr "Сохранить маску в файл палитры GIMP."
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr "Стереть маску."
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr "Открыть онлайн-справку по этому диалогу в браузере."
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr "Сохранить маску как палитру GIMP"
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr "Загрузить маску из файла палитры GIMP"
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr "Установить маску цветового охвата."
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr "Круг HCY"
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -768,164 +824,156 @@ msgstr ""
 "яркость. Круговые срезы имеют одинаковую яркость."
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr "Тон HSV"
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr "Насыщенность HSV"
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr "Значение HSV"
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr "Насыщенность и значение HSV"
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr "Тон и значение HSV"
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr "Тон и насыщенность HSV"
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr "Повернуть куб (показать другие оси)"
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr "Куб HSV"
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 "Куб HSV, который можно поворачивать, чтобы использовать разные плоские срезы."
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr "Квадрат HSV"
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 "Куб HSV, который можно поворачивать, чтобы использовать разные плоские срезы."
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr "Треугольник HSV"
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr "Стандартный способ выбора цветов GTK"
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr "Круг HSV"
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr "Изменяет насыщенность и оттенок."
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr "Свойства палитры"
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr "Палитра"
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr "Выбрать цвет из загружаемой и редактируемой палитры."
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr "Безымянная палитра"
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr "Редактор палитры"
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr "Загрузить из файла палитры GIMP"
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr "Сохранить в файл палитры GIMP"
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr "Добавить новую пустую ячейку"
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr "Удалить текущую ячейку"
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr "Удалить все ячейки"
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr "Название:"
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr "Имя или описание для данной палитры"
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr "Столбцов:"
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr "Количество столбцов"
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr "Название цвета:"
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr "Название текущего цвета"
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr "Пустая ячейка палитры"
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr "Загрузить палитру"
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr "Сохранить палитру"
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -936,381 +984,378 @@ msgstr ""
 "Добавляйте цвета сюда и\n"
 "перетаскивайте их, чтобы упорядочить."
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr "Пустая ячейка палитры (перетащите сюда цвет)"
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr "Добавить пустую ячейку"
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr "Вставить ряд"
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr "Вставить столбец"
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr "Заполнить промежуток (RGB)"
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr "Заполнить промежуток (HCY)"
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr "Заполнить промежуток (HSV)"
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "Файл палитры GIMP (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr "Все файлы (*)"
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "Файл палитры GIMP (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr "Все файлы (*)"
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr "Выбрать цвет с экрана"
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr "R"
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr "G"
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr "B"
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr "H"
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr "C"
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr "Y"
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr "Ползунки компонентов"
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr "Настроить отдельные компоненты цвета."
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr "Красный RGB"
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr "Зеленый RGB"
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr "Синий RGB"
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr "Тон HSV"
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr "Насыщенность HSV"
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr "Значение HSV"
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr "Тон HCY"
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr "Насыщенность HCY"
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr "Яркость HCY (Y')"
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr "Плавная волна"
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr "Выбрать цвет используя размытые близлежащие цвета."
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr "Концентрические круги"
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr "Выбрать цвет используя концентрические HSV круги."
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr "Скрещенная чаша"
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 "Выбрать цвет с помощью HSV наклонных перекрещивающих лучеобразную чашу с "
 "цветом."
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr "Манипулятор"
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr "Ластик"
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr "Клавиатура"
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr "Мышь"
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr "Перо"
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr "Сенсорная панель"
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr "Сенсорный экран"
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr "Игнорировать"
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr "Для любых действий"
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr "Не для рисования"
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr "Только для навигации"
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr "Масштаб"
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr "Перемещение"
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr "Устройство"
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr "Оси"
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr "Тип"
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr "Использовать для…"
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr "Прокрутка…"
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Имя"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr "Перезаписать кисть?"
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr "Заменить"
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr "Переименовать"
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr "Заменить всё"
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr "Переименовать все"
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr "Импортированная кисть"
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr "Существующая кисть"
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 "<b>Кисть под именем '%s' уже существует.</b>\n"
 "Хотите ли вы заменить её, или переименовать новую кисть?"
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr "Перезаписать группу кистей?"
 
-#: ../gui/dialogs.py:190
-#, python-brace-format
+#: ../gui/dialogs.py:220
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 "<b>Группа под именем '{groupname}' уже существует.</b>\n"
 "Хотите ли вы заменить её, или переименовать новую группу?\n"
 "Если вы замените группу, кисти из неё будут перемещены в группу "
 "'{deleted_groupname}'."
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr "Импортировать пакет с кистями?"
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, fuzzy, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr "<b>Вы действительно хотите импортировать пакет '%s'?</b>"
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr "Загрузить настройки кисти из слота быстрого доступа %d"
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr "Сохранить настройки кисти в слот быстрого доступа %d"
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr "Выбрать кисть %d"
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr "Сохранить кисть %d"
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr "Отменить %s"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Отменить"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr "Вернуть %s"
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Вернуть"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr "{button_combination} - {resultant_action}"
@@ -1320,104 +1365,147 @@ msgstr "{button_combination} - {resultant_action}"
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ";  "
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr "Зажать {modifiers} с:  {button_actions}."
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
-msgstr "Название слоя"
-
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
-#, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
-"<b>{name}</b>\n"
-"{description}"
+
+#: ../gui/document.py:909
+#, python-brace-format
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
+msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr "%s - MyPaint"
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr "MyPaint"
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Открыть"
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr "Выбрать текущий цвет"
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr "Покинуть полноэкранный режим"
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr "Покинуть полноэкранный режим"
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr "Перейти в полноэкранный режим"
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Во весь экран"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Выход"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+#, fuzzy
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr "Действительно выйти?"
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Выход"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr "Импортировать пакет кистей…"
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr "Пакет кистей MyPaint (*.zip)"
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr "Запущено приложение {app_name} для редактирования слоя “{layer_name}”"
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 "Ошибка: не удалось запустить {app_name} для редактирования слоя "
 "“{layer_name}”"
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 "Редактирование отменено. Вы можете редактировать “{layer_name}” из меню Слои."
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr "Слой “{layer_name}” обновлен со внешними изменениями"
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr "Невозможно загрузить “{file_basename}”."
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
@@ -1426,7 +1514,7 @@ msgstr ""
 "MyPaint нужно редактировать файл типа “{type_name}” ({content_type}). Какое "
 "приложение нужно использовать?"
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
@@ -1435,161 +1523,378 @@ msgstr ""
 "Какое приложение должна использовать MyPaint для редактирования файлов типа "
 "“{type_name}” ({content_type})?"
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr "Открыть с помощью…"
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr "Значок"
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr "нет описания"
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
+#: ../gui/filehandling.py:126
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
+msgstr "Загрузка “{file_basename}”…"
+
+#: ../gui/filehandling.py:130
+#, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:134
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
+msgstr "Сохранение “{file_basename}”…"
+
+#: ../gui/filehandling.py:138
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
+msgstr "Экспорт в “{file_basename}”…"
+
+#: ../gui/filehandling.py:145
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr "Экспорт в “{file_basename}” не удался."
+
+#: ../gui/filehandling.py:149
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr "Сохранение “{file_basename}” не удалось."
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr "Невозможно загрузить “{file_basename}”."
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "Сохранить палитру"
+
+#: ../gui/filehandling.py:168
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr "Экспортировать в файл"
+
+#: ../gui/filehandling.py:172
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr "Экспортировать в файл"
+
+#: ../gui/filehandling.py:176
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr "Открыть недавние рисунки"
+
+#: ../gui/filehandling.py:183
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr "Экспорт в “{file_basename}” успешно завершен."
+
+#: ../gui/filehandling.py:187
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr "“{file_basename}” успешно сохранен."
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr "“{file_basename}” успешно загружен."
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: ../gui/filehandling.py:221
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
+msgstr "“{file_basename}” успешно загружен."
+
+#: ../gui/filehandling.py:427
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "All Recognized Formats"
 msgstr "Все известные форматы"
 
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
+#: ../gui/filehandling.py:432
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "OpenRaster (*.ora)"
 msgstr "OpenRaster (*.ora)"
 
-#: ../gui/filehandling.py:95
+#: ../gui/filehandling.py:437
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "PNG (*.png)"
 msgstr "PNG (*.png)"
 
-#: ../gui/filehandling.py:96
+#: ../gui/filehandling.py:442
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "JPEG (*.jpg; *.jpeg)"
 msgstr "JPEG (*.jpg; *.jpeg)"
 
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
+#: ../gui/filehandling.py:490
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "By extension (prefer default format)"
 msgstr "По расширению"
 
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
+#: ../gui/filehandling.py:494
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:498
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
 msgstr "PNG с непрозрачным фоном (*.png)"
 
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
+#: ../gui/filehandling.py:502
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:506
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
 msgstr "Прозрачный PNG (*.png)"
 
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
+#: ../gui/filehandling.py:510
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
 msgstr "Серия прозрачных PNG (*.XXX.png)"
 
-#: ../gui/filehandling.py:113
+#: ../gui/filehandling.py:514
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr "Серия прозрачных PNG (*.XXX.png)"
+
+#: ../gui/filehandling.py:518
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr "JPEG с качеством 90% (*.jpg; *.jpeg)"
 
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr "Сохранить…"
+#: ../gui/filehandling.py:576
+#, fuzzy
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr "Экспортировать…"
 
-#: ../gui/filehandling.py:177
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Сохранить как…"
+
+#: ../gui/filehandling.py:601
+#, fuzzy
+msgctxt "save dialogs: formats and options: (label)"
 msgid "Format to save as:"
 msgstr "Формат для сохранения:"
 
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr "Подтверждение"
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
+#: ../gui/filehandling.py:668
+#, fuzzy
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
 msgstr "Вы действительно хотите продолжить?"
 
-#: ../gui/filehandling.py:234
-#, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
-msgstr "Это отменит {abbreviated_time} несохранённого рисования"
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
+#: ../gui/filehandling.py:705
+#, fuzzy
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
 msgstr "Сохранить как _черновик"
 
-#: ../gui/filehandling.py:282
-#, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
-msgstr "Загрузка “{file_basename}”…"
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
 
-#: ../gui/filehandling.py:296
-#, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
-msgstr "Невозможно загрузить “{file_basename}”."
+#: ../gui/filehandling.py:734
+#, fuzzy, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr "Это отменит {abbreviated_time} несохранённого рисования"
 
-#: ../gui/filehandling.py:321
-#, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
-msgstr "“{file_basename}” успешно загружен."
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
 
-#: ../gui/filehandling.py:422
-#, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
-msgstr "Экспорт в “{file_basename}”…"
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
 
-#: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
-msgstr "Сохранение “{file_basename}”…"
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
-msgstr "Экспорт в “{file_basename}” не удался."
-
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
-msgstr "Сохранение “{file_basename}” не удалось."
-
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
-msgstr "Экспорт в “{file_basename}” успешно завершен."
-
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
-msgstr "“{file_basename}” успешно сохранен."
-
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
 msgstr "Открыть…"
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Открыть недавние рисунки"
+
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr "Открыть блокнот…"
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Импортированная кисть"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Открыть"
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Открыть последний"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Открыть"
+
+#: ../gui/filehandling.py:1446
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
 msgstr "Файлы черновиков с приставкой '%s' пока отсутствуют."
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1455
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr "Открыть следующий черновик"
+
+#: ../gui/filehandling.py:1463
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr "Открыть предыдущий черновик"
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Открыть"
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+#, fuzzy
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr "Вернуть"
+
+#: ../gui/fill.py:121
+#, fuzzy
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr "Заливка"
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+#, fuzzy
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr "Заливка областей цветом"
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+#, fuzzy
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr "Порог:"
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+#, fuzzy
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
@@ -1597,38 +1902,86 @@ msgstr ""
 "Допустимое отклонение количества цветов пикселов, \n"
 "которое заливка откажется заливать"
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+#, fuzzy
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr "Основа:"
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
-msgstr "Какие видимые слои должны быть залиты"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
+msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+#, fuzzy
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr "Выборочное объединение"
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+#, fuzzy
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr "Временное объединение всех видимых слоев под текущим слоем"
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+#, fuzzy
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr "По размеру рисунка"
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+#, fuzzy
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr "Цель:"
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+#, fuzzy
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr "Где должен быть результат"
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr "Новый слой (единожды)"
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+#, fuzzy
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
@@ -1636,21 +1989,108 @@ msgstr ""
 "Создать новый слой с результатами заливки.\n"
 "Отключается автоматически после использования."
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Непрозрачность:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr "Сбросить"
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+#, fuzzy
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr "Сбросить к значениям по умолчанию"
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "Выбрать слой"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr "<b>{brush_name}</b>"
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1660,131 +2100,143 @@ msgstr ""
 "<b>{brush_name}</b>\n"
 "{brush_desc}"
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr "Изменить рамку"
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr "Переключить рамку документа"
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr "Размер рамки"
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr "px"
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr "Высота:"
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr "Ширина:"
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr "Разрешение:"
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr "DPI"
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr "Количество точек на дюйм (в действительности пикселов на дюйм)"
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr "Цвет:"
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr "Цвет рамки"
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr "<b>Размеры рамки</b>"
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr "<b>Плотность пикселей</b>"
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr "Рамка по размерам слоя"
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr "Установить рамку по размерам текущего слоя"
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr "Рамка по размерам документа"
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr "Установить рамку по размерам объединения всех слоев"
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr "Обрезать слой по рамке"
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr "Обрезать части слоя, находящиеся вне установленной рамки"
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr "Включено"
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr "{width:g}×{height:g} {units}"
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr "дюймы"
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr "см"
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr "мм"
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr "Рисование от руки"
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr "Свободное рисование"
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr "Стабилизация:"
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr "Сила нажатия:"
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr "Обнаружена ошибка"
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 "<big><b>Во время выполнения этой программы обнаружена ошибка.</b></big>"
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1798,35 +2250,35 @@ msgstr ""
 "Пожалуйста, сообщите разработчикам о проблеме в трекере, если никто еще "
 "этого не сделал."
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr "Искать по трекеру…"
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr "Сообщить о баге…"
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr "Игнорировать ошибку"
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr "Выйти из MyPaint"
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr "Подробнее…"
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr "Ошибка при анализе исключения."
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1872,45 +2324,50 @@ msgstr ""
 "            #### Traceback\n"
 "        "
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr "Контуры"
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr "Рисование сглаженных линий с возможностью дальнейшего редактирования"
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr "Проверка устройств ввода"
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr "(нет нажатия)"
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr "Сила нажатия:"
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr "(нет наклона)"
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr "Наклон:"
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr "(нет устройства)"
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
 msgstr "Устройство:"
 
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+#, fuzzy
+msgid "Barrel Rotation:"
+msgstr "Сбросить вращение"
+
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr "Переместить слой"
 
@@ -1918,163 +2375,231 @@ msgstr "Переместить слой"
 msgid "Move the current layer"
 msgstr "Переместить текущий слой"
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
-msgstr "{default_name} в {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
+msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
-msgstr "Тип"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
+msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+#, fuzzy
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr "Свойства"
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr "Видим"
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Слой"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+#, fuzzy
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr "Заблокирован"
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+#, fuzzy
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ", "
+
+#: ../gui/layers.py:990
+#, fuzzy, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr "Добавить {layer_default_name}"
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Слои"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr "Расположить слои и назначенить эффекты"
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr "Непрозрачность слоя: %d%%"
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr "Переместить слой в стопке…"
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr "Переместить слой в стопке"
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr "Слой"
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
-msgstr "Режим:"
+#: ../gui/layervis.py:53
+#, fuzzy, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
+msgstr "<b>{brush_name}</b>"
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
-msgstr "Режим смешивания: как текущий слой объединяется со слоями под ним."
-
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Непрозрачность:"
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
-"Непрозрачность слоя: какую долю текущего слоя использовать. Меньшие значения "
-"делают слой более прозрачным."
 
-#: ../gui/linemode.py:37
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "Вращение"
+
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr "Сила нажатия в начале линии"
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr "Сила нажатия в начале для инструментов, проводящих линии"
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr "Сила нажатия в середине линии"
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr "Сила нажатия в середине для инструментов, проводящих линии"
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr "Сила нажатия в конце линии"
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr "Сила нажатия в конце для инструментов, проводящих линии"
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr "Начало штриха"
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 msgid "Stroke lead-in end"
 msgstr "Время удержания штриха"
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr "Конец штриха"
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr "Конец штриха"
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr "Вариация силы нажатия…"
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr "Линии и кривые"
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr "Режим простых линий и кривых"
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 "Рисование прямых линий; Shift добавляет кривизну, Ctrl ограничивает угол "
 "наклона"
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr "Связанные линии"
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 "Рисование связанных линий; Shift добавляет кривизну, Ctrl ограничивает угол "
 "наклона"
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr "Эллипсы и круги"
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 "Рисование эллипсов; Shift позволяет поворачивать эллипс, Ctrl ограничивает "
 "отношение сторон и угол поворота"
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
+#, fuzzy
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 "Авторские права © 2005-2015\n"
 "Мартин Ренольд и команда разработчиков MyPaint"
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -2093,72 +2618,72 @@ msgstr ""
 "Эта программа распространяется в надежде, что она будет полезной, но БЕЗО "
 "ВСЯКИХ ГАРАНТИЙ. См. файл COPYING за подробностями."
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr "программирование"
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr "портируемость"
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr "управление проектом"
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr "кисти"
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr "текстуры"
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr "значки инструментов"
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr "значок программы"
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr "палитры"
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr "документация"
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr "поддержка"
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr "распространение"
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr "сообщество"
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ", "
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
@@ -2166,186 +2691,216 @@ msgstr ""
 "Александр Прокудин <alexandre.prokoudine@gmail.com>\n"
 "zb13y"
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr "Размер:"
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr "Непрозрачность:"
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr "Жесткость:"
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr "Нажим:"
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr "Параметры инструментов"
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr "Параметры предназначенные для текущего инструмента"
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr "<b>{mode_name}</b>"
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr "<i>Параметры отсутствуют</i>"
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr "Масштаб: %.01f%%"
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr "Выбрать настройки и цвет мазка, слой…"
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr "Выбрать цвет…"
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr "Параметры"
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr "Обзор"
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr "Показать миниатюру всей поверхности рисования"
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr "Показать видоискатель"
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr "Блокнот"
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr "Смешивайте цвета и делайте наброски на отдельных страницах блокнота"
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr "Предыдущий элемент"
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr "Следующий элемент"
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
 msgstr "(нечего показывать)"
 
-#: ../gui/symmetry.py:76
+#: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Place axis"
 msgstr "Разместить ось"
 
-#: ../gui/symmetry.py:80
+#: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Move axis"
 msgstr "Переместить ось"
 
-#: ../gui/symmetry.py:84
+#: ../gui/symmetry.py:88
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr "Удалить ось"
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr "Настроить ось симметрии"
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr "Регулировать ось симметрии для рисования."
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
+#, fuzzy
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr "Позиция:"
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr "Позиция:"
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr "Нет"
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr "%d px"
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr "Альфа:"
 
-#: ../gui/symmetry.py:352
+#: ../gui/symmetry.py:376
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
+msgstr "Симметрия"
+
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+#, fuzzy
 msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+msgid "X axis Position"
 msgstr "Позиция оси"
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:477
+#, fuzzy
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr "Позиция оси"
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr "Включено"
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr "Управление файлами"
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr "Переключатель черновиков"
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr "Отмена и возврат"
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr "Режимы смешивания"
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr "Режимы линий"
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr "Вид (главная)"
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr "Вид (вторичная)"
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr "Вид (сброс)"
 
@@ -2353,188 +2908,214 @@ msgstr "Вид (сброс)"
 msgid "<b>MyPaint</b>"
 msgstr "<b>MyPaint</b>"
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr "Переместить вид"
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr "Переместить отображение холста"
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr "Масштаб"
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr "Увеличить отображение холста"
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr "Вращение"
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr "Повернуть отображение холста"
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, fuzzy, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr "%s: закрыть панель"
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
-msgstr "%s: свойства"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
+msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr "Неизвестное действие"
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr "Неопределенное значение (команда еще не началась)"
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr "{seconds:.01f}с рисования с {brush_name}"
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr "Заливка"
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr "Обрезать слой"
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "Переименовать группу"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr "Очистить слой"
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr "Вставить слой"
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr "Сделать слой видимым"
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr "Объединить видимые слои"
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr "Объединить с нижним"
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr "Обычный слой"
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Импортированная кисть"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr "Добавить {layer_default_name}"
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr "Удалить слой"
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr "Выбрать слой"
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr "Создать копию слоя"
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr "Переместить слой вверх"
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr "Переместить слой вниз"
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr "Переместить слой в стеке"
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr "Переименовать слой"
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr "Сделать слой видимым"
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr "Сделать слой невидимым"
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr "Заблокировать слой"
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr "Разблокировать слой"
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr "Непрозрачность слоя: %0.1f%%"
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr "Неизвестный режим"
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr "Изменить режим смешивания слоя: %s"
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr "Включить рамку"
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr "Отключить рамку"
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr "Обновить рамку"
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr "Редактировать слой извне"
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr "Не удалось загрузить “{basename}”."
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr "Логи могут содержать больше информации о данной ошибке."
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr "с этого момента"
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr "назад"
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2546,13 +3127,13 @@ msgstr ""
 "Возможно запущено несколько экземпляров MyPaint?\n"
 "Закройте программу и ждите {cache_update_interval}с перед повторной попыткой."
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr "Незавершенная резервная копия обновлена {last_modified_time} {ago}"
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2562,11 +3143,11 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 "Резервная копия обновлена {last_modified_time} {ago}\n"
-"Размер: {autosave.width}×{autosave.height} пикселов, Слои: "
-"{autosave.num_layers}\n"
+"Размер: {autosave.width}×{autosave.height} пикселов, Слои: {autosave."
+"num_layers}\n"
 "Содержит {unsaved_time} несохраненного рисования."
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2576,13 +3157,13 @@ msgstr ""
 "Не удается сохранить “{filename}”: {err}\n"
 "Достаточно ли места на диске?"
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr "Не удается сохранить “{filename}”: {err}"
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2592,7 +3173,7 @@ msgstr ""
 "{error_loading_common}\n"
 "Файл не существует."
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2602,7 +3183,7 @@ msgstr ""
 "{error_loading_common}\n"
 "У вас недостаточно прав для открытия файла."
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2618,7 +3199,7 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2628,7 +3209,13 @@ msgstr ""
 "{error_loading_common}\n"
 "Неизвестное расширение: “{ext}”"
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+#, fuzzy
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr "Импортированная кисть"
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2642,7 +3229,7 @@ msgstr ""
 "Вместо этого попробуйте сохранить в PNG, если у вашего устройства немного "
 "памяти. Функция сохранения в PNG у MyPaint более эффективная."
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2658,108 +3245,218 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/helpers.py:402
-#, python-brace-format
+#: ../lib/floodfill.py:131
+#, fuzzy
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr "Залить"
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr "{days}д{hours}ч"
 
-#: ../lib/helpers.py:404
-#, python-brace-format
+#: ../lib/helpers.py:537
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr "{hours}ч{minutes}м"
 
-#: ../lib/helpers.py:406
-#, python-brace-format
+#: ../lib/helpers.py:539
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr "{minutes}м{seconds}с"
 
-#: ../lib/helpers.py:408
-#, python-brace-format
+#: ../lib/helpers.py:541
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr "{seconds}с"
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr "Слой"
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr "%(name)s %(number)d"
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr "^(.*?)\\s*(\\d+)$"
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
+#, fuzzy
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr "Векторный слой"
+
+#: ../lib/layer/data.py:1158
+#, fuzzy
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr "Векторный слой"
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
-msgstr "Неизвестный растровый слой"
+msgid "Bitmap"
+msgstr ""
 
-#: ../lib/layer/data.py:1169
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1244
 msgctxt "layer default names"
-msgid "Unknown Data Layer"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
 msgstr "Неизвестный слой данных"
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "Новый слой"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr "Группа"
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "Создать группу"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr "Заполнитель"
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr "Корень"
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ", "
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+#, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "Вид"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+#, fuzzy
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr "Добавить слой"
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+#, fuzzy
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr "Удалить слой"
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr "Заблокировать слой"
+
+#: ../lib/layervis.py:697
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr "Разблокировать слой"
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr "Сквозной"
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr "Содержимое группы применяется непосредственно на нижний слой"
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr "Нормальный"
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr "Только верхний слой, без смешивания цветов."
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr "Умножение"
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
-msgstr "Похоже на работу проектора, в который вставили два слайда одновременно."
+msgstr ""
+"Похоже на работу проектора, в который вставили два слайда одновременно."
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr "Экран"
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
@@ -2767,11 +3464,11 @@ msgstr ""
 "Аналогично направлению двух различных проекторов на один экран одновременно. "
 "Противоположность 'Умножению'."
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr "Перекрытие"
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
@@ -2779,27 +3476,27 @@ msgstr ""
 "Перекрывает нижний слой верхним, сохраняя яркие участки и тени нижнего слоя. "
 "Противоположность 'Жесткому свету'."
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr "Темнее"
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr "Верхний слой используется только там, где он темнее, чем нижний слой."
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr "Светлее"
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr "Верхний слой используется только там, где он светлее, чем нижний слой."
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr "Осветление"
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
@@ -2809,11 +3506,11 @@ msgstr ""
 "комнате для фотографий с тем же названием, которая используется для "
 "исправления контраста в тенях."
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr "Затемнение"
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
@@ -2823,54 +3520,54 @@ msgstr ""
 "комнате для фотографий с тем же названием, которая используется для "
 "ослабления засвеченных участков."
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr "Жёсткий свет"
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr "Похоже на направление резкого луча света на нижний слой."
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr "Мягкий свет"
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr "Аналогично направлению рассеянного света на нижний слой."
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr "Разница"
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr "Вычитает более темный цвет из более светлого."
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr "Исключение"
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr "Похоже на режим 'Разница', но результат менее контрастный."
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr "Тон"
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 "Объединяет оттенок верхнего слоя с насыщенностью и светлотой нижнего слоя."
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr "Насыщенность"
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
@@ -2878,36 +3575,36 @@ msgstr ""
 "Применяет насыщенность цветов верхнего слоя к оттенку и светлоте нижнего "
 "слоя."
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 "Применяет оттенок и насыщенность верхнего слоя к светлоте нижнего слоя."
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr "Яркость"
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr "Применяет яркость верхнего слоя к оттенку и насыщенности нижнего слоя."
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr "Добавление"
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr "Этот слой и нижний просто добавляются друг к другу."
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr "Цель внутри"
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
@@ -2915,11 +3612,11 @@ msgstr ""
 "Использует нижний слой только там где этот слой его перекрывает. Все "
 "остальное игнорируется."
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr "Цель снаружи"
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
@@ -2927,22 +3624,22 @@ msgstr ""
 "Использует нижний слой только там где этот слой его не перекрывает. Все "
 "остальное игнорируется."
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr "Основа сверху"
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 "Основа перекрывающая цель, заменяет цель. Цель размещается в другом месте."
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr "Цель сверху"
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
@@ -2950,7 +3647,18 @@ msgstr ""
 "Цель перекрывающая основу, заменяет основу. Основа размещается в другом "
 "месте."
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, fuzzy, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr "%(name)s %(number)d"
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
@@ -2959,7 +3667,7 @@ msgstr ""
 "Не удается создать важный внутренний объект. Возможно в вашей системе "
 "недостаточно памяти для выполнения данной операции."
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2973,7 +3681,30 @@ msgstr ""
 "Причина: {err}\n"
 "Папка назначения: “{dirname}”."
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+#, fuzzy
+msgid "Vertical"
+msgstr "Отразить по вертикали"
+
+#: ../lib/tiledsurface.py:49
+#, fuzzy
+msgid "Horizontal"
+msgstr "Отразить по горизонтали"
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+#, fuzzy
+msgid "Rotational"
+msgstr "Сбросить вращение"
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr "Не удалось прочитать PNG: %s"
@@ -2982,55 +3713,93 @@ msgstr "Не удалось прочитать PNG: %s"
 msgid "Recover interrupted work?"
 msgstr "Восстановить прерванную работу?"
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
-msgstr "_Восстановить и сохранить…"
+msgid "_Look for backups at startup"
+msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr "Удалить"
+
+#: ../po/tmp/autorecover.glade.h:9
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr "Удалить эту кисть"
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr "_Восстановить и сохранить…"
+
+#: ../po/tmp/autorecover.glade.h:12
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr "Сохранить эту резервную копию на диск, и продолжить с ней работу."
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
-msgstr "_Пока игнорировать"
+msgid "Decide _Later"
+msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr "Начать работу с чистого холста. Эти резервные копии останутся."
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
+#, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 "MyPaint закрылась с несохраненной работой, но сделала резервные копии. Вы "
 "можете восстановить файл сейчас, или отложить все до нового запуска MyPaint."
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr "Миниатюра"
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr "Описание"
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
-msgstr "Дублировать"
+msgid "Live update"
+msgstr "Обновлять"
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
-msgstr "Копировать эти параметры и текущий значок кисти в новую кисть"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
+msgstr ""
+"Обновлять последний штрих на холсте с параметрами в этом окне, в реальном "
+"времени"
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
-msgstr "Переименовать кисть"
+msgid "Save these settings to the brush"
+msgstr "Сохранить эти параметры в кисть"
 
 #: ../po/tmp/brusheditor.glade.h:5
 msgid "Edit Icon"
@@ -3053,20 +3822,16 @@ msgid "Delete this brush from the disk"
 msgstr "Удалить эту кисть"
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
-msgstr "Обновлять"
+msgid "Copy to New"
+msgstr "Дублировать"
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
-msgstr ""
-"Обновлять последний штрих на холсте с параметрами в этом окне, в реальном "
-"времени"
+msgid "Copy these settings and the current brush's icon to a new brush"
+msgstr "Копировать эти параметры и текущий значок кисти в новую кисть"
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
-msgstr "Сохранить эти параметры в кисть"
+msgid "Rename this brush"
+msgstr "Переименовать кисть"
 
 #: ../po/tmp/brusheditor.glade.h:13
 msgid "Brush Setting"
@@ -3094,12 +3859,7 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr "Заметки:"
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr "Название параметра:"
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
@@ -3107,19 +3867,16 @@ msgstr ""
 "параметр."
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
-msgstr "Основное значение:"
+#: ../po/tmp/brusheditor.glade.h:22
+#, fuzzy
+msgid "Value:"
+msgstr "Значение HSV"
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr "Сбросить основное значение к параметрам по умолчанию"
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr "Сбросить это значение, чтобы не влияло на параметр"
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
@@ -3127,11 +3884,7 @@ msgstr ""
 "Минимальное значение для выходной оси.\n"
 "Можно установить используя главный ползунок настройки {dname}."
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr "<ymin>"
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
@@ -3139,27 +3892,23 @@ msgstr ""
 "Максимальное значение для выходной оси.\n"
 "Можно установить используя главный ползунок настройки {dname}."
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr "<ymax>"
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr "Выход"
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr "Вход"
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr "Регулирует максимальное значение"
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr "Регулирует минимальное значение"
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
@@ -3167,11 +3916,7 @@ msgstr ""
 "Минимальное значение для входной оси.\n"
 "Для регулирования используйте всплывающую шкалу."
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr "<xmin>"
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
@@ -3179,38 +3924,36 @@ msgstr ""
 "Максимальное значение для входной оси.\n"
 "Для регулирования используйте всплывающую шкалу."
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr "<xmax>"
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr "Вариация основного значения вводом пера и другими показателями"
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr "Динамика кисти"
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr "Основные настройки для этого параметра"
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr "Редактировать параметр"
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr "Подробно настроить отображение этого значения"
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr "{tooltip}"
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
 msgstr "{dname}:"
+
+#: ../po/tmp/brusheditor.glade.h:42
+#, fuzzy
+msgid "Brush dynamics are not available for this setting."
+msgstr "Основные настройки для этого параметра"
+
+#: ../po/tmp/brusheditor.glade.h:43
+#, fuzzy
+msgid "<big><b>No Brush Dynamics</b></big>"
+msgstr "<big><b>{accel_label}</b></big>"
 
 #: ../po/tmp/inktool.glade.h:1
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
@@ -3222,7 +3965,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr "Сила нажатия:"
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3267,6 +4010,141 @@ msgstr "Удалить узел"
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
 msgstr "Удалить выбранный узел"
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+#, fuzzy
+msgid "Insert Point"
+msgstr "Вставить ряд"
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+#, fuzzy
+msgid "Cull Points"
+msgstr "Удалить узел"
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Имя"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr "Режим"
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Непрозрачность"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr "Обрезать рамку до размера текущего слоя"
+
+#: ../po/tmp/layervis.glade.h:2
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr "Повернуть отображение холста"
+
+#: ../po/tmp/layervis.glade.h:3
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr "Повернуть отображение холста"
+
+#: ../po/tmp/layervis.glade.h:4
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr "Какие видимые слои должны быть залиты"
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
+msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
 msgctxt "footer: color picker button: tooltip"
@@ -3496,8 +4374,8 @@ msgstr ""
 "Подразумевается что экран откалиброван близко к sRGB, стандартному цветовому "
 "пространству для сети и приблизительно для большинства мониторов. Если вы "
 "знаете что ваш экран радикально отличается от этих настроек, используйте "
-"вместо этого настройку \"Без автоматического конвертирования или "
-"маркирования\"."
+"вместо этого настройку \"Без автоматического конвертирования или маркирования"
+"\"."
 
 #: ../po/tmp/preferenceswindow.glade.h:47
 msgctxt "Prefs Dialog|Load & Save|Color Management|"
@@ -3673,13 +4551,34 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr "Скрыть курсор во время рисования"
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+#, fuzzy
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr "Включено"
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr "Вид"
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
@@ -3688,18 +4587,18 @@ msgstr ""
 "Набор цветов для показа как основных в цветовых кругах.\n"
 "У разных традиций разные цветовые гармонии."
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr "Основные цвета:"
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr "Стандартный цифровой Красный/Зеленый/Синий"
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
@@ -3707,7 +4606,7 @@ msgstr ""
 "Основные цвета &apos;компьютерного монитора&apos; - красный, зеленый и "
 "синий, равномерно расположенные по кругу. Зеленый противоположен пурпурному."
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
@@ -3716,12 +4615,12 @@ msgstr ""
 "Основные цвета 'компьютерного монитора' - красный, зеленый и синий, "
 "равномерно расположенные по кругу. Зеленый противоположен пурпурному."
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr "Традиционный Красный/Желтый/Синий"
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
@@ -3731,7 +4630,7 @@ msgstr ""
 "с 18 века, близкий к чистому отображению цветов равномерно расположенных по "
 "кругу. Зеленый противоположен красному."
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3742,12 +4641,12 @@ msgstr ""
 "с 18 века, близкий к чистому отображению цветов равномерно расположенных по "
 "кругу. Зеленый противоположен красному."
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr "Противоположные пары Красный-Зеленый и Синий-Желтый"
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3762,7 +4661,7 @@ msgstr ""
 "NCS представляют схожие модели. Здесь мы используем чистое отображение "
 "красного, желтого и т.д. как четыре основных цвета."
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3779,28 +4678,28 @@ msgstr ""
 "четыре основных цвета."
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr "<b>Цветовой круг</b>"
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr "Цвет"
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr "Экран (обычный)"
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr "Отключено (без чувствительности к силе нажатия)"
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr "Окно (не рекомендуется)"
@@ -3861,246 +4760,304 @@ msgid "Reload the file your current work was loaded from."
 msgstr "Заново загрузить файл текущего проекта."
 
 #: ../po/tmp/resources.xml.h:12
+#, fuzzy
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Import Layers…"
+msgstr "Импортировать кисти…"
+
+#: ../po/tmp/resources.xml.h:13
+msgctxt "Accel Editor (descriptions)"
+msgid "Import layers from one or more files."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save"
 msgstr "Сохранить"
 
-#: ../po/tmp/resources.xml.h:13
+#: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file."
 msgstr "Сохранить в файл."
 
-#: ../po/tmp/resources.xml.h:14
+#: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As…"
 msgstr "Сохранить как…"
 
-#: ../po/tmp/resources.xml.h:15
+#: ../po/tmp/resources.xml.h:17
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file, assigning it a new name."
 msgstr "Сохранить в файл с другим именем."
 
-#: ../po/tmp/resources.xml.h:16
+#: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Export…"
 msgstr "Экспортировать…"
 
-#: ../po/tmp/resources.xml.h:17
+#: ../po/tmp/resources.xml.h:19
 msgid "Export your work to a file, but keep working on the same file."
-msgstr "Экспортировать работу в другой файл, но продолжить работу в этом файле."
+msgstr ""
+"Экспортировать работу в другой файл, но продолжить работу в этом файле."
 
-#: ../po/tmp/resources.xml.h:18
+#: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As Scrap"
 msgstr "Сохранить как черновик"
 
-#: ../po/tmp/resources.xml.h:19
+#: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
 msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr "Сохранить в новый файл черновика, или перезаписать если это черновик."
 
-#: ../po/tmp/resources.xml.h:20
+#: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Previous Scrap"
 msgstr "Открыть предыдущий черновик"
 
-#: ../po/tmp/resources.xml.h:21
+#: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file before the current one."
 msgstr "Загрузить предыдущий файл черновика."
 
-#: ../po/tmp/resources.xml.h:22
+#: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Next Scrap"
 msgstr "Открыть следующий черновик"
 
-#: ../po/tmp/resources.xml.h:23
+#: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file after the current one."
 msgstr "Загрузить следующий файл черновика."
 
-#: ../po/tmp/resources.xml.h:24
+#: ../po/tmp/resources.xml.h:26
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Recover File from an Automated Backup…"
 msgstr "Восстановить файл из резервной копии…"
 
-#: ../po/tmp/resources.xml.h:25
+#: ../po/tmp/resources.xml.h:27
 msgctxt "Accel Editor (descriptions)"
 msgid "Try to save and resume interrupted unsaved work."
 msgstr ""
 "Попытаться восстановить несохранённую прерванную работу и продолжить её."
 
-#: ../po/tmp/resources.xml.h:26
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr "Группы кистей"
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr "Кисти"
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr "Список групп кистей."
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr "Подбор цветов"
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr "Цвета"
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr "Подбор цветов."
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr "Режим"
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr "Режим"
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr "Режим смешивания текущего слоя."
 
-#: ../po/tmp/resources.xml.h:35
+#: ../po/tmp/resources.xml.h:37
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Pressure"
+msgstr "Сила нажатия в начале линии"
+
+#: ../po/tmp/resources.xml.h:38
+msgctxt "Accel Editor (descriptions)"
+msgid "Send harder pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:39
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Pressure"
+msgstr "Сила нажатия в начале линии"
+
+#: ../po/tmp/resources.xml.h:40
+msgctxt "Accel Editor (descriptions)"
+msgid "Send softer pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:41
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Rotation"
+msgstr "Увеличить насыщенность"
+
+#: ../po/tmp/resources.xml.h:42
+msgctxt "Accel Editor (descriptions)"
+msgid "Increase barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:43
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
+msgstr "Уменьшить насыщенность"
+
+#: ../po/tmp/resources.xml.h:44
+msgctxt "Accel Editor (descriptions)"
+msgid "Decrease barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:45
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Size"
 msgstr "Увеличить радиус кисти"
 
-#: ../po/tmp/resources.xml.h:36
+#: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush bigger."
 msgstr "Увеличить рабочую кисть."
 
-#: ../po/tmp/resources.xml.h:37
+#: ../po/tmp/resources.xml.h:47
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Size"
 msgstr "Уменьшить радиус кисти"
 
-#: ../po/tmp/resources.xml.h:38
+#: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush smaller."
 msgstr "Уменьшить рабочую кисть."
 
-#: ../po/tmp/resources.xml.h:39
+#: ../po/tmp/resources.xml.h:49
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Opacity"
 msgstr "Уменьшить прозрачность кисти"
 
-#: ../po/tmp/resources.xml.h:40
+#: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush more opaque."
 msgstr "Рабочая кисть менее прозрачная."
 
-#: ../po/tmp/resources.xml.h:41
+#: ../po/tmp/resources.xml.h:51
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Opacity"
 msgstr "Увеличить прозрачность кисти"
 
-#: ../po/tmp/resources.xml.h:42
+#: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush less opaque."
 msgstr "Рабочая кисть более прозрачная."
 
-#: ../po/tmp/resources.xml.h:43
+#: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Lighten Painting Color"
 msgstr "Цвет светлее"
 
-#: ../po/tmp/resources.xml.h:44
+#: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase the lightness of the current painting color."
 msgstr "Увеличить светлоту текущего цвета."
 
-#: ../po/tmp/resources.xml.h:45
+#: ../po/tmp/resources.xml.h:55
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Darken Painting Color"
 msgstr "Цвет темнее"
 
-#: ../po/tmp/resources.xml.h:46
+#: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease the lightness of the current painting color."
 msgstr "Уменьшить светлоту текущего цвета."
 
-#: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
-msgstr "Повернуть оттенок против часовой стрелки"
-
-#: ../po/tmp/resources.xml.h:48
-msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
-msgstr "Повернуть оттенок цвета против часовой стрелки на цветовом круге."
-
-#: ../po/tmp/resources.xml.h:49
+#: ../po/tmp/resources.xml.h:57
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Change Hue Clockwise"
 msgstr "Повернуть тон по часовой стрелке"
 
-#: ../po/tmp/resources.xml.h:50
+#: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
 msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr "Повернуть оттенок цвета по часовой стрелке на цветовом круге."
 
-#: ../po/tmp/resources.xml.h:51
+#: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr "Повернуть оттенок против часовой стрелки"
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr "Повернуть оттенок цвета против часовой стрелки на цветовом круге."
+
+#: ../po/tmp/resources.xml.h:61
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Increase Saturation"
 msgstr "Увеличить насыщенность"
 
-#: ../po/tmp/resources.xml.h:52
+#: ../po/tmp/resources.xml.h:62
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color more saturated (more colorful, purer)."
 msgstr "Цвет более насыщен (более чистый)."
 
-#: ../po/tmp/resources.xml.h:53
+#: ../po/tmp/resources.xml.h:63
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Decrease Saturation"
 msgstr "Уменьшить насыщенность"
 
-#: ../po/tmp/resources.xml.h:54
+#: ../po/tmp/resources.xml.h:64
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color less saturated (grayer)."
 msgstr "Цвет менее насыщен (серее)."
 
-#: ../po/tmp/resources.xml.h:55
+#: ../po/tmp/resources.xml.h:65
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Reload Brush Settings"
 msgstr "Перезагрузить параметры кисти"
 
-#: ../po/tmp/resources.xml.h:56
+#: ../po/tmp/resources.xml.h:66
 msgctxt "Accel Editor (descriptions)"
 msgid "Restore all brush settings to the current brush’s saved values."
 msgstr "Вернуть все настройки кисти к значениям, сохраненным в текущей кисти."
 
-#: ../po/tmp/resources.xml.h:57
+#: ../po/tmp/resources.xml.h:67
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Pick Stroke and Layer"
 msgstr "Выбрать мазок и слой"
 
-#: ../po/tmp/resources.xml.h:58
+#: ../po/tmp/resources.xml.h:68
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
 msgstr "Снять мазок кистью с холста: восстановить выбор кисти, цвета и слоя."
 
-#: ../po/tmp/resources.xml.h:59
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr "Горячие клавиши восстанавливают цвет кисти"
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
@@ -4108,215 +5065,266 @@ msgid ""
 msgstr ""
 "Кисть вызванная из горячей клавиши также восстанавливает сохраненный цвет."
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr "Сохранить кисть на последнюю горячую клавишу"
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr "Сохранить настройки кисти на последнюю использованную горячую клавишу."
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "Очистить слой"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr "Очистить текущий слой."
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+#, fuzzy
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr "Параметры инструментов"
+
+#: ../po/tmp/resources.xml.h:76
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr "Обрезать слой по рамке"
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr "Очистить части текущего слоя лежащие за рамкой."
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr "Очистить части текущего слоя лежащие за рамкой."
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "Создать группу ниже"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "Создать группу ниже"
+
+#: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr "Копировать слой"
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr "Скопировать текущий слой в буфер обмена."
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr "Вставить слой"
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr "Заменить текущий слой содержимым буфера обмена."
 
-#: ../po/tmp/resources.xml.h:71
+#: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Edit Layer in External App…"
 msgstr "Редактировать слой в другой программе…"
 
-#: ../po/tmp/resources.xml.h:72
+#: ../po/tmp/resources.xml.h:90
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
+msgid "Edit the active layer in an external application."
 msgstr "Начать редактирование текущего слоя в другой программе."
 
-#: ../po/tmp/resources.xml.h:73
+#: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Update Layer with External Edits"
 msgstr "Обновить слой внешними изменениями"
 
-#: ../po/tmp/resources.xml.h:74
+#: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
 msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 "Ввести изменения сохраненные из другой программы (обычно автоматически)."
 
-#: ../po/tmp/resources.xml.h:75
+#: ../po/tmp/resources.xml.h:93
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer at Cursor"
 msgstr "Выбрать слой под курсором"
 
-#: ../po/tmp/resources.xml.h:76
+#: ../po/tmp/resources.xml.h:94
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr "Выбрать слой, указав на объект на нем."
 
-#: ../po/tmp/resources.xml.h:77
+#: ../po/tmp/resources.xml.h:95
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Above"
 msgstr "Перейти на слой выше"
 
-#: ../po/tmp/resources.xml.h:78
+#: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer up in the layer stack."
 msgstr "Перейти на один уровень выше в стеке слоёв."
 
-#: ../po/tmp/resources.xml.h:79
+#: ../po/tmp/resources.xml.h:97
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Below"
 msgstr "Перейти на слой ниже"
 
-#: ../po/tmp/resources.xml.h:80
+#: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer down in the layer stack."
 msgstr "Перейти на один уровень ниже в стеке слоёв."
 
-#: ../po/tmp/resources.xml.h:81
+#: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer"
 msgstr "Новый слой"
 
-#: ../po/tmp/resources.xml.h:82
+#: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer above the current layer."
 msgstr "Добавить новый слой над текущим слоем."
 
-#: ../po/tmp/resources.xml.h:83
+#: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer…"
 msgstr "Создать векторный слой…"
 
-#: ../po/tmp/resources.xml.h:84
+#: ../po/tmp/resources.xml.h:102
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer above the current layer, and begin editing it."
 msgstr ""
 "Добавить новый векторный слой над текущим слоем, и начать его редактирование."
 
-#: ../po/tmp/resources.xml.h:85
+#: ../po/tmp/resources.xml.h:103
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group"
 msgstr "Создать группу"
 
-#: ../po/tmp/resources.xml.h:86
+#: ../po/tmp/resources.xml.h:104
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group above the current layer."
 msgstr "Добавить новую группу над текущим слоем."
 
-#: ../po/tmp/resources.xml.h:87
+#: ../po/tmp/resources.xml.h:105
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer Below"
 msgstr "Новый слой ниже"
 
-#: ../po/tmp/resources.xml.h:88
+#: ../po/tmp/resources.xml.h:106
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer below the current layer."
 msgstr "Добавить новый слой под текущим слоем."
 
-#: ../po/tmp/resources.xml.h:89
+#: ../po/tmp/resources.xml.h:107
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer Below…"
 msgstr "Создать векторный слой ниже…"
 
-#: ../po/tmp/resources.xml.h:90
+#: ../po/tmp/resources.xml.h:108
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer below the current layer, and begin editing it."
 msgstr ""
 "Добавить новый векторный слой под текущим слоем, и начать его редактирование."
 
-#: ../po/tmp/resources.xml.h:91
+#: ../po/tmp/resources.xml.h:109
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group Below"
 msgstr "Создать группу ниже"
 
-#: ../po/tmp/resources.xml.h:92
+#: ../po/tmp/resources.xml.h:110
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group below the current layer."
 msgstr "Добавить новую группу под текущим слоем."
 
-#: ../po/tmp/resources.xml.h:93
+#: ../po/tmp/resources.xml.h:111
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Layer Down"
 msgstr "Объединить со слоем ниже"
 
-#: ../po/tmp/resources.xml.h:94
+#: ../po/tmp/resources.xml.h:112
 msgctxt "Accel Editor (descriptions)"
 msgid "Merge the current layer with the layer beneath it."
 msgstr "Объединить слой с тем, который находится ниже его."
 
-#: ../po/tmp/resources.xml.h:95
+#: ../po/tmp/resources.xml.h:113
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Visible Layers"
 msgstr "Объединить видимые слои"
 
-#: ../po/tmp/resources.xml.h:96
+#: ../po/tmp/resources.xml.h:114
 msgctxt "Accel Editor (descriptions)"
 msgid "Consolidate all visible layers, and delete the originals."
 msgstr "Объединить все видимые слои, и удалить оригиналы."
 
-#: ../po/tmp/resources.xml.h:97
+#: ../po/tmp/resources.xml.h:115
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer from Visible"
 msgstr "Создать слой из видимого"
 
-#: ../po/tmp/resources.xml.h:98
+#: ../po/tmp/resources.xml.h:116
 msgctxt "Accel Editor (descriptions)"
 msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
 msgstr "Схоже с  'Объединить видимые слои' , но не удаляет оригиналы."
 
-#: ../po/tmp/resources.xml.h:99
+#: ../po/tmp/resources.xml.h:117
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Delete Layer"
 msgstr "Удалить слой"
 
-#: ../po/tmp/resources.xml.h:100
+#: ../po/tmp/resources.xml.h:118
 msgctxt "Accel Editor (descriptions)"
 msgid "Remove the current layer from the layer stack."
 msgstr "Удалить текущий слой из стопки слоев."
 
-#: ../po/tmp/resources.xml.h:101
+#: ../po/tmp/resources.xml.h:119
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Convert to Normal Painting Layer"
 msgstr "Преобразовать в обычный слой"
 
-#: ../po/tmp/resources.xml.h:102
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
@@ -4325,72 +5333,74 @@ msgstr ""
 "Преобразовать текущий слой или группу в слой с режимом 'Нормальный', "
 "сохраняя его изменения."
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr "Уменьшить прозрачность"
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr "Сделать слой менее прозрачным."
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr "Увеличить прозрачность"
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr "Сделать слой более прозрачным."
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr "Поднять слой"
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr "Поднять текущий слой на один шаг вверх в стопке слоев."
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr "Опустить слой"
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr "Опустить текущий слой на один шаг вниз в стопке слоев."
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr "Создать копию слоя"
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr "Создать точную копию текущего слоя."
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
+#, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
-msgstr "Переименовать слой…"
+msgid "Layer Properties…"
+msgstr "Свойства"
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
-msgstr "Введите новое имя для текущего слоя."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr "Слой заблокирован"
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
@@ -4398,709 +5408,801 @@ msgstr ""
 "Состояние блокировки текущего слоя: рисование на заблокированных слоях "
 "невозможно."
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr "Слой виден"
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr "Переключить видимость текущего слоя, спрятав его."
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr "Показать фон"
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr "Переключить видимость фона."
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr "Удалить текущий слой из стопки слоев."
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr "Сбросить и отцентрировать"
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr "Сбросить масштаб, вращение и отражение, и отцентрировать документ."
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr "По размеру рисунка"
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 "Переключаться между видом всего рисунка и вашим рабочим положением и "
 "масштабом."
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr "Сбросить"
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr "Сбросить масштаб"
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr "Восстановить масштаб к значениям по умолчанию."
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr "Сбросить вращение"
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr "Восстановить вращение до 0°"
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr "Сбросить отражение"
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
-msgstr "Отключить отражение."
+msgid "Reset the view's mirroring."
+msgstr "Сбросить отражение"
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr "Приблизить"
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr "Увеличить масштаб."
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Отдалить"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr "Уменьшить масштаб."
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
+#, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
-msgstr "Повернуть против часовой стрелки"
+msgid "Pan Left"
+msgstr "Вид"
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
-msgstr "Повернуть отображение против часовой стрелки."
+msgid "Move your view of the canvas to the left."
+msgstr "Вращение: вращать отображение холста."
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr "Жёсткий свет"
+
+#: ../po/tmp/resources.xml.h:159
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr "Вид: перемещать отображение холста горизонтально или вертикально."
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr "Вращение: вращать отображение холста."
+
+#: ../po/tmp/resources.xml.h:162
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr "Вид"
+
+#: ../po/tmp/resources.xml.h:163
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr "Вращение: вращать отображение холста."
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr "Повернуть по часовой стрелке"
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr "Повернуть отображение по часовой стрелке."
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr "Повернуть против часовой стрелки"
+
+#: ../po/tmp/resources.xml.h:167
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr "Повернуть отображение против часовой стрелки."
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr "Отразить по горизонтали"
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr "Отразить отображение слева направо."
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr "Отразить по вертикали"
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr "Отразить отображение сверху вниз."
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr "Показать только активный слой"
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr "Виден только текущий слой."
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr "Симметричное рисование"
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr "Отражать мазки кисти вдоль оси симметрии"
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr "Рамка включена"
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr "Переключить видимость рамки документа."
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr "Выводить входные величины кисти в консоль"
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
-msgstr "Показать внутренне генерируемые входные данные движка кистей в консоли."
+msgstr ""
+"Показать внутренне генерируемые входные данные движка кистей в консоли."
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr "Визуализировать рендеринг"
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr "Показывать обновления рендеринга на экране, для отладки."
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr "Двойная буферизация отключена"
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr "Отключить двойную буфферизацию GTK, обычно включен."
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+#, fuzzy
+msgid "Delete Point"
+msgstr "Удалить узел"
+
+#: ../po/tmp/resources.xml.h:187
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr "Удалить выбранный узел"
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr "Режим рисования"
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr "Обычный режим рисования"
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr "Наносить цвета нормально во время рисования."
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr "Ластик"
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr "Использовать текущую кисть как ластик."
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr "Заблокировать альфа-канал"
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr "Использование кисти не влияет на непрозрачность слоя."
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr "Тонирование"
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 "Наносить цвет на текущем слое не затрагивая его яркость или непрозрачность."
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Файл"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "Выход"
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr "Закрыть главное окно и выйти из программы."
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "Правка"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr "Текущий инструмент"
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "Цвет"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr "Настроить цвет"
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr "История цветов"
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr "Вывести под курсором историю последних цветов."
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr "Подробнее о цвете"
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr "Показать диалог настройки цвета с числовым вводом."
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr "Следующий цвет в палитре"
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr "Выбрать следующий цвет в палитре."
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr "Предыдущий цвет в палитре"
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr "Выбрать предыдущий цвет в палитре."
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr "Добавить цвет в палитру"
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr "Добавить текущий цвет в палитру."
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "Слой"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr "Непрозрачность"
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr "Перейти к слою"
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr "Создать слой ниже"
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr "Свойства"
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr "Блокнот"
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr "Создать блокнот"
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr "Загрузить блокнот по умолчанию как холст нового блокнота."
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr "Открыть блокнот…"
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr "Загрузить файл изображения на диске в блокнот."
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr "Сохранить блокнот"
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr "Сохранить блокнот в свой существующий файл на диске."
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr "Экспортировать блокнот как…"
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr "Экспортировать блокнот на диск, под любым именем."
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr "Восстановить блокнот"
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr "Вернуть блокнот к предыдущему состоянию сохранения."
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr "Сохранить как блокнот по умолчанию"
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr "Сохранить как блокнот по умолчанию для 'Создать блокнот'."
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr "Очистить блокнот по умолчанию"
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr "Очистить используемый по умолчанию блокнот."
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr "Копировать фон в блокнот"
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr "Копировать фон рабочего документа в блокнот."
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "Окно"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "Кисть"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr "Горячие клавиши"
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr "Справка по горячим клавишам для кистей"
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr "Показать объяснение работы горячих клавиш."
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "Выбор кисти…"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr "Вывести под курсором меню смены кисти."
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "Выбор цвета…"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr "Вывести под курсором меню выбора цветов, со всеми способами выбора."
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "Выбор цвета (быстрый подбор)…"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr "Вывести под курсором меню выбора цветов, с выбором в один клик."
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr "Найти больше кистей…"
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr "Скачать пакеты кистей из вики MyPaint."
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr "Импортировать кисти…"
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr "Загрузить пакет кистей с диска."
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Справка"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr "Справка"
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr "Перейти к документации MyPaint."
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "О MyPaint"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr "Показать лицензию, номер версии и состав команды MyPaint."
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Отладка"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr "Вывести информацию об утечке памяти в консоль (долго!)"
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr "Отладка утечки памяти."
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr "Запустить сборщик мусора"
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 "Освободить память использованную для объектов Python которая уже не "
 "используется."
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr "Запустить/остановить профайлер…"
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr "Запустить или остановить профайлер Python (cProfile)"
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr "Имитировать ошибку…"
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr "Вызвать ошибку Python, для испытания диалога ошибки."
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "Вид"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr "Обратная связь"
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr "Настроить вид"
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
+#, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr "Всплывающее меню"
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr "Показать всплывающее главное меню."
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "Во весь экран"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr "Переключение между полноэкранным и оконным режимами."
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "Параметры"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr "Изменить главные настройки MyPaint."
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr "Проверка устройств ввода"
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 "Показать диалог который записывает все события отправляемые вашим "
 "устройством."
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr "Выбор фона"
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr "Изменить текстуру фона."
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr "Редактор параметров кисти"
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr "Редактировать параметры кисти."
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr "Редактор значка кисти"
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr "Редактировать значки кистей."
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr "Слои"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
-msgstr "Слои (располагать слои или задавать режимы)."
+msgid "Dockable panel for managing layers."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr "Показать панель слоев"
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr "Показать панель слоев (располагать слои или задавать режимы)."
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr "Круг HCY"
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
@@ -5109,42 +6211,32 @@ msgstr ""
 "Панель с цилиндрическим выбором цветов тон/насыщенность/яркость. Круговые "
 "срезы имеют одинаковую яркость."
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "Палитра"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr "Панель палитры."
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr "Круг HSV"
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr "Панель для смены насыщенности и значения."
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr "Треугольник HSV"
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr "Панель выбора цветов: старый цветовой треугольник GTK."
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr "Куб HSV"
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
@@ -5152,216 +6244,213 @@ msgid ""
 msgstr ""
 "Куб HSV, который можно поворачивать, чтобы использовать разные плоские срезы."
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr "Квадрат HSV"
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
-msgstr ""
-"Панель выбора цветов: квадрат HSV который можно вращать для показа различных "
-"оттенков."
+msgid "Dockable color selector: HSV square with Hue ring."
+msgstr "Панель выбора цветов с концентрическими HSV кругами."
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr "Ползунки компонентов"
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr "Панель выбора цветов с отдельными компонентами цветов."
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr "Плавная волна"
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr "Панель выбора цветов с размытыми близлежащими цветами."
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr "Концентрические круги"
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr "Панель выбора цветов с концентрическими HSV кругами."
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr "Скрещенная чаша"
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 "Панель выбора цветов с HSV наклонными перекрещивающими лучеобразную чашу с "
 "цветом."
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr "Блокнот"
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
-msgstr "Блокнот (смешивать цвета и делать наброски)."
+msgid "Dockable Panel for mixing colors and testing brushes."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr "Показать панель с блокнотом"
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr "Показать блокнот (смешивать цвета и делать наброски)."
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr "Обзор"
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
-msgstr "Обзор (обзор всей области рисования)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "Обзор"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr "Показать панель обзора (обзор всей области рисования)."
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr "Параметры инструментов"
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
-msgstr "Параметры инструментов (параметры текущего инструмента)."
+msgid "Dockable panel for adjusting the options with the activated tool."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr "Показать параметры инструментов"
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr "Показать параметры инструментов (параметры текущего инструмента)."
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr "История кистей и цветов"
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
-msgstr "История (недавно использованные кисти и цвета)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr "Недавние кисти и цвета"
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr "Показать панель истории (недавно использованные кисти и цвета)."
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr "Скрыть интерфейс в полноэкранном режиме"
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 "Переключить автоматическое скрытие пользовательского интерфейса в "
 "полноэкранном режиме."
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr "Масштаб просмотра"
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr "Масштаб просмотра."
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr "Последняя точка рисования"
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr "Показать где завершился последний мазок."
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr "Фильтр отображения"
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr "Отображать цвета нормально"
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr "Фильтр цветов: показать цвета без изменений."
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr "Оттенки серого"
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr "Фильтр цветов: показать только яркость (HCY/YCbCr Luma)"
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr "Инвертированные цвета"
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 "Фильтр цветов: негативное изображение. Черный - белый, красный - голубой."
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr "Имитация нечувствительности к красному"
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
@@ -5369,354 +6458,558 @@ msgstr ""
 "Фильтровать цвета для имитации дейтеранопии, распространенной формы "
 "дальтонизма."
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr "Имитация нечувствительности к зеленому"
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 "Фильтровать цвета для имитации протанопии, распространенной формы "
 "дальтонизма."
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr "Имитация нечувствительности к синему"
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr "Фильтровать цвета для имитации тританопии, редкой формы дальтонизма."
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr "От руки"
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr "От руки"
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
-msgstr "Рисование от руки: свободное рисование, без геометрических ограничений."
+msgstr ""
+"Рисование от руки: свободное рисование, без геометрических ограничений."
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr "От руки"
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr "Рисовать свободно, без геометрических ограничений."
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr "Вид"
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr "Перемещение"
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr "Вид: перемещать отображение холста горизонтально или вертикально."
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr "Вид"
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr "Перемещать отображение холста горизонтально или вертикально."
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr "Вращение"
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr "Вращение"
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr "Вращение: вращать отображение холста."
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr "Вращение"
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr "Вращать отображение холста."
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr "Масштаб"
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr "Масштаб"
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr "Масштаб: приблизить или отдалить холст."
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr "Масштаб"
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr "Приблизить или отдалить холст."
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr "Линии и кривые"
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr "Линии"
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr "Линии и кривые: рисовать прямые или кривые линии."
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr "Линии и кривые"
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr "Рисовать прямые или кривые линии."
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr "Связанные линии"
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr "Связанные линии"
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr "Связанные линии: рисовать последовательности прямых или кривых линий."
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr "Связанные линии"
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr "Рисовать последовательности прямых или кривых линий."
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr "Эллипсы и круги"
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr "Эллипс"
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr "Эллипсы и круги: рисовать округлые формы."
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr "Эллипсы и круги"
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr "Рисовать круги и эллипсы."
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr "Контуры"
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr "Контур"
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr "Контуры: рисовать плавные регулируемые линии."
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr "Контуры"
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr "Рисовать плавные регулируемые линии."
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr "Переместить слой"
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr "Позиция слоя"
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr "Переместить слой: переместить слой на холсте."
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr "Переместить слой"
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr "Переместить текущий слой на холсте."
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr "Рамка"
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr "Рамка"
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr "Рамка: установить рамку на холсте ограничив его размер."
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr "Изменить рамку"
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr "Установить рамку на холсте ограничив его размер."
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Симметричное рисование"
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr "Симметрия"
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr "Симметричное рисование: регулировать ось для симметричного рисования."
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Симметричное рисование"
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr "Регулировать ось для симметричного рисования."
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr "Пипетка"
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr "Пипетка"
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr "Пипетка: выбрать цвет на холсте."
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "Выбрать цвет"
+
+#: ../po/tmp/resources.xml.h:401
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr "Выбрать цвет для рисования с холста."
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "Выбрать цвет"
+
+#: ../po/tmp/resources.xml.h:403
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr "Выбрать цвет для рисования с холста."
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "Выбрать цвет"
+
+#: ../po/tmp/resources.xml.h:405
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr "Выбрать цвет для рисования с холста."
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr "Пипетка"
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr "Выбрать цвет для рисования с холста."
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr "Заливка"
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr "Залить"
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr "Заливка: залить область цветом."
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr "Заливка"
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr "Залить область цветом."
+
+#~ msgctxt "Accelerator map editor: action column markup"
+#~ msgid ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+#~ msgstr ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+
+#~ msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
+#~ msgid "{action_label} {action_desc} {accel_label}"
+#~ msgstr "{action_label} {action_desc} {accel_label}"
+
+#~ msgctxt "brush list context menu"
+#~ msgid "Delete"
+#~ msgstr "Удалить"
+
+#~ msgctxt "brush list commands"
+#~ msgid "Really delete brush from disk?"
+#~ msgstr "Действительно удалить кисть?"
+
+#~ msgid "HSV Triangle"
+#~ msgstr "Треугольник HSV"
+
+#~ msgid "The standard GTK color selector"
+#~ msgstr "Стандартный способ выбора цветов GTK"
+
+#~ msgid "Pick a color from the screen"
+#~ msgstr "Выбрать цвет с экрана"
+
+#~ msgid "Layer Name"
+#~ msgstr "Название слоя"
+
+#~ msgid ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+#~ msgstr ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+
+#~ msgid "Save..."
+#~ msgstr "Сохранить…"
+
+#~ msgid "Confirm"
+#~ msgstr "Подтверждение"
+
+#~ msgid "Open..."
+#~ msgstr "Открыть…"
+
+#~ msgid "{default_name} at {path}"
+#~ msgstr "{default_name} в {path}"
+
+#~ msgid "Type"
+#~ msgstr "Тип"
+
+#~ msgid "Mode:"
+#~ msgstr "Режим:"
+
+#~ msgid ""
+#~ "Blending mode: how the current layer combines with the layers underneath "
+#~ "it."
+#~ msgstr "Режим смешивания: как текущий слой объединяется со слоями под ним."
+
+#~ msgid ""
+#~ "Layer opacity: how much of the current layer to use. Smaller values make "
+#~ "it more transparent."
+#~ msgstr ""
+#~ "Непрозрачность слоя: какую долю текущего слоя использовать. Меньшие "
+#~ "значения делают слой более прозрачным."
+
+#~ msgid "%s: edit properties"
+#~ msgstr "%s: свойства"
+
+#~ msgctxt "layer unique names: match regex (leave untranslated if unsure)"
+#~ msgid "^(.*?)\\s*(\\d+)$"
+#~ msgstr "^(.*?)\\s*(\\d+)$"
+
+#~ msgctxt "layer default names"
+#~ msgid "Unknown Bitmap Layer"
+#~ msgstr "Неизвестный растровый слой"
+
+#~ msgctxt "Autosave Recovery dialog|"
+#~ msgid "_Ignore for Now"
+#~ msgstr "_Пока игнорировать"
+
+#~ msgid "Setting name:"
+#~ msgstr "Название параметра:"
+
+#~ msgid "Base value:"
+#~ msgstr "Основное значение:"
+
+#~ msgid "Reset the base value to its default"
+#~ msgstr "Сбросить основное значение к параметрам по умолчанию"
+
+#~ msgid "<ymin>"
+#~ msgstr "<ymin>"
+
+#~ msgid "<ymax>"
+#~ msgstr "<ymax>"
+
+#~ msgid "<xmin>"
+#~ msgstr "<xmin>"
+
+#~ msgid "<xmax>"
+#~ msgstr "<xmax>"
+
+#~ msgid "Edit Setting"
+#~ msgstr "Редактировать параметр"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Trim Layer to Frame"
+#~ msgstr "Обрезать слой по рамке"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Rename Layer…"
+#~ msgstr "Переименовать слой…"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Enter a new name for the current layer."
+#~ msgstr "Введите новое имя для текущего слоя."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Turn off mirroring of the view."
+#~ msgstr "Отключить отражение."
+
+#~ msgctxt "Menu→Edit (labels)"
+#~ msgid "Current Tool"
+#~ msgstr "Текущий инструмент"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+#~ msgstr "Слои (располагать слои или задавать режимы)."
+
+#~ msgctxt "Menu→Color (labels), Accel Editor (labels)"
+#~ msgid "HSV Triangle"
+#~ msgstr "Треугольник HSV"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Dockable color selector: the old GTK color triangle."
+#~ msgstr "Панель выбора цветов: старый цветовой треугольник GTK."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid ""
+#~ "Dockable color selector: HSV square which can be rotated to show "
+#~ "different hues."
+#~ msgstr ""
+#~ "Панель выбора цветов: квадрат HSV который можно вращать для показа "
+#~ "различных оттенков."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+#~ msgstr "Блокнот (смешивать цвета и делать наброски)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+#~ msgstr "Обзор (обзор всей области рисования)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+#~ msgstr "Параметры инструментов (параметры текущего инструмента)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the History panel (recently used brushes and colors)."
+#~ msgstr "История (недавно использованные кисти и цвета)."
 
 #~ msgid ""
 #~ "\"%s\" has an alpha channel. Background images with transparency are not "
@@ -5926,9 +7219,6 @@ msgstr "Залить область цветом."
 #~ "(сила нажатия, скорость и т.п.) доступны в виде всплывающих подсказок. "
 #~ "Поместите указатель мыши над надписью, чтобы увидеть их.\n"
 
-#~ msgid "Open Recent files"
-#~ msgstr "Открыть недавние рисунки"
-
 #~ msgid "This will discard %d second of unsaved painting."
 #~ msgid_plural "This will discard %d seconds of unsaved painting."
 #~ msgstr[0] "Это отменит %d секунду несохранённого рисования."
@@ -5937,9 +7227,6 @@ msgstr "Залить область цветом."
 
 #~ msgid "Crop to Current Layer"
 #~ msgstr "По краям слоя"
-
-#~ msgid "Crop frame to the currently active layer"
-#~ msgstr "Обрезать рамку до размера текущего слоя"
 
 #~ msgid ""
 #~ "While the frame is enabled, it \n"
@@ -6048,9 +7335,6 @@ msgstr "Залить область цветом."
 #~ msgid "Brush Blend Mode"
 #~ msgstr "Режим смешивания кисти"
 
-#~ msgid "Add Layer"
-#~ msgstr "Добавить слой"
-
 #~ msgid "Move Layer on Canvas"
 #~ msgstr "Переместить слой на холсте"
 
@@ -6088,9 +7372,6 @@ msgstr "Залить область цветом."
 #~ msgctxt "Menu|File|"
 #~ msgid "Save"
 #~ msgstr "Сохранить"
-
-#~ msgid "Export to a file"
-#~ msgstr "Экспортировать в файл"
 
 #~ msgid ""
 #~ "Saves to a new scrap file. If the drawing is currently saved as a scrap, "

--- a/po/se.po
+++ b/po/se.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:19+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Northern Sami <https://hosted.weblate.org/projects/mypaint/"
@@ -19,27 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n == 1) ? 0 : ((n == 2) ? 1 : 2);\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -47,39 +27,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -87,214 +67,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Ivdni"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Iežat"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -333,98 +323,133 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Vurke"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Ođđa"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
@@ -432,44 +457,44 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -477,58 +502,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -537,51 +562,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -591,137 +640,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -729,162 +778,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -892,373 +933,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Namma"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Gađa"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Daga ođđasit"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1268,324 +1306,679 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Raba …"
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr ""
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Heaittit"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Heaittit"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Raba …"
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Vurke"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr ""
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr ""
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Fiila"
+
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Raba …"
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Aiddo geavahuvvon"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Raba …"
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Raba …"
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr ""
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1593,130 +1986,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1725,35 +2130,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1777,45 +2182,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1823,153 +2232,217 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr ""
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr ""
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr ""
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1981,256 +2454,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2238,188 +2736,212 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+msgid "Import Layers"
+msgstr ""
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2428,13 +2950,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2444,7 +2966,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2452,13 +2974,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2466,7 +2988,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2474,7 +2996,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2485,7 +3007,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2493,7 +3015,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2503,7 +3030,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2514,285 +3041,394 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr ""
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2802,7 +3438,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2811,52 +3467,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2878,17 +3565,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2917,112 +3602,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3035,7 +3695,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3076,6 +3736,133 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Namma"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3445,56 +4232,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3502,12 +4309,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3516,7 +4323,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3527,28 +4334,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3610,1828 +4417,2018 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Unnidit"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Fiila"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Hjälp"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/se.po
+++ b/po/se.po
@@ -514,17 +514,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1185,12 +1185,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1407,7 +1407,7 @@ msgid "_Quit"
 msgstr "Heaittit"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1457,7 +1457,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1635,13 +1635,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Vurke"
 
@@ -1707,7 +1707,7 @@ msgstr "Fiila"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -2131,12 +2131,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2148,7 +2148,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2333,7 +2333,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2403,7 +2403,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/sk.po
+++ b/po/sk.po
@@ -537,18 +537,18 @@ msgstr "Balík štetcov MyPaint (*.zip)"
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
-msgstr "Nová skupina..."
+msgid "New Group…"
+msgstr "Nová skupina…"
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
-msgstr "Importovať štetce..."
+msgid "Import Brushes…"
+msgstr "Importovať štetce…"
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
-msgstr "Získať viac štetcov..."
+msgid "Get More Brushes…"
+msgstr "Získať viac štetcov…"
 
 #: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
@@ -1232,13 +1232,13 @@ msgstr "Typ"
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
-msgstr "Použiť pre..."
+msgid "Use for…"
+msgstr "Použiť pre…"
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
-msgstr "Posunúť..."
+msgid "Scroll…"
+msgstr "Posunúť…"
 
 #. Name and preview column: will be indented
 #: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
@@ -1461,8 +1461,8 @@ msgid "_Quit"
 msgstr "Ukončenie"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
-msgstr "Import balíka štetcov..."
+msgid "Import brush package…"
+msgstr "Import balíka štetcov…"
 
 #: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
@@ -1517,8 +1517,8 @@ msgstr ""
 "„{type_name}” ({content_type})?"
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
-msgstr "Otvorenie pomocou..."
+msgid "Open With…"
+msgstr "Otvorenie pomocou…"
 
 #: ../gui/externalapp.py:123
 msgid "Icon"
@@ -1709,13 +1709,13 @@ msgstr "JPEG 90% kvalita (*.jpg; *.jpeg)"
 
 #: ../gui/filehandling.py:576
 #, fuzzy
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr "Exportovať…"
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Uložiť ako…"
 
@@ -1787,8 +1787,8 @@ msgstr "Otvoriť"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
-msgstr "Otvorenie náčrtníka..."
+msgid "Open Scratchpad…"
+msgstr "Otvorenie náčrtníka…"
 
 #: ../gui/filehandling.py:1099
 #, fuzzy
@@ -2241,13 +2241,13 @@ msgstr ""
 "sledovanie chýb, ak to už niekto nespravil."
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
-msgstr "Nahlásiť..."
+msgid "Report…"
+msgstr "Nahlásiť…"
 
 #: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
@@ -2258,8 +2258,8 @@ msgid "Quit MyPaint"
 msgstr "Ukončiť MyPaint"
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
-msgstr "Podrobnosti..."
+msgid "Details…"
+msgstr "Podrobnosti…"
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
@@ -2467,8 +2467,8 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
-msgstr "Presunúť vrstvu v zásobníku..."
+msgid "Move layer in stack…"
+msgstr "Presunúť vrstvu v zásobníku…"
 
 #: ../gui/layerswindow.py:110
 msgid ""
@@ -2540,8 +2540,8 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
-msgstr "Variácia tlaku..."
+msgid "Pressure variation…"
+msgstr "Variácia tlaku…"
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
@@ -3720,7 +3720,7 @@ msgstr "Odstráni tento štetec z disku"
 #, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid "_Recover & Save…"
-msgstr "_Obnoviť a uložiť..."
+msgstr "_Obnoviť a uložiť…"
 
 #: ../po/tmp/autorecover.glade.h:12
 #, fuzzy

--- a/po/sk.po
+++ b/po/sk.po
@@ -6,11 +6,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: libmypaint for mypaint 1.2.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2016-04-05 07:52+0000\n"
 "Last-Translator: Dušan Kazik <prescott66@gmail.com>\n"
-"Language-Team: Slovak "
-"<https://hosted.weblate.org/projects/mypaint/mypaint/sk/>\n"
+"Language-Team: Slovak <https://hosted.weblate.org/projects/mypaint/mypaint/"
+"sk/>\n"
 "Language: sk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -18,29 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 2.6-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr "<big><b>{accel_label}</b></big>"
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr "{action_label} {action_desc} {accel_label}"
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "Akcia"
 
@@ -49,32 +27,32 @@ msgid "Key combination"
 msgstr "Kombinácia klávesov"
 
 # dialog title
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr "Úprava klávesy pre „%s“"
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "Akcia:"
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "Cesta:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "Klávesa:"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr "Stlačte klávesy pre aktualizovanie tohto pridelenia"
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "Neznáma akcia"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
@@ -83,7 +61,7 @@ msgstr ""
 "<b>{accel} sa už používa pre akciu '{action}'. Existujúce pridelenie bude "
 "nahradené.</b>"
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr "Otvoriť priečinok „{folder_basename}”…"
@@ -91,204 +69,209 @@ msgstr "Otvoriť priečinok „{folder_basename}”…"
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "OK"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr "Vo vyrovnávacej pamäti neboli nájdené žiadne zálohy."
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr "Žiadne dostupné zálohy"
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr "Otvoriť priečinok vyrovnávacej pamäte…"
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr "Zlyhanie obnovy zálohy"
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr "Otvoriť priečinok zálohy…"
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr "Súbor obnovený zo súboru {iso_datetime}.ora"
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "Uložiť ako predvolené"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "Pozadie"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "Vzor"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Farba"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "Pridať farbu do vzorov"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr "Jedno alebo viac pozadí sa nepodarilo načítať"
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr "Chyba pri načítavaní pozadí"
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 "Prosím, odstráňte súbory, ktoré nie je možné načítať, alebo skontrolujte "
 "vašu inštaláciu knižnice libgdkpixbuf."
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 "Knižnici Gdk-Pixbuf sa nepodarilo načítať súbor „{filename}“ a nahlásila "
 "chybu „{error}“"
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr "{filename} má nulovú veľkosť (š={w}, v={h})"
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr "Editor nastavení štetca"
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr "O štetci"
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "Experimentálne"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr "Základné"
 
-#: ../gui/brusheditor.py:300
-#: ../brushsettings-gen.h:4
-#: ../po/tmp/resources.xml.h:183
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr "Krytie"
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr "Kvapky"
 
-#: ../gui/brusheditor.py:323
-#: ../brushsettings-gen.h:33
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "Rozmazanie"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr "Rýchlosť"
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr ""
+
+#: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr "Sledovanie"
 
-#: ../gui/brusheditor.py:359
-#: ../brushsettings-gen.h:57
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "Ťah"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr "Farba"
 
-#: ../gui/brusheditor.py:385
-#: ../brushsettings-gen.h:61
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Vlastné"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 "Nie je vybraný žiadny štetec. Prosím, použite namiesto toho „Pridať ako "
 "nový“."
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr "Nie je vybraný žiadny štetec!"
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "Premenovanie štetca"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "Štetec s týmto názvom už existuje!"
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr "Nie je vybraný žiadny štetec!"
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr "Skutočne odstrániť štetec „{brush_name}“ z disku?"
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr "(Nepomenovaný štetec)"
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr "{brush_name} [neuložený]"
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr "Ikona štetca"
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr "Ikona štetca (úprava)"
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr "Nie je vybraný žiadny štetec"
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -297,7 +280,7 @@ msgstr ""
 "<b>%s</b>\n"
 "<small>Najskôr vyberte platný štetec</small>"
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
@@ -306,7 +289,7 @@ msgstr ""
 "<b>%s</b> <i>(upravený)</i>\n"
 "<small>Zmeny zatiaľ nie sú uložené</small>"
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
@@ -315,7 +298,7 @@ msgstr ""
 "<b>%s</b> (úprava)\n"
 "<small>Kreslenie akýmkoľvek štetcom alebo farbou</small>"
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -356,98 +339,138 @@ msgstr "Automatická"
 msgid "Use the default icon"
 msgstr "Použije predvolenú ikonu"
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Uložiť"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr "Uloží túto ikonu náhľadu a dokončí úpravu"
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr "Straty a nálezy"
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr "Odstránené"
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr "Obľúbené"
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr "Atrament"
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr "Klasické"
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr "Sada č. 1"
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr "Sada č. 2"
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr "Sada č. 3"
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr "Sada č. 4"
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr "Sada č. 5"
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr "Experimentálne"
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Nové"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr "Neznámy štetec"
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr "Pridať medzi obľúbené"
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr "Odstrániť z obľúbených"
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr "Klonovať"
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr "Upraviť nastavenia štetca"
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
-msgstr "Odstrániť"
+#: ../gui/brushselectionwindow.py:250
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
+msgstr "Premenovať skupinu"
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
-msgstr "Skutočne odstrániť štetec z disku?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, fuzzy, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
+msgstr "Skutočne odstrániť štetec „{brush_name}“ z disku?"
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
@@ -455,44 +478,44 @@ msgstr[0] "%d štetec"
 msgstr[1] "%d štetce"
 msgstr[2] "%d štetcov"
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr "Skupina „{group_name}“"
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr "Premenovať skupinu"
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr "Exportovať ako zazipovanú sadu štetcov"
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr "Odstrániť skupinu"
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr "Premenovanie skupiny"
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "Skupina s týmto názvom už existuje!"
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr "Skutočne odstrániť skupinu „{group_name}“?"
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -502,58 +525,58 @@ msgstr ""
 "Nepodarilo sa odstrániť skupinu „{group_name}“.\n"
 "Niektoré špeciálne skupiny sa nedajú odstrániť."
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr "Export štetcov"
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr "Balík štetcov MyPaint (*.zip)"
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "Nová skupina..."
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr "Importovať štetce..."
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr "Získať viac štetcov..."
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "Vytvorenie skupiny"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr "Tlačidlo"
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr "Tlačidlo"
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr "Stlačenie tlačidla"
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr "Pridá nové previazanie"
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr "Odstráni aktuálne previazanie"
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr "Úprava previazania pre „%s“"
@@ -562,7 +585,7 @@ msgstr "Úprava previazania pre „%s“"
 msgid "Button press:"
 msgstr "Stlačenie tlačidla:"
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
@@ -570,47 +593,75 @@ msgstr ""
 "Na nastavenie nového previazania podržte stlačené modifikačné klávesy a "
 "stlačte tlačidlo nad týmto textom."
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 "{button} nie je možné nájsť bez modifikátorov (význam bol opravený, prepáčte)"
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr "{button_combination} je už previazaná s akciou '{action_name}'"
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr "Vybrať farbu"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr "Nastaví farbu použitý pri kreslení"
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+#, fuzzy
+msgid "Set the color Hue used for painting"
+msgstr "Nastaví farbu použitý pri kreslení"
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "Vyberie farbu."
+
+#: ../gui/colorpicker.py:296
+#, fuzzy
+msgid "Set the color Chroma used for painting"
+msgstr "Nastaví farbu použitý pri kreslení"
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+#, fuzzy
+msgid "Set the color Luma used for painting"
+msgstr "Nastaví farbu použitý pri kreslení"
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr "Podrobnosti o farbe"
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr "Aktuálna farba štetca a naposledy použitá farba pri kreslení"
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr "Maska gamutu aktívna"
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr "Obmedzí vašu paletu podľa nálady použitím gamutovej masky."
@@ -620,7 +671,7 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr "Odtieň HCY a farebnosť."
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
@@ -629,12 +680,12 @@ msgstr ""
 "Editor gamutovej masky. Kliknutím do stredu vytvoríte, alebo začnete "
 "manipulovať tvarmi, alebo otáčajte masku okrajmi disku."
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr "Atmosférická triáda"
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
@@ -643,34 +694,34 @@ msgstr ""
 "Náladové a subjektívne odtiene, definvoané jednou dominantnou a dvomi menej "
 "intenzívnymi primárnymi farbami."
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr "Posunutá triáda"
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr "Výraznejšie posunutá smerom k dominantnej farbe."
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr "Doplňujúca sa dvojica"
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr "Kontrastné protiklady, vyvážené stredovými neutrálnymi odtieňmi."
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr "Atmosféra s dôrazom"
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
@@ -679,12 +730,12 @@ msgstr ""
 "Jedna hlavná množina farieb s doplňujúcim akcentom pre rôznorodosť a "
 "zdôraznenie."
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr "Doplňujúca sa trojica"
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
@@ -693,72 +744,72 @@ msgstr ""
 "Dve analogické farby a jedna kontrastná pre ich doplnenie, bez druhotných "
 "farieb medzi nimi."
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr "Nová maska gamutu zo šablóny"
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr "Editor masiek gamutu"
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr "Aktívna"
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr "Pomocník…"
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr "Vytvorí masku zo šablóny."
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr "Načíta masku zo súboru palety programu GIMP."
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr "Uloží masku do súboru palety programu GIMP."
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr "Vymaže masku."
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr "Otvorí online pomocníka pre tento dialóg vo vašom webovom prehliadači."
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr "Uloženie masky ako palety programu Gimp"
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr "Načítanie masky zo súboru palety programu GIMP"
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr "Nastavenie masky gamutu."
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr "Kruh farieb HCY"
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -768,164 +819,156 @@ msgstr ""
 "Platí rovnosť kruhových výrezov."
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr "Odtieň HSV"
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr "Sýtosť HSV"
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr "Hodnota HSV"
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr "Sýtosť a hodnota HSV"
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr "Odtieň a hodnota HSV"
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr "Odtieň a sýtosť HSV"
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr "Otočná kocka (zobrazenie rôznych osí)"
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr "Kocka farieb HSV"
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 "HSV kocka, ktorá môže byť pootočená pre zobrazenie rôznych rovinných "
 "prierezov."
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr "Štvorec HSV"
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr "HSV štvorec, ktorý môže byť pootočený pre zobrazenie rôznych odtieňov."
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr "Trojuholník farieb HSV"
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr "Štandardný nástroj GTK na výber farby"
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr "Kruh farieb HSV"
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr "Menič hodnôt sýtosti a farby."
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr "Vlastnosti palety"
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr "Paleta"
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr "Nastaví farbu z palety, ktorú je možno načítať alebo upraviť."
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr "Paleta bez názvu"
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr "Editor palety"
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr "Načíta zo súboru palety programu GIMP"
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr "Uloží do súboru palety programu GIMP"
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr "Pridá novú prázdnu vzorku"
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr "Odstráni aktuálnu vzorku"
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr "Odstráni všetky vzorky"
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr "Názov:"
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr "Názov alebo popis tejto palety"
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr "Stĺpce:"
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr "Počet stĺpcov"
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr "Názov farby:"
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr "Názov aktuálnej farby"
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr "Prázdny slot palety"
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr "Načítanie palety"
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr "Uloženie palety"
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -936,381 +979,377 @@ msgstr ""
 "Pridajte, alebo organizujte\n"
 "farby pretiahnutím."
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr "Prázdny slot palety (sem pretiahnite farbu)"
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr "Pridať prázdny slot"
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr "Vložiť riadok"
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr "Vložiť stĺpec"
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr "Vyplniť medzeru (RGB)"
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr "Vyplniť medzeru (HCY)"
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr "Vyplniť medzeru (HSV)"
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "Súbor palety programu GIMP (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr "Všetky súbory (*)"
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "Súbor palety programu GIMP (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr "Všetky súbory (*)"
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr "Vyberie farbu z obrazovky"
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr "R"
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr "G"
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr "B"
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr "H"
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr "C"
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr "Y"
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr "Posuvníky zložiek"
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr "Upraví individuálne zložky farby."
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr "RGB červená"
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr "RGB zelená"
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr "RGB modrá"
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr "Odtieň HSV"
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr "Sýtosť HSV"
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr "Hodnota HSV"
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr "Odtieň HCY"
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr "HCY farebnosť"
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr "HCY svetlosť (Y')"
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr "Tekuté rozpúšťadlo"
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 "Mení farbu pomocou napodobovania rozpúšťania susediacich farieb tekutinou."
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr "Koncentrické kruhy"
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr "Mení farbu pomocou koncentrických HSV kruhov."
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr "Prekrížený ovál"
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr "Mení farbu pomocou kruhovej misky farieb prekríženej HSV rampami."
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr "Kurzor/puk"
 
-#: ../gui/device.py:50
-#: ../brushsettings-gen.h:36
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr "Guma"
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr "Klávesnica"
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr "Myš"
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr "Pero"
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr "Touchpad"
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr "Dotyková obrazovka"
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr "Ignorovať"
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr "Akákoľvek úloha"
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr "Úlohy mimo kreslenia"
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr "Iba navigácia"
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr "Priblíženie"
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr "Pero"
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr "Zariadenie"
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr "Osi"
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr "Typ"
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr "Použiť pre..."
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr "Posunúť..."
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Názov"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr "Prepísať štetec?"
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr "Nahradiť"
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr "Premenovať"
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr "Nahradiť všetko"
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr "Premenovať všetko"
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr "Importovaný štetec"
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr "Existujúci štetec"
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 "<b>Štetec s názvom „%s“ už existuje.</b>\n"
 "Chcete ho nahradiť, alebo by sa má nový štetec premenovať?"
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr "Prepísať skupinu štetcov?"
 
-#: ../gui/dialogs.py:190
-#, python-brace-format
+#: ../gui/dialogs.py:220
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 "<b>Skupina s názvom „{groupname}“ už existuje.</b>\n"
 "Chcete ju nahradiť, alebo sa má nová skupina premenovať?\n"
 "Ak ju nahradíte, štetce môžu byť presunuté do skupiny s názvom "
 "„{deleted_groupname}“."
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr "Importovať balík štetcov?"
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, fuzzy, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr "<b>Skutočne chcete importovať balík „%s“?</b>"
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr "Načítať nastavenia štetca zo slotu rýchleho prístupu %d"
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr "Uložiť nastavenia štetca do slotu rýchleho prístupu %d"
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr "Obnoviť štetec %d"
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr "Uložiť do štetca %d"
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr "Vrátiť späť %s"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Vráti späť"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr "Znovu vykonať %s"
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Znovu vykoná"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr "{button_combination} umožní {resultant_action}"
@@ -1320,103 +1359,146 @@ msgstr "{button_combination} umožní {resultant_action}"
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ";  "
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr "Stlačením klávesov {modifiers} :  {button_actions}."
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
-msgstr "Názov vrstvy"
-
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
-#, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
-"<b>{name}</b>\n"
-"{description}"
+
+#: ../gui/document.py:909
+#, python-brace-format
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
+msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr "%s - MyPaint"
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr "MyPaint"
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Otvoriť"
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr "Nastavenie aktuálnej farby"
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr "Opustí režim na celú obrazovku"
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr "Opustiť režim na celú obrazovku"
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr "Zaháji režim na celú obrazovku"
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Režim na celú obrazovku"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Ukončenie"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+#, fuzzy
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr "Skutočne ukončiť?"
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Ukončenie"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr "Import balíka štetcov..."
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr "Balík štetcov MyPaint (*.zip)"
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr "Spustený program {app_name} na úpravu vrstvy “{layer_name}”"
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 "Chyba: zlyhalo spustenie programu {app_name} na úpravu vrstvy “{layer_name}”"
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 "Úprava zrušená. Stále môžete upraviť vrstvu „{layer_name}“ z ponuky Vrstvy."
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr "Vrstva „{layer_name}“ aktualizovaná pomocou externých úprav"
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr "Nepodarilo sa načítať súbor „{file_basename}”."
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
@@ -1425,7 +1507,7 @@ msgstr ""
 "MyPaint potrebuje upraviť súbor typu „{type_name}“ ({content_type}). Ktorá "
 "aplikácia sa má použiť?"
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
@@ -1434,180 +1516,410 @@ msgstr ""
 "Ktorú aplikáciu by mal program Mypaint použiť na úpravu súborov typu "
 "„{type_name}” ({content_type})?"
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr "Otvorenie pomocou..."
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr "Ikona"
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr "bez popisu"
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
+#: ../gui/filehandling.py:126
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
+msgstr "Načítava sa súbor „{file_basename}“…"
+
+#: ../gui/filehandling.py:130
+#, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:134
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
+msgstr "Ukladá sa súbor „{file_basename}”…"
+
+#: ../gui/filehandling.py:138
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
+msgstr "Exportuje sa do súboru „{file_basename}”…"
+
+#: ../gui/filehandling.py:145
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr "Zlyhalo exportovanie do súboru „{file_basename}“."
+
+#: ../gui/filehandling.py:149
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr "Zlyhalo uloženie súboru „{file_basename}“."
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr "Nepodarilo sa načítať súbor „{file_basename}”."
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "Uloženie palety"
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr "Úspešne exportované do súboru „{file_basename}“."
+
+#: ../gui/filehandling.py:187
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr "Úspešne uložené do súboru „{file_basename}“."
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr "Načítaný súbor „{file_basename}”."
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: ../gui/filehandling.py:221
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
+msgstr "Načítaný súbor „{file_basename}”."
+
+#: ../gui/filehandling.py:427
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "All Recognized Formats"
 msgstr "Všetky známe formáty"
 
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
+#: ../gui/filehandling.py:432
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "OpenRaster (*.ora)"
 msgstr "OpenRaster (*.ora)"
 
-#: ../gui/filehandling.py:95
+#: ../gui/filehandling.py:437
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "PNG (*.png)"
 msgstr "PNG (*.png)"
 
-#: ../gui/filehandling.py:96
+#: ../gui/filehandling.py:442
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "JPEG (*.jpg; *.jpeg)"
 msgstr "JPEG (*.jpg; *.jpeg)"
 
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
+#: ../gui/filehandling.py:490
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "By extension (prefer default format)"
 msgstr "Podľa prípony (uprednostniť predvolený formát)"
 
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
+#: ../gui/filehandling.py:494
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:498
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
 msgstr "PNG s pevným pozadím (*.png)"
 
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
+#: ../gui/filehandling.py:502
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:506
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
 msgstr "Priehľadné PNG (*.png)"
 
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
+#: ../gui/filehandling.py:510
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
 msgstr "Viacero priehľadných PNG (*.XXX.png)"
 
-#: ../gui/filehandling.py:113
+#: ../gui/filehandling.py:514
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr "Viacero priehľadných PNG (*.XXX.png)"
+
+#: ../gui/filehandling.py:518
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr "JPEG 90% kvalita (*.jpg; *.jpeg)"
 
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr "Uloženie..."
+#: ../gui/filehandling.py:576
+#, fuzzy
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr "Exportovať…"
 
-#: ../gui/filehandling.py:177
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Uložiť ako…"
+
+#: ../gui/filehandling.py:601
+#, fuzzy
+msgctxt "save dialogs: formats and options: (label)"
 msgid "Format to save as:"
 msgstr "Formát na uloženie:"
 
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr "Potvrdenie"
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
+#: ../gui/filehandling.py:668
+#, fuzzy
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
 msgstr "Skutočne pokračovať?"
 
-#: ../gui/filehandling.py:234
-#, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+#, fuzzy
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr "_Uložiť ako nákres"
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, fuzzy, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
 msgstr ""
 "Týmto sa zahodí neuložené kreslenie, ktoré vám trvalo {abbreviated_time}"
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr "_Uložiť ako nákres"
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
 
-#: ../gui/filehandling.py:282
-#, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
-msgstr "Načítava sa súbor „{file_basename}“…"
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
 
-#: ../gui/filehandling.py:296
-#, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
-msgstr "Nepodarilo sa načítať súbor „{file_basename}”."
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
 
-#: ../gui/filehandling.py:321
-#, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
-msgstr "Načítaný súbor „{file_basename}”."
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr "Otvoriť…"
 
-#: ../gui/filehandling.py:422
-#, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
-msgstr "Exportuje sa do súboru „{file_basename}”…"
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Otvoriť"
 
-#: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
-msgstr "Ukladá sa súbor „{file_basename}”…"
-
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
-msgstr "Zlyhalo exportovanie do súboru „{file_basename}“."
-
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
-msgstr "Zlyhalo uloženie súboru „{file_basename}“."
-
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
-msgstr "Úspešne exportované do súboru „{file_basename}“."
-
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
-msgstr "Úspešne uložené do súboru „{file_basename}“."
-
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Otvorenie..."
-
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr "Otvorenie náčrtníka..."
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Importovaný štetec"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Otvoriť"
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Otvoriť posledný"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Otvoriť"
+
+#: ../gui/filehandling.py:1446
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
 msgstr "Zatiaľ neexistuje žiadny súbor nákresu s názvom „%s“."
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1455
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr "Otvoriť nasledujúci nákres"
+
+#: ../gui/filehandling.py:1463
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr "Otvoriť predchádzajúci nákres"
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Otvoriť"
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+#, fuzzy
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr "Vráti"
+
+#: ../gui/fill.py:121
+#, fuzzy
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr "Vyplnenie"
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+#, fuzzy
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr "Vyplní oblasti farbou"
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+#, fuzzy
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr "Tolerancia:"
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+#, fuzzy
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr "Zdroj:"
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
-msgstr "Ktoré viditeľné vrstvy majú byť vyplnené"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
+msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+#, fuzzy
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr "Zlúčená vzorka"
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+#, fuzzy
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
@@ -1617,19 +1929,50 @@ msgstr ""
 "zlúčiťvvšetky viditeľné vrstvy pod\n"
 "aktuálnou vrstvou"
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+#, fuzzy
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr "Prispôsobiť zobrazeniu"
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+#, fuzzy
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr "Cieľ:"
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+#, fuzzy
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr "Kde má ísť výstup"
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr "Nová vrstva (raz)"
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+#, fuzzy
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
@@ -1637,21 +1980,108 @@ msgstr ""
 "Vytvorí novú vrstvu s výsledkami vyplnenia.\n"
 "Po použití je táto funkcia automaticky vypnutá."
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Krytie:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr "Vynulovať"
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+#, fuzzy
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr "Znovu nastaví voľby na ich predvolené hodnoty"
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "Vybratie vrstvy"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr "<b>{brush_name}</b>"
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1661,130 +2091,142 @@ msgstr ""
 "<b>{brush_name}</b>\n"
 "{brush_desc}"
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr "Úprava orámovania"
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr "Upraví rám dokumentu"
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr "Veľkosť orámovania"
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr "px"
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr "Výška:"
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr "Šírka:"
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr "Rozlíšenie:"
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr "DPI"
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr "Bodov na palec (v skutočnosti pixelov na palec)"
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr "Farba:"
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr "Farba orámovania"
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr "<b>Rozmery orámovania</b>"
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr "<b>Hustota pixelov</b>"
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr "Nastaviť orámovanie vrstvy"
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr "Nastaví orámovanie na oblasti aktuálnej vrstvy"
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr "Nastaviť orámovanie dokumentu"
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr "Nastaví orámovanie kombinácie vrstiev"
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr "Orezať vrstvu podľa orámovania"
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr "Oreže časti aktuálnej vrstvy, ktoré ležia mimo orámovania"
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr "Povolené"
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr "{width:g}×{height:g} {units}"
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr "palce"
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr "cm"
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr "mm"
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr "Kreslenie voľnou rukou"
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr "Kreslenie voľných ťahov štetcom"
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr "Plynulosť:"
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr "Tlak:"
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr "Zistila sa chyba"
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr "<big><b>Bola zistená chyba s programovaním.</b></big>"
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1798,35 +2240,35 @@ msgstr ""
 "Prosím, informujte vývojárov o tejto chybe prostredníctvom nástroja na "
 "sledovanie chýb, ak to už niekto nespravil."
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr "Nahlásiť..."
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr "Ignorovať chybu"
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr "Ukončiť MyPaint"
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr "Podrobnosti..."
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr "Výnimka počas analýzy výnimky."
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1869,45 +2311,50 @@ msgstr ""
 "            #### Výpis chyby\n"
 "        "
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr "Farbenie"
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr "Nakreslí a potom umožní upravovať hladkosť čiar"
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr "Skúška vstupného zariadenia"
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr "(žiadny tlak)"
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr "Tlak:"
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr "(žiadny sklon)"
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr "Sklon:"
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr "(žiadne zariadenie)"
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
 msgstr "Zariadenie:"
 
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+#, fuzzy
+msgid "Barrel Rotation:"
+msgstr "Vynulovať otočenie"
+
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr "Presun vrstvy"
 
@@ -1915,165 +2362,233 @@ msgstr "Presun vrstvy"
 msgid "Move the current layer"
 msgstr "Presunie aktuálnu vrstvu"
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
-msgstr "{default_name} v {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
+msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
-msgstr "Typ"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
+msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+#, fuzzy
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr "Vlastnosti"
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr "Viditeľná"
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Vrstva"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+#, fuzzy
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr "Uzamknutá"
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+#, fuzzy
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ", "
+
+#: ../gui/layers.py:990
+#, fuzzy, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr "Pridanie {layer_default_name}"
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Vrstvy"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr "Usporiada vrstvy a pridelí im efekty"
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr "Krytie vrstvy: %d%%"
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr "Presunúť vrstvu v zásobníku..."
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 "Presunie vrstvu v zásobníku (pustenie do regulárnej vrstvy vytvorí novú "
 "skupinu)"
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr "Vrstva"
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
-msgstr "Režim:"
+#: ../gui/layervis.py:53
+#, fuzzy, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
+msgstr "<b>{brush_name}</b>"
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
-msgstr "Režim prechodu: ako sa skombinuje aktuálna vrstva s vrstvami pod ňou."
-
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Krytie:"
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
-"Krytie vrstvy: koľko použiť z aktuálnej vrstvy. Menšie hodnoty ju urobia "
-"viac priehľadnou."
 
-#: ../gui/linemode.py:37
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "Otočenie zobrazenia"
+
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr "Vstupný tlak"
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr "Vstupný tlak ťahu pre nástroje čiar"
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr ""
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr "Výstupný tlak"
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr "Výstupný tlak ťahu pre nástroje čiar"
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr ""
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 msgid "Stroke lead-in end"
 msgstr ""
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr ""
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr "Variácia tlaku..."
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr "Čiary a krivky"
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr "Všeobecný režim čiary/krivky"
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 "Nakreslí rovné čiary; Klávesou Shift sa pridajú krivky, klávesou Ctrl sa "
 "upravuje uhol"
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr "Spojené čiary"
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 "Nakreslí postupnosť čiar; Klávesou Shift sa pridajú čiary, klávesou Ctrl sa "
 "upravuje uhol"
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr "Elipsy a kruhy"
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
-"Nakreslí elipsy; Klávesou Shift sa otáča, klávesou Ctrl sa upravuje "
-"pomer/uhol"
+"Nakreslí elipsy; Klávesou Shift sa otáča, klávesou Ctrl sa upravuje pomer/"
+"uhol"
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
+#, fuzzy
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 "Autorské práva (C) 2005-2015\n"
 "Martin Renold a tím vývojárov aplikácie MyPaint"
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -2092,72 +2607,72 @@ msgstr ""
 "Tento program je distribuovaný v nádeji, že bude užitočný, no BEZ AKEJKOĽVEK "
 "ZÁRUKY. Pozrite súbor „COPYING“ pre viac podrobností."
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr "programovanie"
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr "portovateľnosť"
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr "správa projektu"
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr "štetce"
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr "vzory"
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr "ikony nástrojov"
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr "ikona plochy"
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr "palety"
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr "dokumentácia"
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr "podpora"
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr "marketing"
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr "komunita"
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ", "
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
@@ -2165,186 +2680,216 @@ msgstr ""
 "Patrik Bubák <bubakpatrik@gmail.com>\n"
 "Blake <adam.otruba@gmail.com>"
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr "Veľkosť:"
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr "Krytie:"
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr "Ostrosť:"
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr "Zisk:"
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr "Voľby nástrojov"
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr "Špecializované nastavenia aktuálneho nástroja použitého pri úpravách"
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr "<b>{mode_name}</b>"
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr "<i>Nie sú dostupné žiadne voľby</i>"
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr "Priblíženie: %.01f%%"
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr "Vyberie nastavenia ťahu štetcom, farbu ťahu a vrstvu…"
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr "Vyberie farbu…"
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr "Nastavenia"
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr "Náhľad"
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr "Zobrazí náhľad celej kresliacej oblasti"
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr "Zobraziť hľadáčik"
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr "Náčrtník"
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr "Zamieša farby a vytvorí nákresy na oddelených stránkach"
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr "Predchádzajúca položka"
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr "Nasledujúca položka"
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
 msgstr "(Nič na zobrazenie)"
 
-#: ../gui/symmetry.py:76
+#: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Place axis"
 msgstr "Umiestni os"
 
-#: ../gui/symmetry.py:80
+#: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Move axis"
 msgstr "Presunie os"
 
-#: ../gui/symmetry.py:84
+#: ../gui/symmetry.py:88
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr "Odstráni os"
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr "Úprava osi symetrie"
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr "Upraví os symetrie kreslenia."
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
+#, fuzzy
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr "Pozícia:"
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr "Pozícia:"
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr "Žiadna"
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr "%d px"
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr "Alfa kanál:"
 
-#: ../gui/symmetry.py:352
+#: ../gui/symmetry.py:376
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
+msgstr "Symetria"
+
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+#, fuzzy
 msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+msgid "X axis Position"
 msgstr "Pozícia osi"
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:477
+#, fuzzy
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr "Pozícia osi"
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr "Povolená"
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr "Správa súborov"
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr "Prepínač nákresov"
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr "Vrátenie späť a zopakovanie"
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr "Režimy prechodov"
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr "Režimy čiar"
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr "Zobrazenie (hlavné)"
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr "Zobrazenie (alternatívne/sekundárne)"
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr "Zobrazenie (vynulovanie)"
 
@@ -2352,188 +2897,214 @@ msgstr "Zobrazenie (vynulovanie)"
 msgid "<b>MyPaint</b>"
 msgstr "<b>MyPaint</b>"
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr "Posúvanie zobrazenia"
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr "Presunie zobrazenie plátna"
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr "Priblížiť zobrazenie"
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr "Priblíži zobrazenie plátna"
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr "Otočenie zobrazenia"
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr "Otočí zobrazenie plátna"
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, fuzzy, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr "%s: zavrie kartu"
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
-msgstr "%s: upraví vlastnosti"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
+msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr "Neznámy príkaz"
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr "Neurčený (príkaz zatiaľ nebol spustený)"
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr "{seconds:.01f}s kreslenia so štetcom {brush_name}"
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr "Vyplnenie"
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr "Orezanie vrstvy"
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "Premenovať skupinu"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr "Vymazanie vrstvy"
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr "Vloženie vrstvy"
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr "Nová vrstva z viditeľného"
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr "Zlúčenie viditeľných vrstiev"
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr "Zlúčenie nadol"
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr "Režim normalizácie vrstvy"
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Importovaný štetec"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr "Pridanie {layer_default_name}"
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr "Odstránenie vrstvy"
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr "Vybratie vrstvy"
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr "Duplikovanie vrstvy"
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr "Presun vrstvy hore"
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr "Presun vrstvy dole"
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr "Presun vrstvy v zásobníku"
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr "Premenovanie vrstvy"
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr "Zviditeľnenie vrstvy"
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr "Skrytie vrstvy"
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr "Uzamknutie vrstvy"
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr "Odomknutie vrstvy"
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr "Nastavenie krytia vrstvy: %0.1f%%"
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr "Neznámy režim"
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr "Nastavenie režimu vrstvy: %s"
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr "Povoliť orámovanie"
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr "Zakázať orámovanie"
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr "Aktualizovať orámovanie"
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr "Externé upravenie vrstvy"
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr "Chyba pri načítavaní „{basename}“."
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr "Záznamy môžu obsahovať viac podrobností o tejto chybe."
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr "doteraz"
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr "pred"
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2545,13 +3116,13 @@ msgstr ""
 "Máte spustených viac inštancií aplikácie MyPaint?\n"
 "Zatvorte aplikáciu a počkajte {cache_update_interval}s na ďalší pokus."
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr "Neúplná záloha aktualizovaná {ago} {last_modified_time}"
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2561,11 +3132,11 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 "Záloha aktualizovaná {ago} {last_modified_time}\n"
-"Veľkosť: {autosave.width}×{autosave.height} pixelov, Vrstvy: "
-"{autosave.num_layers}\n"
+"Veľkosť: {autosave.width}×{autosave.height} pixelov, Vrstvy: {autosave."
+"num_layers}\n"
 "Obsahuje neuložené kreslenie, ktoré vám trvalo {unsaved_time}."
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2575,13 +3146,13 @@ msgstr ""
 "Nie je možné zapísať súbor „{filename}“: {err}\n"
 "Máte dostatok voľného miesta na zariadení?"
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr "Nie je možné zapísať súbor „{filename}“: {err}"
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2591,7 +3162,7 @@ msgstr ""
 "{error_loading_common}\n"
 "Súbor neexistuje."
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2601,7 +3172,7 @@ msgstr ""
 "{error_loading_common}\n"
 "Nemáte dostatočné oprávnenia na otvorenie tohoto súboru."
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2617,7 +3188,7 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2627,7 +3198,13 @@ msgstr ""
 "{error_loading_common}\n"
 "Neznáma prípona formátu súboru: „{ext}“"
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+#, fuzzy
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr "Importovaný štetec"
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2641,7 +3218,7 @@ msgstr ""
 "Ak vaše zariadenie nemá dostatok pamäte RAM, skúste formát PNG. Funkcia "
 "ukladania vo formáte PNG je v programe MyPaint oveľa efektívnejšia."
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2657,98 +3234,207 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/helpers.py:402
-#, python-brace-format
+#: ../lib/floodfill.py:131
+#, fuzzy
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr "Vyplnenie"
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr "{days}d{hours}h"
 
-#: ../lib/helpers.py:404
-#, python-brace-format
+#: ../lib/helpers.py:537
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr "{hours}h{minutes}m"
 
-#: ../lib/helpers.py:406
-#, python-brace-format
+#: ../lib/helpers.py:539
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr "{minutes}m{seconds}s"
 
-#: ../lib/helpers.py:408
-#, python-brace-format
+#: ../lib/helpers.py:541
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr "{seconds}s"
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr "Vrstva"
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr "%(name)s %(number)d"
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr "^(.*?)\\s*(\\d+)$"
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
+#, fuzzy
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr "Vektorová vrstva"
+
+#: ../lib/layer/data.py:1158
+#, fuzzy
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr "Vektorová vrstva"
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
-msgstr "Neznáma bitmapová vrstva"
+msgid "Bitmap"
+msgstr ""
 
-#: ../lib/layer/data.py:1169
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1244
 msgctxt "layer default names"
-msgid "Unknown Data Layer"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
 msgstr "Neznáma údajová vrstva"
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "Nová kresliaca vrstva"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr "Skupina"
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "Nová skupina vrstiev"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr "Zástupný text"
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr "Koreňová"
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ", "
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+#, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "Zobrazenie"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+#, fuzzy
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr "Vrstva viditeľná"
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+#, fuzzy
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr "Odstránenie vrstvy"
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr "Uzamknutie vrstvy"
+
+#: ../lib/layervis.py:697
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr "Odomknutie vrstvy"
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr "Prechod"
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr "Obsah skupiny sa aplikuje priamo na pozadie skupiny"
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr "Normálny"
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr "Iba vrchná vrstva, bez prechodu farieb."
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr "Násobenie"
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
@@ -2756,11 +3442,11 @@ msgstr ""
 "Podobné načítaniu dvoch snímok v projektore a následná projekcia "
 "kombinovaného výsledku."
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr "Obrazovka"
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
@@ -2768,11 +3454,11 @@ msgstr ""
 "Ako súčasné presvetlenie dvoch oddelených snímkov projektorom na obrazovku. "
 "Toto je opakom režimu „Násobenie“."
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr "Prekrytie"
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
@@ -2780,27 +3466,27 @@ msgstr ""
 "Prekryje pozadie vrchnou vrstvou pri zachovaní rysov a tieňov pozadia. Toto "
 "je opakom režimu „Tvrdé svetlo“."
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr "Stmavenie"
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr "Použije sa vrchná vrstva, pričom je tmavšia ako pozadie."
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr "Zosvetlenie"
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr "Použije sa vrchná vrstva, pričom je svetlejšia ako pozadie."
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr "Dodge"
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
@@ -2810,11 +3496,11 @@ msgstr ""
 "fotografov v tmavej komore známej pod rovnakým názvom, ktorá sa používa na "
 "vylepšenie kontrastu v tieňoch."
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr "Burn"
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
@@ -2824,130 +3510,141 @@ msgstr ""
 "v tmavej komore známej pod rovnakým názvom, ktorá sa používa na zníženie "
 "veľmi jasných rysov."
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr "Tvrdé svetlo"
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr "Podobné ostrému svetlu baterky na pozadí."
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr "Mäkké svetlo"
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr "Rozdiel"
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr "Odpočíta tmavšiu farbu od tej svetlejšej."
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr "Odtieň"
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr "Sýtosť"
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr "Svietivosť"
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr "Sčítanie"
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr "Táto vrstva a jej pozadie sú jednoducho spojené dokopy."
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr "Nadradený zdroj"
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, fuzzy, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr "%(name)s %(number)d"
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2957,7 +3654,30 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+#, fuzzy
+msgid "Vertical"
+msgstr "Zrkadliť zvislo"
+
+#: ../lib/tiledsurface.py:49
+#, fuzzy
+msgid "Horizontal"
+msgstr "Zrkadliť vodorovne"
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+#, fuzzy
+msgid "Rotational"
+msgstr "Vynulovať otočenie"
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr "Nástroj na čítanie PNG zlyhal: %s"
@@ -2966,56 +3686,94 @@ msgstr "Nástroj na čítanie PNG zlyhal: %s"
 msgid "Recover interrupted work?"
 msgstr "Obnoviť prerušenú prácu?"
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
-msgstr "_Obnoviť a uložiť..."
+msgid "_Look for backups at startup"
+msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr "Odstrániť"
+
+#: ../po/tmp/autorecover.glade.h:9
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr "Odstráni tento štetec z disku"
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr "_Obnoviť a uložiť..."
+
+#: ../po/tmp/autorecover.glade.h:12
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr "Uložiť túto zálohu na disk, potom pokračovať v práci na nej."
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
-msgstr "Teraz _ignorovať"
+msgid "Decide _Later"
+msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr "Začať prácu na novom plátne. Tieto zálohy budú uchované."
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
+#, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 "Program MyPaint bol predčasne ukončený s neuloženou prácou, ale vytvoril "
 "zálohy. Môžete obnoviť súbor teraz, alebo spustiť obnovu pri ďalšom spustení "
 "programu MyPaint."
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr "Miniatúra"
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr "Popis"
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
-msgstr "Kopírovať do novej"
+msgid "Live update"
+msgstr "Živá aktualizácia"
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
-msgstr "Skopíruje tieto nastavenia a ikonu aktuálneho štetca do nového štetca"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
+msgstr ""
+"Aktualizuje posledný ťah na plátne s nastaveniami v tomto okne, v reálnom "
+"čase"
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
-msgstr "Premenuje tento štetec"
+msgid "Save these settings to the brush"
+msgstr "Uloží tieto nastavenia pre štetec"
 
 #: ../po/tmp/brusheditor.glade.h:5
 msgid "Edit Icon"
@@ -3038,20 +3796,16 @@ msgid "Delete this brush from the disk"
 msgstr "Odstráni tento štetec z disku"
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
-msgstr "Živá aktualizácia"
+msgid "Copy to New"
+msgstr "Kopírovať do novej"
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
-msgstr ""
-"Aktualizuje posledný ťah na plátne s nastaveniami v tomto okne, v reálnom "
-"čase"
+msgid "Copy these settings and the current brush's icon to a new brush"
+msgstr "Skopíruje tieto nastavenia a ikonu aktuálneho štetca do nového štetca"
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
-msgstr "Uloží tieto nastavenia pre štetec"
+msgid "Rename this brush"
+msgstr "Premenuje tento štetec"
 
 #: ../po/tmp/brusheditor.glade.h:13
 msgid "Brush Setting"
@@ -3079,113 +3833,91 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr "Poznámky:"
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr "Názov nastavenia:"
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
-msgstr "Základná hodnota:"
+#: ../po/tmp/brusheditor.glade.h:22
+#, fuzzy
+msgid "Value:"
+msgstr "Hodnota HSV"
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr "Znovu nastaví základnú hodnotu na jej predvolenú hodnotu"
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr "<ymin>"
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr "<ymax>"
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr "Výstup"
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr "Vstup"
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr "Upraví hodnotu maxima"
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr "Upraví hodnotu minima"
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr "<xmin>"
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr "<xmax>"
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr "Dynamika štetca"
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr "Základné podrobnosti tohto nastavenia"
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr "Upraviť nastavenie"
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr "Podrobne upraví toto vstupné mapovanie"
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr "{tooltip}"
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
 msgstr "{dname}:"
+
+#: ../po/tmp/brusheditor.glade.h:42
+#, fuzzy
+msgid "Brush dynamics are not available for this setting."
+msgstr "Základné podrobnosti tohto nastavenia"
+
+#: ../po/tmp/brusheditor.glade.h:43
+#, fuzzy
+msgid "<big><b>No Brush Dynamics</b></big>"
+msgstr "<big><b>{accel_label}</b></big>"
 
 #: ../po/tmp/inktool.glade.h:1
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
@@ -3197,7 +3929,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr "Tlak:"
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3242,6 +3974,141 @@ msgstr "Odstrániť bod"
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
 msgstr "Odstráni aktuálnu vybratý bod"
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+#, fuzzy
+msgid "Insert Point"
+msgstr "Vložiť riadok"
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+#, fuzzy
+msgid "Cull Points"
+msgstr "Odstrániť bod"
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Názov"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr "Režim"
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Krytie"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr "Režim kompozície aktuálnej vrstvy."
+
+#: ../po/tmp/layervis.glade.h:2
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr "Otočí zobrazenie plátna"
+
+#: ../po/tmp/layervis.glade.h:3
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr "Otočí zobrazenie plátna"
+
+#: ../po/tmp/layervis.glade.h:4
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr "Ktoré viditeľné vrstvy majú byť vyplnené"
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
+msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
 msgctxt "footer: color picker button: tooltip"
@@ -3371,7 +4238,6 @@ msgstr "<b>Globálne mapovanie tlaku</b>"
 
 #. Tab label in preferences dialog
 #: ../po/tmp/preferenceswindow.glade.h:27
-#: ../brushsettings-gen.h:53
 msgctxt "Prefs Dialog|"
 msgid "Pressure"
 msgstr "Tlak"
@@ -3629,56 +4495,77 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr "Skryť kurzor počas kreslenia"
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+#, fuzzy
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr "Povolené"
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr "Zobrazenie"
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr "Hlavné sú:"
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr "Štandardná digitálna červená/zelená/modrá"
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr "Tradičná umelecká červená/žltá/modrá"
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3686,12 +4573,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr "Červeno-zelené a modro-žlté opačné páry"
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3700,7 +4587,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3711,28 +4598,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr "<b>Farebný kruh</b>"
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr "Farba"
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr "Obrazovka (normálne)"
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr "Zakázané (žiadna citlivosť na tlak)"
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr "Okno (neodporúčané)"
@@ -3793,460 +4680,570 @@ msgid "Reload the file your current work was loaded from."
 msgstr "Znovu načíta súbor, z ktorého bola načítaná vaša aktuálna práca."
 
 #: ../po/tmp/resources.xml.h:12
+#, fuzzy
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Import Layers…"
+msgstr "Importovať štetce…"
+
+#: ../po/tmp/resources.xml.h:13
+msgctxt "Accel Editor (descriptions)"
+msgid "Import layers from one or more files."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save"
 msgstr "Uložiť"
 
-#: ../po/tmp/resources.xml.h:13
+#: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file."
 msgstr "Uloží vašu prácu do súboru."
 
-#: ../po/tmp/resources.xml.h:14
+#: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As…"
 msgstr "Uložiť ako…"
 
-#: ../po/tmp/resources.xml.h:15
+#: ../po/tmp/resources.xml.h:17
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file, assigning it a new name."
 msgstr "Uloží vašu prácu do súboru s novým názvom."
 
-#: ../po/tmp/resources.xml.h:16
+#: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Export…"
 msgstr "Exportovať…"
 
-#: ../po/tmp/resources.xml.h:17
+#: ../po/tmp/resources.xml.h:19
 msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 "Exportuje vašu prácu do súboru, ale umožní pracovať na tom istom súbore."
 
-#: ../po/tmp/resources.xml.h:18
+#: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As Scrap"
 msgstr "Uložiť ako nákres"
 
-#: ../po/tmp/resources.xml.h:19
+#: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
 msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 "Uloží do nového súboru nákresu, alebo uloží nové vydanie predchádzajúceho "
 "nákresu."
 
-#: ../po/tmp/resources.xml.h:20
+#: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Previous Scrap"
 msgstr "Otvoriť predchádzajúci nákres"
 
-#: ../po/tmp/resources.xml.h:21
+#: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file before the current one."
 msgstr "Načíta súbor nákresu pred aktuálnym."
 
-#: ../po/tmp/resources.xml.h:22
+#: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Next Scrap"
 msgstr "Otvoriť nasledujúci nákres"
 
-#: ../po/tmp/resources.xml.h:23
+#: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file after the current one."
 msgstr "Načíta súbor nákresu po aktuálnom."
 
-#: ../po/tmp/resources.xml.h:24
+#: ../po/tmp/resources.xml.h:26
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Recover File from an Automated Backup…"
 msgstr "Obnoviť súbor z automatickej zálohy…"
 
-#: ../po/tmp/resources.xml.h:25
+#: ../po/tmp/resources.xml.h:27
 msgctxt "Accel Editor (descriptions)"
 msgid "Try to save and resume interrupted unsaved work."
 msgstr "Pokúsi sa uložiť a pokračovať v prerušenej neuloženej práci."
 
-#: ../po/tmp/resources.xml.h:26
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr "Skupiny štetcov"
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr "Štetce"
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr "Zoznam skupín štetcov."
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr "Nástroje na úpravu farby"
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr "Farby"
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr "Dostupné nástroje na úpravu farby."
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr "Režim"
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr "Režim"
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr "Režim kompozície aktuálnej vrstvy."
 
-#: ../po/tmp/resources.xml.h:35
+#: ../po/tmp/resources.xml.h:37
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Pressure"
+msgstr "Vstupný tlak"
+
+#: ../po/tmp/resources.xml.h:38
+msgctxt "Accel Editor (descriptions)"
+msgid "Send harder pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:39
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Pressure"
+msgstr "Vstupný tlak"
+
+#: ../po/tmp/resources.xml.h:40
+msgctxt "Accel Editor (descriptions)"
+msgid "Send softer pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:41
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Rotation"
+msgstr "Zvýšiť sýtosť"
+
+#: ../po/tmp/resources.xml.h:42
+msgctxt "Accel Editor (descriptions)"
+msgid "Increase barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:43
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
+msgstr "Znížiť sýtosť"
+
+#: ../po/tmp/resources.xml.h:44
+msgctxt "Accel Editor (descriptions)"
+msgid "Decrease barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:45
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Size"
 msgstr "Zväčšiť veľkosť štetca"
 
-#: ../po/tmp/resources.xml.h:36
+#: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush bigger."
 msgstr "Zväčší pracovný štetec."
 
-#: ../po/tmp/resources.xml.h:37
+#: ../po/tmp/resources.xml.h:47
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Size"
 msgstr "Zmenšiť veľkosť štetca"
 
-#: ../po/tmp/resources.xml.h:38
+#: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush smaller."
 msgstr "Zmenší pracovný štetec."
 
-#: ../po/tmp/resources.xml.h:39
+#: ../po/tmp/resources.xml.h:49
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Opacity"
 msgstr "Zvýšiť krytie štetca"
 
-#: ../po/tmp/resources.xml.h:40
+#: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush more opaque."
 msgstr "Viac znepriehľadní pracovný štetec."
 
-#: ../po/tmp/resources.xml.h:41
+#: ../po/tmp/resources.xml.h:51
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Opacity"
 msgstr "Znížiť krytie štetca"
 
-#: ../po/tmp/resources.xml.h:42
+#: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush less opaque."
 msgstr "Viac spriehľadní pracovný štetec."
 
-#: ../po/tmp/resources.xml.h:43
+#: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Lighten Painting Color"
 msgstr "Zosvetliť farbu kreslenia"
 
-#: ../po/tmp/resources.xml.h:44
+#: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase the lightness of the current painting color."
 msgstr "Zvýši svetlosť aktuálnej farby kreslenia."
 
-#: ../po/tmp/resources.xml.h:45
+#: ../po/tmp/resources.xml.h:55
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Darken Painting Color"
 msgstr "Stmaviť farbu kreslenia"
 
-#: ../po/tmp/resources.xml.h:46
+#: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease the lightness of the current painting color."
 msgstr "Zníži svetlosť aktuálnej farby kreslenia."
 
-#: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
-msgstr "Zmeniť odtieň doľava"
-
-#: ../po/tmp/resources.xml.h:48
-msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
-msgstr "Otočí odtieň farby kreslenia doľava na kruhu farieb."
-
-#: ../po/tmp/resources.xml.h:49
+#: ../po/tmp/resources.xml.h:57
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Change Hue Clockwise"
 msgstr "Zmeniť odtieň doprava"
 
-#: ../po/tmp/resources.xml.h:50
+#: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
 msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr "Otočí odtieň farby kreslenia doprava na kruhu farieb."
 
-#: ../po/tmp/resources.xml.h:51
+#: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr "Zmeniť odtieň doľava"
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr "Otočí odtieň farby kreslenia doľava na kruhu farieb."
+
+#: ../po/tmp/resources.xml.h:61
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Increase Saturation"
 msgstr "Zvýšiť sýtosť"
 
-#: ../po/tmp/resources.xml.h:52
+#: ../po/tmp/resources.xml.h:62
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color more saturated (more colorful, purer)."
 msgstr "Zvýši sýtosť farby kreslenia (väčšia farebnosť, čistejšia farba)."
 
-#: ../po/tmp/resources.xml.h:53
+#: ../po/tmp/resources.xml.h:63
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Decrease Saturation"
 msgstr "Znížiť sýtosť"
 
-#: ../po/tmp/resources.xml.h:54
+#: ../po/tmp/resources.xml.h:64
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color less saturated (grayer)."
 msgstr "Zníži sýtosť farby kreslenia (šedšia farba)."
 
-#: ../po/tmp/resources.xml.h:55
+#: ../po/tmp/resources.xml.h:65
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Reload Brush Settings"
 msgstr "Znovunačítať nastavenia štetca"
 
-#: ../po/tmp/resources.xml.h:56
+#: ../po/tmp/resources.xml.h:66
 msgctxt "Accel Editor (descriptions)"
 msgid "Restore all brush settings to the current brush’s saved values."
 msgstr "Obnoví všetky nastavenia štetca na uložené hodnoty aktuálneho štetca."
 
-#: ../po/tmp/resources.xml.h:57
+#: ../po/tmp/resources.xml.h:67
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Pick Stroke and Layer"
 msgstr "Vybrať ťah a vrstvu"
 
-#: ../po/tmp/resources.xml.h:58
+#: ../po/tmp/resources.xml.h:68
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
 msgstr "Vybrať ťah štetcom z plátna: obnoví štetec, farbu a vrstvu."
 
-#: ../po/tmp/resources.xml.h:59
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr "Uložiť štetec medzi posledné skratky"
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr "Uloží nastavenia štetca medzi naposledy použité skratky."
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "Vymazať vrstvu"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr "Vymaže obsah aktuálnej vrstvy."
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+#, fuzzy
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr "Voľby nástrojov"
+
+#: ../po/tmp/resources.xml.h:76
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr "Orezať vrstvu podľa orámovania"
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr "Oreže časti aktuálnej vrstvy, ktoré ležia mimo orámovania."
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr "Oreže časti aktuálnej vrstvy, ktoré ležia mimo orámovania."
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "Nová skupina vrstiev nižšie"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "Nová skupina vrstiev nižšie"
+
+#: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr "Skopírovať vrstvu do schránky"
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr "Skopíruje obsah aktuálnej vrstvy do schránky."
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr "Vložiť vrstvu zo schránky"
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr "Nahradí aktuálnu vrstvu obsahom schránky."
 
-#: ../po/tmp/resources.xml.h:71
+#: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Edit Layer in External App…"
 msgstr "Upraviť vrstvu v externej aplikácii…"
 
-#: ../po/tmp/resources.xml.h:72
+#: ../po/tmp/resources.xml.h:90
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
+msgid "Edit the active layer in an external application."
 msgstr "Spustí úpravu aktuálnej vrstvy v externej aplikácii."
 
-#: ../po/tmp/resources.xml.h:73
+#: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Update Layer with External Edits"
 msgstr "Aktualizovať vrstvu s externými úpravami"
 
-#: ../po/tmp/resources.xml.h:74
+#: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
 msgid "Commit changes saved from the external app (normally automatic)."
 msgstr "Aplikuje zmeny uložené z externej aplikácie (obvykle automaticky)."
 
-#: ../po/tmp/resources.xml.h:75
+#: ../po/tmp/resources.xml.h:93
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer at Cursor"
 msgstr "Prejsť na vrstvu pod kurzorom"
 
-#: ../po/tmp/resources.xml.h:76
+#: ../po/tmp/resources.xml.h:94
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr "Zvolí vrstvu vybratím objektu z nej."
 
-#: ../po/tmp/resources.xml.h:77
+#: ../po/tmp/resources.xml.h:95
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Above"
 msgstr "Prejsť na vrstvu vyššie"
 
-#: ../po/tmp/resources.xml.h:78
+#: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer up in the layer stack."
 msgstr "Prejde o jednu vrstvu hore v zásobníku vrstiev."
 
-#: ../po/tmp/resources.xml.h:79
+#: ../po/tmp/resources.xml.h:97
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Below"
 msgstr "Prejsť na vrstvu nižšie"
 
-#: ../po/tmp/resources.xml.h:80
+#: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer down in the layer stack."
 msgstr "Prejde o jednu vrstvu dole v zásobníku vrstiev."
 
-#: ../po/tmp/resources.xml.h:81
+#: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer"
 msgstr "Nová kresliaca vrstva"
 
-#: ../po/tmp/resources.xml.h:82
+#: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer above the current layer."
 msgstr "Pridá novú kresliacu vrstvu ponad aktuálnu vrstvu."
 
-#: ../po/tmp/resources.xml.h:83
+#: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer…"
 msgstr "Nová vektorová vrstva…"
 
-#: ../po/tmp/resources.xml.h:84
+#: ../po/tmp/resources.xml.h:102
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer above the current layer, and begin editing it."
-msgstr "Pridá novú vektorovú vrstvu ponad aktuálnu vrstvu a začne ju upravovať."
+msgstr ""
+"Pridá novú vektorovú vrstvu ponad aktuálnu vrstvu a začne ju upravovať."
 
-#: ../po/tmp/resources.xml.h:85
+#: ../po/tmp/resources.xml.h:103
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group"
 msgstr "Nová skupina vrstiev"
 
-#: ../po/tmp/resources.xml.h:86
+#: ../po/tmp/resources.xml.h:104
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group above the current layer."
 msgstr "Pridá novú skupinu vrstiev ponad aktuálnu vrstvu."
 
-#: ../po/tmp/resources.xml.h:87
+#: ../po/tmp/resources.xml.h:105
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer Below"
 msgstr "Nová kresliaca vrstva nižšie"
 
-#: ../po/tmp/resources.xml.h:88
+#: ../po/tmp/resources.xml.h:106
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer below the current layer."
 msgstr "Pridá novú kresliacu vrstvu popod aktuálnu vrstvu."
 
-#: ../po/tmp/resources.xml.h:89
+#: ../po/tmp/resources.xml.h:107
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer Below…"
 msgstr "Nová vektorová vrstva nižšie…"
 
-#: ../po/tmp/resources.xml.h:90
+#: ../po/tmp/resources.xml.h:108
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer below the current layer, and begin editing it."
-msgstr "Pridá novú vektorovú vrstvu popod aktuálnu vrstvu a začne ju upravovať."
+msgstr ""
+"Pridá novú vektorovú vrstvu popod aktuálnu vrstvu a začne ju upravovať."
 
-#: ../po/tmp/resources.xml.h:91
+#: ../po/tmp/resources.xml.h:109
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group Below"
 msgstr "Nová skupina vrstiev nižšie"
 
-#: ../po/tmp/resources.xml.h:92
+#: ../po/tmp/resources.xml.h:110
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group below the current layer."
 msgstr "Pridá novu skupinu vrstiev popod aktuálnu vrstvu."
 
-#: ../po/tmp/resources.xml.h:93
+#: ../po/tmp/resources.xml.h:111
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Layer Down"
 msgstr "Zlúčiť vrstvu nadol"
 
-#: ../po/tmp/resources.xml.h:94
+#: ../po/tmp/resources.xml.h:112
 msgctxt "Accel Editor (descriptions)"
 msgid "Merge the current layer with the layer beneath it."
 msgstr "Zlúči aktuálnu vrstvu s vrstvou pod ňou."
 
-#: ../po/tmp/resources.xml.h:95
+#: ../po/tmp/resources.xml.h:113
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Visible Layers"
 msgstr "Zlúčiť viditeľné vrstvy"
 
-#: ../po/tmp/resources.xml.h:96
+#: ../po/tmp/resources.xml.h:114
 msgctxt "Accel Editor (descriptions)"
 msgid "Consolidate all visible layers, and delete the originals."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:97
+#: ../po/tmp/resources.xml.h:115
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer from Visible"
 msgstr "Nová vrstva z viditeľného"
 
-#: ../po/tmp/resources.xml.h:98
+#: ../po/tmp/resources.xml.h:116
 msgctxt "Accel Editor (descriptions)"
 msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:99
+#: ../po/tmp/resources.xml.h:117
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Delete Layer"
 msgstr "Odstrániť vrstvu"
 
-#: ../po/tmp/resources.xml.h:100
+#: ../po/tmp/resources.xml.h:118
 msgctxt "Accel Editor (descriptions)"
 msgid "Remove the current layer from the layer stack."
 msgstr "Odstráni aktuálnu vrstvu zo zásobníka vrstiev."
 
-#: ../po/tmp/resources.xml.h:101
+#: ../po/tmp/resources.xml.h:119
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Convert to Normal Painting Layer"
 msgstr "Konvertovať na normálnu kresliacu vrstvu"
 
-#: ../po/tmp/resources.xml.h:102
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
@@ -4255,72 +5252,74 @@ msgstr ""
 "Skonvertuje aktuálnu vrstvu alebo skupinu na kresliacu vrstvu v „normálnom“ "
 "režime. Vzhľad bude zachovaný."
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr "Zvýšiť krytie vrstvy"
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr "Zníži priehľadnosť vrstvy."
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr "Znížiť krytie vrstvy"
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr "Zvýši priehľadnosť vrstvy."
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr "Vyvýšiť vrstvu"
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr "Vyvýši aktuálnu vrstvu o stupeň vyššie v zásobníku vrstiev."
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr "Znížiť vrstvu"
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr "Zníži aktuálnu vrstvu o stupeň nižšie v zásobníku vrstiev."
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr "Duplikovať vrstvu"
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr "Vytvorí presný duplikát aktuálnej vrstvy."
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
+#, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
-msgstr "Premenovať vrstvu…"
+msgid "Layer Properties…"
+msgstr "Vlastnosti"
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
-msgstr "Umožní zadať nový názov aktuálnej vrstvy."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr "Vrstva uzamknutá"
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
@@ -4328,1235 +5327,1314 @@ msgstr ""
 "Prepne stav uzamknutia aktuálnej vrstvy. Uzamknuté vrstvy sa nedajú "
 "upravovať."
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr "Vrstva viditeľná"
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr "Prepne stav viditeľnosti aktuálnej vrstvy jej zneviditeľnením."
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr "Zobraziť pozadie"
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr "Prepne viditeľnosť vrstvy s pozadím."
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr "Odstráni aktuálnu vrstvu zo zásobníka vrstiev."
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr "Vynulovať a vystrediť zobrazenie"
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr "Vynuluje priblíženie, otočenie a zrkadlenie a vystredí dokument."
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr "Prispôsobiť zobrazeniu"
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr "Prepne medzi prispôsobeným zobrazením, miestom práce a priblížením."
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr "Vynulovať"
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr "Vynulovať priblíženie"
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr "Obnoví priblíženie zobrazenia na predvolenú hodnotu."
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr "Vynulovať otočenie"
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr "Obnoví otočenie zobrazenia na 0°"
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr "Vynulovať zrkadlenie"
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
-msgstr "Vypne zrkadlenie zobrazenia."
+msgid "Reset the view's mirroring."
+msgstr "Vynulovať zrkadlenie"
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr "Priblížiť"
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr "Zvýši zväčšenie."
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Oddialiť"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr "Zníži zväčšenie."
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
+#, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
-msgstr "Otočiť doľava"
+msgid "Pan Left"
+msgstr "Posúvanie rukou"
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
-msgstr "Otočí zobrazenie proti smeru hodinových ručičiek."
+msgid "Move your view of the canvas to the left."
+msgstr "Otočenie zobrazenia: nakloní vaše zobrazenie plátna."
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr "Tvrdé svetlo"
+
+#: ../po/tmp/resources.xml.h:159
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+"Posúvanie rukou: presunie vaše zobrazenie plátna vodorovne, alebo zvisle."
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr "Otočenie zobrazenia: nakloní vaše zobrazenie plátna."
+
+#: ../po/tmp/resources.xml.h:162
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr "Posúvanie rukou"
+
+#: ../po/tmp/resources.xml.h:163
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr "Otočenie zobrazenia: nakloní vaše zobrazenie plátna."
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr "Otočiť doprava"
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr "Otočí zobrazenie v smere hodinových ručičiek."
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr "Otočiť doľava"
+
+#: ../po/tmp/resources.xml.h:167
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr "Otočí zobrazenie proti smeru hodinových ručičiek."
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr "Zrkadliť vodorovne"
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr "Preklopí zobrazenie zľava doprava."
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr "Zrkadliť zvislo"
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr "Preklopí zobrazenie zhora nadol."
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr "Sólo vrstva"
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr "Prepne zobrazenie iba tejto vrstvy."
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr "Aktívne symetrické kreslenie"
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr "Zrkadlí ťahy štetcom pozdĺž osi symetrie"
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr "Povolené orámovanie"
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr "Prepne viditeľnosť orámovania dokumentu."
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr "Vypísať vstupné hodnoty štetca do konzoly"
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr "Zobrazí interne generované vstupy výkonného jadra štetcov v konzole."
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr "Vizualizovať vykresľovanie"
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr "Zobrazí aktualizácie vykreslenia na obrazovke, pre ladenie."
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr "Bez dvojitého ukladania do zásobníka"
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 "Vypne dvojité ukladanie do vyrovnávacej pamäte nástroja GTK. Obvykle "
 "povolené."
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+#, fuzzy
+msgid "Delete Point"
+msgstr "Odstrániť bod"
+
+#: ../po/tmp/resources.xml.h:187
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr "Odstráni aktuálnu vybratý bod"
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr "Režim kreslenia"
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr "Režim kreslenia: Normálny"
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr "Pri kreslení použije obvyklú farbu."
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr "Režim kreslenia: Guma"
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr "Vygumuje použitím aktuálneho štetca."
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr "Režim kreslenia: Uzamknutie alfa kanálu"
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr "Použitím štetca sa nezmení krytie vrstvy."
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr "Režim kreslenia: Ofarbenie"
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr "Použije farbu na aktuálnu vrstvu bez vplyvu na jas a krytie."
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Súbor"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "Ukončiť"
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr "Zavrie hlavné okno a skončí aplikáciu."
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "Upraviť"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr "Aktuálny nástroj"
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "Farba"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr "Upraviť farbu"
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr "Rozbaľovacia ponuka s históriou farieb"
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr "Dialógové okno s podrobnosťami o farbe"
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr "Zobrazí dialógové okno s podrobnosťami o farbe so vstupom pre text."
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr "Nasledujúca farba palety"
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr "Nastaví farbu kreslenia na nasledujúcu farbu z palety."
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr "Predchádzajúca farba palety"
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr "Nastaví farbu kreslenia na predchádzajúcu farbu z palety."
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr "Pridať farbu do palety"
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr "Pridá aktuálnu farbu kreslenia do palety."
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "Vrstva"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr "Krytie"
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr "Prejsť na vrstvu"
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr "Nová spodná vrstva"
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr "Vlastnosti"
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr "Náčrtník"
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr "Nový náčrtník"
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr "Načíta predvolený náčrtník ako nové plátno s náčrtníkom."
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr "Otvoriť náčrtník…"
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr "Načíta súbor obrázku z disku do náčrtníka."
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr "Uložiť náčrtník"
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr "Uloží náčrtník do jeho existujúceho súboru na disku."
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr "Exportovať náčrtník ako…"
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr "Exportuje náčrtník na disk pod názvom súboru aký si zvolíte."
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr "Vrátiť náčrtník"
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr "Vráti náčrtník do jeho posledného uloženého stavu."
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr "Uložiť náčrtník ako predvolený"
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr "Uloží náčrtník ako predvolený „Nový náčrtník“."
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr "Vymazať predvolený náčrtník"
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr "Vymaže predvolený náčrtník na prázdne plátno."
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr "Skopírovať hlavné pozadie do náčrtníka"
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr "Skopíruje pozadie obrázku z pracovného dokumentu do náčrtníku."
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "Okno"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "Štetec"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr "Klávesové skratky"
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr "Pomocník pre klávesové skratky štetcov"
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr "Zobrazí vysvetlivku k funkčnosti klávesových skratiek."
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "Zmeniť štetec…"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "Zmeniť farbu…"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "Zmeniť farbu (rýchla podskupina)…"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr "Získať viac štetcov…"
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr "Importovať štetce…"
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr "Načíta balík štetcov z disku."
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Pomocník"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr "Online pomocník"
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "O aplikácii MyPaint"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr "Zobrazí licenciu, verziu a poďakovanie programu MyPaint."
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Ladenie"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr "Vypísať informácie o pretečení pamäte do konzoly (Pomalé!)"
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr "Odladí výpadky pamäte."
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr "Spustiť nástroj na zbieranie odpadu ihneď"
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
-msgstr "Voľná pamäť použitá pre objekty jazyka Python, ktoré sa už nepoužívajú."
+msgstr ""
+"Voľná pamäť použitá pre objekty jazyka Python, ktoré sa už nepoužívajú."
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr "Spustiť alebo zastaviť profilovanie…"
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr "Spustiť alebo zastaviť profilovanie jazyka Python (cProfile)"
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr "Simulovať pád aplikácie…"
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 "Vyvolá výnimku jazyka Python, na otestovanie dialógového okna pre pád "
 "aplikácie."
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "Zobraziť"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr "Spätná väzba"
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr "Upraviť zobrazenie"
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
+#, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr "Rozbaľovacia ponuka"
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "Režim na celú obrazovku"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "Upraviť nastavenia"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr "Upraví globálne nastavenia programu MyPaint."
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr "Vyskúšať vstupné zariadenia"
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 "Zobrazí dialógové okno, ktoré zachytáva všetky udalosti odoslané z vašich "
 "vstupných zariadení."
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr "Nástroj na výber pozadia"
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr "Zmení textúru papiera pozadia."
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr "Editor nastavení štetca"
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr "Upraví nastavenia aktívneho štetca."
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr "Editor ikony štetca"
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr "Upraví ikony štetcov."
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr "Panel s vrstvami"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
-"Prepne pripojiteľný panel vrstiev (usporiadanie vrstiev alebo priradenie "
-"režimu)."
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr "Zobraziť panel s vrstvami"
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 "Odhalí pripojiteľný panel vrstiev (zoradenie vrstiev alebo priradenie "
 "režimov)."
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr "Kruh farieb HCY"
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "Paleta farieb"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr "Pripojiteľný nástroj na výber farby palety."
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr "Kruh farieb HSV"
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr "Pripojiteľný nástroj na zmenu hodnôt sýtosti a farby."
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr "Trojuholník farieb HSV"
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr "Kocka farieb HSV"
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr "Štvorec farieb HSV"
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
-msgstr ""
+msgid "Dockable color selector: HSV square with Hue ring."
+msgstr "Pripojiteľný nástroj na výber farby s koncetrickými kruhmi HSV."
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr "Posuvníky zložiek"
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 "Pripojiteľný nástroj na výber farieb zobrazujúci individuálne zložky farby."
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr "Tekuté rozpúšťadlo"
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr "Koncentrické kruhy"
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr "Pripojiteľný nástroj na výber farby s koncetrickými kruhmi HSV."
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr "Prekrížený ovál"
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr "Panel s náčrtníkom"
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
-"Prepne pripojiteľný panel s náčrtníkom (miešanie farieb a vytváranie "
-"náčrtov)."
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr "Zobraziť náčrtník"
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 "Odhalí pripojiteľný panel s náčrtníkom (miešanie farieb a vytváranie "
 "náčrtov)."
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr "Panel s náhľadom"
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
-msgstr "Prepne pripojiteľný panel náhľadu (náhľad celej kresliacej oblasti)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "Náhľad"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
-msgstr "Odhalí pripojiteľný panel s náhľadom (náhľad celej kresliacej oblasti)."
+msgstr ""
+"Odhalí pripojiteľný panel s náhľadom (náhľad celej kresliacej oblasti)."
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr "Panel s voľbami nástrojov"
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
-"Prepne pripojiteľný panel s voľbami nástroja (voľby pre aktuálny nástroj)."
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr "Zobraziť panel s voľbami nástrojov"
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 "Odhalí pripojiteľný panel s voľbami nástroja (voľby pre aktuálny nástroj)."
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr "Panel s históriou štetcov a farieb"
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
-msgstr "Prepne panel s históriou (nedávno použité štetce a farby)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr "Nedávno použité štetce a farby"
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr "Odhalí panel s históriou (nedávno použité štetce a farby)."
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr "Skryť ovládacie prvky v režime na celú obrazovku"
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 "Prepne automatické skrývanie používateľského rozhrania v režime na celú "
 "obrazovku."
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr "Zobraziť úroveň priblíženia"
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr "Prepne spätnú väzbu úrovne priblíženia."
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr "Zobraziť poslednú pozíciu pri kreslení"
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr "Prepne spätnú väzbu zobrazujúcu, kde skončil posledný ťah."
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr "Filter zobrazenia"
 
 # tooltip
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr "Zobraziť farby normálne"
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr "Filter farieb: zobrazí farby nezmenené."
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr "Zobraziť farby v odtieňoch sivej"
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr "Filter farieb: zobrazí iba jas (HCY/YCbCr Luma)"
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr "Zobraziť farby prevrátene"
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr "Filtruje farby: obrátené video. Čierna je biela a červená je azúrová."
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr "Zobraziť farby so simulovanou necitlivosťou na červenú farbu"
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr "Filtruje farby na simuláciu deuteranopie, bežnej formy farbosleposti."
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr "Zobraziť farby so simulovanou necitlivosťou na zelenú farbu"
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr "Filtruje farby na simuláciu protanopie, bežnej formy farbosleposti."
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr "Zobraziť farby so simulovanou necitlivosťou na modrú farbu"
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
-msgstr "Filtruje farby na simuláciu tritanopie, ojedinelej formy farbosleposti."
+msgstr ""
+"Filtruje farby na simuláciu tritanopie, ojedinelej formy farbosleposti."
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr "Kreslenie voľnou rukou"
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr "Kreslenie voľnou rukou"
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr "Kreslenie voľnou rukou: kreslí a maľuje voľne bez geometrických úprav."
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr "Kreslenie voľnou rukou"
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr "Kreslí a maľuje voľne bez geometrických úprav."
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr "Posúvanie rukou"
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr "Posúvanie"
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 "Posúvanie rukou: presunie vaše zobrazenie plátna vodorovne, alebo zvisle."
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr "Posúvanie rukou"
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr "Interaktívne presunie vaše zobrazenie plátna vodorovne, alebo zvisle."
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr "Otočenie zobrazenia"
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr "Otočiť"
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr "Otočenie zobrazenia: nakloní vaše zobrazenie plátna."
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr "Otočiť zobrazenie"
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr "Interaktívne otočí vaše zobrazenie plátna."
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr "Priblíženie zobrazenia"
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr "Priblíženie"
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr "Priblíženie zobrazenia: priblíži alebo oddiali plátno."
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr "Priblížiť zobrazenie"
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr "Interaktívne priblíži alebo oddiali plátno."
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr "Čiary a krivky"
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr "Čiary"
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr "Čiary a krivky: nakreslí priame alebo zakrivené čiary."
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr "Čiary a krivky"
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr "Nakreslí priame alebo zakrivené čiary."
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr "Spojené čiary"
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr "Spojené čiary"
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr "Spojené čiary: nakreslí postupnosť priamych alebo zakrivených čiar."
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr "Spojené čiary"
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr "Nakreslí postupnosť priamych alebo zakrivených čiar."
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr "Elipsy a kruhy"
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr "Elipsa"
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr "Elipsy a kruhy: nakreslí okrúhle tvary."
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr "Elipsy a kruhy"
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr "Nakreslí kruhy a elipsy."
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr "Farbenie"
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr "Atrament"
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr "Farbenie: nakreslí hladké ovládané čiary."
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr "Farbenie"
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr "Nakreslí hladké ovládané čiary."
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr "Premiestnenie vrstvy"
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr "Pozícia vrstvy"
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr "Premiestniť vrstvu: premiestni aktuálnu vrstvu na plátne."
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr "Premiestniť vrstvu"
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr "Interaktívne premiestni aktuálnu vrstvu na plátne."
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr "Úprava orámovania"
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr "Orámovanie"
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
@@ -5564,89 +6642,288 @@ msgstr ""
 "Upraviť orámovanie: určí orámovanie okolo dokumentu aby získal konečnú "
 "veľkosť."
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr "Upraviť orámovanie"
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 "Interaktívne určí orámovanie okolo dokumentu aby získal konečnú veľkosť."
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Úprava symetrie kreslenia"
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr "Symetria"
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
-msgstr "Upraviť symetriu kreslenia: upraví os použitú pri symetrickom kreslení."
+msgstr ""
+"Upraviť symetriu kreslenia: upraví os použitú pri symetrickom kreslení."
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Upraviť symetriu kreslenia"
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr "Interaktívne upraví os použitú pri symetrickom kreslení."
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr "Výber farby"
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr "Vyberie farbu."
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr "Vybrať farbu: nastaví farbu kreslenia z pixelov obrazovky."
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "Vybrať farbu"
+
+#: ../po/tmp/resources.xml.h:401
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr "Nastaví farbu kreslenia z pixelov obrazovky."
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "Vybrať farbu"
+
+#: ../po/tmp/resources.xml.h:403
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr "Nastaví farbu kreslenia z pixelov obrazovky."
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "Vybrať farbu"
+
+#: ../po/tmp/resources.xml.h:405
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr "Nastaví farbu kreslenia z pixelov obrazovky."
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr "Vybrať farbu"
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr "Nastaví farbu kreslenia z pixelov obrazovky."
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr "Vyplnenie"
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr "Vyplnenie"
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr "Vyplnenie: vyplní oblasť farbou."
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr "Vyplnenie"
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr "Vyplní oblasť farbou."
+
+#~ msgctxt "Accelerator map editor: action column markup"
+#~ msgid ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+#~ msgstr ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+
+#~ msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
+#~ msgid "{action_label} {action_desc} {accel_label}"
+#~ msgstr "{action_label} {action_desc} {accel_label}"
+
+#~ msgctxt "brush list context menu"
+#~ msgid "Delete"
+#~ msgstr "Odstrániť"
+
+#~ msgctxt "brush list commands"
+#~ msgid "Really delete brush from disk?"
+#~ msgstr "Skutočne odstrániť štetec z disku?"
+
+#~ msgid "HSV Triangle"
+#~ msgstr "Trojuholník farieb HSV"
+
+#~ msgid "The standard GTK color selector"
+#~ msgstr "Štandardný nástroj GTK na výber farby"
+
+#~ msgid "Pick a color from the screen"
+#~ msgstr "Vyberie farbu z obrazovky"
+
+#~ msgid "Layer Name"
+#~ msgstr "Názov vrstvy"
+
+#~ msgid ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+#~ msgstr ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+
+#~ msgid "Save..."
+#~ msgstr "Uloženie..."
+
+#~ msgid "Confirm"
+#~ msgstr "Potvrdenie"
+
+#~ msgid "Open..."
+#~ msgstr "Otvorenie..."
+
+#~ msgid "{default_name} at {path}"
+#~ msgstr "{default_name} v {path}"
+
+#~ msgid "Type"
+#~ msgstr "Typ"
+
+#~ msgid "Mode:"
+#~ msgstr "Režim:"
+
+#~ msgid ""
+#~ "Blending mode: how the current layer combines with the layers underneath "
+#~ "it."
+#~ msgstr ""
+#~ "Režim prechodu: ako sa skombinuje aktuálna vrstva s vrstvami pod ňou."
+
+#~ msgid ""
+#~ "Layer opacity: how much of the current layer to use. Smaller values make "
+#~ "it more transparent."
+#~ msgstr ""
+#~ "Krytie vrstvy: koľko použiť z aktuálnej vrstvy. Menšie hodnoty ju urobia "
+#~ "viac priehľadnou."
+
+#~ msgid "%s: edit properties"
+#~ msgstr "%s: upraví vlastnosti"
+
+#~ msgctxt "layer unique names: match regex (leave untranslated if unsure)"
+#~ msgid "^(.*?)\\s*(\\d+)$"
+#~ msgstr "^(.*?)\\s*(\\d+)$"
+
+#~ msgctxt "layer default names"
+#~ msgid "Unknown Bitmap Layer"
+#~ msgstr "Neznáma bitmapová vrstva"
+
+#~ msgctxt "Autosave Recovery dialog|"
+#~ msgid "_Ignore for Now"
+#~ msgstr "Teraz _ignorovať"
+
+#~ msgid "Setting name:"
+#~ msgstr "Názov nastavenia:"
+
+#~ msgid "Base value:"
+#~ msgstr "Základná hodnota:"
+
+#~ msgid "Reset the base value to its default"
+#~ msgstr "Znovu nastaví základnú hodnotu na jej predvolenú hodnotu"
+
+#~ msgid "<ymin>"
+#~ msgstr "<ymin>"
+
+#~ msgid "<ymax>"
+#~ msgstr "<ymax>"
+
+#~ msgid "<xmin>"
+#~ msgstr "<xmin>"
+
+#~ msgid "<xmax>"
+#~ msgstr "<xmax>"
+
+#~ msgid "Edit Setting"
+#~ msgstr "Upraviť nastavenie"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Trim Layer to Frame"
+#~ msgstr "Orezať vrstvu podľa orámovania"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Rename Layer…"
+#~ msgstr "Premenovať vrstvu…"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Enter a new name for the current layer."
+#~ msgstr "Umožní zadať nový názov aktuálnej vrstvy."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Turn off mirroring of the view."
+#~ msgstr "Vypne zrkadlenie zobrazenia."
+
+#~ msgctxt "Menu→Edit (labels)"
+#~ msgid "Current Tool"
+#~ msgstr "Aktuálny nástroj"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+#~ msgstr ""
+#~ "Prepne pripojiteľný panel vrstiev (usporiadanie vrstiev alebo priradenie "
+#~ "režimu)."
+
+#~ msgctxt "Menu→Color (labels), Accel Editor (labels)"
+#~ msgid "HSV Triangle"
+#~ msgstr "Trojuholník farieb HSV"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+#~ msgstr ""
+#~ "Prepne pripojiteľný panel s náčrtníkom (miešanie farieb a vytváranie "
+#~ "náčrtov)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+#~ msgstr ""
+#~ "Prepne pripojiteľný panel náhľadu (náhľad celej kresliacej oblasti)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+#~ msgstr ""
+#~ "Prepne pripojiteľný panel s voľbami nástroja (voľby pre aktuálny nástroj)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the History panel (recently used brushes and colors)."
+#~ msgstr "Prepne panel s históriou (nedávno použité štetce a farby)."

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.9.0-git\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-23 08:18+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/mypaint/"
@@ -16,35 +16,13 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || "
-"n%100==4 ? 2 : 3;\n"
+"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n"
+"%100==4 ? 2 : 3;\n"
 "X-Generator: Weblate 3.5-dev\n"
 "X-Poedit-Language: Slovenian\n"
 "X-Poedit-Country: SLOVENIA\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr "<big><b>{accel_label}</b></big>"
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "Dejanje"
 
@@ -52,41 +30,41 @@ msgstr "Dejanje"
 msgid "Key combination"
 msgstr "Kombinacija tipk"
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr "Uredi tipke za '%s'"
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "Dejanje:"
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "Pot:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "Tipka:"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr "Pritisnite ustrezne tipke, da spremenite to nastavitev"
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "Neznano dejanje"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
-"<b>{accel} je že v uporabi za \"{action}\". Trenutna nastavitev bo "
-"zamenjana.</b>"
+"<b>{accel} je že v uporabi za \"{action}\". Trenutna nastavitev bo zamenjana."
+"</b>"
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -94,227 +72,237 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "V redu"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr "Na voljo ni nobena varnostna kopija"
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "shrani kot privzeto"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "Ozadje"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "Vzorec"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Barva"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "dodaj barvo med vzorce"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 #, fuzzy
 msgid "Error loading backgrounds"
 msgstr "Napaka med nalaganjem: GError %s"
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 #, fuzzy
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr "Nastavitve čopiča"
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 #, fuzzy
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "eksperimentalni"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 #, fuzzy
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr "Prosojnost"
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "razmaži"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr ""
+
+#: ../gui/brusheditor.py:370
 #, fuzzy
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr "Šum sledenja"
 
-#: ../gui/brusheditor.py:359
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "Poteg"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 #, fuzzy
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr "Barva"
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Poljubno"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 #, fuzzy
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr "Čopič ni izbran, uporabite \"dodaj kot nov\"."
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 #, fuzzy
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr "Čopič ni izbran!"
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "Preimenuj čopič"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "Čopič s tem imenom že obstaja!"
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 #, fuzzy
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr "Čopič ni izbran!"
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, fuzzy, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr "Želite res izbrisati ta čopič?"
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 #, fuzzy
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr "Preimenuj čopič"
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 #, fuzzy
 msgid "Brush Icon"
 msgstr "Ikona čopiča"
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 #, fuzzy
 msgid "Brush Icon (editing)"
 msgstr "Nastavitve čopiča"
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 #, fuzzy
 msgid "No brush selected"
 msgstr "Čopič ni izbran!"
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -354,107 +342,143 @@ msgstr ""
 msgid "Use the default icon"
 msgstr "Ponastavi na privzeto vrednost"
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Shrani"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 #, fuzzy
 msgid "Lost & Found"
 msgstr "zgubljeno&najdeno"
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 #, fuzzy
 msgid "Deleted"
 msgstr "izbrisani"
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 #, fuzzy
 msgid "Favorites"
 msgstr "priljubljene"
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 #, fuzzy
 msgid "Ink"
 msgstr "črnilo"
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 #, fuzzy
 msgid "Classic"
 msgstr "klasični"
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 #, fuzzy
 msgid "Experimental"
 msgstr "eksperimentalni"
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Nova slika"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
+#: ../gui/brushselectionwindow.py:220
 #, fuzzy
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr "priljubljene"
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
-msgstr ""
+#: ../gui/brushselectionwindow.py:227
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
+msgstr "Odstrani"
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
+#: ../gui/brushselectionwindow.py:242
 #, fuzzy
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr "Nastavitve čopiča"
 
-#: ../gui/brushselectionwindow.py:201
+#: ../gui/brushselectionwindow.py:250
 #, fuzzy
-msgctxt "brush list context menu"
-msgid "Delete"
-msgstr "izbrisani"
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
+msgstr "Preimenuj skupino"
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, fuzzy, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr "Želite res izbrisati ta čopič?"
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, fuzzy, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
@@ -462,48 +486,48 @@ msgstr[0] "čopiči"
 msgstr[1] "čopiči"
 msgstr[2] "čopiči"
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 #, fuzzy
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr "Preimenuj skupino"
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 #, fuzzy
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr "Izvozi kot paket s čopičem ..."
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 #, fuzzy
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr "Odstrani skupino ..."
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 #, fuzzy
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr "Preimenuj skupino"
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "Skupina s tem imenom že obstaja!"
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, fuzzy, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr "Želite res zbrisati skupino %s?"
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -511,63 +535,63 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 #, fuzzy
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr "Izvozi kot paket s čopičem ..."
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 #, fuzzy
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr "MyPaint čopič paket (*.zip)"
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "Nova skupina ..."
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 #, fuzzy
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr "Uvozi paket s čopičem..."
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 #, fuzzy
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr "Obnovi čopič %d"
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "Ustvari skupino"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 #, fuzzy
 msgid "Remove the current binding"
 msgstr "Odpri nedavne datoteke"
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -576,52 +600,77 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr "Izberi barvo"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "Izberi barvo"
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 #, fuzzy
 msgid "Color details"
 msgstr "Svetlost barve"
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -631,144 +680,144 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 #, fuzzy
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr "Komplementarna barva"
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 #, fuzzy
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr "Loči komplementarne"
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 #, fuzzy
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr "Pomoč"
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 #, fuzzy
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr "Shrani paleto kot ..."
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 #, fuzzy
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr "shrani kot privzeto"
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 #, fuzzy
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr "shrani kot privzeto"
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 #, fuzzy
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr "Shrani paleto kot ..."
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -776,180 +825,170 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 #, fuzzy
 msgid "HSV Value"
 msgstr "Izhodiščna vrednost"
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 #, fuzzy
 msgid "HSV Saturation and Value"
 msgstr "Spremeni svetlost/obarvanost"
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 #, fuzzy
 msgid "HSV Square"
 msgstr "Kvadrat"
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-#, fuzzy
-msgid "HSV Triangle"
-msgstr "Barvni trikotnik ..."
-
-#: ../gui/colors/hsvtriangle.py:51
-#, fuzzy
-msgid "The standard GTK color selector"
-msgstr "MyPaint izbirnik barve"
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 #, fuzzy
 msgid "Saturation and Value color changer."
 msgstr "Spremeni svetlost/obarvanost"
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 #, fuzzy
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr "Gimp palete (*.gpl)"
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 #, fuzzy
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr "Gimp palete (*.gpl)"
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 #, fuzzy
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr "Gimp palete (*.gpl)"
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 #, fuzzy
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr "Shrani paleto kot ..."
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 #, fuzzy
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr "shrani kot privzeto"
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 #, fuzzy
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr "Odpri nedavne datoteke"
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 #, fuzzy
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr "Odpri nedavne datoteke"
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 #, fuzzy
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr "Vzorčenje barve ..."
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 #, fuzzy
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr "Zamenjaj barvo"
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 #, fuzzy
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr "Gimp palete (*.gpl)"
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 #, fuzzy
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr "Shrani paleto kot ..."
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 #, fuzzy
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr "Shrani nastavitve"
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -957,393 +996,390 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 #, fuzzy
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr "Gimp palete (*.gpl)"
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 #, fuzzy
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "shrani kot privzeto"
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 #, fuzzy
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr "Datoteka"
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 #, fuzzy
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "shrani kot privzeto"
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 #, fuzzy
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr "Datoteka"
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 #, fuzzy
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr "Izhodiščna vrednost"
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 #, fuzzy
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr "Spremeni svetlost/obarvanost"
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 #, fuzzy
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr "Izhodiščna vrednost"
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr "radirka"
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 #, fuzzy
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr "Vzorec"
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 #, fuzzy
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr "Celozaslonski"
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 #, fuzzy
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr "Približaj"
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 #, fuzzy
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr "Vzorec"
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 #, fuzzy
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr "Naprava:"
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Ime"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr "Prepiši čopič?"
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr "Nadomesti"
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr "Preimenuj"
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr "Zamenjaj vse"
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr "Preimenuj vse"
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr "Uvožen čopič"
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr "Obstoječi čopič"
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 "<b>Čopič z imenom `%s' že obstaja.</b>\n"
 "Ga želite zamenjati, ali preimenovati v kaj drugega?"
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr "Prepišem skupino čopičev?"
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, fuzzy, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 "<b>Skupina z imenom `%s' že obstaja.</b>\n"
 "Jo želite zamenjati, ali preimenovati?\n"
 "Če jo želite zamenjati, bodo obstoječi čopiči premaknjeni v skupino z imenom "
 "`%s'."
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 #, fuzzy
 msgid "Import brush package?"
 msgstr "Uvozim paket s čopičem?"
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, fuzzy, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr "<b>Ali zares želite uvoziti paket `%s'?</b>"
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr "Obnovi čopič %d"
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr "Shrani kot čopič %d"
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr "Razveljavi %s"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Razveljavi"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, fuzzy, python-format
 msgid "Redo %s"
 msgstr "Obnovi"
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Obnovi"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1353,333 +1389,719 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-#, fuzzy
-msgid "Layer Name"
-msgstr "Plasti"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
+msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, fuzzy, python-format
 msgid "%s - MyPaint"
 msgstr "O programu MyPaint"
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 #, fuzzy
 msgid "MyPaint"
 msgstr "O programu MyPaint"
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Odpri ..."
+
+#: ../gui/drawwindow.py:486
 #, fuzzy
 msgid "Set current color"
 msgstr "Zamenjaj barvo"
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 #, fuzzy
 msgid "Leave Fullscreen Mode"
 msgstr "Celozaslonski"
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 #, fuzzy
 msgid "Leave Fullscreen"
 msgstr "Celozaslonski"
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 #, fuzzy
 msgid "Enter Fullscreen Mode"
 msgstr "Celozaslonski"
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Celozaslonski"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Izhod"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+#, fuzzy
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr "Res želite končati?"
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Izhod"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr "Uvozi paket s čopičem..."
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr "MyPaint čopič paket (*.zip)"
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 #, fuzzy
 msgid "Open With..."
 msgstr "Odpri ..."
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
+#: ../gui/filehandling.py:126
+#, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:130
+#, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:134
+#, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:138
+#, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:145
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "Shrani nastavitve"
+
+#: ../gui/filehandling.py:168
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr "Izvozi paleto ..."
+
+#: ../gui/filehandling.py:172
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr "Izvozi paleto ..."
+
+#: ../gui/filehandling.py:176
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr "Odpri nedavne datoteke"
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: ../gui/filehandling.py:221
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
+msgstr "Napaka med nalaganjem: GError %s"
+
+#: ../gui/filehandling.py:427
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "All Recognized Formats"
 msgstr "Vsi podprti formati"
 
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
+#: ../gui/filehandling.py:432
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "OpenRaster (*.ora)"
 msgstr "OpenRaster (*.ora)"
 
-#: ../gui/filehandling.py:95
+#: ../gui/filehandling.py:437
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "PNG (*.png)"
 msgstr "PNG (*.png)"
 
-#: ../gui/filehandling.py:96
+#: ../gui/filehandling.py:442
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "JPEG (*.jpg; *.jpeg)"
 msgstr "JPEG (*.jpg; *.jpeg)"
 
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
+#: ../gui/filehandling.py:490
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "By extension (prefer default format)"
 msgstr "Glede na končnico (privilegiran privzeti zapis)"
 
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
+#: ../gui/filehandling.py:494
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:498
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
 msgstr "PNG s polnim ozadjem (*.png)"
 
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
+#: ../gui/filehandling.py:502
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:506
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
 msgstr "Prozoren PNG (*.png)"
 
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
+#: ../gui/filehandling.py:510
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
 msgstr "Več prozornih PNG datotek (*.XXX.png)"
 
-#: ../gui/filehandling.py:113
+#: ../gui/filehandling.py:514
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr "Več prozornih PNG datotek (*.XXX.png)"
+
+#: ../gui/filehandling.py:518
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr "JPEG z 90% kvaliteto kompresije (*.jpg; *.jpeg)"
 
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr "Shrani ..."
+#: ../gui/filehandling.py:576
+#, fuzzy
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr "Poročaj ... "
 
-#: ../gui/filehandling.py:177
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Shrani kot …"
+
+#: ../gui/filehandling.py:601
+#, fuzzy
+msgctxt "save dialogs: formats and options: (label)"
 msgid "Format to save as:"
 msgstr "Shrani v obliki:"
 
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr "Potrdi"
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
+#: ../gui/filehandling.py:668
+#, fuzzy
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
 msgstr "Ali res želite nadaljevati?"
 
-#: ../gui/filehandling.py:234
-#, fuzzy, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
-msgstr "S tem bo opuščenih %d minuta ne-shranjenega risanja."
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
+#: ../gui/filehandling.py:705
+#, fuzzy
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
 msgstr "_Shrani kot skico"
 
-#: ../gui/filehandling.py:282
-#, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
 msgstr ""
 
-#: ../gui/filehandling.py:296
-#, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+#: ../gui/filehandling.py:734
+#, fuzzy, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr "S tem bo opuščenih %d minuta ne-shranjenega risanja."
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
 msgstr ""
 
-#: ../gui/filehandling.py:321
-#, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
 msgstr ""
 
-#: ../gui/filehandling.py:422
-#, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
-msgstr ""
-
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
-msgstr ""
-
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
-msgstr ""
-
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
-msgstr ""
-
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
-msgstr ""
-
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Odpri ..."
-
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1007
 #, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr "Odpri…"
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Odpri nedavne datoteke"
+
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr "Odpri naslednjo skico"
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Uvožen čopič"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Odpri ..."
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Odpri nedavne"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Odpri ..."
+
+#: ../gui/filehandling.py:1446
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
 msgstr "Zaenkrat datoteka z osnutkom \"%s\" ne obstaja."
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1455
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr "Odpri naslednjo skico"
+
+#: ../gui/filehandling.py:1463
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr "Odpri prejšnjo skico"
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Odpri ..."
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+#, fuzzy
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
-msgstr ""
+msgstr "Zapolni"
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+#, fuzzy
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
-msgstr ""
+msgstr "Zapolni področje z barvo."
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+#, fuzzy
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr "Prilagodi pogledu"
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
-msgstr ""
+msgstr "Nova skupina plasti"
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Prosojnost:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
 #, fuzzy
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr "Ponastavi na privzeto vrednost"
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "Izberi plast pod kurzorjem"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1687,137 +2109,149 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 #, fuzzy
 msgid "Adjust the document frame"
 msgstr "Preklopi način urejanja"
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 #, fuzzy
 msgid "Color:"
 msgstr "Barva"
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 #, fuzzy
 msgid "Frame Color"
 msgstr "Zamenjaj barvo"
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 #, fuzzy
 msgid "<b>Frame dimensions</b>"
 msgstr "Celozaslonski"
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 #, fuzzy
 msgid "Set Frame to Layer"
 msgstr "Odstrani"
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 #, fuzzy
 msgid "Set frame to the extents of the current layer"
 msgstr "Odpri nedavne datoteke"
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 #, fuzzy
 msgid "Trim Layer to Frame"
 msgstr "Plasti"
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr "Pritisk:"
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr "Zaznana napaka"
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr "<big><b>Zaznana je bila napaka v izvajanju programa.</b></big>"
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1826,36 +2260,36 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr "Poročaj ..."
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 #, fuzzy
 msgid "Quit MyPaint"
 msgstr "O programu MyPaint"
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr "Podrobnosti ..."
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr "Napaka med procesiranjem napake."
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1879,45 +2313,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr "Preizkus vhodne naprave"
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr "(brez pritiska)"
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr "Pritisk:"
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr "(brez naklona)"
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr "Naklon:"
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr "(ni naprave)"
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
 msgstr "Naprava:"
 
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
+msgstr ""
+
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 #, fuzzy
 msgid "Move Layer"
 msgstr "Odstrani"
@@ -1927,162 +2365,230 @@ msgstr "Odstrani"
 msgid "Move the current layer"
 msgstr "Odpri nedavne datoteke"
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+#, fuzzy
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr "Gimp palete (*.gpl)"
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
-msgid "Locked"
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Plasti"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+#, fuzzy
+msgctxt "Layers dockable: description parts: layer locked flag"
+msgid "Locked"
+msgstr "Plasti"
+
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, fuzzy, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr "Plasti"
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Plasti"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 #, fuzzy
 msgid "Move layer in stack..."
 msgstr "Plasti"
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 #, fuzzy
 msgid "Layer"
 msgstr "Plasti"
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Prosojnost:"
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "Zasukaj v smeri urinega kazalca"
 
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
+#: ../gui/linemode.py:40
 #, fuzzy
 msgid "Entrance Pressure"
 msgstr "Pritisk"
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 #, fuzzy
 msgid "Midpoint Pressure"
 msgstr "Pritisk"
 
-#: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:41
-#, fuzzy
-msgid "Exit Pressure"
-msgstr "Pritisk"
-
-#: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
-msgstr ""
-
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
 #, fuzzy
-msgid "Stroke lead-in end"
-msgstr "Čas potega"
+msgid "Exit Pressure"
+msgstr "Pritisk"
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+#, fuzzy
+msgid "Stroke lead-in end"
+msgstr "Čas potega"
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 #, fuzzy
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 "Vse pravice pridržane (C) 2005-2010\n"
 "Martin Renold in MyPaint razvijalska skupina"
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -2094,277 +2600,303 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 "Ta program spada med prosto programje; lahko ga razširjate in/ali "
-"spreminjate pod pogoji Splošnega dovoljenja GNU (GNU General Public License)"
-", kot ga je objavila ustanova Free Software Foundation; bodisi različice 2 "
-"ali (po vaši izbiri) katerekoli poznejše različice.\n"
+"spreminjate pod pogoji Splošnega dovoljenja GNU (GNU General Public "
+"License), kot ga je objavila ustanova Free Software Foundation; bodisi "
+"različice 2 ali (po vaši izbiri) katerekoli poznejše različice.\n"
 "\n"
 "Ta program se razširja v upanju, da bo uporaben, vendar BREZ VSAKRŠNEGA "
 "JAMSTVA; tudi brez posredne zagotovitve CENOVNE VREDNOSTI ali PRIMERNOSTI ZA "
 "DOLOČEN NAMEN. Za podrobnosti glejte besedilo v datoteki COPYING."
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr "programiranje"
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr "prenosljivost"
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 #, fuzzy
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr "čopiči"
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 #, fuzzy
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr "vzorci"
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 #, fuzzy
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr "Namizna ikona"
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr "Namizna ikona"
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 #, fuzzy
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr "Shrani paleto kot ..."
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 #, fuzzy
 msgid "Opaque:"
 msgstr "Manj prosojno"
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 #, fuzzy
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr "Namizna ikona"
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 #, fuzzy
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr "Izberi barvo"
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr "Nastavitve"
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 #, fuzzy
 msgid "Preview"
 msgstr "Velikost predogleda"
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 #, fuzzy
 msgid "Show Viewfinder"
 msgstr "Preklopi podokna"
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 #, fuzzy
 msgid "Previous item"
 msgstr "Velikost predogleda"
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
 msgstr ""
 
-#: ../gui/symmetry.py:76
+#: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Place axis"
 msgstr ""
 
-#: ../gui/symmetry.py:80
+#: ../gui/symmetry.py:84
 #, fuzzy
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Move axis"
 msgstr "Odstrani"
 
-#: ../gui/symmetry.py:84
+#: ../gui/symmetry.py:88
 #, fuzzy
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr "Odstrani"
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
+msgstr "Simetrija"
+
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 #, fuzzy
 msgid "Line Modes"
 msgstr "Pritisk"
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2373,65 +2905,86 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr "Shranjevanje"
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 #, fuzzy
 msgid "Zoom View"
 msgstr "Približaj"
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 #, fuzzy
 msgid "Rotate View"
 msgstr "Zasukaj v smeri urinega kazalca"
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 #, fuzzy
 msgid "Rotate the canvas view"
 msgstr "Zasukaj v obratni smeri urinega kazalca"
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 #, fuzzy
 msgid "Trim Layer"
 msgstr "Počisti"
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "Preimenuj skupino"
+
+#: ../lib/command.py:682
 #, fuzzy
 msgid "Clear Layer"
 msgstr "Počisti"
@@ -2439,141 +2992,146 @@ msgstr "Počisti"
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 #, fuzzy
 msgid "Paste Layer"
 msgstr "Odstrani"
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 #, fuzzy
 msgid "New Layer from Visible"
 msgstr "Vidnost plasti"
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 #, fuzzy
 msgid "Merge Visible Layers"
 msgstr "Plasti"
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr "Spoji navzdol"
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 #, fuzzy
 msgid "Normalize Layer Mode"
 msgstr "Počisti"
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Uvožen čopič"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 #, fuzzy
 msgid "Remove Layer"
 msgstr "Odstrani"
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 #, fuzzy
 msgid "Select Layer"
 msgstr "Izberi plast pod kurzorjem"
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 #, fuzzy
 msgid "Duplicate Layer"
 msgstr "Prilepi plast"
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 #, fuzzy
 msgid "Move Layer Up"
 msgstr "Odstrani"
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 #, fuzzy
 msgid "Move Layer Down"
 msgstr "Odstrani"
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 #, fuzzy
 msgid "Move Layer in Stack"
 msgstr "Odstrani"
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 #, fuzzy
 msgid "Rename Layer"
 msgstr "Odstrani"
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 #, fuzzy
 msgid "Make Layer Visible"
 msgstr "Vidnost plasti"
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 #, fuzzy
 msgid "Make Layer Invisible"
 msgstr "Vidnost plasti"
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 #, fuzzy
 msgid "Lock Layer"
 msgstr "Plasti"
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, fuzzy, python-format
 msgid "Set Layer Mode: %s"
 msgstr "Počisti"
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, fuzzy, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr "Napaka med nalaganjem: GError %s"
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2582,13 +3140,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2598,7 +3156,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, fuzzy, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2608,13 +3166,13 @@ msgstr ""
 "Ni bilo mogoče shraniti: %s\n"
 "Je na disku dovolj prostora?"
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2622,7 +3180,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, fuzzy, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2630,7 +3188,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr "Nimate potrebnih pravic za branje datoteke: %s"
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2641,7 +3199,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, fuzzy, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2649,7 +3207,13 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr "Končnica pripada neznanemu formatu: %s"
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+#, fuzzy
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr "Uvožen čopič"
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2659,7 +3223,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2670,292 +3234,410 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+#, fuzzy
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr "Zapolni"
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 #, fuzzy
 msgctxt "layer default names"
 msgid "Layer"
 msgstr "Plasti"
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 #, fuzzy
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr "Izberi plast pod kurzorjem"
+
+#: ../lib/layer/data.py:1158
+#, fuzzy
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr "Izberi plast pod kurzorjem"
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-#, fuzzy
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1244
 msgctxt "layer default names"
-msgid "Unknown Data Layer"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
 msgstr "Plasti"
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "Nova slikarska plast"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "Nova skupina plasti"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+#, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "Pogled"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+#, fuzzy
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr "Plasti"
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+#, fuzzy
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr "Odstrani"
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr "Plasti"
+
+#: ../lib/layervis.py:697
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr "Plasti"
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 #, fuzzy
 msgid "Screen"
 msgstr "Celozaslonski"
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 #, fuzzy
 msgid "Darken"
 msgstr "Temneje"
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 #, fuzzy
 msgid "Lighten"
 msgstr "Svetlejše"
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 #, fuzzy
 msgid "Difference"
 msgstr "Nastavitve"
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2965,7 +3647,30 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+#, fuzzy
+msgid "Vertical"
+msgstr "Zrcali navpično"
+
+#: ../lib/tiledsurface.py:49
+#, fuzzy
+msgid "Horizontal"
+msgstr "Zrcali vodoravno"
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+#, fuzzy
+msgid "Rotational"
+msgstr "Zasukaj v smeri urinega kazalca"
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2974,54 +3679,87 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr "izbrisani"
+
+#: ../po/tmp/autorecover.glade.h:9
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr "Želite res izbrisati ta čopič?"
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
-msgstr ""
+#, fuzzy
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
+msgstr "Osvežuj zadnjo potezo na platnu"
 
 #: ../po/tmp/brusheditor.glade.h:4
-#, fuzzy
-msgid "Rename this brush"
-msgstr "Preimenuj čopič"
+msgid "Save these settings to the brush"
+msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
 #, fuzzy
@@ -3045,19 +3783,17 @@ msgid "Delete this brush from the disk"
 msgstr "Želite res izbrisati ta čopič?"
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-#, fuzzy
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
-msgstr "Osvežuj zadnjo potezo na platnu"
+msgid "Copy these settings and the current brush's icon to a new brush"
+msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
-msgstr ""
+#, fuzzy
+msgid "Rename this brush"
+msgstr "Preimenuj čopič"
 
 #: ../po/tmp/brusheditor.glade.h:13
 #, fuzzy
@@ -3086,118 +3822,92 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-#, fuzzy
-msgid "Setting name:"
-msgstr "Nastavitve čopiča"
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
+#: ../po/tmp/brusheditor.glade.h:22
 #, fuzzy
-msgid "Base value:"
+msgid "Value:"
 msgstr "Izhodiščna vrednost"
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr "<ymin>"
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr "<ymax>"
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 #, fuzzy
 msgid "Input"
 msgstr "Vhod"
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr "<xmin>"
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr "<xmax>"
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-#, fuzzy
-msgid "Basic details for this setting"
-msgstr "Nastavitve čopiča"
-
-#: ../po/tmp/brusheditor.glade.h:46
-#, fuzzy
-msgid "Edit Setting"
-msgstr "Shrani nastavitve"
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
 msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+#, fuzzy
+msgid "Brush dynamics are not available for this setting."
+msgstr "Nastavitve čopiča"
+
+#: ../po/tmp/brusheditor.glade.h:43
+#, fuzzy
+msgid "<big><b>No Brush Dynamics</b></big>"
+msgstr "<big><b>{accel_label}</b></big>"
 
 #: ../po/tmp/inktool.glade.h:1
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
@@ -3210,7 +3920,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr "Pritisk:"
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3256,6 +3966,138 @@ msgstr "Odstrani skupino ..."
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
 msgstr "Odpri nedavne datoteke"
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+#, fuzzy
+msgid "Insert Point"
+msgstr "Odstrani skupino ..."
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+#, fuzzy
+msgid "Cull Points"
+msgstr "Odstrani skupino ..."
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Ime"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Prosojnost"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr "Zasukaj v obratni smeri urinega kazalca"
+
+#: ../po/tmp/layervis.glade.h:3
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr "Zasukaj v obratni smeri urinega kazalca"
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
+msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
 #, fuzzy
@@ -3641,57 +4483,77 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 #, fuzzy
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr "Pogled"
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3699,12 +4561,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3713,7 +4575,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3724,30 +4586,30 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 #, fuzzy
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr "Celozaslonski"
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 #, fuzzy
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr "Barva"
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3811,1160 +4673,1338 @@ msgid "Reload the file your current work was loaded from."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
+#, fuzzy
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Import Layers…"
+msgstr "Uvozi paket s čopičem..."
+
+#: ../po/tmp/resources.xml.h:13
+msgctxt "Accel Editor (descriptions)"
+msgid "Import layers from one or more files."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save"
 msgstr "Shrani"
 
-#: ../po/tmp/resources.xml.h:13
+#: ../po/tmp/resources.xml.h:15
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file."
 msgstr "shrani kot privzeto"
 
-#: ../po/tmp/resources.xml.h:14
+#: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As…"
 msgstr "Shrani kot …"
 
-#: ../po/tmp/resources.xml.h:15
+#: ../po/tmp/resources.xml.h:17
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:16
+#: ../po/tmp/resources.xml.h:18
 #, fuzzy
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Export…"
 msgstr "Poročaj ... "
 
-#: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:18
-msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
-msgstr "Shrani kot skico"
-
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
-msgstr "Odpri prejšnjo skico"
+msgid "Save As Scrap"
+msgstr "Shrani kot skico"
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
-msgstr "Odpri naslednjo skico"
+msgid "Open Previous Scrap"
+msgstr "Odpri prejšnjo skico"
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Open Next Scrap"
+msgstr "Odpri naslednjo skico"
+
+#: ../po/tmp/resources.xml.h:25
+msgctxt "Accel Editor (descriptions)"
+msgid "Load the scrap file after the current one."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Recover File from an Automated Backup…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:25
+#: ../po/tmp/resources.xml.h:27
 msgctxt "Accel Editor (descriptions)"
 msgid "Try to save and resume interrupted unsaved work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:26
+#: ../po/tmp/resources.xml.h:28
 #, fuzzy
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr "Tipke za čopič"
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr "Tipke za čopič"
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 #, fuzzy
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr "Prepišem skupino čopičev?"
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 #, fuzzy
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr "Svetlost barve"
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr "Barva"
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:35
-#, fuzzy
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr "Zmanjšaj prosojnost plasti"
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:37
 #, fuzzy
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
-msgstr "Povečaj prosojnost plasti"
+msgid "Increase Fake Pressure"
+msgstr "Pritisk"
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 #, fuzzy
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
-msgstr "Zmanjšaj prosojnost plasti"
+msgid "Decrease Fake Pressure"
+msgstr "Pritisk"
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 #, fuzzy
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
-msgstr "Povečaj prosojnost plasti"
+msgid "Increase Fake Rotation"
+msgstr "Zmanjšaj prosojnost plasti"
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
-msgstr ""
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
+msgstr "Povečaj prosojnost plasti"
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
-msgstr ""
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
+msgstr "Zmanjšaj prosojnost plasti"
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
 #, fuzzy
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
-msgstr "Zasukaj v obratni smeri urinega kazalca"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
+msgstr "Povečaj prosojnost plasti"
 
 #: ../po/tmp/resources.xml.h:48
-#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
-msgstr "Zasukaj v obratni smeri urinega kazalca"
+msgid "Make the working brush smaller."
+msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
+msgstr "Zmanjšaj prosojnost plasti"
+
+#: ../po/tmp/resources.xml.h:50
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the working brush more opaque."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:51
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
+msgstr "Povečaj prosojnost plasti"
+
+#: ../po/tmp/resources.xml.h:52
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the working brush less opaque."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:53
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Lighten Painting Color"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:54
+msgctxt "Accel Editor (descriptions)"
+msgid "Increase the lightness of the current painting color."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:55
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:56
+msgctxt "Accel Editor (descriptions)"
+msgid "Decrease the lightness of the current painting color."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:57
 #, fuzzy
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Change Hue Clockwise"
 msgstr "Spremeni svetlost barve (HSV barvni model)"
 
-#: ../po/tmp/resources.xml.h:50
+#: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
 msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:51
+#: ../po/tmp/resources.xml.h:59
+#, fuzzy
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr "Zasukaj v obratni smeri urinega kazalca"
+
+#: ../po/tmp/resources.xml.h:60
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr "Zasukaj v obratni smeri urinega kazalca"
+
+#: ../po/tmp/resources.xml.h:61
 #, fuzzy
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Increase Saturation"
 msgstr "Zmanjšaj prosojnost plasti"
 
-#: ../po/tmp/resources.xml.h:52
+#: ../po/tmp/resources.xml.h:62
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color more saturated (more colorful, purer)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:53
+#: ../po/tmp/resources.xml.h:63
 #, fuzzy
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Decrease Saturation"
 msgstr "Povečaj prosojnost plasti"
 
-#: ../po/tmp/resources.xml.h:54
+#: ../po/tmp/resources.xml.h:64
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color less saturated (grayer)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:55
+#: ../po/tmp/resources.xml.h:65
 #, fuzzy
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Reload Brush Settings"
 msgstr "Nastavitve čopiča"
 
-#: ../po/tmp/resources.xml.h:56
+#: ../po/tmp/resources.xml.h:66
 msgctxt "Accel Editor (descriptions)"
 msgid "Restore all brush settings to the current brush’s saved values."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:57
+#: ../po/tmp/resources.xml.h:67
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Pick Stroke and Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:58
+#: ../po/tmp/resources.xml.h:68
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:59
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 #, fuzzy
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr "Shrani čez zadnjega obnovljenega"
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr "Shrani čez zadnjega obnovljenega"
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "Počisti plast"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr "Odpri nedavne datoteke"
 
-#: ../po/tmp/resources.xml.h:65
+#: ../po/tmp/resources.xml.h:75
 #, fuzzy
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr "Namizna ikona"
+
+#: ../po/tmp/resources.xml.h:76
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr "Plasti"
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "Nova skupina plasti"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "Nova skupina plasti"
+
+#: ../po/tmp/resources.xml.h:85
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr "Dodaj na odložišče"
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr "Dodaj na odložišče"
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:71
+#: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Edit Layer in External App…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:72
+#: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:73
+#: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Update Layer with External Edits"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:74
+#: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
 msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:75
+#: ../po/tmp/resources.xml.h:93
 #, fuzzy
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer at Cursor"
 msgstr "Izberi plast pod kurzorjem"
 
-#: ../po/tmp/resources.xml.h:76
+#: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:77
+#: ../po/tmp/resources.xml.h:95
 #, fuzzy
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Above"
 msgstr "Plasti"
 
-#: ../po/tmp/resources.xml.h:78
+#: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer up in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:79
+#: ../po/tmp/resources.xml.h:97
 #, fuzzy
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Below"
 msgstr "Plasti"
 
-#: ../po/tmp/resources.xml.h:80
+#: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer down in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:81
+#: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer"
 msgstr "Nova slikarska plast"
 
-#: ../po/tmp/resources.xml.h:82
+#: ../po/tmp/resources.xml.h:100
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer above the current layer."
 msgstr "Odpri nedavne datoteke"
 
-#: ../po/tmp/resources.xml.h:83
+#: ../po/tmp/resources.xml.h:101
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer…"
 msgstr "Izberi plast pod kurzorjem"
 
-#: ../po/tmp/resources.xml.h:84
+#: ../po/tmp/resources.xml.h:102
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer above the current layer, and begin editing it."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:85
+#: ../po/tmp/resources.xml.h:103
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group"
 msgstr "Nova skupina plasti"
 
-#: ../po/tmp/resources.xml.h:86
+#: ../po/tmp/resources.xml.h:104
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group above the current layer."
 msgstr "Odpri nedavne datoteke"
 
-#: ../po/tmp/resources.xml.h:87
+#: ../po/tmp/resources.xml.h:105
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:88
+#: ../po/tmp/resources.xml.h:106
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer below the current layer."
 msgstr "Odpri nedavne datoteke"
 
-#: ../po/tmp/resources.xml.h:89
+#: ../po/tmp/resources.xml.h:107
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer Below…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:90
+#: ../po/tmp/resources.xml.h:108
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer below the current layer, and begin editing it."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:91
+#: ../po/tmp/resources.xml.h:109
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:92
+#: ../po/tmp/resources.xml.h:110
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group below the current layer."
 msgstr "Odpri nedavne datoteke"
 
-#: ../po/tmp/resources.xml.h:93
+#: ../po/tmp/resources.xml.h:111
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Layer Down"
 msgstr "Plasti"
 
-#: ../po/tmp/resources.xml.h:94
+#: ../po/tmp/resources.xml.h:112
 msgctxt "Accel Editor (descriptions)"
 msgid "Merge the current layer with the layer beneath it."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:95
+#: ../po/tmp/resources.xml.h:113
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Visible Layers"
 msgstr "Plasti"
 
-#: ../po/tmp/resources.xml.h:96
+#: ../po/tmp/resources.xml.h:114
 msgctxt "Accel Editor (descriptions)"
 msgid "Consolidate all visible layers, and delete the originals."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:97
+#: ../po/tmp/resources.xml.h:115
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer from Visible"
 msgstr "Vidnost plasti"
 
-#: ../po/tmp/resources.xml.h:98
+#: ../po/tmp/resources.xml.h:116
 msgctxt "Accel Editor (descriptions)"
 msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:99
+#: ../po/tmp/resources.xml.h:117
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Delete Layer"
 msgstr "Izbriši plast"
 
-#: ../po/tmp/resources.xml.h:100
+#: ../po/tmp/resources.xml.h:118
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Remove the current layer from the layer stack."
 msgstr "Odpri nedavne datoteke"
 
-#: ../po/tmp/resources.xml.h:101
+#: ../po/tmp/resources.xml.h:119
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Convert to Normal Painting Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:102
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 #, fuzzy
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr "Zmanjšaj prosojnost plasti"
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 #, fuzzy
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr "Povečaj prosojnost plasti"
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr "Odstrani"
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr "Plasti"
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr "Prilepi plast"
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr "Odpri nedavne datoteke"
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
-msgstr "Odstrani"
+msgid "Layer Properties…"
+msgstr "Gimp palete (*.gpl)"
 
-#: ../po/tmp/resources.xml.h:114
-#, fuzzy
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
-msgstr "Odpri nedavne datoteke"
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr "Plasti"
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr "Vidnost plasti"
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 #, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr "Ozadje"
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr "Preklopi status maske za plast "
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr "Odpri nedavne datoteke"
+
+#: ../po/tmp/resources.xml.h:141
 #, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr "Zasukaj v smeri urinega kazalca"
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr "Prilagodi pogledu"
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 #, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr "Približaj"
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr "Zmanjšaj prosojnost plasti"
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Oddalji"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr "Povečaj prosojnost plasti"
 
-#: ../po/tmp/resources.xml.h:136
-msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
-msgstr "Zasukaj v obratni smeri urinega kazalca"
-
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:156
 #, fuzzy
-msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
-msgstr "Zasukaj v obratni smeri urinega kazalca"
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Left"
+msgstr "Pogled"
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:157
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the left."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr "Pogled"
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr "Zasukaj v smeri urinega kazalca"
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr "Zasukaj v obratni smeri urinega kazalca"
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr "Zasukaj v obratni smeri urinega kazalca"
+
+#: ../po/tmp/resources.xml.h:167
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr "Zasukaj v obratni smeri urinega kazalca"
+
+#: ../po/tmp/resources.xml.h:168
 #, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr "Zrcali vodoravno"
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 #, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr "Zrcali navpično"
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr "Samo ta plast"
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr "Odpri nedavne datoteke"
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr "Preklopi način urejanja"
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 #, fuzzy
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr "Izpiši vhodne vrednosti čopiča na standardni izhod"
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr "Vizualiziraj izris"
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr "Onemogoči dvojno medpomnjenje"
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+#, fuzzy
+msgid "Delete Point"
+msgstr "Odstrani skupino ..."
+
+#: ../po/tmp/resources.xml.h:187
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr "Odpri nedavne datoteke"
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr "Način slikanja"
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr "Način slikanja: Normalen"
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr "Izbriši s trenutnim čopičem."
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Datoteka"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "Izhod"
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "Uredi"
 
-#: ../po/tmp/resources.xml.h:169
-#, fuzzy
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr "Zamenjaj barvo"
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "Barva"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 #, fuzzy
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr "Zamenjaj barvo"
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 #, fuzzy
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr "Zgodovina barv"
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 #, fuzzy
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr "Podrobnosti"
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 #, fuzzy
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr "Velikost predogleda"
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 #, fuzzy
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr "Velikost predogleda"
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 #, fuzzy
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr "dodaj barvo med vzorce"
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "Plast"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 #, fuzzy
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr "Prosojnost"
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 #, fuzzy
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr "Plasti"
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 #, fuzzy
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr "Samo ta plast"
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr "Beležka"
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 #, fuzzy
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr "Odpri naslednjo skico"
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 #, fuzzy
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr "Odpri naslednjo skico"
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 #, fuzzy
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr "Shrani paleto kot ..."
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 #, fuzzy
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr "Shrani kot ..."
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 #, fuzzy
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr "Odpri naslednjo skico"
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 #, fuzzy
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr "shrani kot privzeto"
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 #, fuzzy
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr "shrani kot privzeto"
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 #, fuzzy
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr "Ozadje"
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "Okno"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "Čopič"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 #, fuzzy
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr "Bližnjice"
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 #, fuzzy
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr "Bližnjice"
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "Spremeni čopič…"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "Zamenjaj barvo…"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "Zamenjaj barvo (hitra podmnožica)…"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr "Dobi več čopičev…"
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 #, fuzzy
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr "Uvozi paket s čopičem..."
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr "Želite res izbrisati ta čopič?"
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Pomoč"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr "Pomoč na spletu"
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "O programu MyPaint"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Sporočila za razvijalce (debug)"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 #, fuzzy
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
@@ -4972,778 +6012,891 @@ msgstr ""
 "Izpiši podatke o uhajanju pomnilnika na standardni izhod (operacija je "
 "počasna!)"
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 #, fuzzy
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr "Poženi sproščanje nerabljenega spomina"
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "Pogled"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 #, fuzzy
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr "Zamenjaj barvo"
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 #, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr "Pojavni meni"
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "Celozaslonski"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "Nastavitve"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 #, fuzzy
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr "Preizkusi vhodne naprave ..."
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 #, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr "Ozadje"
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr "Urejevalnik nastavitev čopiča"
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr "Nastavitve čopiča"
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 #, fuzzy
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr "Urejevalnik čopičev ..."
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr "Ikona čopiča"
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr "Plasti"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr "Pokaži plasti"
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "Barvna paleta"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 #, fuzzy
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr "Spremeni svetlost/obarvanost"
 
-#: ../po/tmp/resources.xml.h:260
-#, fuzzy
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr "Barvni trikotnik ..."
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 #, fuzzy
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr "Izhodiščna vrednost"
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 #, fuzzy
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr "Kvadrat"
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 #, fuzzy
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr "Odpri naslednjo skico"
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr "Pokaži beležko"
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr "Pult s predogledom"
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "Predogled"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr "Možnosti orodja"
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr "Pokaži pult možnosti orodja"
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr "Zgodovina čopičev & barv"
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr "Nedavni čopiči & barve"
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr "Prostoročno"
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr "Prostoročno"
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 #, fuzzy
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr "Pogled"
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr "Vzorec"
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 #, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr "Pogled"
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 #, fuzzy
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr "Zasukaj v smeri urinega kazalca"
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr "Zasukaj v smeri urinega kazalca"
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 #, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr "Zasukaj v smeri urinega kazalca"
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 #, fuzzy
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr "Približaj"
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 #, fuzzy
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr "Približaj"
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 #, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr "Približaj"
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr "Črte in krivulje"
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr "Povezane črte"
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr "Elipse in krogi: riši okrogle oblike."
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr "Elipse in krogi"
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr "Riši kroge in elipse."
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr "Črnilo"
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr "Risanje s črnilom"
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr "Riši gladke nadzorovane črte."
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr "Premakni plast"
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr "Položaj plasti"
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr "Premakni plast: premakni trenutno plast na platnu."
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr "Premakni plast"
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr "Interaktivno premakni trenutno plast na platnu."
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr "Uredi okvir"
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr "Okvir"
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 "Uredi okvir: nastavite okvir okrog dokumenta, da mu določite končno velikost."
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr "Uredi okvir"
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 "Interaktivno nastavite okvir okrog dokumenta, da mu določite končno velikost."
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Uredi simetrijo slikanja"
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr "Simetrija"
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
-msgstr "Uredi simetrijo slikanja: nastavite vzdolžno os za simetrično slikanje."
+msgstr ""
+"Uredi simetrijo slikanja: nastavite vzdolžno os za simetrično slikanje."
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Uredi simetrijo slikanja"
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr "Interaktivno nastavite vzdolžno os za simetrično slikanje."
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr "Izberi barvo"
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr "Izberi barvo"
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr "Izberi barvo: določite barvo na podlagi zaslonskih točk."
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "Izberi barvo"
+
+#: ../po/tmp/resources.xml.h:401
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr "Nastavi barvo na podlagi zaslonskih točk."
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "Izberi barvo"
+
+#: ../po/tmp/resources.xml.h:403
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr "Nastavi barvo na podlagi zaslonskih točk."
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "Izberi barvo"
+
+#: ../po/tmp/resources.xml.h:405
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr "Nastavi barvo na podlagi zaslonskih točk."
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr "Izberi barvo"
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr "Nastavi barvo na podlagi zaslonskih točk."
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr "Zapolni"
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr "Zapolni"
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr "Zapolni področje z barvo."
+
+#~ msgctxt "Accelerator map editor: action column markup"
+#~ msgid ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+#~ msgstr ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+
+#, fuzzy
+#~ msgctxt "brush list context menu"
+#~ msgid "Delete"
+#~ msgstr "izbrisani"
+
+#~ msgctxt "brush list commands"
+#~ msgid "Really delete brush from disk?"
+#~ msgstr "Želite res izbrisati ta čopič?"
+
+#, fuzzy
+#~ msgid "HSV Triangle"
+#~ msgstr "Barvni trikotnik ..."
+
+#, fuzzy
+#~ msgid "The standard GTK color selector"
+#~ msgstr "MyPaint izbirnik barve"
+
+#~ msgid "Save..."
+#~ msgstr "Shrani ..."
+
+#~ msgid "Confirm"
+#~ msgstr "Potrdi"
+
+#~ msgid "Open..."
+#~ msgstr "Odpri ..."
+
+#, fuzzy
+#~ msgid "Setting name:"
+#~ msgstr "Nastavitve čopiča"
+
+#, fuzzy
+#~ msgid "Base value:"
+#~ msgstr "Izhodiščna vrednost"
+
+#~ msgid "<ymin>"
+#~ msgstr "<ymin>"
+
+#~ msgid "<ymax>"
+#~ msgstr "<ymax>"
+
+#~ msgid "<xmin>"
+#~ msgstr "<xmin>"
+
+#~ msgid "<xmax>"
+#~ msgstr "<xmax>"
+
+#, fuzzy
+#~ msgid "Edit Setting"
+#~ msgstr "Shrani nastavitve"
+
+#, fuzzy
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Trim Layer to Frame"
+#~ msgstr "Plasti"
+
+#, fuzzy
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Rename Layer…"
+#~ msgstr "Odstrani"
+
+#, fuzzy
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Enter a new name for the current layer."
+#~ msgstr "Odpri nedavne datoteke"
+
+#, fuzzy
+#~ msgctxt "Menu→Edit (labels)"
+#~ msgid "Current Tool"
+#~ msgstr "Zamenjaj barvo"
+
+#, fuzzy
+#~ msgctxt "Menu→Color (labels), Accel Editor (labels)"
+#~ msgid "HSV Triangle"
+#~ msgstr "Barvni trikotnik ..."
 
 #~ msgid "Add As New"
 #~ msgstr "Dodaj kot nov"
@@ -5825,9 +6978,6 @@ msgstr "Zapolni področje z barvo."
 #~ "funkcije, ki jih je težje odkriti.\n"
 #~ "\n"
 
-#~ msgid "Open Recent files"
-#~ msgstr "Odpri nedavne datoteke"
-
 #, fuzzy
 #~ msgid "This will discard %d second of unsaved painting."
 #~ msgid_plural "This will discard %d seconds of unsaved painting."
@@ -5885,10 +7035,6 @@ msgstr "Zapolni področje z barvo."
 #~ msgstr "Shrani nastavitve"
 
 #, fuzzy
-#~ msgid "Add Layer"
-#~ msgstr "Plasti"
-
-#, fuzzy
 #~ msgid "Change Layer Visibility"
 #~ msgstr "Vidnost plasti"
 
@@ -5917,10 +7063,6 @@ msgstr "Zapolni področje z barvo."
 #~ msgctxt "Menu|File|"
 #~ msgid "Save"
 #~ msgstr "Shrani"
-
-#, fuzzy
-#~ msgid "Export to a file"
-#~ msgstr "Izvozi paleto ..."
 
 #, fuzzy
 #~ msgctxt "Menu|Brush|"

--- a/po/sl.po
+++ b/po/sl.po
@@ -549,19 +549,19 @@ msgstr "MyPaint čopič paket (*.zip)"
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr "Nova skupina ..."
 
 #: ../gui/brushselectionwindow.py:537
 #, fuzzy
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr "Uvozi paket s čopičem..."
 
 #: ../gui/brushselectionwindow.py:540
 #, fuzzy
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr "Obnovi čopič %d"
 
 #: ../gui/brushselectionwindow.py:554
@@ -1261,12 +1261,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1496,7 +1496,7 @@ msgid "_Quit"
 msgstr "Izhod"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr "Uvozi paket s čopičem..."
 
 #: ../gui/drawwindow.py:698
@@ -1547,7 +1547,7 @@ msgstr ""
 
 #: ../gui/externalapp.py:71
 #, fuzzy
-msgid "Open With..."
+msgid "Open With…"
 msgstr "Odpri ..."
 
 #: ../gui/externalapp.py:123
@@ -1820,7 +1820,7 @@ msgstr "Odpri nedavne datoteke"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr "Odpri naslednjo skico"
 
 #: ../gui/filehandling.py:1099
@@ -2261,12 +2261,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr "Poročaj ..."
 
 #: ../gui/gtkexcepthook.py:180
@@ -2279,7 +2279,7 @@ msgid "Quit MyPaint"
 msgstr "O programu MyPaint"
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr "Podrobnosti ..."
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2470,7 +2470,7 @@ msgstr ""
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
 #, fuzzy
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr "Plasti"
 
 #: ../gui/layerswindow.py:110
@@ -2546,7 +2546,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/sq.po
+++ b/po/sq.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:18+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Albanian <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -19,27 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -47,39 +27,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -87,214 +67,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Ngjyra"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "E personalizuar"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -333,142 +323,177 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Ruaj"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "E re"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -476,58 +501,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -536,51 +561,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -590,137 +639,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -728,162 +777,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -891,373 +932,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Emri"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Anullo"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Rikthe"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1267,324 +1305,673 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Ekran të plotë"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Dalja"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Dalja"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
+msgstr ""
+
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
+msgstr ""
+
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Ruaj"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
 #, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr ""
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "File"
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1427
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1432
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr ""
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1592,130 +1979,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1724,35 +2123,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1776,45 +2175,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1822,153 +2225,217 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr ""
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr ""
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr ""
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1980,256 +2447,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2237,188 +2729,212 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+msgid "Import Layers"
+msgstr ""
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2427,13 +2943,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2443,7 +2959,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2451,13 +2967,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2465,7 +2981,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2473,7 +2989,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2484,7 +3000,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2492,7 +3008,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2502,7 +3023,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2513,285 +3034,394 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr ""
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2801,7 +3431,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2810,52 +3460,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2877,17 +3558,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2916,112 +3595,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3034,7 +3688,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3075,6 +3729,133 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Emri"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3444,56 +4225,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3501,12 +4302,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3515,7 +4316,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3526,28 +4327,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3609,1828 +4410,2018 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Zvogëlo zmadhimin"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "File"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Ndihmë"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/sq.po
+++ b/po/sq.po
@@ -513,17 +513,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1184,12 +1184,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1405,7 +1405,7 @@ msgid "_Quit"
 msgstr "Dalja"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1455,7 +1455,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1632,13 +1632,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Ruaj"
 
@@ -1704,7 +1704,7 @@ msgstr "File"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -2124,12 +2124,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2141,7 +2141,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2326,7 +2326,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2396,7 +2396,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/sr@cyrillic.po
+++ b/po/sr@cyrillic.po
@@ -521,17 +521,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1193,12 +1193,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1381,7 +1381,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Open dragged file confirm dialog: continue button"
 msgid "_Open"
-msgstr "Отвори..."
+msgstr "Отвори…"
 
 #: ../gui/drawwindow.py:486
 msgid "Set current color"
@@ -1415,7 +1415,7 @@ msgid "_Quit"
 msgstr "Изађи"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1465,7 +1465,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1644,13 +1644,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Сними као…"
 
@@ -1718,7 +1718,7 @@ msgstr "Датотекa"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr "Платно"
 
 #: ../gui/filehandling.py:1099
@@ -1736,7 +1736,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Отвори..."
+msgstr "Отвори…"
 
 #: ../gui/filehandling.py:1427
 #, fuzzy
@@ -1748,7 +1748,7 @@ msgstr "Отвори скорашњи"
 #, fuzzy
 msgctxt "File→Open Most Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Отвори..."
+msgstr "Отвори…"
 
 #: ../gui/filehandling.py:1446
 msgctxt "File→Open Next/Prev Scrap: error message"
@@ -1769,7 +1769,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
 msgid "_Open"
-msgstr "Отвори..."
+msgstr "Отвори…"
 
 #: ../gui/filehandling.py:1487
 msgctxt "File→Revert: status message: canvas has no filename yet"
@@ -2146,12 +2146,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2163,7 +2163,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2349,7 +2349,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2419,7 +2419,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/sr@cyrillic.po
+++ b/po/sr@cyrillic.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:19+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Serbian (cyrillic) <https://hosted.weblate.org/projects/"
@@ -16,31 +16,11 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<="
-"4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "Радња"
 
@@ -48,32 +28,32 @@ msgstr "Радња"
 msgid "Key combination"
 msgstr "Комбинација типки"
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr "Измени типку за '%s'"
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "Радња:"
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "Путања:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "Типка:"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr "Притисни типке да ажурираш овај задатак"
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "Непозната радња"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
@@ -82,7 +62,7 @@ msgstr ""
 "<b>{accel} је тренутно у употрби за '{action}'. Постојећи задатак ће бити "
 "замењен.</b>"
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr "Отвори фасциклу “{folder_basename}”…"
@@ -90,217 +70,227 @@ msgstr "Отвори фасциклу “{folder_basename}”…"
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "У реду"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr "Ни једна резерва није пронађена у кешу."
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "Сними као поставку"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "Позадина"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "Предложак"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Боја"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr "Јдна или више позадина нису могле бити учитане"
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr "Грешка при учитавању позадина"
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 "Молимо вас да обришете неучитане датотеке, или проверите вашу libgdkpixbuf "
 "инсталацију."
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 "Gdk-Pixbuf није могао да учита \"{filename}\", и пријавио је \"{error}\""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr "{filename} је празан (w={w}, h={h})"
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr "Управљач опцијама четкица"
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr "О четкицама"
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "Експерименталне"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr "Основне"
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr "Брзина"
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr ""
+
+#: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr "Праћење"
 
-#: ../gui/brusheditor.py:359
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "Потез"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr "Боје"
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "посебна"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -339,98 +329,134 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Сачувај"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Ново"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
+msgstr "Управљач опцијама четкица"
+
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
@@ -438,44 +464,44 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -483,58 +509,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -543,51 +569,76 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "Одабир боја"
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -597,137 +648,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -735,162 +786,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -898,373 +941,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Назив"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr "Опозови %s"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Опозови"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Понови"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1274,324 +1314,686 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Отвори..."
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Цео екран"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Изађи"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Изађи"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "Сними као поставку"
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Сними као…"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr ""
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr "Отвори…"
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Датотекa"
+
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
+msgid "Open Scratchpad..."
+msgstr "Платно"
+
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Слојеви"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
 msgstr "Отвори..."
 
-#: ../gui/filehandling.py:552
-msgid "Open Scratchpad..."
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Отвори скорашњи"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Отвори..."
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Отвори..."
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+#, fuzzy
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr "Уклопи слику у прозор"
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
-msgstr ""
+msgstr "Нова група слојева"
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Непрозирност:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "Обриши слој"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1599,130 +2001,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1731,35 +2145,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1783,45 +2197,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1829,153 +2247,218 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Слојеви"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Слојеви"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Непрозирност:"
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1987,256 +2470,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2244,188 +2752,214 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "Нова група слојева"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Слојеви"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2434,13 +2968,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2450,7 +2984,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2458,13 +2992,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2472,7 +3006,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2480,7 +3014,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2491,7 +3025,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2499,7 +3033,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2509,7 +3048,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2520,285 +3059,399 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
-msgctxt "layer default names"
-msgid "Vector Layer"
-msgstr ""
-
 #: ../lib/layer/data.py:1153
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Vectors"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
+#: ../lib/layer/data.py:1158
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Vector Layer"
+msgstr "Очисти слој"
+
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Data Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr "Непозната радња"
+
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "Нови слој платна"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "Нова група слојева"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+#, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "Приказ"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2808,7 +3461,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2817,52 +3490,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2884,17 +3588,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2923,112 +3625,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3041,7 +3718,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3082,6 +3759,134 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Назив"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Непрозирност:"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3451,56 +4256,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3508,12 +4333,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3522,7 +4347,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3533,28 +4358,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3616,1828 +4441,2024 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
-msgstr "Сними"
+msgid "Import Layers…"
+msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
-msgstr "Сними као…"
+msgid "Save"
+msgstr "Сними"
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
-msgstr ""
+msgid "Save As…"
+msgstr "Сними као…"
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "Очисти слој"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "Нова група слојева"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "Нова група слојева"
+
+#: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:71
+#: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Edit Layer in External App…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
-msgstr "Нови слој платна"
-
-#: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:85
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
-msgstr "Нова група слојева"
-
-#: ../po/tmp/resources.xml.h:86
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:87
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:88
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:89
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
-msgstr "Обриши слој"
+msgid "New Painting Layer"
+msgstr "Нови слој платна"
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr "Нова група слојева"
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr "Обриши слој"
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr "Уклопи слику у прозор"
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Умањи"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Датотекa"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "Напусти"
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "Измени"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "Боје"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "Слојеви"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr "Платно"
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "Прозори"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "Четкице"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "Промени четкицу…"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "Промени боју…"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "Промени боју (брзи подскуп)…"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr "Добиј још четкица…"
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Помоћ"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr "Помоћ на мрежи"
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "О програму MyPaint"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Исправљање"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "Приказ"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "Цео екран"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "Измени поставке"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr "Управљање четкицама"
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr "Прозорче слојева"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr "Прикажи прозорче слојева"
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "Палета боја"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr "Прозорче кретања"
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "Преглед"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr "Прозорче опција алата"
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr "Прикажи прозорче опција алата"
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr "Прозорче историје четкица и боја"
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr "Скорашње четкице и боје"
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr "Слободоручно"
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr "Слободоручно"
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr "Линије и криве"
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr "Спојене линије"
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr "Елипсе и кругови"
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr "Мастило"
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr "Премести слој"
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr "Измени оквир"
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Измени симетрију платна"
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "Одабир боја"
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "Одабир боја"
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "Одабир боја"
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr "Одабир боја"
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/sr_Latn.po
+++ b/po/sr_Latn.po
@@ -515,17 +515,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1186,12 +1186,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1374,7 +1374,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Open dragged file confirm dialog: continue button"
 msgid "_Open"
-msgstr "Otvori..."
+msgstr "Otvori…"
 
 #: ../gui/drawwindow.py:486
 msgid "Set current color"
@@ -1408,7 +1408,7 @@ msgid "_Quit"
 msgstr "Izađi"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1458,7 +1458,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1636,13 +1636,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Sačuvaj kao…"
 
@@ -1710,7 +1710,7 @@ msgstr "Datoteka"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr "Platno"
 
 #: ../gui/filehandling.py:1099
@@ -1728,7 +1728,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Otvori..."
+msgstr "Otvori…"
 
 #: ../gui/filehandling.py:1427
 #, fuzzy
@@ -1740,7 +1740,7 @@ msgstr "Otvori skorašnji"
 #, fuzzy
 msgctxt "File→Open Most Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Otvori..."
+msgstr "Otvori…"
 
 #: ../gui/filehandling.py:1446
 msgctxt "File→Open Next/Prev Scrap: error message"
@@ -1761,7 +1761,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
 msgid "_Open"
-msgstr "Otvori..."
+msgstr "Otvori…"
 
 #: ../gui/filehandling.py:1487
 msgctxt "File→Revert: status message: canvas has no filename yet"
@@ -2138,12 +2138,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2155,7 +2155,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2341,7 +2341,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2411,7 +2411,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/sr_Latn.po
+++ b/po/sr_Latn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-03-05 16:58+0000\n"
 "Last-Translator: Nikola Perović <nikolaperovicccc@gmail.com>\n"
 "Language-Team: Serbian (latin) <https://hosted.weblate.org/projects/mypaint/"
@@ -16,31 +16,11 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<="
-"4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 3.5\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -48,39 +28,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -88,214 +68,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "Pozadina"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Boja"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Prilagođeno"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -334,98 +324,133 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Sačuvaj"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Nov"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
@@ -433,44 +458,44 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -478,58 +503,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -538,51 +563,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -592,137 +641,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -730,162 +779,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -893,373 +934,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Ime:"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr "Opozovi %s"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Opozovi"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Ponovi"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1269,324 +1307,685 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Otvori..."
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Ceo ekran"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Izađi"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Izađi"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Sačuvaj kao…"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr ""
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr "Otvori…"
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Datoteka"
+
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
+msgid "Open Scratchpad..."
+msgstr "Platno"
+
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Slojevi"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
 msgstr "Otvori..."
 
-#: ../gui/filehandling.py:552
-msgid "Open Scratchpad..."
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Otvori skorašnji"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Otvori..."
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Otvori..."
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+#, fuzzy
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr "Ispuni pregled"
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
-msgstr ""
+msgstr "Nova grupa slojeva"
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr ""
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "Obriši sloj"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1594,130 +1993,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1726,35 +2137,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1778,45 +2189,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1824,153 +2239,218 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Slojevi"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Slojevi"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr ""
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1982,256 +2462,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2239,188 +2744,214 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "Nova grupa slojeva"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Slojevi"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2429,13 +2960,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2445,7 +2976,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2453,13 +2984,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2467,7 +2998,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2475,7 +3006,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2486,7 +3017,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2494,7 +3025,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2504,7 +3040,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2515,285 +3051,398 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
-msgctxt "layer default names"
-msgid "Vector Layer"
-msgstr ""
-
 #: ../lib/layer/data.py:1153
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Vectors"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
+#: ../lib/layer/data.py:1158
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Vector Layer"
+msgstr "Obriši sloj"
+
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Data Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "Novi sloj platna"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "Nova grupa slojeva"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+#, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "Pregled"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2803,7 +3452,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2812,52 +3481,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2879,17 +3579,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2918,112 +3616,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3036,7 +3709,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3077,6 +3750,133 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Ime:"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3446,56 +4246,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3503,12 +4323,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3517,7 +4337,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3528,28 +4348,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3611,1828 +4431,2021 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
-msgstr "Sačuvaj"
+msgid "Import Layers…"
+msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
-msgstr "Sačuvaj kao…"
+msgid "Save"
+msgstr "Sačuvaj"
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
-msgstr ""
+msgid "Save As…"
+msgstr "Sačuvaj kao…"
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "Obriši sloj"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "Nova grupa slojeva"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "Nova grupa slojeva"
+
+#: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:71
+#: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Edit Layer in External App…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
-msgstr "Novi sloj platna"
-
-#: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:85
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
-msgstr "Nova grupa slojeva"
-
-#: ../po/tmp/resources.xml.h:86
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:87
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:88
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:89
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
-msgstr "Obriši sloj"
+msgid "New Painting Layer"
+msgstr "Novi sloj platna"
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr "Nova grupa slojeva"
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr "Obriši sloj"
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr "Ispuni pregled"
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Umanji"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Datoteka"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "Izađi"
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "Izmeni"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "Boje"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "Slojevi"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr "Platno"
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "Prozori"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "Četkica"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "Promeni četkicu…"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "Promeni boju…"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "Promeni boju (brzi podskup)…"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr "Dodaj još četkica…"
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Pomoć"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr "Pomoć na mreži"
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "O MyPaint"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Otklanjanje grešaka"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "Pregled"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "Ceo ekran"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "Ismeni postavke"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
-msgstr ""
+msgstr "Slojevi"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.7.1-git\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2018-05-07 20:43+0000\n"
 "Last-Translator: Anders Jonsson <anders.jonsson@norsjovallen.se>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -17,29 +17,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.0-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr "<big><b>{accel_label}</b></big>"
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr "{action_label} {action_desc} {accel_label}"
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "Handling"
 
@@ -47,32 +25,32 @@ msgstr "Handling"
 msgid "Key combination"
 msgstr "Tangentkombination"
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr "Ändra tangent för '%s'"
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "Handling:"
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "Sökväg:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "Tangent:"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr "Tryck en tangent för att uppdatera tilldelningen"
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "Okänd handling"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
@@ -81,7 +59,7 @@ msgstr ""
 "<b>{accel} används redan för '{action}'. Den nuvarande tilldelningen kommer "
 "ersättas.</b>"
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr "Öppna mapp “{folder_basename}”…"
@@ -89,196 +67,206 @@ msgstr "Öppna mapp “{folder_basename}”…"
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "OK"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr "Inga backuper hittades i cachen."
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr "Inga tillgängliga backuper"
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr "Öppna cachemappen…"
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr "Återställning av backup misslyckades"
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr "Öppna backupmappen…"
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr "Återställd fil från {iso_datetime}.ora"
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "Spara som standard"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "Bakgrund"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "Mönster"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Färg"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "Lägg till färg till mönster"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr "En eller fler bakgrundsbilder kunde inte laddas"
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr "Fel när bakgrundsbilder laddades"
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 "Ta bort filerna som inte kunde laddas, eller dubbelkolla installationen av "
 "libgdkpixbuf."
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 "Gdk-Pixbuf kunde inte ladda \"{filename}\", rapporterade felet \"{error}\""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr "{filename} har ingen storlek (w={w}, h={h})"
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr "Redigera penselinställningar"
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr "Om"
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "Experimentella"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr "Grundläggande"
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr "Opacitet"
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr "Penselnedslag"
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "Smeta ut"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr "Hastighet"
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr ""
+
+#: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr "Spårning"
 
-#: ../gui/brusheditor.py:359
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "Penseldrag"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr "Färg"
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Anpassat"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr "Ingen pensel vald, använd \"Lägg till som ny\" istället."
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr "Ingen pensel vald!"
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "Byt namn på pensel"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "En pensel med detta namn finns redan!"
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr "Ingen pensel vald!"
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr "Vill du ta bort penseln “{brush_name}” från hårddisken?"
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr "(Namnlös pensel)"
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr "{brush_name} [osparad]"
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr "Penselikon"
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr "Penselikon (redigera)"
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr "Ingen pensel vald"
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -287,7 +275,7 @@ msgstr ""
 "<b>%s</b>\n"
 "<small>Välj en giltig pensel först</small>"
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
@@ -296,7 +284,7 @@ msgstr ""
 "<b>%s</b> <i>(modifierad)</i>\n"
 "<small>Ändringarna har inte sparats än</small>"
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
@@ -305,7 +293,7 @@ msgstr ""
 "<b>%s</b> (editing)\n"
 "<small>Måla med valfri pensel eller färg</small>"
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -346,142 +334,182 @@ msgstr "Auto"
 msgid "Use the default icon"
 msgstr "Använd standardikonen"
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Spara"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr "Spara denna förhandsvisningsikon, och avsluta redigeringen"
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr "Upphittat"
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr "Raderat"
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr "Favoriter"
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr "Bläck"
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr "Klassiska"
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr "Uppsättning#1"
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr "Uppsättning#2"
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr "Uppsättning#3"
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr "Uppsättning#4"
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr "Uppsättning#5"
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr "Experimentella"
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Ny"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr "Okänd Pensel"
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr "Lägg till i favoriter"
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr "Ta bort från favoriter"
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr "Kloning"
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr "Redigera penselinställningar"
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
-msgstr "Ta bort"
+#: ../gui/brushselectionwindow.py:250
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
+msgstr "Döp om uppsättning"
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
-msgstr "Vill du verkligen radera penseln från hårddisken?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, fuzzy, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
+msgstr "Vill du ta bort penseln “{brush_name}” från hårddisken?"
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] "%d pensel"
 msgstr[1] "%d penslar"
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr "Uppsättning “{group_name}”"
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr "Döp om uppsättning"
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr "Exportera som packat penselpaket"
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr "Ta bort uppsättning"
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr "Döp om uppsättning"
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "Det finns redan en uppsättning med det namnet!"
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr "Vill du verkligen radera uppsättningen “{group_name}”?"
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -491,58 +519,58 @@ msgstr ""
 "Kunde inte ta bort uppsättningen “{group_name}”.\n"
 "Vissa specialuppsättningar kan inte tas bort."
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr "Exportera penslar"
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr "MyPaint penselpaket (*.zip)"
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "Ny uppsättning..."
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr "Importera penslar..."
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr "Hämta fler penslar..."
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "Skapa uppsättning"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr "Knapp"
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr "knapp"
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr "Knappkombination"
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr "Lägg till ny tangentbindning"
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr "Ta bort nuvarande tangentbindning"
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr "Modifiera tangentbindning för '%s'"
@@ -551,7 +579,7 @@ msgstr "Modifiera tangentbindning för '%s'"
 msgid "Button press:"
 msgstr "Knapptryck:"
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
@@ -559,47 +587,75 @@ msgstr ""
 "Håll nere önskade tangenter och klicka över denna text för att sätta en ny "
 "tangentbindning."
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 "{button} kan inte bindas utan en hjälptangent (dess funktion är tyvärr låst)"
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr "{button_combination} är redan knuten till handlingen '{action_name}'"
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr "Välj färg"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr "Välj färg att måla med"
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+#, fuzzy
+msgid "Set the color Hue used for painting"
+msgstr "Välj färg att måla med"
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "Välj färg."
+
+#: ../gui/colorpicker.py:296
+#, fuzzy
+msgid "Set the color Chroma used for painting"
+msgstr "Välj färg att måla med"
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+#, fuzzy
+msgid "Set the color Luma used for painting"
+msgstr "Välj färg att måla med"
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr "Färgdetaljer"
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr "Nyvald färg och senast använda färg vid målning"
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr "Tonskalemask aktiv"
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr "Avgränsa din palett med hjälp av en tonskalemask."
@@ -609,7 +665,7 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr "HCY nyans och kulörthet."
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
@@ -618,12 +674,12 @@ msgstr ""
 "Redigerare för tonskalemask. Klicka i mitten för att skapa eller ändra "
 "former, eller rotera masken från utkanten av hjulet."
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr "Atmosfärisk triad"
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
@@ -632,34 +688,34 @@ msgstr ""
 "Emotionell och subjektiv, definierad av en dominant primär och två mindre "
 "intensiva primärer."
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr "Förskjuten triad"
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr "Mer viktad mot den dominanta färgen."
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr "Komplementfärger"
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr "Motsatskontraster, balanserade med neutrala färger mellan sig."
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr "Humör och accent"
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
@@ -668,12 +724,12 @@ msgstr ""
 "En huvudsaklig färgskala med komplementerande accenter för variationer och "
 "högdagrar."
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr "Delad komplementfärg"
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
@@ -681,72 +737,72 @@ msgid ""
 msgstr ""
 "Två likartade färger och ett komplement, utan sekundärfärger mellan sig."
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr "Ny tonskalemask från mall"
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr "Redigerare för tonskalemask"
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr "Aktiv"
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr "Hjälp…"
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr "Skapa mask från mall."
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr "Ladda mask från palettfil (GIMP)."
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr "Spara mask till palettfil (GIMP)."
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr "Radera masken."
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr "Öppna online-hjälpen för den här dialogrutan i en webbläsare."
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr "Spara mask som palett (GIMP)"
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr "Ladda mask från palettfil (GIMP)"
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr "Definiera tonskalemask."
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr "HCY-hjul"
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -756,162 +812,154 @@ msgstr ""
 "cirkulärt snitt har likvärdig ljusstyrka."
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr "HSV-nyans"
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr "HSV Mättnadsgrad"
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr "HSV Värde"
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr "HSV Mättnad och Värde"
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr "HSV nyans och valör"
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr "HSV nyans och mättnad"
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr "Rotera kub (visa olika axlar)"
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr "HSV kub"
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr "EN HSV-kub som kan roteras för att visa olika plana snitt."
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr "HSV-kvadrat"
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr "En HSV-kub som kan roteras för att visa olika nyanser."
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr "HSV-triangel"
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr "Standard GTK-färgväljare"
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr "HSV-hjul"
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr "Ändra mättnad/värde."
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr "Palettegenskaper"
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr "Palett"
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr "Välj färg från en palett du kan ladda och ändra."
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr "Namnlös palett"
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr "Palettredigerare"
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr "Ladda en palettfil (GIMP)"
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr "Spara till palettfil (GIMP)"
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr "Lägg till ny tom färgruta"
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr "Ta bort aktuell färgruta"
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr "Ta bort alla färgrutor"
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr "Titel:"
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr "Namn eller beskrivning av denna palett"
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr "Kolumner:"
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr "Antal kolumner"
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr "Färgnamn:"
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr "Namn på aktuell färg"
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr "Tom palettlucka"
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr "Ladda palett"
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr "Spara palett"
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -922,379 +970,377 @@ msgstr ""
 "Släpp färger här och \n"
 "dra runt för att arrangera dem."
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr "Tom palettlucka (dra och släpp en färg här)"
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr "Lägg till tom lucka"
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr "Infoga rad"
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr "Infoga spalt"
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr "Fyll mellanrum (RGB)"
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr "Fyll mellanrum (HCY)"
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr "Fyll mellanrum (HSV)"
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "GIMP-palettfil (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr "Alla filer (*)"
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "GIMP-palettfil (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr "Alla filer (*)"
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr "Hämta en färg från skärmen"
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr "R"
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr "G"
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr "B"
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr "H"
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr "C"
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr "Y"
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr "Komponentreglage"
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr "Justera färgens individuella komponenter."
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr "RGB-röd"
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr "RGB-grön"
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr "RGB-blå"
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr "HSV-nyans"
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr "HSV-mättnad"
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr "HSV-valör"
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr "HCY-nyans"
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr "HCY kulörthet"
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr "HCY-ljusstyrka (Y')"
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr "Lavering"
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr "Ändra färg med en vätskeliknande bestrykning av närliggande färger."
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr "Koncentriska ringar"
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr "Byt färg med de koncentriska HSV-ringarna."
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr "Korsad skål"
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
-msgstr "Ändra färg med övergångar i HSV som korsar en radiell \"skål\" av färg."
+msgstr ""
+"Ändra färg med övergångar i HSV som korsar en radiell \"skål\" av färg."
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr "Pekare/puck"
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr "Sudd"
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr "Tangentbord"
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr "Mus"
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr "Penna"
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr "Pekplatta"
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr "Pekskärm"
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr "Ignorera"
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr "Vilken uppgift som helst"
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr "Uppgifter vid Icke-målning"
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr "Endast navigation"
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr "Zoom"
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr "Panorera"
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr "Enhet"
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr "Axlar"
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr "Typ"
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr "Använd för..."
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr "Bläddra…"
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Namn"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr "Skriv över pensel?"
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr "Ersätt"
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr "Döp om"
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr "Ersätt alla"
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr "Byt namn på alla"
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr "Importerad pensel"
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr "Existerande pensel"
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 "<b>En pensel vid namn '%s' existerar redan.</b>\n"
 "Vill du ersätta den gamla, eller ska den nya penseln döpas om?"
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr "Skriva över penselgrupp?"
 
-#: ../gui/dialogs.py:190
-#, python-brace-format
+#: ../gui/dialogs.py:220
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 "<b>En grupp vid namn `{groupname}' existerar redan.</b>\n"
 "Vill du ersätta den, eller ska namnet på den nya gruppen bytas?\n"
 "Om du ersätter den gamla så kommer dess penslar att flyttas till en grupp "
 "kallad `{deleted_groupname}'."
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr "Importera penselpaket?"
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, fuzzy, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr "<b>Vill du verkligen importera paketet '%s'?</b>"
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr "Ladda penselinställningar från genvägen plats %d"
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr "Spara penselinställningarna i genvägen plats %d"
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr "Återställ pensel %d"
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr "Spara till pensel %d"
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr "Ångra %s"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Ångra"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr "Gör om %s"
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Gör om"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr "{button_combination} = {resultant_action}"
@@ -1304,92 +1350,129 @@ msgstr "{button_combination} = {resultant_action}"
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ",  "
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr "Knappkombinationer med {modifiers}:  {button_actions}."
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
-msgstr "Lager Namn"
-
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
-#, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
-"<b>{name}</b>\n"
-"{description}"
+
+#: ../gui/document.py:909
+#, python-brace-format
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
+msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr "%s - MyPaint"
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr "Om MyPaint"
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Öppna"
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr "Ange aktuell färg"
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr "Lämna helskärmsläge"
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr "Lämna helskärmsläge"
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr "Starta helskärmsläge"
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Helskärm"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Avsluta"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+#, fuzzy
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr "Är du säker på att du vill avsluta?"
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Avsluta"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr "Importera penselpaket..."
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr "MyPaint penselpaket (*.zip)"
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr "Startade {app_name} för att redigera lager “{layer_name}”"
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 "Fel: det gick inte att starta {app_name} för att redigera lager "
 "“{layer_name}”"
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
@@ -1397,12 +1480,18 @@ msgstr ""
 "Redigering avbruten. Du kan fortfarande redigera “{layer_name}” via "
 "lagermenyn."
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr "Uppdaterade lager “{layer_name}” med extern redigering"
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr "Det gick inte att läsa in \"{file_basename}\"."
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
@@ -1411,7 +1500,7 @@ msgstr ""
 "MyPaint behöver redigera en fil av typen “{type_name}” ({content_type}). "
 "Vilket program ska det använda?"
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
@@ -1420,164 +1509,380 @@ msgstr ""
 "Vilket program ska MyPaint använda för att redigera filer av typen "
 "“{type_name}” ({content_type})?"
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr "Öppna med…"
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr "Ikon"
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr "ingen beskrivning"
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
+#: ../gui/filehandling.py:126
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
+msgstr "Laddar \"{file_basename}\"…"
+
+#: ../gui/filehandling.py:130
+#, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:134
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
+msgstr "Sparar \"{file_basename}\"…"
+
+#: ../gui/filehandling.py:138
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
+msgstr "Exporterar till \"{file_basename}\"…"
+
+#: ../gui/filehandling.py:145
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr "Det gick inte att exportera till \"{file_basename}\"."
+
+#: ../gui/filehandling.py:149
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr "Det gick inte att spara \"{file_basename}\"."
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr "Det gick inte att läsa in \"{file_basename}\"."
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "Spara palett"
+
+#: ../gui/filehandling.py:168
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr "Exportera till fil"
+
+#: ../gui/filehandling.py:172
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr "Exportera till fil"
+
+#: ../gui/filehandling.py:176
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr "Öppna senaste filer"
+
+#: ../gui/filehandling.py:183
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr "Export till “{file_basename}” lyckades."
+
+#: ../gui/filehandling.py:187
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr "Lyckades spara “{file_basename}”."
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr "Laddade \"{file_basename}\"."
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
+msgstr "Laddade \"{file_basename}\"."
+
+#: ../gui/filehandling.py:427
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "All Recognized Formats"
 msgstr "Alla kända format"
 
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
+#: ../gui/filehandling.py:432
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "OpenRaster (*.ora)"
 msgstr "OpenRaster (*.ora)"
 
-#: ../gui/filehandling.py:95
+#: ../gui/filehandling.py:437
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "PNG (*.png)"
 msgstr "PNG (*.png)"
 
-#: ../gui/filehandling.py:96
+#: ../gui/filehandling.py:442
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "JPEG (*.jpg; *.jpeg)"
 msgstr "JPEG (*.jpg; *.jpeg)"
 
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
+#: ../gui/filehandling.py:490
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "By extension (prefer default format)"
 msgstr "Efter filändelse (föredra standardformat)"
 
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
+#: ../gui/filehandling.py:494
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:498
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
 msgstr "PNG med solid bakground (*.png)"
 
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
+#: ../gui/filehandling.py:502
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:506
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
 msgstr "PNG med genomskinlighet (*.png)"
 
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
+#: ../gui/filehandling.py:510
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
 msgstr "Flerfils-transparent PNG (*.XXX.png)"
 
-#: ../gui/filehandling.py:113
+#: ../gui/filehandling.py:514
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr "Flerfils-transparent PNG (*.XXX.png)"
+
+#: ../gui/filehandling.py:518
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr "JPEG 90% kvalitet (*.jpg; *.jpeg)"
 
-# duplication?
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr "Spara..."
+#: ../gui/filehandling.py:576
+#, fuzzy
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr "Exportera…"
 
-#: ../gui/filehandling.py:177
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Spara som…"
+
+#: ../gui/filehandling.py:601
+#, fuzzy
+msgctxt "save dialogs: formats and options: (label)"
 msgid "Format to save as:"
 msgstr "Filformat:"
 
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr "Bekräfta"
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
+#: ../gui/filehandling.py:668
+#, fuzzy
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
 msgstr "Är du säker på att du vill fortsätta?"
 
-#: ../gui/filehandling.py:234
-#, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
-msgstr "Detta kommer att ta bort {abbreviated_time} av osparat målande"
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
 
 # "Scrap" -> "kladd"
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
+#: ../gui/filehandling.py:705
+#, fuzzy
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
 msgstr "_Spara som skiss"
 
-#: ../gui/filehandling.py:282
-#, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
-msgstr "Laddar \"{file_basename}\"…"
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
 
-#: ../gui/filehandling.py:296
-#, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
-msgstr "Det gick inte att läsa in \"{file_basename}\"."
+#: ../gui/filehandling.py:734
+#, fuzzy, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr "Detta kommer att ta bort {abbreviated_time} av osparat målande"
 
-#: ../gui/filehandling.py:321
-#, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
-msgstr "Laddade \"{file_basename}\"."
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
 
-#: ../gui/filehandling.py:422
-#, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
-msgstr "Exporterar till \"{file_basename}\"…"
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
 
-#: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
-msgstr "Sparar \"{file_basename}\"…"
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
-msgstr "Det gick inte att exportera till \"{file_basename}\"."
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr "Öppna…"
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
-msgstr "Det gick inte att spara \"{file_basename}\"."
-
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
-msgstr "Export till “{file_basename}” lyckades."
-
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
-msgstr "Lyckades spara “{file_basename}”."
-
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Öppna..."
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Öppna senaste filer"
 
 # "Scrap" -> "kladd"
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr "Öppna kladdblock..."
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Importerad pensel"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Öppna"
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Öppna den senaste"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Öppna"
+
+#: ../gui/filehandling.py:1446
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
 msgstr "Det finns inga skissfiler med namnet \"%s\" än."
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+# "Scrap" -> "kladd"
+#: ../gui/filehandling.py:1455
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr "Öppna nästa skiss"
+
+#: ../gui/filehandling.py:1463
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr "Öppna föregående skiss"
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Öppna"
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+#, fuzzy
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr "Återställ"
+
+#: ../gui/fill.py:121
+#, fuzzy
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr "Flödningsfyllning"
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+#, fuzzy
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr "Fylla områden med färg"
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+#, fuzzy
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr "Tolerans:"
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+#, fuzzy
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
@@ -1585,19 +1890,36 @@ msgstr ""
 "Hur mycket pixelfärger tillåts variera i början\n"
 "innan flödningsfyllningen vägrar fylla dem"
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+#, fuzzy
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr "Källa:"
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
-msgstr "Vilka synliga lager ska fyllas"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
+msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+#, fuzzy
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr "Prov på sammanslagning"
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+#, fuzzy
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
@@ -1607,19 +1929,50 @@ msgstr ""
 "använd en tillfällig sammanslagning av alla synliga lager\n"
 "under det aktuella lagret"
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+#, fuzzy
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr "Anpassa till visning"
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+#, fuzzy
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr "Mål:"
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+#, fuzzy
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr "Dit utdatan ska"
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr "Nytt lager (en gång)"
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+#, fuzzy
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
@@ -1627,21 +1980,108 @@ msgstr ""
 "Skapa ett nytt lager med resultaten av fyllningen.\n"
 "Detta stängs av automatiskt efter användning."
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Opacitet:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr "Återställ"
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+#, fuzzy
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr "Återställ alternativen till standardinställningarna"
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "Välj Lager"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr "<b>{brush_name}</b>"
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1651,130 +2091,142 @@ msgstr ""
 "<b>{brush_name}</b>\n"
 "{brush_desc}"
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr "Redigera ram"
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr "Justera dokumentets ram"
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr "Ramstorlek"
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr "px"
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr "Höjd:"
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr "Bredd:"
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr "Upplösning:"
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr "DPI"
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr "Punkter per tum (egentligen pixlar per tum)"
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr "Färg:"
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr "Ramens färg"
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr "<b>Ramens mått</b>"
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr "<b>Pixeltäthet</b>"
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr "Ställ in ramen utifrån lager"
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr "Ställ in ramen till det aktuella lagrets omfång"
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr "Ställ in ram utifrån dokument"
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr "Ställ in ramen på kombinationen av alla lager"
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr "Beskär lagret utifrån ramen"
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr "Beskär de delar av det aktuella lagret som ligger utanför ramen"
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr "Aktiverad"
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr "{width:g}×{height:g} {units}"
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr "tum"
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr "cm"
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr "mm"
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr "Frihandsteckning"
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr "Måla på fri hand"
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr "Jämnhet:"
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr "Tryck:"
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr "Bugg upptäckt"
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr "<big><b>Ett programmeringsfel har upptäckts i programmet.</b></big>"
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1788,35 +2240,35 @@ msgstr ""
 "Vänligen underrätta utvecklarna om detta, genom att använda problemspårning "
 "om ingen annan har rapporterat det än."
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr "Spårningssökare…"
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr "Rapport..."
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr "Ignorera fel"
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr "Avsluta MyPaint"
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr "Detaljer..."
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr "Undantag inträffade medan undantaget analyserades."
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1861,45 +2313,50 @@ msgstr ""
 "            #### Stackspår\n"
 "        "
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr "Bläckteckning"
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr "Rita, och justera sedan jämna linjer"
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr "Test av inmatningsenhet"
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr "(inget tryck)"
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr "Tryck:"
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr "(ingen lutning)"
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr "Lutning:"
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr "(ingen enhet)"
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
 msgstr "Enhet:"
 
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+#, fuzzy
+msgid "Barrel Rotation:"
+msgstr "Återställ rotation"
+
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr "Flytta lager"
 
@@ -1907,161 +2364,228 @@ msgstr "Flytta lager"
 msgid "Move the current layer"
 msgstr "Flytta det aktuella lagret"
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
-msgstr "{default_name} vid {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
+msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
-msgstr "Typ"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
+msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+#, fuzzy
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr "Egenskaper"
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr "Synlig"
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Lager"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+#, fuzzy
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr "Låst"
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+#, fuzzy
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ", "
+
+#: ../gui/layers.py:990
+#, fuzzy, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr "Lägg till {layer_default_name}"
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Lager"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr "Ordna lager och tilldela effekter"
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr "Lagrets opacitet: %d%%"
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr "Flytta på lager i grupp…"
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 "Flytta på lager i grupp (att släppa på ett vanligt lager kommer att skapa en "
 "ny grupp)"
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr "Lager"
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
-msgstr "Läge:"
+#: ../gui/layervis.py:53
+#, fuzzy, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
+msgstr "<b>{brush_name}</b>"
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
-"Mixningsläge: hur det nuvarande lagret blandas med underliggande lager."
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Opacitet:"
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "Roteravy"
 
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-"Lagrets opacitet: Hur mycket av lagret som ska synas. Lägre värde gör det "
-"mer genomskinligt."
-
-#: ../gui/linemode.py:37
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr "Ursprungligt inmatningstryck"
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr "Inmatningstryck för linjeverktyg"
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr "Inmatningstryck (mittpunkt)"
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr "Inmatningstryck för linjeverktyg (mittpunkt)"
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr "Utgångstryck"
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr "Utgångstryck för linjeverktyg"
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr "Huvud"
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 msgid "Stroke lead-in end"
 msgstr "Penseldrag, slut av inledning"
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr "Ände"
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr "Penseldrag, början av uttunning"
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr "Tryckvariation…"
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr "Linjer och kurvor"
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr "Allmänt läge för linje/kurva"
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr "Rita raka linjer; Shift lägger till kurvor, Ctrl begränsar vinkeln"
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr "Sammanbundna linjer"
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 "Rita en sekvens av linjer; Shift lägger till kurvor, Ctrl begränsar vinkeln"
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr "Ellipser och cirklar"
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr "Rita ellipser; Shift roterar, Ctrl begränsar förhållandet/vinkeln"
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
+#, fuzzy
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 "Copyright (C) 2005-2015\n"
 "Martin Renold och MyPaints utvecklingsteam"
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -2080,258 +2604,288 @@ msgstr ""
 "Detta program distribueras med förhoppningen att det kan komma till nytta, "
 "men UTAN NÅGRA GARANTIER. Läs mer i filen COPYING."
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr "programmering"
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr "flyttbarhet"
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr "Projekthantering"
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr "penslar"
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr "mönster"
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr "verktygsikoner"
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr "skrivbordsikon"
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr "paletter"
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr "dokumentation"
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr "support"
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr "uppsökande"
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr "mötesplats"
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ", "
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr "översättare"
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr "Storlek:"
 
 # "opaque" -> ikke gjennomsiktig
 # er dette den beste oversettelsen?
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr "Opacitet:"
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr "Skärpa:"
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr "Förstärkning:"
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr "Verktygsalternativ"
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr "Speciella inställningar för det aktuella redigeringsverktyget"
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr "<b>{mode_name}</b>"
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr "<i>Inga tillgängliga alternativ</i>"
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr "Zoom: %.01f%%"
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr "Välj inställningar för penseldrag, penselfärg och lager…"
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr "Välj färg…"
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr "Inställningar"
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr "Förhandsvisning"
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr "Visa förhandsvisning av hela teckningsytan"
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr "Visa sökarfönster"
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr "Kladdblock"
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr "Blanda färger och skissa på separata skissidor"
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr "Föregående objekt"
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr "Nästa objekt"
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
 msgstr "(Inget att visa)"
 
-#: ../gui/symmetry.py:76
+#: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Place axis"
 msgstr "Placera axel"
 
-#: ../gui/symmetry.py:80
+#: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Move axis"
 msgstr "Flytta axel"
 
-#: ../gui/symmetry.py:84
+#: ../gui/symmetry.py:88
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr "Ta bort axel"
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr "Visa symmetriaxel"
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr "Justera målningens symmetriaxel."
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
+#, fuzzy
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr "Position:"
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr "Position:"
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr "Ingen"
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr "%d px"
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr "Alfa:"
 
-#: ../gui/symmetry.py:352
+#: ../gui/symmetry.py:376
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
+msgstr "Symmetri"
+
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+#, fuzzy
 msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+msgid "X axis Position"
 msgstr "Axelposition"
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:477
+#, fuzzy
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr "Axelposition"
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr "Aktiverad"
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr "Filhantering"
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr "Skissväxlare"
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr "Ångra och Gör om"
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr "Blandlägen"
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr "Linjelägen"
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr "Se (Huvudsaklig)"
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr "Se (Alternativ/Sekundär)"
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr "Se (Nollställning)"
 
@@ -2339,188 +2893,214 @@ msgstr "Se (Nollställning)"
 msgid "<b>MyPaint</b>"
 msgstr "<b>MyPaint</b>"
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr "Bläddringsvy"
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr "Dra arbetsytans vy"
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr "Zoomvy"
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr "Zooma arbetsytans vy"
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr "Roteravy"
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr "Rotera arbetsytans vy"
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, fuzzy, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr "%s: stäng flik"
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
-msgstr "%s: redigera egenskaper"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
+msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr "Okänt kommando"
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr "Odefinierat (kommandot har inte börjat än)"
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr "{seconds:.01f}s av målande med {brush_name}"
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr "Flödningsfyllning"
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr "Beskär lager"
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "Döp om uppsättning"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr "Radera Lager"
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr "Klistra in lager"
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr "Nytt lager utifrån allt synligt"
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr "Lägg samman synliga lager"
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr "Lägg samman nedåt"
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr "Normalisera lagerläge"
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Importerad pensel"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr "Lägg till {layer_default_name}"
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr "Ta bort Lager"
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr "Välj Lager"
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr "Kopiera Lager"
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr "Flytta lager upp"
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr "Flytta lager ner"
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr "Flytta lager i grupp"
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr "Byt namn på lager"
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr "Gör lager synligt"
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr "Gör lager osynligt"
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr "Lås lager"
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr "Lås upp lager"
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr "Ange opacitet: %0.1f%%"
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr "Okänt läge"
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr "Ange lagerläge: %s"
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr "Aktivera ram"
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr "Avaktivera ram"
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr "Uppdatera ram"
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr "Redigera lager externt"
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr "Fel vid inläsning av “{basename}”."
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr "Loggarna kan innehålla mer om det här felet."
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr "från och med nu"
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr "sedan"
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2532,13 +3112,13 @@ msgstr ""
 "Kör du mer än en instans av MyPaint?\n"
 "Stäng programmet och vänta {cache_update_interval}s innan du försöker igen."
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr "Ofullständig backup uppdaterad {last_modified_time} {ago}"
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2548,11 +3128,11 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 "Backupp uppdaterad {last_modified_time} {ago}\n"
-"Storlek: {autosave.width}×{autosave.height} pixlar, lager: "
-"{autosave.num_layers}\n"
+"Storlek: {autosave.width}×{autosave.height} pixlar, lager: {autosave."
+"num_layers}\n"
 "Innehåller {unsaved_time} av osparad målning."
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2562,13 +3142,13 @@ msgstr ""
 "Kunde inte spara “{filename}”: {err}\n"
 "Finns det ledigt utrymme kvar på enheten?"
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr "Kunde inte spara “{filename}”: {err}"
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2578,7 +3158,7 @@ msgstr ""
 "{error_loading_common}\n"
 "Filen finns inte."
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2588,7 +3168,7 @@ msgstr ""
 "{error_loading_common}\n"
 "Du har inte rättigheter att öppna filen."
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2604,7 +3184,7 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2614,7 +3194,13 @@ msgstr ""
 "{error_loading_common}\n"
 "Okänt filnamnstillägg: “{ext}”"
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+#, fuzzy
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr "Importerad pensel"
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2628,7 +3214,7 @@ msgstr ""
 "Försök spara som PNG istället, om din maskin inte har mycket minne. MyPaint "
 "kan effektivare spara som PNG."
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2644,98 +3230,207 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/helpers.py:402
-#, python-brace-format
+#: ../lib/floodfill.py:131
+#, fuzzy
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr "Fyll"
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr "{days}d{hours}t"
 
-#: ../lib/helpers.py:404
-#, python-brace-format
+#: ../lib/helpers.py:537
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr "{hours}t{minutes}m"
 
-#: ../lib/helpers.py:406
-#, python-brace-format
+#: ../lib/helpers.py:539
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr "{minutes}m{seconds}s"
 
-#: ../lib/helpers.py:408
-#, python-brace-format
+#: ../lib/helpers.py:541
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr "{seconds}s"
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr "Lager"
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr "%(name)s %(number)d"
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr "^(.*?)\\s*(\\d+)$"
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
+#, fuzzy
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr "Vektorlager"
+
+#: ../lib/layer/data.py:1158
+#, fuzzy
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr "Vektorlager"
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
-msgstr "Okänt bitmaplager"
+msgid "Bitmap"
+msgstr ""
 
-#: ../lib/layer/data.py:1169
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1244
 msgctxt "layer default names"
-msgid "Unknown Data Layer"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
 msgstr "Okänt datalager"
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "Nytt målningslager"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr "Grupp"
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "Ny lagergrupp"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr "Platshållare"
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr "Rot"
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ", "
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+#, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "Visa"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+#, fuzzy
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr "Lägg till Lager"
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+#, fuzzy
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr "Ta bort Lager"
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr "Lås lager"
+
+#: ../lib/layervis.py:697
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr "Lås upp lager"
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr "Gå igenom"
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr "Gruppens innehåll läggs till direkt mot gruppens bakgrund"
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr "Normalt"
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr "Bara det översta lagret, utan färgblandning."
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr "Multiplicera"
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
@@ -2743,11 +3438,11 @@ msgstr ""
 "Kan liknas vid att montera två diabilder i en projektor och visa det "
 "sammanslagna resultatet."
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr "Raster"
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
@@ -2755,11 +3450,11 @@ msgstr ""
 "Kan liknas vid att rikta två projektorers bilder mot samma skärm. Motsatsen "
 "till Multiplicera."
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr "Täcka över"
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
@@ -2767,27 +3462,27 @@ msgstr ""
 "Täcker över bakgrunden med översta lagret, bevarar bakgrundens högdagrar och "
 "skuggor. Motsatsen till Skarpt ljus."
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr "Mörkare"
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr "Lagrets innehåll används bara där det är mörkare än bakgrunden."
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr "Ljusare"
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr "Lagret används bara där det är ljusare än bakgrunden."
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr "Skugga"
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
@@ -2796,11 +3491,11 @@ msgstr ""
 "Lagret används för att göra bakgrunden ljusare. Effekten liknar mörkrums-"
 "tekniken med samma namn, för att förbättra kontrasten i skuggor."
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr "Efterbelys"
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
@@ -2809,126 +3504,140 @@ msgstr ""
 "Lagret används för att göra bakgrunden mörkare. Effekten liknar mörkrums-"
 "tekniken med samma namn, för att minska överdrivet ljusa högdagrar."
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr "Skarpt ljus"
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr "Kan liknas vid att belysa bakgrunden med en skarp strålkastare."
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr "Mjukt ljus"
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr "Kan liknas vid att belysa bakgrunden med en diffus strålkastare."
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr "Differens"
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr "Subtraherar mörkare färg från ljusare färg i lagren."
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr "Uteslutning"
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr "Liknar Differens, men med lägre kontrast."
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr "Nyans"
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
-msgstr "Kombinerar lagrets nyans med mättnaden och ljusstyrkan från bakgrunden."
+msgstr ""
+"Kombinerar lagrets nyans med mättnaden och ljusstyrkan från bakgrunden."
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr "Mättnad"
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
-msgstr "Kombinerar lagrets mättnad med nyansen och ljusstyrkan från bakgrunden."
+msgstr ""
+"Kombinerar lagrets mättnad med nyansen och ljusstyrkan från bakgrunden."
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr "Använder lagrets nyans och mättnad på bakgrundens ljusstyrka."
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr "Luminiscens"
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr "Använder lagrets ljusstyrka på bakgrundens nyans och mättnad."
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr "Plus"
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr "Lagret och bakgrunden läggs helt enkelt ihop."
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr "Mål in"
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
-msgstr "Använder bakgrunden endast där lagret täcker den. Allt annan ignoreras."
+msgstr ""
+"Använder bakgrunden endast där lagret täcker den. Allt annan ignoreras."
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr "Mål ut"
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 "Använder bakgrunden endast där lagret inte täcker den. Allt annat ignoreras."
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr "Källa överst"
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 "Källa som överlappar målet ersätter målet. Målet placeras någon annanstans."
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr "Mål överst"
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 "Mål som överlappar källan ersätter källan. Källan placeras någon annanstans."
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, fuzzy, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr "%(name)s %(number)d"
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
@@ -2937,7 +3646,7 @@ msgstr ""
 "Det går inte att konstruera ett viktigt inre objekt. Ditt system kanske inte "
 "har tillräckligt med minne för att utföra åtgärden."
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2951,7 +3660,30 @@ msgstr ""
 "Orsak: {err}\n"
 "Målmapp: ”{dirname}”."
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+#, fuzzy
+msgid "Vertical"
+msgstr "Spegla vertikalt"
+
+#: ../lib/tiledsurface.py:49
+#, fuzzy
+msgid "Horizontal"
+msgstr "Spegla horisontellt"
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+#, fuzzy
+msgid "Rotational"
+msgstr "Återställ rotation"
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr "PNG-läsaren misslyckades: %s"
@@ -2960,56 +3692,93 @@ msgstr "PNG-läsaren misslyckades: %s"
 msgid "Recover interrupted work?"
 msgstr "Återställ avbrutet arbete?"
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
-msgstr "_Återställ och spara..."
+msgid "_Look for backups at startup"
+msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr "Ta bort"
+
+#: ../po/tmp/autorecover.glade.h:9
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr "Ta bort penseln från hårddisken"
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr "_Återställ och spara..."
+
+#: ../po/tmp/autorecover.glade.h:12
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr "Spara denna backup på disken, fortsätt sedan att arbeta med den."
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
-msgstr "_Ignorera tills vidare"
+msgid "Decide _Later"
+msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr "Börja arbete på en ny arbetsyta. Backuperna behålls."
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
+#, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 "MyPaint kraschade med osparat arbete, men gjorde backuper. Du kan återställa "
 "en fil nu, eller lämna den tills du startar MyPaint igen."
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr "Miniatyr"
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr "Beskrivning"
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
-msgstr "Kopiera till ny"
+msgid "Live update"
+msgstr "Direkt uppdatering"
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
-"Kopiera inställningarna och den aktuella penselns ikon till en ny pensel"
+"Uppdatera arbetsytans senaste penseldrag i realtid, med fönstrets "
+"inställningar"
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
-msgstr "Byt namn på penseln"
+msgid "Save these settings to the brush"
+msgstr "Spara inställningarna till penseln"
 
 #: ../po/tmp/brusheditor.glade.h:5
 msgid "Edit Icon"
@@ -3032,20 +3801,17 @@ msgid "Delete this brush from the disk"
 msgstr "Ta bort penseln från hårddisken"
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
-msgstr "Direkt uppdatering"
+msgid "Copy to New"
+msgstr "Kopiera till ny"
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
-"Uppdatera arbetsytans senaste penseldrag i realtid, med fönstrets "
-"inställningar"
+"Kopiera inställningarna och den aktuella penselns ikon till en ny pensel"
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
-msgstr "Spara inställningarna till penseln"
+msgid "Rename this brush"
+msgstr "Byt namn på penseln"
 
 #: ../po/tmp/brusheditor.glade.h:13
 msgid "Brush Setting"
@@ -3073,12 +3839,7 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr "Anteckningar:"
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr "Inställningens namn:"
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
@@ -3086,19 +3847,16 @@ msgstr ""
 "detta."
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
-msgstr "Basvärde:"
+#: ../po/tmp/brusheditor.glade.h:22
+#, fuzzy
+msgid "Value:"
+msgstr "HSV Värde"
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr "Återställ basvärdet till standard"
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr "Återställ detta invärde för att inte ha någon effekt på inställningen"
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
@@ -3106,11 +3864,7 @@ msgstr ""
 "Minivärdet för axelns utdata.\n"
 "Detta kan ändras med huvudreglaget för {dname}."
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr "<ymin>"
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
@@ -3118,27 +3872,23 @@ msgstr ""
 "Maxvärdet för axelns utdata.\n"
 "Detta kan ändras med huvudreglaget för {dname}."
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr "<ymax>"
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr "Utdata"
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr "Indata"
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr "Justerar maxvärdet"
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr "Justerar minimumvärdet"
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
@@ -3146,11 +3896,7 @@ msgstr ""
 "Minsta värdet för in-axeln.\n"
 "Justera det med skalan i pop-upen."
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr "<xmin>"
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
@@ -3158,38 +3904,36 @@ msgstr ""
 "Högsta värdet för in-axeln.\n"
 "Justera det med skalan i pop-upen."
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr "<xmax>"
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr "Variation av basvärdet via pennans indata och andra kriterier"
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr "Penseldynamik"
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr "Grundläggande detaljer för den här inställningen"
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr "Redigera inställningen"
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr "Justera indata-mappningen i detalj"
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr "{tooltip}"
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
 msgstr "{dname}:"
+
+#: ../po/tmp/brusheditor.glade.h:42
+#, fuzzy
+msgid "Brush dynamics are not available for this setting."
+msgstr "Grundläggande detaljer för den här inställningen"
+
+#: ../po/tmp/brusheditor.glade.h:43
+#, fuzzy
+msgid "<big><b>No Brush Dynamics</b></big>"
+msgstr "<big><b>{accel_label}</b></big>"
 
 #: ../po/tmp/inktool.glade.h:1
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
@@ -3201,7 +3945,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr "Tryck:"
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3246,6 +3990,141 @@ msgstr "Ta bort punkt"
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
 msgstr "Ta bort den markerade punkten"
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+#, fuzzy
+msgid "Insert Point"
+msgstr "Infoga rad"
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+#, fuzzy
+msgid "Cull Points"
+msgstr "Ta bort punkt"
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Namn"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr "Läge"
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Opacitet"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr "Begränsa till nuvarande aktivt lager"
+
+#: ../po/tmp/layervis.glade.h:2
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr "Rotera arbetsytans vy"
+
+#: ../po/tmp/layervis.glade.h:3
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr "Rotera arbetsytans vy"
+
+#: ../po/tmp/layervis.glade.h:4
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr "Vilka synliga lager ska fyllas"
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
+msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
 msgctxt "footer: color picker button: tooltip"
@@ -3652,13 +4531,34 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr "Göm pekaren när du målar"
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+#, fuzzy
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr "Aktiverad"
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr "Visa"
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
@@ -3667,18 +4567,18 @@ msgstr ""
 "Färguppsättningen visar primärer i ett färghjul.\n"
 "Olika traditioner har olika färgharmonier."
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr "Primärerna är:"
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr "Standard digital röd/grön/blå"
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
@@ -3686,7 +4586,7 @@ msgstr ""
 "De röda, gröna och blå &apos;bildskärms&apos;primärerna, jämnt fördelade "
 "runt cirkeln. Grönt är mitt emot magenta."
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
@@ -3695,12 +4595,12 @@ msgstr ""
 "De röda, gröna och blå 'bildskärms'primärerna, jämnt fördelade runt cirkeln. "
 "Grönt är mitt emot magenta."
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr "Konstnärers traditionella röd/gul/blå"
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
@@ -3710,7 +4610,7 @@ msgstr ""
 "konstnärer sedan 1700-talet, återgivna med rena bildskärmsfärger jämnt "
 "fördelade runt cirkeln. Grönt är mitt emot rött."
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3721,12 +4621,12 @@ msgstr ""
 "konstnärer sedan 1700-talet, återgiva med rena bildskärmsfärger jämnt "
 "fördelade runt cirkeln. Grönt är mitt emot rött."
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr "Röd-grön och blå-gul motsatspar"
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3740,7 +4640,7 @@ msgstr ""
 "CIECAM02 och NCS använder en liknande modell. Här använder vi skärmens rena "
 "röda, gula och så vidare som de fyra primärerna."
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3756,28 +4656,28 @@ msgstr ""
 "och så vidare som de fyra primärerna."
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr "<b>Färghjul</b>"
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr "Färg"
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr "Skärm (standard)"
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr "Inaktiverad (ingen tryckkänslighet)"
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr "Fönster (rekommenderas inte)"
@@ -3838,250 +4738,307 @@ msgid "Reload the file your current work was loaded from."
 msgstr "Öppna filen igen, som ditt nuvarande arbete laddades från."
 
 #: ../po/tmp/resources.xml.h:12
+#, fuzzy
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Import Layers…"
+msgstr "Importera penselpaket…"
+
+#: ../po/tmp/resources.xml.h:13
+msgctxt "Accel Editor (descriptions)"
+msgid "Import layers from one or more files."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save"
 msgstr "Spara"
 
-#: ../po/tmp/resources.xml.h:13
+#: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file."
 msgstr "Spara ditt arbete i en fil."
 
-#: ../po/tmp/resources.xml.h:14
+#: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As…"
 msgstr "Spara som…"
 
-#: ../po/tmp/resources.xml.h:15
+#: ../po/tmp/resources.xml.h:17
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file, assigning it a new name."
 msgstr "Spara ditt arbete till en fil, med ett nytt namn."
 
-#: ../po/tmp/resources.xml.h:16
+#: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Export…"
 msgstr "Exportera…"
 
-#: ../po/tmp/resources.xml.h:17
+#: ../po/tmp/resources.xml.h:19
 msgid "Export your work to a file, but keep working on the same file."
 msgstr "Exportera ditt arbete till en fil, men fortsätt arbeta med samma fil."
 
 # "Scrap" -> "kladd"
-#: ../po/tmp/resources.xml.h:18
+#: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As Scrap"
 msgstr "Spara som skiss"
 
-#: ../po/tmp/resources.xml.h:19
+#: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
 msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 "Spara till ny skissfil, eller spara en ny version om den redan är en skiss."
 
-#: ../po/tmp/resources.xml.h:20
+#: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Previous Scrap"
 msgstr "Öppna föregående skiss"
 
-#: ../po/tmp/resources.xml.h:21
+#: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file before the current one."
 msgstr "Öppna skissfilen innan den aktuella."
 
 # "Scrap" -> "kladd"
-#: ../po/tmp/resources.xml.h:22
+#: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Next Scrap"
 msgstr "Öppna nästa skiss"
 
-#: ../po/tmp/resources.xml.h:23
+#: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file after the current one."
 msgstr "Öppna skissfilen efter den aktuella."
 
-#: ../po/tmp/resources.xml.h:24
+#: ../po/tmp/resources.xml.h:26
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Recover File from an Automated Backup…"
 msgstr "Återställ fil från en automatisk backup…"
 
-#: ../po/tmp/resources.xml.h:25
+#: ../po/tmp/resources.xml.h:27
 msgctxt "Accel Editor (descriptions)"
 msgid "Try to save and resume interrupted unsaved work."
 msgstr "Försök att spara och återuppta osparat arbete."
 
-#: ../po/tmp/resources.xml.h:26
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr "Penseluppsättningar"
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr "Penslar"
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr "Lista över penseluppsättningar."
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr "Färgväljare"
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr "Färger"
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr "Tillgängliga färgjusterare."
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr "Läge"
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr "Läge"
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr "Det aktuella lagrets sammansättningsläge."
 
-#: ../po/tmp/resources.xml.h:35
+#: ../po/tmp/resources.xml.h:37
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Pressure"
+msgstr "Ursprungligt inmatningstryck"
+
+#: ../po/tmp/resources.xml.h:38
+msgctxt "Accel Editor (descriptions)"
+msgid "Send harder pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:39
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Pressure"
+msgstr "Ursprungligt inmatningstryck"
+
+#: ../po/tmp/resources.xml.h:40
+msgctxt "Accel Editor (descriptions)"
+msgid "Send softer pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:41
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Rotation"
+msgstr "Öka mättnad"
+
+#: ../po/tmp/resources.xml.h:42
+msgctxt "Accel Editor (descriptions)"
+msgid "Increase barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:43
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
+msgstr "Minska mättnad"
+
+#: ../po/tmp/resources.xml.h:44
+msgctxt "Accel Editor (descriptions)"
+msgid "Decrease barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:45
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Size"
 msgstr "Öka penselstorlek"
 
-#: ../po/tmp/resources.xml.h:36
+#: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush bigger."
 msgstr "Gör aktuell pensel större."
 
-#: ../po/tmp/resources.xml.h:37
+#: ../po/tmp/resources.xml.h:47
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Size"
 msgstr "Minska penselstorlek"
 
-#: ../po/tmp/resources.xml.h:38
+#: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush smaller."
 msgstr "Gör aktuell pensel mindre."
 
-#: ../po/tmp/resources.xml.h:39
+#: ../po/tmp/resources.xml.h:49
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Opacity"
 msgstr "Öka penselns opacitet"
 
-#: ../po/tmp/resources.xml.h:40
+#: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush more opaque."
 msgstr "Gör penseln mer täckande."
 
-#: ../po/tmp/resources.xml.h:41
+#: ../po/tmp/resources.xml.h:51
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Opacity"
 msgstr "Minska penselns opacitet"
 
-#: ../po/tmp/resources.xml.h:42
+#: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush less opaque."
 msgstr "Gör penseln mindre täckande."
 
-#: ../po/tmp/resources.xml.h:43
+#: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Lighten Painting Color"
 msgstr "Ljusare målarfärg"
 
-#: ../po/tmp/resources.xml.h:44
+#: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase the lightness of the current painting color."
 msgstr "Öka aktuell målarfärgs ljushet."
 
-#: ../po/tmp/resources.xml.h:45
+#: ../po/tmp/resources.xml.h:55
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Darken Painting Color"
 msgstr "Mörkare målarfärg"
 
-#: ../po/tmp/resources.xml.h:46
+#: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease the lightness of the current painting color."
 msgstr "Minska ljusheten på den aktuella målarfärgen."
 
-#: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
-msgstr "Ändra nyans motsols"
-
-#: ../po/tmp/resources.xml.h:48
-msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
-msgstr "Rotera målarfärgens nyans motsols på färghjulet."
-
-#: ../po/tmp/resources.xml.h:49
+#: ../po/tmp/resources.xml.h:57
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Change Hue Clockwise"
 msgstr "Ändra nyans medsols"
 
-#: ../po/tmp/resources.xml.h:50
+#: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
 msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr "Rotera målarfärgens nyans medsols på färghjulet."
 
-#: ../po/tmp/resources.xml.h:51
+#: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr "Ändra nyans motsols"
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr "Rotera målarfärgens nyans motsols på färghjulet."
+
+#: ../po/tmp/resources.xml.h:61
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Increase Saturation"
 msgstr "Öka mättnad"
 
-#: ../po/tmp/resources.xml.h:52
+#: ../po/tmp/resources.xml.h:62
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color more saturated (more colorful, purer)."
 msgstr "Gör målarfärgen mer mättad (mer färgdjup, renare)."
 
-#: ../po/tmp/resources.xml.h:53
+#: ../po/tmp/resources.xml.h:63
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Decrease Saturation"
 msgstr "Minska mättnad"
 
-#: ../po/tmp/resources.xml.h:54
+#: ../po/tmp/resources.xml.h:64
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color less saturated (grayer)."
 msgstr "Gör målarfärgen mindre mättad (gråare)."
 
-#: ../po/tmp/resources.xml.h:55
+#: ../po/tmp/resources.xml.h:65
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Reload Brush Settings"
 msgstr "Ladda penselinställningar igen"
 
-#: ../po/tmp/resources.xml.h:56
+#: ../po/tmp/resources.xml.h:66
 msgctxt "Accel Editor (descriptions)"
 msgid "Restore all brush settings to the current brush’s saved values."
 msgstr ""
 "Återställ alla penselinställningar till den aktuella penselns sparade värden."
 
-#: ../po/tmp/resources.xml.h:57
+#: ../po/tmp/resources.xml.h:67
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Pick Stroke and Layer"
 msgstr "Välj penseldrag och lager"
 
-#: ../po/tmp/resources.xml.h:58
+#: ../po/tmp/resources.xml.h:68
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
 msgstr ""
 "Välj ett penseldrag från arbetsytan: återställer pensel, färg och lager."
 
-#: ../po/tmp/resources.xml.h:59
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr "Penselns snabbkommand återställer färg"
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
@@ -4090,215 +5047,267 @@ msgstr ""
 "Växla mellan om återställning av penseln från snabbkommando även återställer "
 "sparad färg, eller inte."
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr "Spara pensel till senaste snabbkommando"
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr "Spara pensel till senaste snabbkommando."
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "Rensa lager"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr "Rensar det aktuella lagrets innehåll."
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Trim Layer to Frame"
-msgstr "Beskär lager utifrån ram"
+#: ../po/tmp/resources.xml.h:75
+#, fuzzy
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr "Verktygsalternativ"
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:76
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Trim Layer to Frame"
+msgstr "Beskär lagret utifrån ramen"
+
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr "Raderar delar av det aktuella lagret som ligger utanför ramen."
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr "Raderar delar av det aktuella lagret som ligger utanför ramen."
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "Ny lagergrupp under"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "Ny lagergrupp under"
+
+#: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr "Kopiera lager till klippbordet"
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr "Kopiera det aktuella lagrets innehåll till klippbordet."
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr "Klistra in lager från klippbordet"
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr "Ersätter det aktuella lagret med klippbordets innehåll."
 
-#: ../po/tmp/resources.xml.h:71
+#: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Edit Layer in External App…"
 msgstr "Redigera lager i externt program…"
 
-#: ../po/tmp/resources.xml.h:72
+#: ../po/tmp/resources.xml.h:90
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
+msgid "Edit the active layer in an external application."
 msgstr "Börja redigera det aktuella lagret i ett externt program."
 
-#: ../po/tmp/resources.xml.h:73
+#: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Update Layer with External Edits"
 msgstr "Uppdatera lager med extern redigering"
 
-#: ../po/tmp/resources.xml.h:74
+#: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
 msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 "Utför ändringar sparade i det externa programmet (vanligtvis automatiskt)."
 
-#: ../po/tmp/resources.xml.h:75
+#: ../po/tmp/resources.xml.h:93
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer at Cursor"
 msgstr "Välj lagret vid pekaren"
 
-#: ../po/tmp/resources.xml.h:76
+#: ../po/tmp/resources.xml.h:94
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr "Välj ett lager genom att välja ett objekt på det."
 
-#: ../po/tmp/resources.xml.h:77
+#: ../po/tmp/resources.xml.h:95
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Above"
 msgstr "Gå till lager ovanför"
 
-#: ../po/tmp/resources.xml.h:78
+#: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer up in the layer stack."
 msgstr "Uppåt ett lager i lagerlistan."
 
-#: ../po/tmp/resources.xml.h:79
+#: ../po/tmp/resources.xml.h:97
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Below"
 msgstr "Gå till lager under"
 
-#: ../po/tmp/resources.xml.h:80
+#: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer down in the layer stack."
 msgstr "Nedåt ett lager i lagerlistan."
 
-#: ../po/tmp/resources.xml.h:81
+#: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer"
 msgstr "Nytt målningslager"
 
-#: ../po/tmp/resources.xml.h:82
+#: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer above the current layer."
 msgstr "Lägg till nytt målningslager ovanför det aktuella lagret."
 
-#: ../po/tmp/resources.xml.h:83
+#: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer…"
 msgstr "Nytt vektorlager…"
 
-#: ../po/tmp/resources.xml.h:84
+#: ../po/tmp/resources.xml.h:102
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer above the current layer, and begin editing it."
 msgstr ""
 "Lägg till nytt vektorlager ovanför det aktuella lagret, och börja redigera i "
 "det."
 
-#: ../po/tmp/resources.xml.h:85
+#: ../po/tmp/resources.xml.h:103
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group"
 msgstr "Ny lagergrupp"
 
-#: ../po/tmp/resources.xml.h:86
+#: ../po/tmp/resources.xml.h:104
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group above the current layer."
 msgstr "Lägg till ny lagergrupp ovanför det aktuella lagret."
 
-#: ../po/tmp/resources.xml.h:87
+#: ../po/tmp/resources.xml.h:105
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer Below"
 msgstr "Nytt målarlager under"
 
-#: ../po/tmp/resources.xml.h:88
+#: ../po/tmp/resources.xml.h:106
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer below the current layer."
 msgstr "Lägg till nytt målarlager under det aktuella lagret."
 
-#: ../po/tmp/resources.xml.h:89
+#: ../po/tmp/resources.xml.h:107
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer Below…"
 msgstr "Nytt vektorlager under…"
 
-#: ../po/tmp/resources.xml.h:90
+#: ../po/tmp/resources.xml.h:108
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer below the current layer, and begin editing it."
 msgstr "Nytt vektorlager under det aktuella lagret, och börja redigera i det."
 
-#: ../po/tmp/resources.xml.h:91
+#: ../po/tmp/resources.xml.h:109
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group Below"
 msgstr "Ny lagergrupp under"
 
-#: ../po/tmp/resources.xml.h:92
+#: ../po/tmp/resources.xml.h:110
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group below the current layer."
 msgstr "Lägg till ny lagergrupp under det aktuella lagret."
 
-#: ../po/tmp/resources.xml.h:93
+#: ../po/tmp/resources.xml.h:111
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Layer Down"
 msgstr "Slå samman lager nedåt"
 
-#: ../po/tmp/resources.xml.h:94
+#: ../po/tmp/resources.xml.h:112
 msgctxt "Accel Editor (descriptions)"
 msgid "Merge the current layer with the layer beneath it."
 msgstr "Slår samman lagret med det underliggande lagret."
 
-#: ../po/tmp/resources.xml.h:95
+#: ../po/tmp/resources.xml.h:113
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Visible Layers"
 msgstr "Slå samman synliga lager"
 
-#: ../po/tmp/resources.xml.h:96
+#: ../po/tmp/resources.xml.h:114
 msgctxt "Accel Editor (descriptions)"
 msgid "Consolidate all visible layers, and delete the originals."
 msgstr "Slår samman alla synliga lager och raderar de ursprungliga."
 
-#: ../po/tmp/resources.xml.h:97
+#: ../po/tmp/resources.xml.h:115
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer from Visible"
 msgstr "Nytt lager från synliga lager"
 
-#: ../po/tmp/resources.xml.h:98
+#: ../po/tmp/resources.xml.h:116
 msgctxt "Accel Editor (descriptions)"
 msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
-msgstr "Samma som 'Slå samman synliga lager', men raderar inte de ursprungliga."
+msgstr ""
+"Samma som 'Slå samman synliga lager', men raderar inte de ursprungliga."
 
-#: ../po/tmp/resources.xml.h:99
+#: ../po/tmp/resources.xml.h:117
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Delete Layer"
 msgstr "Ta bort lager"
 
-#: ../po/tmp/resources.xml.h:100
+#: ../po/tmp/resources.xml.h:118
 msgctxt "Accel Editor (descriptions)"
 msgid "Remove the current layer from the layer stack."
 msgstr "Tar bort det aktuella lagret från lagerlistan."
 
-#: ../po/tmp/resources.xml.h:101
+#: ../po/tmp/resources.xml.h:119
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Convert to Normal Painting Layer"
 msgstr "Konvertera till normalläge"
 
-#: ../po/tmp/resources.xml.h:102
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
@@ -4307,571 +5316,660 @@ msgstr ""
 "Konverterar det aktuella lagret eller gruppen till ett nytt målningslager i "
 "'Normalläge'. Bibehåller dess utseende."
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr "Öka lagrets opacitet"
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr "Gör lagret mindre genomskinligt."
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr "Minska lagrets opacitet"
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr "Gör lagret mer genomskinligt."
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr "Lyft lager"
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr "Flyttar upp lagret ett steg i lagerlistan."
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr "Sänk lager"
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr "Flyttar ner lagret ett steg i lagerlistan."
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr "Kopiera lager"
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr "Skapa en exakt kopia av aktuellt lager."
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
+#, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
-msgstr "Byt namn på lager…"
+msgid "Layer Properties…"
+msgstr "Egenskaper"
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
-msgstr "Ange ett nytt namn för det aktuella lagret."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr "Låst"
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr "Växlar mellan lagrets låsstatus. Låsta lager kan inte förändras."
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr "Synligt"
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr "Växlar mellan lagrets synlighet, släcker det."
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr "Visa bakgrund"
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr "Växlar bakgrundslagrets synlighet."
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr "Tar bort det aktuella lagret från lagerlistan."
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr "Nollställ och centrera visningen"
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr "Återställer zoomnivå, rotation och spegling, och centrerar dokumentet."
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr "Anpassa till visning"
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 "Växla mellan en anpassad visning och din aktuella arbetsvisning (placering "
 "och zoom)."
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr "Återställ"
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr "Återställ zoom"
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr "Återställer visningens zoomnivå till standard."
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr "Återställ rotation"
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr "Återställer visningens rotation till 0°"
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr "Återställ spegling"
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
-msgstr "Stänger av speglingen av vyn."
+msgid "Reset the view's mirroring."
+msgstr "Återställ spegling"
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr "Zooma in"
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr "Öka förstoring."
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Zooma ut"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr "Minska förstoring."
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
+#, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
-msgstr "Rotera motsols"
+msgid "Pan Left"
+msgstr "Panorera vy"
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
-msgstr "Rotera visningen motsols."
+msgid "Move your view of the canvas to the left."
+msgstr "Rotera vy: luta visningen av arbetsytan."
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr "Skarpt ljus"
+
+#: ../po/tmp/resources.xml.h:159
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr "Panorera vy: flytta arbetsytan horisontellt eller vertikalt."
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr "Rotera vy: luta visningen av arbetsytan."
+
+#: ../po/tmp/resources.xml.h:162
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr "Panorera vy"
+
+#: ../po/tmp/resources.xml.h:163
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr "Rotera vy: luta visningen av arbetsytan."
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr "Rotera medsols"
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr "Rotera visningen medsols."
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr "Rotera motsols"
+
+#: ../po/tmp/resources.xml.h:167
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr "Rotera visningen motsols."
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr "Spegla horisontellt"
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr "Speglar visningen från vänster till höger."
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr "Spegla vertikalt"
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr "Speglar visningen upp och ner."
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr "Sololager"
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr "Växlar visningen för att visa endast det aktuella lagret."
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr "Symmetrisk målning aktiv"
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr "Speglar penseldrag längs med symmetriaxeln"
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr "Ram aktiverad"
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr "Dokumentram av/på."
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr "Skriv ut penselns invärden till konsollen"
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr "Visar penselmotorns internt genererade invärden till konsolen."
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr "Visualisera återgivning"
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr "Visar uppdateringar av återgivning på skärmen, för felsökning."
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr "Ingen dubbelbuffring"
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr "Stäng av GTK's dubbelbuffring, som normalt är aktiv."
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+#, fuzzy
+msgid "Delete Point"
+msgstr "Ta bort punkt"
+
+#: ../po/tmp/resources.xml.h:187
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr "Ta bort den markerade punkten"
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr "Målningsläge"
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr "Normalt"
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr "Applicera färg normalt vid målning."
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr "Suddgummi"
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr "Sudda med den aktuella penseln."
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr "Alfa låst"
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr "Målning påverkar inte lagrets opacitet."
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr "Färgläggning"
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 "Målning påverkar endast lagrets färg, utan att ändra ljushet eller opacitet."
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Arkiv"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "Avsluta"
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr "Stäng huvudfönstret och avsluta programmet."
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "Redigera"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr "Aktuellt verktyg"
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "Färg"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr "Justera färg"
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr "Visa färghistoria"
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr "Visa en tidslinje av nyligen använda färger vid pekaren."
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr "Dialogruta för färgdetaljer"
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr "Färgdetaljsdialog med text."
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr "Nästa palettfärg"
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr "Välj nästa målarfärg i paletten."
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr "Föregående palettfärg"
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr "Välj föregående målarfärg i paletten."
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr "Lägg till färg i palett"
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr "Lägg till den aktuella målarfärgen till paletten."
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "Lager"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr "Opacitet"
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr "Gå till lager"
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr "Nytt lager under"
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr "Egenskaper"
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr "Kladdblock"
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr "Nytt kladdblock"
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr "Ladda standard-kladdblocket."
 
 # "Scrap" -> "kladd"
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr "Öppna kladdblock …"
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr "Läs in en bildfil till kladdblocket från disk."
 
 # "Scrap" -> "kladd"
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr "Spara kladdblock"
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr "Spara kladdblocket till dess existerande fil på disk."
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr "Exportera kladdblock som…"
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr "Spara kladdblocket."
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr "Återställ kladdblock"
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr "Återställ kladdblocket till dess senast sparade version."
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr "Spara kladdblock som standard"
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr "Spara kladdblocket som standard för valet Nytt kladdblock."
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr "Töm standard-kladdblocket"
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr "Töm standard-kladdblocket till en tom arbetsyta."
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr "Kopiera huvudbakgrunden till kladdblocket"
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr "Kopiera bakgrundsbilden från arbetsdokumentet till kladdblocket."
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "Fönster"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "Pensel"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr "Snabbval"
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr "Hjälp för snabbval för penslar"
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr "Visa en förklaring för hur snabbvalstangenter fungerar."
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "Ändra pensel…"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr "Pop-up vid pekaren för byte av penslar."
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "Ändra färg…"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr "Pop-up vid pekaren för byte av färg, med alla färgväljare listade."
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "Ändra färg (snabb delmängd)…"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
@@ -4879,207 +5977,211 @@ msgid ""
 msgstr ""
 "Pop-up vid pekaren för byte av färg, med endast enkel-klicksval listade."
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr "Hämta fler penslar…"
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr "Ladda hem penselpaket från MyPaint-wikin."
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr "Importera penselpaket…"
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr "Öppna ett penselpaket från disken."
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Hjälp"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr "Online-hjälp"
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr "Gå till MyPaints dokumentationswiki."
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "Om MyPaint"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr "Visa MyPaints licens, versionsnummer och tacklista."
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Felsökning"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr "Skriv ut information om minnesläcka i konsolen (långsamt!)"
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr "Felsök minnesläckor."
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr "Kör sophanterare nu"
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr "Ledigt minne för Python-objekt som inte längre används."
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr "Starta/stoppa Pythonprofilering…"
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr "Starta/stoppa Pythonprofilering (cProfile)"
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr "Simulera en krasch…"
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr "Starta en Python-undantag, för att testa kraschdialogen."
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "Visa"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr "Återkoppling"
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr "Justera vy"
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
+#, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr "Popup-meny"
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr "Visa huvudmenyn som en popup."
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "Helskärm"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr "Växla mellan helskärmsläge och fönsterläge."
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "Redigera inställningar"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr "Redigera MyPaints globala inställningar."
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr "Testa inmatningsenheter"
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr "Visa en dialogruta som fångar alla händelser dina inenheter skickar."
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr "Bakgrundsväljare"
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr "Ändrar bakgrundens papperstextur."
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr "Redigera penselinställningar"
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr "Redigera den aktiva penselns inställningar."
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr "Redigera penselikon"
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr "Redigera penselikon."
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr "Lager"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
-msgstr "Lager (ordna lager eller ändra färglägen)."
+msgid "Dockable panel for managing layers."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr "Visa lagerpanel"
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr "Visa lagerpanelen (ordna lager eller ändra färglägen)."
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr "HCY-hjul"
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
@@ -5088,42 +6190,32 @@ msgstr ""
 "Dockningsbar väljare för cylindrisk nyans/kulörthet/ljusstyrka. Varje "
 "cirkulärt snitt har likvärdig ljusstyrka."
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "Färgpalett"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr "Dockningsbar palett för att välja färg."
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr "HSV-hjul"
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr "Dockningsbar väljare för att ändra mättnad och valör."
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr "HSV-triangel"
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr "Dockningsbar färgväljare: den gamla GTK-färgtriangeln."
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr "HSV-kub"
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
@@ -5132,216 +6224,213 @@ msgstr ""
 "Dockingsbar färgväljare: En HSV-kub som kan roteras för att visa olika plana "
 "snitt."
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr "HSV-kvadrat"
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
-msgstr ""
-"Dockningsbar färgväljare: En HSV-ruta som kan roteras för att visa olika "
-"nyanser."
+msgid "Dockable color selector: HSV square with Hue ring."
+msgstr "Dockningsbar färgväljare med koncentriska HSV-ringar."
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr "Komponentreglage"
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr "Dockningsbar färgväljare som visar färgens individuella komponenter."
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr "Lavering"
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 "Dockningsbar färgväljare som visar vätskeliknande bestrykning av närliggande "
 "färger."
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr "Koncentriska ringar"
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr "Dockningsbar färgväljare med koncentriska HSV-ringar."
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr "Korsad skål"
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 "Dockningsbar färgväljare med övergångar i HSV som korsar en radiell \"skål\" "
 "av färger."
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr "Kladdblock"
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
-msgstr "Kladdblock (blanda färger och skissa)."
+msgid "Dockable Panel for mixing colors and testing brushes."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr "Visa kladdblockspanel"
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr "Visa kladdblockspanelen (blanda färger och skissa)."
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr "Förhandsvisning"
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
-msgstr "Förhandsvisning (översikt av teckningsytan)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "Förhandsvisning"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr "Visa panelen för förhandsvisning (översikt av hela teckningsytan)."
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr "Verktygsval"
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
-msgstr "Verktygsval (val för det aktuella verktyget)."
+msgid "Dockable panel for adjusting the options with the activated tool."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr "Visa panelen för verktygsval"
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr "Visa panelen för verktygsval (val för det aktuella verktyget)."
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr "Pensel- och färghistoria"
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
-msgstr "Historik (senaste använda penslar och färger)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr "Senaste penslar och färger"
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr "Visa panelen för histork (senaste använda penslar och färger)."
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr "Dölj verktyg i helskärmsläge"
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 "Växla mellan att automatiskt gömma användargränssnittet i helskärmsläge."
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr "Visa zoomnivå"
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr "Växla återkoppling av zoomnivå."
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr "Visa senaste målningsposition"
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr "Växla återkoppling som visar var senaste penseldraget slutade."
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr "Skärmfilter"
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr "Visa färger normalt"
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr "Färgfilter: visa oförändrade färger."
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr "Visa färger i gråskala"
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr "Färgfilter: visa bara ljushet (HCY/YCbCr Luma)"
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr "Visa inverterade färger"
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr "Färgfilter: inverterad video. Svart blir vitt och rött blir cyan."
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr "Visa färger med simulerad okänslighet för rött"
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
@@ -5349,276 +6438,276 @@ msgstr ""
 "Filtrerar färger för att simulera deuteranopi, en vanlig form av "
 "färgblindhet."
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr "Visa färger med simulerad okänslighet för grönt"
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 "Filtrerar färger för att simulera protanopi, en vanlig form av färgblindhet."
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr "Visa färger med simulerad okänslighet för blått"
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 "Filtrerar färger för att simulera tritanopi, en ovanlig form av färgblindhet."
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr "Frihand"
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr "Frihand"
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr "Frihandsritning: rita och måla fritt utan geometriska begränsningar."
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr "Frihand"
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr "Frihandsritning: rita och måla fritt utan geometriska begränsningar."
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr "Panorera vy"
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr "Panorera"
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr "Panorera vy: flytta arbetsytan horisontellt eller vertikalt."
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr "Panorera vy"
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr "Flytta arbetsytan interaktivt, horisontellt eller vertikalt."
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr "Rotera vy"
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr "Rotera"
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr "Rotera vy: luta visningen av arbetsytan."
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr "Rotera vy"
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr "Rotera arbetsytan interaktivt."
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr "Zooma vy"
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr "Zoom"
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr "Zooma vy: zooma in eller ut från arbetsytan."
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr "Zooma vy"
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr "Zooma interaktivt in eller ut från arbetsytan."
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr "Linjer och kurvor"
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr "Linjer"
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr "Linjer och kurvor: rita raka eller böjda linjer."
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr "Linjer och kurvor"
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr "Rita raka eller böjda linjer."
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr "Sammanbundna linjer"
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr "Sam.bnda. linjer"
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr "Sammanbundna linjer: rita sekvenser av raka eller böjda linjer."
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr "Sammanbundna linjer"
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr "Rita sekvens av raka eller böjda linjer."
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr "Ellipser och cirklar"
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr "Ellips"
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr "Ellipser och cirklar: rita runda former."
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr "Ellipser och cirklar"
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr "Rita cirklar och ellipser."
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr "Bläckteckning"
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr "Bläck"
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr "Bläckteckning: teckna följsamma kontrollerade linjer."
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr "Bläckteckning"
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr "Teckna jämna och kontrollerade linjer."
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr "Flytta lager"
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr "Lagerpos."
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr "Flytta lager: flytta det aktuella lagret på arbetsytan."
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr "Flytta lager"
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr "Flytta det aktuella lagret på arbetsytan, interaktivt."
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr "Redigera ram"
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr "Ram"
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 "Redigera ram: definiera bilden en ram för att ge den en avgränsad storlek."
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr "Redigera ram"
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
@@ -5626,80 +6715,285 @@ msgstr ""
 "Definiera en ram runt dokumentet, interaktivt, för att ge den en avgränsad "
 "storlek."
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Redigera symmetrimålning"
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr "Symmetri"
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr "Redigera symmetrimålning: justera axel för symmetrimålning."
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Redigera symmetrimålning"
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr "Justera axeln för symmetrimålning, interaktivt."
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr "Välj färg"
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr "Välj färg."
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr "Välj färg: ange färg från skärmpixlar."
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "Välj färg"
+
+#: ../po/tmp/resources.xml.h:401
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr "Ange målarfärgen från skärmpixlar."
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "Välj färg"
+
+#: ../po/tmp/resources.xml.h:403
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr "Ange målarfärgen från skärmpixlar."
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "Välj färg"
+
+#: ../po/tmp/resources.xml.h:405
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr "Ange målarfärgen från skärmpixlar."
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr "Välj färg"
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr "Ange målarfärgen från skärmpixlar."
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr "Flödningsfyllning"
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr "Fyll"
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr "Flödningsfyllning: fyll en yta med färg."
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr "Flödningsfyllning"
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr "Fyll en yta med färg."
+
+#~ msgctxt "Accelerator map editor: action column markup"
+#~ msgid ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+#~ msgstr ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+
+#~ msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
+#~ msgid "{action_label} {action_desc} {accel_label}"
+#~ msgstr "{action_label} {action_desc} {accel_label}"
+
+#~ msgctxt "brush list context menu"
+#~ msgid "Delete"
+#~ msgstr "Ta bort"
+
+#~ msgctxt "brush list commands"
+#~ msgid "Really delete brush from disk?"
+#~ msgstr "Vill du verkligen radera penseln från hårddisken?"
+
+#~ msgid "HSV Triangle"
+#~ msgstr "HSV-triangel"
+
+#~ msgid "The standard GTK color selector"
+#~ msgstr "Standard GTK-färgväljare"
+
+#~ msgid "Pick a color from the screen"
+#~ msgstr "Hämta en färg från skärmen"
+
+#~ msgid "Layer Name"
+#~ msgstr "Lager Namn"
+
+#~ msgid ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+#~ msgstr ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+
+# duplication?
+#~ msgid "Save..."
+#~ msgstr "Spara..."
+
+#~ msgid "Confirm"
+#~ msgstr "Bekräfta"
+
+#~ msgid "Open..."
+#~ msgstr "Öppna..."
+
+#~ msgid "{default_name} at {path}"
+#~ msgstr "{default_name} vid {path}"
+
+#~ msgid "Type"
+#~ msgstr "Typ"
+
+#~ msgid "Mode:"
+#~ msgstr "Läge:"
+
+#~ msgid ""
+#~ "Blending mode: how the current layer combines with the layers underneath "
+#~ "it."
+#~ msgstr ""
+#~ "Mixningsläge: hur det nuvarande lagret blandas med underliggande lager."
+
+#~ msgid ""
+#~ "Layer opacity: how much of the current layer to use. Smaller values make "
+#~ "it more transparent."
+#~ msgstr ""
+#~ "Lagrets opacitet: Hur mycket av lagret som ska synas. Lägre värde gör det "
+#~ "mer genomskinligt."
+
+#~ msgid "%s: edit properties"
+#~ msgstr "%s: redigera egenskaper"
+
+#~ msgctxt "layer unique names: match regex (leave untranslated if unsure)"
+#~ msgid "^(.*?)\\s*(\\d+)$"
+#~ msgstr "^(.*?)\\s*(\\d+)$"
+
+#~ msgctxt "layer default names"
+#~ msgid "Unknown Bitmap Layer"
+#~ msgstr "Okänt bitmaplager"
+
+#~ msgctxt "Autosave Recovery dialog|"
+#~ msgid "_Ignore for Now"
+#~ msgstr "_Ignorera tills vidare"
+
+#~ msgid "Setting name:"
+#~ msgstr "Inställningens namn:"
+
+#~ msgid "Base value:"
+#~ msgstr "Basvärde:"
+
+#~ msgid "Reset the base value to its default"
+#~ msgstr "Återställ basvärdet till standard"
+
+#~ msgid "<ymin>"
+#~ msgstr "<ymin>"
+
+#~ msgid "<ymax>"
+#~ msgstr "<ymax>"
+
+#~ msgid "<xmin>"
+#~ msgstr "<xmin>"
+
+#~ msgid "<xmax>"
+#~ msgstr "<xmax>"
+
+#~ msgid "Edit Setting"
+#~ msgstr "Redigera inställningen"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Trim Layer to Frame"
+#~ msgstr "Beskär lager utifrån ram"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Rename Layer…"
+#~ msgstr "Byt namn på lager…"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Enter a new name for the current layer."
+#~ msgstr "Ange ett nytt namn för det aktuella lagret."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Turn off mirroring of the view."
+#~ msgstr "Stänger av speglingen av vyn."
+
+#~ msgctxt "Menu→Edit (labels)"
+#~ msgid "Current Tool"
+#~ msgstr "Aktuellt verktyg"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+#~ msgstr "Lager (ordna lager eller ändra färglägen)."
+
+#~ msgctxt "Menu→Color (labels), Accel Editor (labels)"
+#~ msgid "HSV Triangle"
+#~ msgstr "HSV-triangel"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Dockable color selector: the old GTK color triangle."
+#~ msgstr "Dockningsbar färgväljare: den gamla GTK-färgtriangeln."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid ""
+#~ "Dockable color selector: HSV square which can be rotated to show "
+#~ "different hues."
+#~ msgstr ""
+#~ "Dockningsbar färgväljare: En HSV-ruta som kan roteras för att visa olika "
+#~ "nyanser."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+#~ msgstr "Kladdblock (blanda färger och skissa)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+#~ msgstr "Förhandsvisning (översikt av teckningsytan)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+#~ msgstr "Verktygsval (val för det aktuella verktyget)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the History panel (recently used brushes and colors)."
+#~ msgstr "Historik (senaste använda penslar och färger)."
 
 #~ msgid ""
 #~ "\"%s\" has an alpha channel. Background images with transparency are not "
@@ -5905,9 +7199,6 @@ msgstr "Fyll en yta med färg."
 #~ "Penslarnas olika inställningar beskrivs av hjälp-text-rutor. Håll musen "
 #~ "över inställningen du undrar över för att få hjälp.\n"
 
-#~ msgid "Open Recent files"
-#~ msgstr "Öppna senaste filer"
-
 #~ msgid "This will discard %d second of unsaved painting."
 #~ msgid_plural "This will discard %d seconds of unsaved painting."
 #~ msgstr[0] "Detta kommer att kasta bort arbete gjort under %d sekund."
@@ -5915,9 +7206,6 @@ msgstr "Fyll en yta med färg."
 
 #~ msgid "Crop to Current Layer"
 #~ msgstr "Begränsa till nuvarande lager"
-
-#~ msgid "Crop frame to the currently active layer"
-#~ msgstr "Begränsa till nuvarande aktivt lager"
 
 #~ msgid ""
 #~ "While the frame is enabled, it \n"
@@ -6022,9 +7310,6 @@ msgstr "Fyll en yta med färg."
 #~ msgid "Brush Blend Mode"
 #~ msgstr "Pensel-blandläge"
 
-#~ msgid "Add Layer"
-#~ msgstr "Lägg till Lager"
-
 #~ msgid "Move Layer on Canvas"
 #~ msgstr "Flytta Lager på duken"
 
@@ -6062,9 +7347,6 @@ msgstr "Fyll en yta med färg."
 #~ msgctxt "Menu|File|"
 #~ msgid "Save"
 #~ msgstr "Spara"
-
-#~ msgid "Export to a file"
-#~ msgstr "Exportera till fil"
 
 #~ msgid ""
 #~ "Saves to a new scrap file. If the drawing is currently saved as a scrap, "

--- a/po/sv.po
+++ b/po/sv.po
@@ -531,18 +531,18 @@ msgstr "MyPaint penselpaket (*.zip)"
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
-msgstr "Ny uppsättning..."
+msgid "New Group…"
+msgstr "Ny uppsättning…"
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
-msgstr "Importera penslar..."
+msgid "Import Brushes…"
+msgstr "Importera penslar…"
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
-msgstr "Hämta fler penslar..."
+msgid "Get More Brushes…"
+msgstr "Hämta fler penslar…"
 
 #: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
@@ -1223,12 +1223,12 @@ msgstr "Typ"
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
-msgstr "Använd för..."
+msgid "Use for…"
+msgstr "Använd för…"
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr "Bläddra…"
 
 #. Name and preview column: will be indented
@@ -1452,8 +1452,8 @@ msgid "_Quit"
 msgstr "Avsluta"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
-msgstr "Importera penselpaket..."
+msgid "Import brush package…"
+msgstr "Importera penselpaket…"
 
 #: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
@@ -1510,7 +1510,7 @@ msgstr ""
 "“{type_name}” ({content_type})?"
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr "Öppna med…"
 
 #: ../gui/externalapp.py:123
@@ -1704,13 +1704,13 @@ msgstr "JPEG 90% kvalitet (*.jpg; *.jpeg)"
 
 #: ../gui/filehandling.py:576
 #, fuzzy
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr "Exportera…"
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Spara som…"
 
@@ -1783,8 +1783,8 @@ msgstr "Öppna senaste filer"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
-msgstr "Öppna kladdblock..."
+msgid "Open Scratchpad…"
+msgstr "Öppna kladdblock…"
 
 #: ../gui/filehandling.py:1099
 #, fuzzy
@@ -2241,13 +2241,13 @@ msgstr ""
 "om ingen annan har rapporterat det än."
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr "Spårningssökare…"
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
-msgstr "Rapport..."
+msgid "Report…"
+msgstr "Rapport…"
 
 #: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
@@ -2258,8 +2258,8 @@ msgid "Quit MyPaint"
 msgstr "Avsluta MyPaint"
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
-msgstr "Detaljer..."
+msgid "Details…"
+msgstr "Detaljer…"
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
@@ -2469,7 +2469,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr "Flytta på lager i grupp…"
 
 #: ../gui/layerswindow.py:110
@@ -2542,7 +2542,7 @@ msgid "Stroke trail-off beginning"
 msgstr "Penseldrag, början av uttunning"
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr "Tryckvariation…"
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777
@@ -3726,7 +3726,7 @@ msgstr "Ta bort penseln från hårddisken"
 #, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid "_Recover & Save…"
-msgstr "_Återställ och spara..."
+msgstr "_Återställ och spara…"
 
 #: ../po/tmp/autorecover.glade.h:12
 #, fuzzy
@@ -5849,7 +5849,7 @@ msgstr "Ladda standard-kladdblocket."
 #: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
-msgstr "Öppna kladdblock …"
+msgstr "Öppna kladdblock…"
 
 #: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-23 08:18+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Tamil <https://hosted.weblate.org/projects/mypaint/mypaint/ta/"
@@ -19,27 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -47,39 +27,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -87,214 +67,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "பாணி"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "நிறம்"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "தனிபயன்"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -333,142 +323,177 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "சேமி"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "புதிய"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -476,58 +501,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -536,51 +561,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -590,137 +639,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -728,162 +777,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -891,373 +932,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "பெயர்"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "செயல்நீக்கு"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "மீளச்செய்"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1267,324 +1305,679 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "திற..."
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "முழுத்திரை"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "வெளிச்செல்"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "வெளிச்செல்"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "திற..."
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "சேமி"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr ""
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr ""
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "கோப்பு"
+
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "அடுக்குகள்"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "திற..."
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "கிட்டியன திற"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "திற..."
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "திற..."
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr ""
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1592,130 +1985,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1724,35 +2129,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1776,45 +2181,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1822,153 +2231,218 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "அடுக்குகள்"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "அடுக்குகள்"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr ""
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1980,256 +2454,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2237,188 +2736,213 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "அடுக்குகள்"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2427,13 +2951,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2443,7 +2967,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2451,13 +2975,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2465,7 +2989,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2473,7 +2997,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2484,7 +3008,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2492,7 +3016,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2502,7 +3031,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2513,285 +3042,394 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr ""
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2801,7 +3439,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2810,52 +3468,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2877,17 +3566,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2916,112 +3603,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3034,7 +3696,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3075,6 +3737,133 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "பெயர்"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3444,56 +4233,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3501,12 +4310,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3515,7 +4324,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3526,28 +4335,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3609,1828 +4418,2019 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "பெரிதாக்கு"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "கோப்பு"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "உதவி"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "வழுநீக்கு"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
-msgstr ""
+msgstr "அடுக்குகள்"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/ta.po
+++ b/po/ta.po
@@ -513,17 +513,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1184,12 +1184,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1372,7 +1372,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Open dragged file confirm dialog: continue button"
 msgid "_Open"
-msgstr "திற..."
+msgstr "திற…"
 
 #: ../gui/drawwindow.py:486
 msgid "Set current color"
@@ -1406,7 +1406,7 @@ msgid "_Quit"
 msgstr "வெளிச்செல்"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1456,7 +1456,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1633,13 +1633,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "சேமி"
 
@@ -1705,7 +1705,7 @@ msgstr "கோப்பு"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -1723,7 +1723,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "திற..."
+msgstr "திற…"
 
 #: ../gui/filehandling.py:1427
 #, fuzzy
@@ -1735,7 +1735,7 @@ msgstr "கிட்டியன திற"
 #, fuzzy
 msgctxt "File→Open Most Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "திற..."
+msgstr "திற…"
 
 #: ../gui/filehandling.py:1446
 msgctxt "File→Open Next/Prev Scrap: error message"
@@ -1756,7 +1756,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
 msgid "_Open"
-msgstr "திற..."
+msgstr "திற…"
 
 #: ../gui/filehandling.py:1487
 msgctxt "File→Revert: status message: canvas has no filename yet"
@@ -2130,12 +2130,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2147,7 +2147,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2333,7 +2333,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2403,7 +2403,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/te.po
+++ b/po/te.po
@@ -514,17 +514,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1186,12 +1186,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1374,7 +1374,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Open dragged file confirm dialog: continue button"
 msgid "_Open"
-msgstr "తెరువు..."
+msgstr "తెరువు…"
 
 #: ../gui/drawwindow.py:486
 msgid "Set current color"
@@ -1408,7 +1408,7 @@ msgid "_Quit"
 msgstr "నిష్క్రమించు"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1458,7 +1458,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1635,13 +1635,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "సేవ్ చేయండి…"
 
@@ -1709,8 +1709,8 @@ msgstr "దస్త్రము"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
-msgstr "స్క్రాచ్ప్యాడ్ను తెరువు …"
+msgid "Open Scratchpad…"
+msgstr "స్క్రాచ్ప్యాడ్ను తెరువు…"
 
 #: ../gui/filehandling.py:1099
 #, fuzzy
@@ -1727,7 +1727,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "తెరువు..."
+msgstr "తెరువు…"
 
 #: ../gui/filehandling.py:1427
 #, fuzzy
@@ -1739,7 +1739,7 @@ msgstr "ఇటీవలివి తెరువండి"
 #, fuzzy
 msgctxt "File→Open Most Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "తెరువు..."
+msgstr "తెరువు…"
 
 #: ../gui/filehandling.py:1446
 msgctxt "File→Open Next/Prev Scrap: error message"
@@ -1760,7 +1760,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
 msgid "_Open"
-msgstr "తెరువు..."
+msgstr "తెరువు…"
 
 #: ../gui/filehandling.py:1487
 msgctxt "File→Revert: status message: canvas has no filename yet"
@@ -2137,12 +2137,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2154,7 +2154,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2341,7 +2341,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2411,7 +2411,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777
@@ -5501,7 +5501,7 @@ msgstr "డిఫాల్ట్ స్క్రాచ్ప్యాడ్న�
 #: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
-msgstr "స్క్రాచ్ప్యాడ్ను తెరువు …"
+msgstr "స్క్రాచ్ప్యాడ్ను తెరువు…"
 
 #: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:19+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -19,27 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr "<big><b>{accel_label}</b></big>"
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr "{action_label} {action_desc} {accel_label}"
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "చర్య"
 
@@ -47,39 +27,39 @@ msgstr "చర్య"
 msgid "Key combination"
 msgstr "మీటల జోడు"
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "చర్య:"
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "దారి:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "మీట:"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "తెలియని చర్య"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -87,214 +67,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "సరే"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr "కాష్ ఫోల్డర్ని తెరవండి…"
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr "ప్రత్యామ్నాయం తేరుకోవడం లేదు"
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr "ప్రత్యామ్నాయం ఫోల్డర్ని తెరవండి…"
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "నేపథ్యం"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "మాదిరి"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "వర్ణము"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr "పరస్థలము తెరుచుకోవటం లేదు"
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr "కుంచె అమరికల ఎడిటర్"
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr "గురించి"
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "ప్రయోగాత్మక"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr "ప్రాథమిక"
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr "ముద్దలు"
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr "వేగము"
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "మలుచుకొనిన"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -333,142 +323,178 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "దాచు"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "కొత్తది"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
+msgstr "కుంచె అమరికల ఎడిటర్"
+
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -476,58 +502,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -536,51 +562,76 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "రంగుని ఎంచుకోండి"
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -590,137 +641,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -728,162 +779,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -891,373 +934,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "నామము"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, fuzzy, python-format
 msgid "Undo %s"
 msgstr "రద్దుచెయ్యి"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "రద్దుచేయి"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "మళ్లీచేయి"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1267,324 +1307,684 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ";  "
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "తెరువు..."
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "పూర్తితెర"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "నిష్క్రమించు"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "నిష్క్రమించు"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "సేవ్ చేయండి…"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr ""
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr "తెరవండి…"
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "దస్త్రము"
+
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
+msgid "Open Scratchpad..."
+msgstr "స్క్రాచ్ప్యాడ్ను తెరువు …"
+
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "పొరకు వెళ్ళండి"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
 msgstr "తెరువు..."
 
-#: ../gui/filehandling.py:552
-msgid "Open Scratchpad..."
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "ఇటీవలివి తెరువండి"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "తెరువు..."
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "తెరువు..."
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+#, fuzzy
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr "వీక్షించడానికి అమర్చు"
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
-msgstr ""
+msgstr "కొత్త లేయర్ గ్రూప్"
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr ""
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "లేయర్ను తొలగించండి"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1592,130 +1992,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1724,35 +2136,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1776,45 +2188,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1822,153 +2238,219 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+#, fuzzy
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr "గుణాలు"
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "పొర"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "పొరలు"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr ""
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1980,256 +2462,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2237,188 +2744,214 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "కొత్త లేయర్ గ్రూప్"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "పొరకు వెళ్ళండి"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2427,13 +2960,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2443,7 +2976,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2451,13 +2984,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2465,7 +2998,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2473,7 +3006,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2484,7 +3017,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2492,7 +3025,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2502,7 +3040,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2513,285 +3051,401 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
-msgctxt "layer default names"
-msgid "Vector Layer"
-msgstr ""
-
 #: ../lib/layer/data.py:1153
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Vectors"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
+#: ../lib/layer/data.py:1158
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Vector Layer"
+msgstr "పోర చెరిపివేయి"
+
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Data Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr "తెలియని చర్య"
+
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "కొత్త పెయింటింగ్ లేయర్"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "కొత్త లేయర్ గ్రూప్"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+#, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "వీక్షణ"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+#, fuzzy
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr "క్రింద కొత్త లేయర్"
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+#, fuzzy
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr "క్రింద కొత్త లేయర్"
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2801,7 +3455,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2810,52 +3484,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2877,17 +3582,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2916,113 +3619,89 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
 msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+#, fuzzy
+msgid "<big><b>No Brush Dynamics</b></big>"
+msgstr "<big><b>{accel_label}</b></big>"
 
 #: ../po/tmp/inktool.glade.h:1
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
@@ -3034,7 +3713,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3075,6 +3754,133 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "నామము"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3444,56 +4250,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3501,12 +4327,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3515,7 +4341,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3526,28 +4352,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3609,1830 +4435,2033 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
-msgstr "భద్రపరుచు"
+msgid "Import Layers…"
+msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
-msgstr "సేవ్ చేయండి…"
+msgid "Save"
+msgstr "భద్రపరుచు"
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
-msgstr ""
+msgid "Save As…"
+msgstr "సేవ్ చేయండి…"
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "పోర చెరిపివేయి"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "కొత్త లేయర్ గ్రూప్"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "కొత్త లేయర్ గ్రూప్"
+
+#: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:71
+#: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Edit Layer in External App…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
-msgstr "కొత్త పెయింటింగ్ లేయర్"
-
-#: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:85
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
-msgstr "కొత్త లేయర్ గ్రూప్"
-
-#: ../po/tmp/resources.xml.h:86
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:87
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:88
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:89
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
-msgstr "లేయర్ను తొలగించండి"
+msgid "New Painting Layer"
+msgstr "కొత్త పెయింటింగ్ లేయర్"
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr "కొత్త లేయర్ గ్రూప్"
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr "లేయర్ను తొలగించండి"
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
+#, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
-msgstr ""
+msgid "Layer Properties…"
+msgstr "గుణాలు"
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr "వీక్షించడానికి అమర్చు"
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "జూమ్ తగ్గించు"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr "పెయింట్ మోడ్"
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
-msgstr ""
-"దాని ప్రకాశం లేదా అస్పష్టతను ప్రభావితం చేయకుండా ప్రస్తుత పొరకు రంగును "
-"వర్తించండి."
+msgstr "దాని ప్రకాశం లేదా అస్పష్టతను ప్రభావితం చేయకుండా ప్రస్తుత పొరకు రంగును వర్తించండి."
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "దస్త్రము"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "విడిచిపెట్టు"
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr "ప్రధాన విండోను మూసివేసి అనువర్తనం నుండి నిష్క్రమించండి."
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "మార్చు"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr "ప్రస్తుత సాధనం"
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "రంగు"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr "రంగు సర్దు"
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr "రంగు చరిత్ర పాప్అప్"
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr "కర్సర్ కింద ఇటీవలి రంగులు యొక్క కాలపట్టిక పాప్ అప్ చేయండి."
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr "రంగు వివరాలు డైలాగ్"
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr "వచన నమోదుతో రంగు వివరాల డైలాగ్ను చూపు."
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr "తదుపరి పాలెట్ కలర్"
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr "పెయింటింగ్ రంగును పాలెట్ లో తదుపరి రంగుకి సెట్ చేయండి."
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr "మునుపటి పాలెట్ కలర్"
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr "పెయింటింగ్ కలర్ను పూర్వపు రంగులోకి మార్చండి."
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr "పాలెట్ రంగుని జోడించండి"
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr "ప్రస్తుత పెయింటింగ్ రంగును పాలెట్కు చేర్చండి."
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "పొర"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr "పొరకు వెళ్ళండి"
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr "క్రింద కొత్త లేయర్"
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr "గుణాలు"
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr "స్క్రాచ్ప్యాడ్"
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr "కొత్త స్క్రాచ్ప్యాడ్"
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr "డిఫాల్ట్ స్క్రాచ్ప్యాడ్ను కొత్త స్క్రాచ్ప్యాడ్ కాన్వాస్గా లోడ్ చేయండి."
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr "స్క్రాచ్ప్యాడ్ను తెరువు …"
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr "డిస్క్లో ఇమేజ్ ఫైల్ని స్క్రాచ్ప్యాడ్లో లోడ్ చేయండి."
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr "స్క్రాచ్ప్యాడ్ను సేవ్ చేయండి"
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr "ప్రస్తుత  స్క్రాచ్ప్యాడ్ ఫైల్ ని డిస్క్లో సేవ్ చేయండి."
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr "స్క్రాచ్ప్యాడ్ను ఎగుమతి చెయ్యి …"
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr "మీ ఎంపిక పేరుతో, స్క్రాచ్ప్యాడ్ను డిస్క్కి ఎగుమతి చెయ్యండి."
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr "స్క్రాచ్ప్యాడ్ను పునరుద్ధరించు"
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr "స్క్రాచ్ప్యాడ్ను దాని చివరిగా సేవ్ చేయబడిన స్థితికి మార్చండి."
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr "స్క్రాచ్ప్యాడ్ డిఫాల్ట్గా సేవ్ చేయి"
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr "స్క్రాచ్ప్యాడ్ ని స్క్రాచ్ప్యాడ్ను డిఫాల్ట్గా సేవ్ చేయండి."
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr "డిఫాల్ట్ స్క్రాచ్ప్యాడ్ను క్లియర్ చేయండి"
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr "డిఫాల్ట్ స్క్రాచ్ప్యాడ్ను ఖాళీ కాన్వాస్కు క్లియర్ చేయండి."
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr "స్క్రాచ్ప్యాడ్కు ప్రధాన నేపథ్యాన్ని కాపీ చేయండి"
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr "పని పత్రం నుండి స్క్రాచ్ప్యాడ్కు నేపథ్య చిత్రాన్ని కాపీ చేయండి."
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "కిటికీ"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "కుంచె"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr "సత్వరమార్గం కీలు"
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr "బ్రష్ సత్వరమార్గం కీలు సహాయం"
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr "సత్వరమార్గం కీలు ఎలా పని చేస్తాయి అనేదాని వివరణను చూపించు."
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "కుంచె మార్చు…"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr "కర్సర్ కింద ఒక బ్రష్ మారకం పాప్ అప్."
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "రంగు మార్చు…"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "రంగు మార్చు (fast subset)…"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr "మరిన్ని కుంచెలు పొందండి…"
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "సహాయం"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr "ఆన్లైన్ సహాయం"
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "నా పెయింట్ గురించి"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "డీబగ్"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "వీక్షణ"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "పూర్తి స్క్రీన్"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "ప్రాధాన్యతలు సవరించు"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr "కుంచె అమరికల ఎడిటర్"
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr "పొరల ప్యానెలు"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr "పొరల ప్యానెలును చూపించు"
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "రంగుల పాలెట్"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr "చిత్తు పుస్తకం చూపించు"
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr "మున్నుచూపు ప్యానెల్"
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "మునుజూపు"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr "పనిముట్టు ఎంపికల ప్యానెల్"
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr "పనిముట్టు ఎంపికల ప్యానెల్ చూపించు"
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr "కుంచె, రంగుల చరిత్ర ప్యానెల్"
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr "ఇటీవలి కుంచె, రంగులు"
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr "గీత మరియు విక్రము"
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr "కలిపిన గీతలు"
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr "దీర్ఘవృత్తం, వృత్తం"
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr "సిరా"
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr "పొర స్థానం మార్చు"
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr "ఫ్రేమ్ సరిదిదు"
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "చిత్తరువు సౌష్ఠవం సరిదిదు"
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "రంగుని ఎంచుకోండి"
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "రంగుని ఎంచుకోండి"
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "రంగుని ఎంచుకోండి"
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr "రంగుని ఎంచుకోండి"
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""
+
+#~ msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
+#~ msgid "{action_label} {action_desc} {accel_label}"
+#~ msgstr "{action_label} {action_desc} {accel_label}"
+
+#~ msgctxt "Menu→Edit (labels)"
+#~ msgid "Current Tool"
+#~ msgstr "ప్రస్తుత సాధనం"

--- a/po/tg.po
+++ b/po/tg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:19+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Tajik <https://hosted.weblate.org/projects/mypaint/mypaint/tg/"
@@ -19,27 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -47,39 +27,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -87,214 +67,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Рангӣ"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Ихтисосӣ"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -333,141 +323,176 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Нигоҳ доштан"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Нав"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -475,58 +500,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -535,51 +560,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -589,137 +638,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -727,162 +776,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -890,373 +931,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Ном"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Баргашти амал"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Анҷоми амал"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1266,324 +1304,677 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Кушодан..."
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr ""
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Баромадан"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Баромадан"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Кушодан..."
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Нигоҳ доштан"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr ""
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr ""
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Файл"
+
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Кушодан..."
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Кушодани охиринҳо"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Кушодан..."
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Кушодан..."
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr ""
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1591,130 +1982,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1723,35 +2126,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1775,45 +2178,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1821,153 +2228,217 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr ""
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr ""
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr ""
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1979,256 +2450,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2236,188 +2732,212 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+msgid "Import Layers"
+msgstr ""
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2426,13 +2946,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2442,7 +2962,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2450,13 +2970,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2464,7 +2984,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2472,7 +2992,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2483,7 +3003,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2491,7 +3011,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2501,7 +3026,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2512,285 +3037,394 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr ""
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2800,7 +3434,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2809,52 +3463,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2876,17 +3561,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2915,112 +3598,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3033,7 +3691,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3074,6 +3732,133 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Ном"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3443,56 +4228,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3500,12 +4305,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3514,7 +4319,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3525,28 +4330,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3608,1828 +4413,2018 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Хурд кардан"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Файл"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Роҳнамо"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/tg.po
+++ b/po/tg.po
@@ -512,17 +512,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1183,12 +1183,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1371,7 +1371,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Open dragged file confirm dialog: continue button"
 msgid "_Open"
-msgstr "Кушодан..."
+msgstr "Кушодан…"
 
 #: ../gui/drawwindow.py:486
 msgid "Set current color"
@@ -1405,7 +1405,7 @@ msgid "_Quit"
 msgstr "Баромадан"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1455,7 +1455,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1631,13 +1631,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Нигоҳ доштан"
 
@@ -1703,7 +1703,7 @@ msgstr "Файл"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -1720,7 +1720,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Кушодан..."
+msgstr "Кушодан…"
 
 #: ../gui/filehandling.py:1427
 #, fuzzy
@@ -1732,7 +1732,7 @@ msgstr "Кушодани охиринҳо"
 #, fuzzy
 msgctxt "File→Open Most Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Кушодан..."
+msgstr "Кушодан…"
 
 #: ../gui/filehandling.py:1446
 msgctxt "File→Open Next/Prev Scrap: error message"
@@ -1753,7 +1753,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
 msgid "_Open"
-msgstr "Кушодан..."
+msgstr "Кушодан…"
 
 #: ../gui/filehandling.py:1487
 msgctxt "File→Revert: status message: canvas has no filename yet"
@@ -2127,12 +2127,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2144,7 +2144,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2329,7 +2329,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2399,7 +2399,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/th.po
+++ b/po/th.po
@@ -512,17 +512,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
-msgstr "กลุ่มใหม่..."
+msgid "New Group…"
+msgstr "กลุ่มใหม่…"
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1184,12 +1184,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1372,7 +1372,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Open dragged file confirm dialog: continue button"
 msgid "_Open"
-msgstr "เปิด..."
+msgstr "เปิด…"
 
 #: ../gui/drawwindow.py:486
 msgid "Set current color"
@@ -1407,7 +1407,7 @@ msgid "_Quit"
 msgstr "เลิก"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1457,7 +1457,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1644,13 +1644,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr "JPEG 90% คุณภาพ (*.jpg; *.jpeg)"
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "บันทึก"
 
@@ -1719,7 +1719,7 @@ msgstr "แฟ้ม"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr "เปิดชิ้นส่วนถัดไป"
 
 #: ../gui/filehandling.py:1099
@@ -1737,7 +1737,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "เปิด..."
+msgstr "เปิด…"
 
 #: ../gui/filehandling.py:1427
 #, fuzzy
@@ -1749,7 +1749,7 @@ msgstr "เปิดเอกสารที่เคยเรียกใช้
 #, fuzzy
 msgctxt "File→Open Most Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "เปิด..."
+msgstr "เปิด…"
 
 #: ../gui/filehandling.py:1446
 #, fuzzy
@@ -1773,7 +1773,7 @@ msgstr "เปิดชิ้นส่วนก่อนหน้า"
 #, fuzzy
 msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
 msgid "_Open"
-msgstr "เปิด..."
+msgstr "เปิด…"
 
 #: ../gui/filehandling.py:1487
 msgctxt "File→Revert: status message: canvas has no filename yet"
@@ -2147,13 +2147,13 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
-msgstr "รายงาน..."
+msgid "Report…"
+msgstr "รายงาน…"
 
 #: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
@@ -2164,8 +2164,8 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
-msgstr "รายละเอียด..."
+msgid "Details…"
+msgstr "รายละเอียด…"
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
@@ -2350,7 +2350,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2421,7 +2421,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/th.po
+++ b/po/th.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-23 08:18+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
-"Language-Team: Thai <https://hosted.weblate.org/projects/mypaint/mypaint/th/>"
-"\n"
+"Language-Team: Thai <https://hosted.weblate.org/projects/mypaint/mypaint/th/"
+">\n"
 "Language: th\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,27 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -47,39 +27,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -87,214 +67,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "บันทึกเป็นค่าเริ่มต้น"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "พื้นหลัง"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "รูปแบบ"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "สี"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "เพิ่มสีสันให้กับรูปแบบ"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "รอยเปื้อน"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr ""
+
+#: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr ""
 
-#: ../gui/brusheditor.py:359
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "การลาก"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "กำหนดเอง"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "เปลี่ยนชื่อแปรง"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "แปรงที่ใช้มีชื่อนี้มีอยู่แล้ว!"
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -333,141 +323,176 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "บันทึก"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "สร้างใหม่"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
-msgstr "ลบแปรงจากดิสก์จริงๆใช่ไหม?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
+msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "กลุ่มที่มีชื่อนี้ มีอยู่แล้ว!"
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -475,58 +500,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "กลุ่มใหม่..."
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "สร้างกลุ่ม"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -535,51 +560,76 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr "เลือกสี"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "เลือกสี"
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -589,137 +639,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -727,162 +777,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -890,373 +932,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr "ยางลบ"
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "ชื่อ"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr "เรียกคืนแปรง %d"
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr "บันทึกไปยังแปรง %d"
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "เลิกทำ"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "ทำซ้ำ"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1266,324 +1305,696 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "เปิด..."
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "เต็มจอ"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "เลิก"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+#, fuzzy
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr "ออกจริง ๆ ?"
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "เลิก"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr "ทุกรูปแบบที่ได้รับการยอมรับ"
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr "OpenRaster (*.ora)"
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr "PNG (*.png)"
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr "JPEG (*.jpg; *.jpeg)"
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr "PNG ที่โปร่งใส (* .png)"
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr "หลาย PNG ที่โปร่งใส (* .XXX.png)"
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr "JPEG 90% คุณภาพ (*.jpg; *.jpeg)"
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr "_บันทึกเป็น Scrap"
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "บันทึกเป็นค่าเริ่มต้น"
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
+msgstr "ทุกรูปแบบที่ได้รับการยอมรับ"
+
+#: ../gui/filehandling.py:432
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:437
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:442
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
+msgstr "JPEG (*.jpg; *.jpeg)"
+
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:494
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:502
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:506
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr "PNG ที่โปร่งใส (* .png)"
+
+#: ../gui/filehandling.py:510
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr "หลาย PNG ที่โปร่งใส (* .XXX.png)"
+
+#: ../gui/filehandling.py:514
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr "หลาย PNG ที่โปร่งใส (* .XXX.png)"
+
+#: ../gui/filehandling.py:518
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr "JPEG 90% คุณภาพ (*.jpg; *.jpeg)"
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "บันทึก"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:668
+#, fuzzy
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr "ออกจริง ๆ ?"
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
+#: ../gui/filehandling.py:705
+#, fuzzy
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr "_บันทึกเป็น Scrap"
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr ""
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr ""
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "แฟ้ม"
+
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
+msgid "Open Scratchpad..."
+msgstr "เปิดชิ้นส่วนถัดไป"
+
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "ชั้นเอกสาร"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
 msgstr "เปิด..."
 
-#: ../gui/filehandling.py:552
-msgid "Open Scratchpad..."
-msgstr ""
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "เปิดเอกสารที่เคยเรียกใช้"
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "เปิด..."
+
+#: ../gui/filehandling.py:1446
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
 msgstr "ยังไม่ไมีชื่อแฟ้ม scrap  \"%s\" เลย."
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1455
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr "เปิดชิ้นส่วนถัดไป"
+
+#: ../gui/filehandling.py:1463
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr "เปิดชิ้นส่วนก่อนหน้า"
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "เปิด..."
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "ความทึบแสง:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1591,130 +2002,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr "ข้อผิดพลาดที่ตรวจพบ"
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr "<big><b>ตรวจพบข้อผิดพลาดของการเขียนโปรแกรม</b></big>"
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1723,35 +2146,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr "รายงาน..."
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr "รายละเอียด..."
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1775,45 +2198,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1821,153 +2248,219 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "ชั้นเอกสาร"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "ชั้นเอกสาร"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "ความทึบแสง:"
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "เปลี่ยนชื่อแปรง"
 
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr ""
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr ""
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr ""
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr ""
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 msgid "Stroke lead-in end"
 msgstr ""
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr ""
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1978,263 +2471,288 @@ msgid ""
 "This program is distributed in the hope that it will be useful, but WITHOUT "
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
-"โปรแกรมนี้เป็นฟรีซอฟต์แวร์ คุณสามารถแจกจ่ายต่อและ / หรือแก้ไขได้ภายใต้เงื่อนไ"
-"ขของสัญญาอนุญาตสาธารณะทั่วไปที่เผยแพร่โดยมูลนิธิฟรีซอฟต์แวร์; ทั้ง 2 "
+"โปรแกรมนี้เป็นฟรีซอฟต์แวร์ คุณสามารถแจกจ่ายต่อและ / "
+"หรือแก้ไขได้ภายใต้เงื่อนไขของสัญญาอนุญาตสาธารณะทั่วไปที่เผยแพร่โดยมูลนิธิฟรีซอฟต์แวร์; ทั้ง 2 "
 "รุ่นของใบอนุญาตหรือ (ที่คุณจะเลือก) รุ่นใด ๆ ในภายหลัง \n"
 " \n"
 "โปรแกรมนี้มีการกระจายความหวังว่ามันจะเป็นประโยชน์ แต่ไม่มีการรับประกันใด ๆ "
 "ดูแฟ้มสำเนาสำหรับรายละเอียดเพิ่มเติม "
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr "การเขียนโปรแกรม"
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr "การพกพา"
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr "ไอคอนเดสก์ท็อป"
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2242,188 +2760,214 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "สร้างกลุ่ม"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr "ผสานการลง"
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "ชั้นเอกสาร"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2432,13 +2976,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2448,7 +2992,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2456,13 +3000,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2470,7 +3014,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2478,7 +3022,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2489,7 +3033,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2497,7 +3041,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2507,7 +3056,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2518,285 +3067,395 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "สร้างกลุ่ม"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2806,7 +3465,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2815,52 +3494,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2882,17 +3592,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2921,112 +3629,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3039,7 +3722,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3080,6 +3763,134 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "ชื่อ"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "ความทึบแสง:"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3449,56 +4260,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3506,12 +4337,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3520,7 +4351,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3531,28 +4362,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3614,1828 +4445,2028 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
-msgstr "บันทึกเป็น Scrap"
+msgid "Export…"
+msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
-msgstr "เปิดชิ้นส่วนก่อนหน้า"
+msgid "Save As Scrap"
+msgstr "บันทึกเป็น Scrap"
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
-msgstr "เปิดชิ้นส่วนถัดไป"
+msgid "Open Previous Scrap"
+msgstr "เปิดชิ้นส่วนก่อนหน้า"
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Open Next Scrap"
+msgstr "เปิดชิ้นส่วนถัดไป"
+
+#: ../po/tmp/resources.xml.h:25
+msgctxt "Accel Editor (descriptions)"
+msgid "Load the scrap file after the current one."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Recover File from an Automated Backup…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:25
+#: ../po/tmp/resources.xml.h:27
 msgctxt "Accel Editor (descriptions)"
 msgid "Try to save and resume interrupted unsaved work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:26
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "ขยายออก"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
-msgstr "หมุนทวนเข็มนาฬิกา"
-
-#: ../po/tmp/resources.xml.h:137
-msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:157
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the left."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr "หมุนตามเข็มนาฬิกา"
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
-msgstr ""
+msgid "Rotate the canvas clockwise."
+msgstr "หมุนทวนเข็มนาฬิกา"
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr "หมุนทวนเข็มนาฬิกา"
+
+#: ../po/tmp/resources.xml.h:167
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr "หมุนทวนเข็มนาฬิกา"
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr "Layer Solo"
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr "เห็นภาพการแสดงผล"
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "แฟ้ม"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "แปรง"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "วิธีใช้"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "เกี่ยวกับ MyPaint"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "ดีบั๊ก"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
-msgstr ""
+msgstr "ชั้นเอกสาร"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "เลือกสี"
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "เลือกสี"
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "เลือกสี"
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""
+
+#~ msgctxt "brush list commands"
+#~ msgid "Really delete brush from disk?"
+#~ msgstr "ลบแปรงจากดิสก์จริงๆใช่ไหม?"

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-08-27 08:23+0000\n"
 "Last-Translator: leela <53352@protonmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -19,29 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.9-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr "<big><b>{accel_label}</b></big>"
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr "{action_label} {action_desc} {accel_label}"
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "Eylem"
 
@@ -49,41 +27,41 @@ msgstr "Eylem"
 msgid "Key combination"
 msgstr "Tuş Kombinasyonu"
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr "'%s' için tuşu düzenle"
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "Eylem:"
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "Yol:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "Tuş:"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr "Bu atamayı güncellemek için tuşlara bas"
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "Bilinmeyen Eylem"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
-"<b>{accel} zaten '{action}' için kullanılıyor. Varolan atama "
-"değiştirilecek.</b>"
+"<b>{accel} zaten '{action}' için kullanılıyor. Varolan atama değiştirilecek."
+"</b>"
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr "Klasörü Aç “{folder_basename}”…"
@@ -91,198 +69,208 @@ msgstr "Klasörü Aç “{folder_basename}”…"
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "Tamam"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr "Önbellekte herhangi bir yedek bulunamadı."
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr "Kullanılabilir Yedek Yok"
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr "Önbellek Klasörünü Aç…"
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr "Yedek Kurtarma Başırısız Oldu"
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr "Yedekler Klasörünü Aç…"
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr "Kurtarılmış dosya {iso_datetime}.ora"
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "Varsayılan Olarak Kaydet"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "Arkaplan"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "Desen"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Renk"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "Desenlere renk ekle"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr "Bir yada daha fazla arkaplan yüklenemedi"
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr "Arkaplanlar yüklenirken hata"
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 "Lütfen yüklenemez dosyaları silin, yada libgdkpixbuf kurulumunu gözden "
 "geçirin."
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 "Gdk-Pixbuf \"{filename}\" dosyasını yükleyemedi ve \"{error}\" hatası "
 "raporladı"
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr "{filename} dosyasının boyutu sıfır (g={w}, y={h})"
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr "Fırça Ayarları Düzenleyici"
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr "Hakkında"
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "Deneysel"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr "Temel"
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr "Matlık"
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr "Damlalar"
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "Lekeleme"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr "Hız"
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr ""
+
+#: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr "İzleme"
 
-#: ../gui/brusheditor.py:359
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "Darbe"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr "Renk"
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Özel"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 "Hiçbir fırça seçilmedi, lütfen onun yerine \"Yeni Olarak Ekle\"'yi kullan."
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr "Hiçbir fırça seçilmedi!"
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "Fırçayı Yeniden Adlandır"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "Bu adla bir fırça zaten var!"
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr "Hiçbir fırça seçilmedi!"
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr "\"{brush_name}\" fırçası gerçekten silinsin mi?"
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr "(Adsız fırça)"
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr "{brush_name} [kaydedilmedi]"
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr "Fırça Simgesi"
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr "Fırça Simgesi (düzenleniyor)"
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr "Hiçbir fırça seçilmedi"
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -291,7 +279,7 @@ msgstr ""
 "<b>%s</b>\n"
 "<small>Önce geçerli bir fırça seç</small>"
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
@@ -300,7 +288,7 @@ msgstr ""
 "<b>%s</b> <i>(değiştirildi)</i>\n"
 "<small>Değişiklikler daha kaydedilmedi</small>"
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
@@ -309,7 +297,7 @@ msgstr ""
 "<b>%s</b> (düzenleniyor)\n"
 "<small>Herhangi bir fırça veya renkle boyayın</small>"
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -350,142 +338,182 @@ msgstr "Otomatik"
 msgid "Use the default icon"
 msgstr "Varsayılan simgeyi kullan"
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Kaydet"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr "Bu önizleme simgesini kaydet ve düzenlemeyi bitir"
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr "Kayıp ve Bulunmuş"
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr "Silindi"
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr "Yer İmleri"
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr "Mürekkep"
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr "Klasik"
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr "Set#1"
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr "Set#2"
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr "Set#3"
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr "Set#4"
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr "Set#5"
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr "Deneysel"
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Yeni"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr "Bilinmeyen Fırça"
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr "Yer İmlerine Ekle"
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr "Yer İmlerinden Kaldır"
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr "Kopyala"
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr "Fırça Ayarlarını Düzenle"
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
-msgstr "Sil"
+#: ../gui/brushselectionwindow.py:250
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
+msgstr "Grubu Yeniden Adlandır"
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
-msgstr "Bu fırçayı diskten silmek istediğinize emin misiniz?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, fuzzy, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
+msgstr "\"{brush_name}\" fırçası gerçekten silinsin mi?"
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] "%d fırça"
 msgstr[1] "%d fırça"
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr "Grup “{group_name}”"
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr "Grubu Yeniden Adlandır"
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr "Sıkıştırılmış Fırça Seti Olarak Dışa Aktar"
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr "Grubu Sil"
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr "Grubu Yeniden Adlandır"
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "Bu adla bir grup zaten var!"
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr "\"{group_name}\" grubunu gerçekten silinsin mi?"
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -495,58 +523,58 @@ msgstr ""
 "“{group_name}” grubu silinemedi.\n"
 "Bazı özel gruplar silinemez."
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr "Fırçaları Dışa Aktar"
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr "MyPaint fırça paketi (*.zip)"
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "Yeni Grup..."
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr "Fırçaları İçe Aktar..."
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr "Daha Fazla Fırça Edin..."
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "Grup Oluştur"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr "Düğme"
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr "Btn"
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr "Düğme Basışı"
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr "Yeni bağlama ekle"
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr "Geçerli bağlamayı kaldır"
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr "'%s' için bağlamayı düzenle"
@@ -555,7 +583,7 @@ msgstr "'%s' için bağlamayı düzenle"
 msgid "Button press:"
 msgstr "Buton baskısı:"
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
@@ -563,7 +591,7 @@ msgstr ""
 "Değiştirme tuşlarını basılı tutun ve yeni bir atama ayarlamak için bu metnin "
 "üzerinde bir düğmeye bas."
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
@@ -571,40 +599,68 @@ msgstr ""
 "{button} değiştirici tuşlar olmadan bağlanamaz (bunun anlamı sabit "
 "olduğudur, üzgünüz)"
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr "{button_combination} zaten '{action_name}' eylemine bağlı"
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr "Renk Seç"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr "Boyama için kullanılacak Rengi seç"
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+#, fuzzy
+msgid "Set the color Hue used for painting"
+msgstr "Boyama için kullanılacak Rengi seç"
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "Renk Seç"
+
+#: ../gui/colorpicker.py:296
+#, fuzzy
+msgid "Set the color Chroma used for painting"
+msgstr "Boyama için kullanılacak Rengi seç"
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+#, fuzzy
+msgid "Set the color Luma used for painting"
+msgstr "Boyama için kullanılacak Rengi seç"
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr "Renk ayrıntıları"
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr "Geçerli fırça rengi ve boyama için kullanılan en son renk"
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr "Gamut Maskesi Etkin"
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr "Gamut maskesi kullanarak belirli ruh halleri için paleti sınırla."
@@ -614,7 +670,7 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr "HCY ton ve renk saflığı."
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
@@ -623,12 +679,12 @@ msgstr ""
 "Gamut maskesi düzenleyici. Şekil oluşturmak veya işlemek için ortasına tıkla "
 "veya diskin kenarlarını kullanarak maskeyi döndür."
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr "Atmosferik Triad"
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
@@ -637,34 +693,34 @@ msgstr ""
 "Ruh halli ve özne, bir baskın ana renk ve daha az yoğun iki ana renk ile "
 "tanımlanır."
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr "Değişmiş Triad"
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr "Baskın renge karşı daha güçlü tartılır."
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr "Tamamlayıcı"
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr "Ruh Hali ve Vurgu"
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
@@ -672,84 +728,84 @@ msgid ""
 msgstr ""
 "Varyasyon ve vurgulamalar için tamamlayıcı vurgu ile bir ana renk yelpazesi."
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr "Tamamlayıcı Bölünmüş"
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr "İki benzer renk ve bir tamamlayıcı, aralarında ikincil renk olmadan."
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr "Şablondan Yeni Gamut Maskesi"
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr "Gamut Maskesi Düzenleyici"
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr "Etkin"
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr "Yardım…"
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr "Şablondan maske oluştur."
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr "GIMP palet dosyasından maske yükle."
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr "GIMP palet dosyasına maske kaydet."
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr "Maskeyi sil."
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr "Bu iletişim kutusunun çevrimiçi yardımını web tarayıcısında aç."
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr "Maskeyi GIMP Paleti Olarak Kaydet"
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr "GIMP Paletinden Maske Yükle"
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr "Gamut maskesi seç."
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr "HCY Tekerleği"
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -759,162 +815,154 @@ msgstr ""
 "Dairesel dilimler eşittir."
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr "HSV Tonu"
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr "HSV Doygunluğu"
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr "HSV Değeri"
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr "HSV Doygunluğu ve Değeri"
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr "HSV Tonu ve Değeri"
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr "HSV Tonu ve Doygunluğu"
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr "Küpü döndür (farklı ekseni göster)"
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr "HSV Küpü"
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr "Farklı düzlemsel dilimleri göstermek için döndürülebilen bir HSV Küpü."
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr "HSV Karesi"
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr "Farklı tonları göstermek için döndürülebilen bir HSV Karesi."
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr "HSV Üçgen"
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr "Standard GTK renk seçici"
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr "HSV Tekerleği"
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr "Doygunluk ve Değer renk değiştiricisi."
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr "Palet Özellikleri"
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr "Palet"
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr "Yüklenebilir, düzenlenebilir bir paletten renk seç."
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr "Başlıksız Palet"
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr "Palet Düzenleyici"
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr "GIMP palet dosyasından yükle"
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr "GIMP palet dosyasına kaydet"
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr "Yeni boş renk örneği ekle"
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr "Geçerli renk örneğini kaldır"
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr "Tüm renk örneklerini kaldır"
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr "Başlık:"
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr "Bu palet için ad veya açıklama"
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr "Sütun:"
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr "Sütun sayısı"
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr "Renk adı:"
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr "Geçerli rengin adı"
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr "Boş palet yuvası"
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr "Paleti yükle"
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr "Paleti kaydet"
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -925,379 +973,376 @@ msgstr ""
 "Renkleri buraya bırak,\n"
 "organize etmek için sürükle."
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr "Boş palet yuvası (buraya bir renk sürükle)"
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr "Boş Yuva Ekle"
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr "Satır Ekle"
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr "Sütun Ekle"
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr "Boşluk Doldur (RGB)"
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr "Boşluk Doldur (HCY)"
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr "Boşluk Doldur (HSV)"
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "GIMP palet dosyası (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr "Tüm dosyalar (*)"
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "GIMP palet dosyası (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr "Tüm dosyalar (*)"
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr "Ekrandan bir renk seç"
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr "R"
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr "G"
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr "B"
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr "H"
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr "C"
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr "Y"
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr "Bileşen Sürgüleri"
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr "Rengin bağımsız bileşenlerini ayarla."
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr "RGB Kırmızı"
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr "RGB Yeşil"
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr "RGB Mavi"
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr "HSV Tonu"
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr "HSV Doygunluğu"
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr "HSV Değeri"
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr "HCY Tonu"
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr "HCY Renk Saflığı"
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr "HCY Renk Parlaklığı (Y')"
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr "Sıvı Boya Tabakası"
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr "Yakındaki renklerden sıvı boya tabakası kullanarak renk değiştir."
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr "Eşmerkezli Halkalar"
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr "Eşmerkezli HSV halkaları kullanarak renk değiştir."
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr "Çapraz Kase"
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr "Radyal bir renk kabının üstünden geçen HSV rampalarla renk değiştir."
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr "İmleç/puck"
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr "Silgi"
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr "Klavye"
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr "Fare"
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr "Kalem"
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr "Dokunmatik yüzey"
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr "Dokunmatik ekran"
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr "Yoksay"
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr "Herhangi bir görev"
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr "Boyama dışındaki görevler"
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr "Sadece gezinti"
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr "Yakınlaştır"
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr "Kaydır"
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr "Aygıt"
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr "Eksen"
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr "Tür"
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr "Kullanım Amacı"
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr "Kaydır"
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Ad"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr "Fırçanın üzerine yazılsın mı?"
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr "Değiştir"
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr "Yeniden Adlandır"
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr "Tümünü değiştir"
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr "Tümünü yeniden adlandır"
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr "İçe aktarılmış fırça"
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr "Varolan fırça"
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 "<b>%s adında bir fırça zaten var.</b>\n"
 "Olanı değiştirmek mi, veya yeni fırçayı yeniden adlandırmak mı istersiniz?"
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr "Fırça grubunun üzerine yazılsın mı?"
 
-#: ../gui/dialogs.py:190
-#, python-brace-format
+#: ../gui/dialogs.py:220
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 "<b>{groupname} adında bir grup zaten var.</b>\n"
 "Olanı değiştirmek mi, yoksa yeni grubu yeniden adlandırmak mı istersiniz?\n"
 "Eğer değiştirirseniz, fırçalar {deleted_groupname} adındaki gruba "
 "aktarılabilir."
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr "Fırça paketi içe aktarılsın mı?"
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, fuzzy, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr "<b>`%s' paketini içeri almayı gerçekten istiyor musunuz?</b>"
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr "%d nolu kısayol yuvasından fırça ayarlarını yükle"
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr "%d nolu kısayol yuvasında fırça ayarlarını sakla"
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr "%d Nolu Fırçayı Geri Yükle"
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr "%d Nolu Kısayola Kaydet"
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr "Geri Al %s"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Geri Al"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr "Yinele %s"
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Yinele"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr "{button_combination} {resultant_action}"
@@ -1307,93 +1352,130 @@ msgstr "{button_combination} {resultant_action}"
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ";  "
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr "{modifiers} basılı tutulduğunda: {button_actions}."
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
-msgstr "Katman Adı"
-
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
-#, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
-"<b>{name}</b>\n"
-"{description}"
+
+#: ../gui/document.py:909
+#, python-brace-format
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
+msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr "%s - MyPaint"
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr "MyPaint"
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Aç"
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr "Geçerli Rengi Ayarla"
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr "Tam Ekran Kipinden Çık"
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr "Tam Ekrandan Çık"
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr "Tam Ekran Kipine Gir"
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Tam Ekran"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Çıkış"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+#, fuzzy
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr "Çıkış"
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Çıkış"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr "Fırça paketini içe aktar..."
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr "MyPaint fırça paketi (*.zip)"
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 "“{layer_name}” katmanını düzenlemek için {app_name} uygulaması başlatıldı"
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 "Hata: {app_name} uygulaması “{layer_name}” katmanını düzenlemek için "
 "başlatılamadı"
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
@@ -1401,12 +1483,18 @@ msgstr ""
 "Düzenleme iptal edildi. Yine de “{layer_name}” katmanını Katmanlar "
 "menüsünden düzenleyebilirsin."
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr "“{layer_name}” katmanı harici düzenlemeyle güncellendi"
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr "“{file_basename}” dosyası yüklenemedi."
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
@@ -1415,7 +1503,7 @@ msgstr ""
 "MyPaint'in “{type_name}” ({content_type}) türündeki bir dosyayı düzenlemesi "
 "gerekiyor. Hangi uygulamayı kullansın?"
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
@@ -1424,161 +1512,374 @@ msgstr ""
 "“{type_name}” ({content_type}) türündeki dosyaları düzenlemek için MyPaint "
 "hangi uygulamayı kullansın?"
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr "Birlikte Aç..."
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr "Simge"
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr "açıklama yok"
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
+#: ../gui/filehandling.py:126
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
+msgstr "“{file_basename}” dosyası yükleniyor…"
+
+#: ../gui/filehandling.py:130
+#, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:134
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
+msgstr "“{file_basename}” dosyası kaydediliyor…"
+
+#: ../gui/filehandling.py:138
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
+msgstr "“{file_basename}” dosyasına dışa aktarılıyor…"
+
+#: ../gui/filehandling.py:145
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr "“{file_basename}” dosyasına dışa aktarılamadı."
+
+#: ../gui/filehandling.py:149
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr "“{file_basename}” dosyasına kaydedilemedi."
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr "“{file_basename}” dosyası yüklenemedi."
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "Paleti kaydet"
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr "“{file_basename}” dosyasına dışa aktarıldı."
+
+#: ../gui/filehandling.py:187
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr "“{file_basename}” dosyası kaydedildi."
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr "“{file_basename}” dosyası yüklendi."
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
+msgstr "“{file_basename}” dosyası yüklendi."
+
+#: ../gui/filehandling.py:427
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "All Recognized Formats"
 msgstr "Tüm Tanınan Biçimler"
 
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
+#: ../gui/filehandling.py:432
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "OpenRaster (*.ora)"
 msgstr "OpenRaster (*.ora)"
 
-#: ../gui/filehandling.py:95
+#: ../gui/filehandling.py:437
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "PNG (*.png)"
 msgstr "PNG (*.png)"
 
-#: ../gui/filehandling.py:96
+#: ../gui/filehandling.py:442
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "JPEG (*.jpg; *.jpeg)"
 msgstr "JPEG (*.jpg; *.jpeg)"
 
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
+#: ../gui/filehandling.py:490
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "By extension (prefer default format)"
 msgstr "Uzantıya göre (varsayılan biçimi tercih et)"
 
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
+#: ../gui/filehandling.py:494
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:498
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
 msgstr "PNG artalanla birlikte görünür (* .png)"
 
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
+#: ../gui/filehandling.py:502
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:506
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
 msgstr "PNG saydam (*.png)"
 
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
+#: ../gui/filehandling.py:510
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
 msgstr "Çoklu PNG saydam (*.XXX.png)"
 
-#: ../gui/filehandling.py:113
+#: ../gui/filehandling.py:514
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr "Çoklu PNG saydam (*.XXX.png)"
+
+#: ../gui/filehandling.py:518
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr "JPEG %90 kalite (*.jpg; *.jpeg)"
 
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr "Kaydet..."
+#: ../gui/filehandling.py:576
+#, fuzzy
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr "Dışa Aktar…"
 
-#: ../gui/filehandling.py:177
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Farklı Kaydet…"
+
+#: ../gui/filehandling.py:601
+#, fuzzy
+msgctxt "save dialogs: formats and options: (label)"
 msgid "Format to save as:"
 msgstr "Farklı kaydetme biçimi:"
 
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr "Onayla"
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
+#: ../gui/filehandling.py:668
+#, fuzzy
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
 msgstr "Devam Etmek İstiyor Musun?"
 
-#: ../gui/filehandling.py:234
-#, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
-msgstr "Bu kaydedilmemiş boyamanın {abbreviated_time} zamanından vazgeçecek"
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
+#: ../gui/filehandling.py:705
+#, fuzzy
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
 msgstr "_Karalama Olarak Kaydet"
 
-#: ../gui/filehandling.py:282
-#, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
-msgstr "“{file_basename}” dosyası yükleniyor…"
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
 
-#: ../gui/filehandling.py:296
-#, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
-msgstr "“{file_basename}” dosyası yüklenemedi."
+#: ../gui/filehandling.py:734
+#, fuzzy, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr "Bu kaydedilmemiş boyamanın {abbreviated_time} zamanından vazgeçecek"
 
-#: ../gui/filehandling.py:321
-#, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
-msgstr "“{file_basename}” dosyası yüklendi."
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
 
-#: ../gui/filehandling.py:422
-#, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
-msgstr "“{file_basename}” dosyasına dışa aktarılıyor…"
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
 
-#: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
-msgstr "“{file_basename}” dosyası kaydediliyor…"
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
-msgstr "“{file_basename}” dosyasına dışa aktarılamadı."
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr "Aç…"
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
-msgstr "“{file_basename}” dosyasına kaydedilemedi."
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Aç"
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
-msgstr "“{file_basename}” dosyasına dışa aktarıldı."
-
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
-msgstr "“{file_basename}” dosyası kaydedildi."
-
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Aç..."
-
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr "Karalama Defteri Aç..."
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "İçe aktarılmış fırça"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Aç"
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Son Kullanılan Dosyayı Aç"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Aç"
+
+#: ../gui/filehandling.py:1446
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
 msgstr "\"%s\" adında bir karalama dosyası henüz yok."
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1455
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr "Sonraki Karalamayı Aç"
+
+#: ../gui/filehandling.py:1463
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr "Önceki Karalamayı Aç"
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Aç"
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+#, fuzzy
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr "Geri döndür"
+
+#: ../gui/fill.py:121
+#, fuzzy
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr "Akıcı Dolgu"
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+#, fuzzy
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr "Alanları renkle doldur"
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+#, fuzzy
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr "Tolerans:"
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+#, fuzzy
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
@@ -1586,19 +1887,36 @@ msgstr ""
 "Akıcı Dolgusu bunları doldurmayı reddetmeden önce piksel \n"
 "renklerinin başlangıçtan ne kadar farklı olmasına izin verilir"
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+#, fuzzy
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr "Kaynak:"
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
-msgstr "Hangi görünür katmanlar doldurulmalı"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
+msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+#, fuzzy
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr "Birleştirme Örneği"
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+#, fuzzy
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
@@ -1608,19 +1926,50 @@ msgstr ""
 "geçerli katmanın altındaki tüm görünür katmanların \n"
 "geçici birleştirilmesini kullan"
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+#, fuzzy
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr "Görünüme Sığdır"
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+#, fuzzy
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr "Hedef:"
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+#, fuzzy
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr "Çıktının kaydedileceği konum"
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr "Yeni Katman (bir kere)"
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+#, fuzzy
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
@@ -1628,21 +1977,108 @@ msgstr ""
 "Dolgu sonuçları ile yeni katman oluştur.\n"
 "Bu kullanımdan sonra otomatik olarak kapanır."
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Matlık:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr "Sıfırla"
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+#, fuzzy
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr "Seçenekleri varsayılanlarına sıfırla"
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "Katman Seç"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr "<b>{brush_name}</b>"
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1652,130 +2088,142 @@ msgstr ""
 "<b>{brush_name}</b>\n"
 "{brush_desc}"
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr "Çerçeveyi Düzenle"
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr "Belgenin çerçevesini ayarla"
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr "Çerçeve Boyutu"
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr "px"
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr "Yükseklik:"
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr "Genişlik:"
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr "Çözünürlük:"
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr "DPI"
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr "İnç Başına Nokta (gerçekte İnç Başına Piksel)"
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr "Renk:"
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr "Çerçeve Rengi"
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr "<b>Çerçeve boyutları</b>"
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr "<b>Pixel yoğunluğu</b>"
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr "Çerçeveyi Katmana Ayarla"
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr "Çerçeveyi geçerli katmanın uzantılarına ayarla"
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr "Çerçeveyi Belgeye Ayarla"
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr "Çerçeveyi tüm katmanların birleşimine ayarla"
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr "Katmanı Çerçeveye Kırp"
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr "Geçerli katmanın çerçevesinin dışında kalan kısımlarını kes"
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr "Etkinleştirildi"
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr "{width:g}×{height:g} {units}"
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr "inç"
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr "cm"
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr "mm"
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr "Serbest Çizim"
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr "Serbest biçim fırça darbeleriyle boya."
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr "Pürüzsüzleştir:"
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr "Basınç:"
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr "Hata Algılandı"
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr "<big><b>Programlama hatası tespit edildi</b></big>"
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1789,35 +2237,35 @@ msgstr ""
 "Henüz hiç kimse raporlamadıysa, hata takipçisini kullanarak bu konu hakkında "
 "geliştiricilere bilgi verebilirsin."
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr "Hata Takipçisinde Ara"
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr "Raporla..."
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr "Hatayı Yoksay"
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr "MyPaint'den Çık"
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr "Ayrıntılar..."
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr "İstisna analiz edilirken istisna oluştu."
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1857,45 +2305,50 @@ msgstr ""
 "#### Traceback\n"
 "      "
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr "Mürekkepleme"
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr "Çiz ve sonrasında pürüzsüz çizgileri ayarla"
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr "Girdi Aygıtı Testi"
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr "(basınç yok)"
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr "Basınç:"
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr "(eğim yok)"
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr "Eğim:"
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr "(aygıt yok)"
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
 msgstr "Aygıt:"
 
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+#, fuzzy
+msgid "Barrel Rotation:"
+msgstr "Döndürmeyi Sıfırla"
+
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr "Katmanı Taşı"
 
@@ -1903,159 +2356,225 @@ msgstr "Katmanı Taşı"
 msgid "Move the current layer"
 msgstr "Geçerli katmanı taşı"
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
-msgstr "{default_name} : {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
+msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
-msgstr "Tür"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
+msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+#, fuzzy
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr "Özellikler"
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr "Görünür"
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Katman"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+#, fuzzy
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr "Kilitli"
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+#, fuzzy
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ", "
+
+#: ../gui/layers.py:990
+#, fuzzy, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr "{layer_default_name} Ekle"
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Katmanlar"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr "Katmanları düzenle ve etki ata"
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr "Katman matlığı: %%%d"
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr "Katmanı yığında taşı..."
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr "Katmanı yığında taşı (normal bir katmana bırakmak yeni grup oluştur)"
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr "Katman"
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
-msgstr "Mod:"
+#: ../gui/layervis.py:53
+#, fuzzy, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
+msgstr "<b>{brush_name}</b>"
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
-"Harmanlama kipi: geçerli katmanın altındaki katmanlarla nasıl "
-"birleştirileceği."
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Matlık:"
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "Görünümü Döndür"
 
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-"Katman matlığı: geçerli katmanın ne kadarının kullanılacağı. Daha küçük "
-"değerler daha saydam yapar."
-
-#: ../gui/linemode.py:37
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr "Giriş Basıncı"
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr "Çizgi araçları için darbe giriş basıncı"
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr "Orta Nokta Basıncı"
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr "Çizgi araçları için orta darbe basıncı"
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr "Çıkış Basıncı"
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr "Çizgi araçları için darbe çıkış basıncı"
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr "Baş"
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 msgid "Stroke lead-in end"
 msgstr "Bitişe yol gösteren darbe"
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr "Kuyruk"
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr "Başlangıçtan azalarak yok olan darbe"
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr "Basınç Çeşitliliği"
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr "Çizgiler ve Eğriler"
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr "Genel çizgi/eğri kipi"
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr "Düz çizgiler çiz; Shift eğri ekler, Ctrl açıyı kısıtlar"
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr "Bağlı Çizgiler"
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr "Çizgi parçası çiz; Shift eğri ekler, Ctrl açıyı kısıtlar"
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr "Elipsler ve Daireler"
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr "Elips çiz; Shift döndürür, Ctrl en boy oranı/açıyı kısıtlar"
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
+#, fuzzy
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 "Copyright (C) 2005-2019\n"
 "Martin Renold ve the MyPaint Geliştirme Ekibi"
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -2066,80 +2585,80 @@ msgid ""
 "This program is distributed in the hope that it will be useful, but WITHOUT "
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
-"MyPaint özgür bir yazılımdır; onu Özgür Yazılım Vakfı'nın yayınladığı GNU \""
-"Genel Kamu Lisansı'nın 2. sürümü veya (tercihinize bağlı) daha sonraki "
+"MyPaint özgür bir yazılımdır; onu Özgür Yazılım Vakfı'nın yayınladığı GNU "
+"\"Genel Kamu Lisansı'nın 2. sürümü veya (tercihinize bağlı) daha sonraki "
 "sürümleri altında dağıtabilir ve/veya değiştirebilirsiniz.\"\n"
 "\n"
 "MyPaint faydalı olacağı umut edilerek dağıtılmaktadır, fakat HİÇBİR "
 "GARANTİSİ YOKTUR. Daha fazla ayrıntı için GNU Genel Kamu Lisansı'nı "
 "inceleyin."
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr "programlama"
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr "taşınabilirlik"
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr "proje yönetimi"
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr "fırçalar"
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr "desenler"
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr "araç simgeleri"
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr "masaüstü simgesi"
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr "paletler"
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr "belgelendirme"
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr "destek"
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr "sosyal yardım"
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr "topluluk"
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ", "
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
@@ -2158,186 +2677,216 @@ msgstr ""
 "------------------------------------------------------------\n"
 "Sabri Ünal <libreajans@gmail.com>, 2019"
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr "Boyut:"
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr "Matlık:"
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr "Keskinlik:"
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr "Kazanç:"
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr "Araç Seçenekleri"
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr "Geçerli düzenleme aracı için özelleştirilmiş ayarlar"
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr "<b>{mode_name}</b>"
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr "<i>Seçenek yok</i>"
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr "Yakınlaştır: %%%.01f"
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr "Fırça darbesi ayarlarını, darbe rengini ve katmanı seç…"
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr "Renk seç…"
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr "Tercihler"
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr "Önizle"
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr "Tüm çizim alanının önizlemesini göster."
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr "Görüntü Bulucuyu Göster"
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr "Karalama Defteri"
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr "Renkleri karıştır ve ayrı karalama sayfalarda çizimler yap."
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr "Önceki öğe"
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr "Sonraki öğe"
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
 msgstr "(Gösterecek bir şey yok)"
 
-#: ../gui/symmetry.py:76
+#: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Place axis"
 msgstr "Ekseni konumlandır"
 
-#: ../gui/symmetry.py:80
+#: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Move axis"
 msgstr "Ekseni taşı"
 
-#: ../gui/symmetry.py:84
+#: ../gui/symmetry.py:88
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr "Ekseni kaldır"
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr "Simetri Eksenini Düzenle"
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr "Boyama simetri eksenini ayarla."
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
+#, fuzzy
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr "Pozisyon:"
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr "Pozisyon:"
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr "Hiçbiri"
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr "%d px"
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr "Alfa:"
 
-#: ../gui/symmetry.py:352
+#: ../gui/symmetry.py:376
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
+msgstr "Simetri"
+
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+#, fuzzy
 msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+msgid "X axis Position"
 msgstr "Eksen Konumu"
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:477
+#, fuzzy
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr "Eksen Konumu"
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr "Etkinleştirildi"
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr "Dosya Dullanımı"
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr "Karalama Değiştirici"
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr "Geri Al ve Yinele"
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr "Harmanlama Kipleri"
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr "Çizgi Kipleri"
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr "Görünüm (Ana)"
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr "Görünüm (Alternatif/İkincil)"
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr "Görünüm (Sıfırlama)"
 
@@ -2345,188 +2894,214 @@ msgstr "Görünüm (Sıfırlama)"
 msgid "<b>MyPaint</b>"
 msgstr "<b>MyPaint</b>"
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr "Görümümü Kaydır"
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr "Tuval görünümünü sürükle"
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr "Görünümü Yakınlaştır"
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr "Tuval görünümünü yakınlaştır"
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr "Görünümü Döndür"
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr "Tuval görünümünü döndür"
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, fuzzy, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr "%s: sekmeyi kapat"
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
-msgstr "%s: özellikleri düzenle"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
+msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr "Bilinmeyen Komut"
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr "Tanımlanmadı (komut henüz başlatılmadı)"
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr "{brush_name} fırçasıyla {seconds:.01f} saniyelik boyama"
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr "Akıcı Dolgu"
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr "Katmanı Kırp"
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "Grubu Yeniden Adlandır"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr "Katmanı Temizle"
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr "Katmanı Yapıştır"
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr "Görünürden Yeni Katman"
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr "Görünür Katmanları Birleştir"
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr "Aşağı Birleştir"
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr "Katman Kipini Normalleştir"
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "İçe aktarılmış fırça"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr "{layer_default_name} Ekle"
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr "Katmanı Kaldır"
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr "Katman Seç"
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr "Katmanı Çoğalt"
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr "Katmanı Yukarı Taşı"
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr "Katmanı Aşağı Taşı"
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr "Katmanı Yığında Taşı"
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr "Katmanı Yeniden Adlandır"
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr "Katmanı Görünür Yap"
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr "Katmanı Görünmez Yap"
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr "Katmanı Kilitle"
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr "Katmanın Kilidini Aç"
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr "Katman Matlığını Ayarla: %%%0.1f"
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr "Bilinmeyen Kip"
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr "Katman Kipini Ayarla: %s"
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr "Çerçeveyi Etkinleştir"
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr "Çerçeveyi Pasifleştir"
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr "Çerçeveyi Güncelle"
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr "Katmanı Harici Olarak Düzenle"
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr "“{basename}” yüklenirken hata."
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr "Günlükler bu hata hakkında daha fazla ayrıntı içerebilir."
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr "şimdiden"
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr "önce"
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2539,13 +3114,13 @@ msgstr ""
 "Uygulamayı kapatın ve yeniden denemek için {cache_update_interval} saniye "
 "bekleyin."
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr "Tamamlanmamış yedek {last_modified_time} {ago} güncellendi"
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2555,11 +3130,11 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 "Yedek {last_modified_time} {ago} güncellendi.\n"
-"Boyut: {autosave.width}×{autosave.height} piksel, Katman: "
-"{autosave.num_layers}.\n"
+"Boyut: {autosave.width}×{autosave.height} piksel, Katman: {autosave."
+"num_layers}.\n"
 "{unsaved_time} kaydedilmemiş boyama içeriyor."
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2569,13 +3144,13 @@ msgstr ""
 "“{filename}” dosyası yazılamadı : {err}\n"
 "Aygıtta yeterli boş alan var mı?"
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr "“{filename}” dosyası yazılamadı : {err}"
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2585,7 +3160,7 @@ msgstr ""
 "{error_loading_common}\n"
 "Dosya yok."
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2595,7 +3170,7 @@ msgstr ""
 "{error_loading_common}\n"
 "Bu dosyayı açmak için gereken izinlere sahip değilsin."
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2611,7 +3186,7 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2621,7 +3196,13 @@ msgstr ""
 "{error_loading_common}\n"
 "Bilinmeyen dosya biçimi uzantısı: “{ext}”"
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+#, fuzzy
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr "İçe aktarılmış fırça"
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2635,7 +3216,7 @@ msgstr ""
 "Bilgisayarda yeterli bellek yoksa PNG biçiminde kaydetmeyi dene. MyPaint’in "
 "PNG kaydetme işlevi çok daha verimlidir."
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2651,98 +3232,207 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/helpers.py:402
-#, python-brace-format
+#: ../lib/floodfill.py:131
+#, fuzzy
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr "Doldur"
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr "{days} gün {hours} sa"
 
-#: ../lib/helpers.py:404
-#, python-brace-format
+#: ../lib/helpers.py:537
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr "{hours} sa {minutes} dk"
 
-#: ../lib/helpers.py:406
-#, python-brace-format
+#: ../lib/helpers.py:539
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr "{minutes} dk {seconds} sn"
 
-#: ../lib/helpers.py:408
-#, python-brace-format
+#: ../lib/helpers.py:541
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr "{seconds} sn"
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr "Katman"
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr "%(name)s %(number)d"
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr "^(.*?)\\s*(\\d+)$"
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
+#, fuzzy
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr "Vektör Katmanı"
+
+#: ../lib/layer/data.py:1158
+#, fuzzy
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr "Vektör Katmanı"
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
-msgstr "Bilinmeyen Bit Eşlem Katmanı"
+msgid "Bitmap"
+msgstr ""
 
-#: ../lib/layer/data.py:1169
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1244
 msgctxt "layer default names"
-msgid "Unknown Data Layer"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
 msgstr "Bilinmeyen Veri Katmanı"
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "Yeni Boyama Katmanı"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr "Grup"
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "Yeni Katman Grubu"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr "Tutucu"
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr "Kök"
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ", "
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+#, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "Görünüm"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+#, fuzzy
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr "Katman Görünür"
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+#, fuzzy
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr "Katmanı Kaldır"
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr "Katmanı Kilitle"
+
+#: ../lib/layervis.py:697
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr "Katmanın Kilidini Aç"
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr "İçinden Geçen"
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr "Grup içeriğini doğrudan grubun zeminine uygular."
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr "Normal"
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr "Renkleri harmanlamadan sadece en üst katman."
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr "Çoğalt"
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
@@ -2750,11 +3440,11 @@ msgstr ""
 "Bir projektöre iki slayt yerleştirmeye ve birleştirilmiş sonucu yansıtmaya "
 "benzer."
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr "Ekran"
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
@@ -2762,11 +3452,11 @@ msgstr ""
 "İki ayrı slayt projektörünü aynı anda tek ekrana yansıtmak gibidir. 'Çoğalt' "
 "işleminin tersidir."
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr "Kaplama"
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
@@ -2774,27 +3464,27 @@ msgstr ""
 "Zeminin vurgularını ve gölgelerini koruyarak, zemini üst katman ile kaplar. "
 "'Sert Işık' işleminin tersidir."
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr "Koyulaştır"
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr "Üst katman, zeminden daha koyu olduğu yerlerde kullanılır."
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr "Açıklaştır"
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr "Üst katman, zeminden daha açık olduğu yerlerde kullanılır."
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr "Soldurma"
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
@@ -2803,11 +3493,11 @@ msgstr ""
 "Üst katmanı kullanarak zemini açıklaştır. Bu etki, gölgelerde zıtlığı "
 "arttırmak için kullanılan aynı addaki karanlık oda tekniğine benzer."
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr "Yakma"
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
@@ -2817,54 +3507,54 @@ msgstr ""
 "parlaklığı azaltmak için kullanılan aynı addaki karanlık oda tekniğine "
 "benzer."
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr "Sert Işık"
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr "Zemin üzerine sert spot ışık tutmaya benzer."
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr "Yumuşak Işık"
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr "Zemin üzerine dağınık spot ışık tutmaya benzer."
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr "Fark"
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr "Koyu rengi, ikisinin açığından çıkarır."
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr "Çıkarma"
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr "'Fark' kipine benzer, ancak karşıtlığı daha düşüktür."
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr "Ton"
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 "Üst katmanın tonunu, zeminin doygunluğu ve renk parlaklığı ile birleştirir."
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr "Doygunluk"
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
@@ -2872,35 +3562,36 @@ msgstr ""
 "Üst katmanların renk doygunluğunu, zeminin tonuna ve renk parlaklığına "
 "uygular."
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr "Üst katmanın tonunu ve doygunluğunu zeminin renk parlaklığına uygular."
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr "Renk Parlaklığı"
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
-msgstr "Üst katmanın renk parlaklığını, zeminin tonuna ve doygunluğuna uygular."
+msgstr ""
+"Üst katmanın renk parlaklığını, zeminin tonuna ve doygunluğuna uygular."
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr "Artı"
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr "Bu katman ve zemini basitçe birbirine eklenir."
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr "Hedef İçinde"
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
@@ -2908,11 +3599,11 @@ msgstr ""
 "Zemin sadece bu katmanın kapladığı yerlerde kullanır. Diğer her şey "
 "görmezden gelinir."
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr "Hedef Dışında"
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
@@ -2920,11 +3611,11 @@ msgstr ""
 "Zemin sadece bu katmanın kaplamadığı yerlerde kullanır. Diğer her şey "
 "görmezden gelinir."
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr "Kaynak En Üstte"
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
@@ -2932,11 +3623,11 @@ msgstr ""
 "Hedefle örtüşen kaynak hedefin yerini alır. Hedef başka bir yere "
 "konumlandırılır."
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr "Hedef En Altta"
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
@@ -2944,7 +3635,18 @@ msgstr ""
 "Kaynakla örtüşen hedef kaynağın yerini alır. Kaynak başka bir yere "
 "konumlandırılır."
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, fuzzy, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr "%(name)s %(number)d"
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
@@ -2953,7 +3655,7 @@ msgstr ""
 "Hayati bir iç nesne inşa edilemiyor. İşletim sisteminde, bu işlemi "
 "gerçekleştirmek için yeterli bellek olmayabilir."
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2967,7 +3669,30 @@ msgstr ""
 "Sebep: {err}\n"
 "Hedef klasör: “{dirname}”."
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+#, fuzzy
+msgid "Vertical"
+msgstr "Dikey Çevir"
+
+#: ../lib/tiledsurface.py:49
+#, fuzzy
+msgid "Horizontal"
+msgstr "Yatay Çevir"
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+#, fuzzy
+msgid "Rotational"
+msgstr "Döndürmeyi Sıfırla"
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr "PNG okuyucu başarısız oldu: %s"
@@ -2977,55 +3702,93 @@ msgstr "PNG okuyucu başarısız oldu: %s"
 msgid "Recover interrupted work?"
 msgstr "Kesintiye işe kurtarmak?"
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
-msgstr "_Kurtar ve Kaydet"
+msgid "_Look for backups at startup"
+msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr "Sil"
+
+#: ../po/tmp/autorecover.glade.h:9
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr "Bu fırçayı diskten sil"
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr "_Kurtar ve Kaydet"
+
+#: ../po/tmp/autorecover.glade.h:12
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr "Bu yedeği diske kaydet ve üzerinde çalışmaya devam et."
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
-msgstr "Şimdilik _Görmezden Gel"
+msgid "Decide _Later"
+msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr "Yedekleri koru ve yeni tuval üstünde çalışmaya başla."
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
+#, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 "MyPaint kaydedilmemiş çalışma ile çöktü, ancak yedekleme yaptı. Dosyayı "
 "şimdi kurtarabilir veya MyPaint'i yeniden başlatana kadar erteleyebilirsiniz."
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr "Küçük Resim"
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr "Açıklama"
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
-msgstr "Yeniye Kopyala"
+msgid "Live update"
+msgstr "Canlı güncelle"
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
-msgstr "Bu ayarları ve geçerli fırçanın simgesini yeni fırçaya kopyala"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
+msgstr ""
+"Tuval üzerindeki son darbeyi, bu penceredeki ayarlarla, gerçek zamanlı "
+"olarak güncelle"
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
-msgstr "Bu fırçayı yeniden adlandır"
+msgid "Save these settings to the brush"
+msgstr "Bu ayarları fırçaya kaydet"
 
 #: ../po/tmp/brusheditor.glade.h:5
 msgid "Edit Icon"
@@ -3048,20 +3811,16 @@ msgid "Delete this brush from the disk"
 msgstr "Bu fırçayı diskten sil"
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
-msgstr "Canlı güncelle"
+msgid "Copy to New"
+msgstr "Yeniye Kopyala"
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
-msgstr ""
-"Tuval üzerindeki son darbeyi, bu penceredeki ayarlarla, gerçek zamanlı "
-"olarak güncelle"
+msgid "Copy these settings and the current brush's icon to a new brush"
+msgstr "Bu ayarları ve geçerli fırçanın simgesini yeni fırçaya kopyala"
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
-msgstr "Bu ayarları fırçaya kaydet"
+msgid "Rename this brush"
+msgstr "Bu fırçayı yeniden adlandır"
 
 #: ../po/tmp/brusheditor.glade.h:13
 msgid "Brush Setting"
@@ -3089,12 +3848,7 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr "Notlar:"
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr "Ayar adı:"
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
@@ -3102,19 +3856,16 @@ msgstr ""
 "eder."
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
-msgstr "Temel değer:"
+#: ../po/tmp/brusheditor.glade.h:22
+#, fuzzy
+msgid "Value:"
+msgstr "HSV Değeri"
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr "Temel değeri varsayılanına sıfırla"
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr "Ayarı etkilemeyecek şekilde bu girdiyi sıfırla"
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
@@ -3122,11 +3873,7 @@ msgstr ""
 "Çıktı ekseni için en düşük değer.\n"
 "Bu, {dname} için ana kaydırma çubuğu kullanılarak ayarlanabilir."
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr "<ymin>"
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
@@ -3134,27 +3881,23 @@ msgstr ""
 "Çıktı ekseni için en yüksek değer.\n"
 "Bu, {dname} için ana kaydırma çubuğu kullanılarak ayarlanabilir."
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr "<ymax>"
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr "Çıktı"
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr "Girdi"
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr "En yüksek değeri ayarla"
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr "En düşük değeri ayarla"
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
@@ -3162,11 +3905,7 @@ msgstr ""
 "Girdi ekseni için en düşük değer.\n"
 "Bunu ayarlamak için açılır pencere ölçeğini kullan."
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr "<xmin>"
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
@@ -3174,38 +3913,36 @@ msgstr ""
 "Girdi ekseni için en yüksek değer.\n"
 "Bunu ayarlamak için açılır pencere ölçeğini kullan."
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr "<xmax>"
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr "Temel değerin prob ucu girdisi ve diğer kriterler ile değişimi"
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr "Fırça Hareketleri"
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr "Bu ayar için genel detaylar"
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr "Ayarı Düzenle"
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr "Bu girdi eşlemini ayrıntılarıyla ayarla"
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr "{tooltip}"
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
 msgstr "{dname}:"
+
+#: ../po/tmp/brusheditor.glade.h:42
+#, fuzzy
+msgid "Brush dynamics are not available for this setting."
+msgstr "Bu ayar için genel detaylar"
+
+#: ../po/tmp/brusheditor.glade.h:43
+#, fuzzy
+msgid "<big><b>No Brush Dynamics</b></big>"
+msgstr "<big><b>{accel_label}</b></big>"
 
 #: ../po/tmp/inktool.glade.h:1
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
@@ -3217,7 +3954,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr "Baskı:"
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3262,6 +3999,141 @@ msgstr "Noktayı Sil"
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
 msgstr "Geçerli seçilmiş noktayı sil"
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+#, fuzzy
+msgid "Insert Point"
+msgstr "Satır Ekle"
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+#, fuzzy
+msgid "Cull Points"
+msgstr "Noktayı Sil"
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Ad"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr "Kip"
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Matlık"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr "Geçerli katmanın harmanlama kipi."
+
+#: ../po/tmp/layervis.glade.h:2
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr "Tuval görünümünü döndür"
+
+#: ../po/tmp/layervis.glade.h:3
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr "Tuval görünümünü döndür"
+
+#: ../po/tmp/layervis.glade.h:4
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr "Hangi görünür katmanlar doldurulmalı"
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
+msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
 msgctxt "footer: color picker button: tooltip"
@@ -3489,8 +4361,8 @@ msgstr ""
 "\n"
 "Bu, ekranın sRGB'ye (web için standart renk uzayı ve çoğu bilgisayar "
 "ekranının kötümser yaklaşımıdır) yakın bir şeye ayarlandığını varsayar. "
-"Ekranın bundan radikal şekilde farklı olduğunu biliyorsan, bunun yerine \""
-"Otomatik dönüşüm ve etiketleme yok\" ayarını kullan."
+"Ekranın bundan radikal şekilde farklı olduğunu biliyorsan, bunun yerine "
+"\"Otomatik dönüşüm ve etiketleme yok\" ayarını kullan."
 
 #: ../po/tmp/preferenceswindow.glade.h:47
 msgctxt "Prefs Dialog|Load & Save|Color Management|"
@@ -3656,8 +4528,8 @@ msgstr ""
 "alışkınsanız rahatsız edici olabilir.\n"
 "\n"
 "Yumuşak kaydırma destekleniyorsa, kaydırma yaparken, adım kaydırma tuşu "
-"basılı tutularak kısa süreliğine adım adım kaydırma işlemi tekrar açılabilir."
-"\n"
+"basılı tutularak kısa süreliğine adım adım kaydırma işlemi tekrar "
+"açılabilir.\n"
 "\n"
 "Görünümü kaydırmak için kaydırma, bu ayarın açık olmasını ve aygıtın iki "
 "yönlü kaydırma eylemlerini gönderecek şekilde yapılandırılmasını gerektirir."
@@ -3666,13 +4538,34 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr "Boyarken imleci gizle"
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+#, fuzzy
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr "Etkinleştirildi"
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr "Görünüm"
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
@@ -3681,18 +4574,18 @@ msgstr ""
 "Disk benzeri renk tekerlerinde birincil olarak gösterilecek renk kümesi.\n"
 "Farklı geleneklerin farklı renk uyumları vardır."
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr "Ana renkler:"
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr "Standart dijital Kırmızı/Yeşil/Mavi"
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
@@ -3700,7 +4593,7 @@ msgstr ""
 "Kırmızı, yeşil ve mavi 'bilgisayar monitörü' ana renkleri, dairenin etrafına "
 "eşit olarak yerleştirilir. Yeşil camgöbeğinin karşısındadır."
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
@@ -3709,12 +4602,12 @@ msgstr ""
 "Kırmızı, yeşil ve mavi 'bilgisayar monitörü' ana renkleri, dairenin etrafına "
 "eşit olarak yerleştirilir. Yeşil camgöbeğinin karşısındadır."
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr "Geleneksel artistik Kırmızı/Sarı/Mavi"
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
@@ -3725,7 +4618,7 @@ msgstr ""
 "etrafında eşit şekilde düzenlendiği bir yaklaşımdır. Yeşil kırmızının "
 "karşısındadır."
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3737,12 +4630,12 @@ msgstr ""
 "etrafında eşit şekilde düzenlendiği bir yaklaşımdır. Yeşil kırmızının "
 "karşısındadır."
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr "Kırmızı-Yeşil ve Mavi-Sarı rakip çiftleri"
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3756,7 +4649,7 @@ msgstr ""
 "ise mavinin karşısındadır. CIECAM02 ve NCS benzer bir model sunar. Burada "
 "dört ana rengin gösterimi olarak saf kırmızı, sarı vb. kullanıyoruz."
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3772,28 +4665,28 @@ msgstr ""
 "dört ana rengin gösterimi olarak saf kırmızı, sarı vb. kullanıyoruz."
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr "<b>Renk Tekerleği</b>"
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr "Renk"
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr "Ekran (normal)"
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr "Pasifleştirildi (basınç hassasiyeti yok)"
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr "Pencere (tavsiye edilmez)"
@@ -3854,248 +4747,305 @@ msgid "Reload the file your current work was loaded from."
 msgstr "Geçerli çalışmanın yüklendiği dosyayı yeniden yükle."
 
 #: ../po/tmp/resources.xml.h:12
+#, fuzzy
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Import Layers…"
+msgstr "Fırçaları İçe Aktar…"
+
+#: ../po/tmp/resources.xml.h:13
+msgctxt "Accel Editor (descriptions)"
+msgid "Import layers from one or more files."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save"
 msgstr "Kaydet"
 
-#: ../po/tmp/resources.xml.h:13
+#: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file."
 msgstr "Çalışmayı dosyaya kaydet."
 
-#: ../po/tmp/resources.xml.h:14
+#: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As…"
 msgstr "Farklı Kaydet…"
 
-#: ../po/tmp/resources.xml.h:15
+#: ../po/tmp/resources.xml.h:17
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file, assigning it a new name."
 msgstr "Yeni ad belirleyerek çalışmayı dosyaya kaydet."
 
-#: ../po/tmp/resources.xml.h:16
+#: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Export…"
 msgstr "Dışa Aktar…"
 
-#: ../po/tmp/resources.xml.h:17
+#: ../po/tmp/resources.xml.h:19
 msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 "Çalışmayı dosyaya dışa aktar, fakat aynı dosya üstünde çalışmaya devam et."
 
-#: ../po/tmp/resources.xml.h:18
+#: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As Scrap"
 msgstr "Karalama Olarak Kaydet"
 
-#: ../po/tmp/resources.xml.h:19
+#: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
 msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 "Yeni karalama dosyasına kaydet veya zaten bir karalama varsa yeni düzenleme "
 "kaydet."
 
-#: ../po/tmp/resources.xml.h:20
+#: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Previous Scrap"
 msgstr "Önceki Karalamayı Aç"
 
-#: ../po/tmp/resources.xml.h:21
+#: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file before the current one."
 msgstr "Karalamayı geçerli dosyadan önce yükle."
 
-#: ../po/tmp/resources.xml.h:22
+#: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Next Scrap"
 msgstr "Sonraki Karalamayı Aç"
 
-#: ../po/tmp/resources.xml.h:23
+#: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file after the current one."
 msgstr "Karalamayı geçerli dosyadan sonra yükle."
 
-#: ../po/tmp/resources.xml.h:24
+#: ../po/tmp/resources.xml.h:26
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Recover File from an Automated Backup…"
 msgstr "Dosyayı Otomatik Yedekten Kurtar…"
 
-#: ../po/tmp/resources.xml.h:25
+#: ../po/tmp/resources.xml.h:27
 msgctxt "Accel Editor (descriptions)"
 msgid "Try to save and resume interrupted unsaved work."
 msgstr "Kaydetmeye ve yarıda kesilmiş çalışmayı devam ettirmeye çalış."
 
-#: ../po/tmp/resources.xml.h:26
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr "Fırça Grupları"
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr "Fırçalar"
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr "Fırça gruplarının listesi."
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr "Renk Ayarlayıcılar"
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr "Renkler"
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr "Kullanılabilir renk ayarlayıcılar."
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr "Kip"
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr "Kip"
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr "Geçerli katmanın harmanlama kipi."
 
-#: ../po/tmp/resources.xml.h:35
+#: ../po/tmp/resources.xml.h:37
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Pressure"
+msgstr "Giriş Basıncı"
+
+#: ../po/tmp/resources.xml.h:38
+msgctxt "Accel Editor (descriptions)"
+msgid "Send harder pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:39
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Pressure"
+msgstr "Giriş Basıncı"
+
+#: ../po/tmp/resources.xml.h:40
+msgctxt "Accel Editor (descriptions)"
+msgid "Send softer pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:41
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Rotation"
+msgstr "Doygunluğu Artır"
+
+#: ../po/tmp/resources.xml.h:42
+msgctxt "Accel Editor (descriptions)"
+msgid "Increase barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:43
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
+msgstr "Doygunluğu Azalt"
+
+#: ../po/tmp/resources.xml.h:44
+msgctxt "Accel Editor (descriptions)"
+msgid "Decrease barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:45
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Size"
 msgstr "Fırça Boyutunu Artır"
 
-#: ../po/tmp/resources.xml.h:36
+#: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush bigger."
 msgstr "Çalışma fırçasının boyutunu büyüt."
 
-#: ../po/tmp/resources.xml.h:37
+#: ../po/tmp/resources.xml.h:47
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Size"
 msgstr "Fırça Boyutunu Azalt"
 
-#: ../po/tmp/resources.xml.h:38
+#: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush smaller."
 msgstr "Çalışma fırçasının boyutunu küçült."
 
-#: ../po/tmp/resources.xml.h:39
+#: ../po/tmp/resources.xml.h:49
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Opacity"
 msgstr "Fırça Matlığını Artır"
 
-#: ../po/tmp/resources.xml.h:40
+#: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush more opaque."
 msgstr "Çalışma fırçasınının matlığını artır."
 
-#: ../po/tmp/resources.xml.h:41
+#: ../po/tmp/resources.xml.h:51
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Opacity"
 msgstr "Fırça Matlığını Azalt"
 
-#: ../po/tmp/resources.xml.h:42
+#: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush less opaque."
 msgstr "Çalışma fırçasınının matlığını azalt."
 
-#: ../po/tmp/resources.xml.h:43
+#: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Lighten Painting Color"
 msgstr "Boyama Rengini Açıklaştır"
 
-#: ../po/tmp/resources.xml.h:44
+#: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase the lightness of the current painting color."
 msgstr "Geçerli boyama renginin açıklığını artır."
 
-#: ../po/tmp/resources.xml.h:45
+#: ../po/tmp/resources.xml.h:55
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Darken Painting Color"
 msgstr "Boyama Rengini Koyulaştır"
 
-#: ../po/tmp/resources.xml.h:46
+#: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease the lightness of the current painting color."
 msgstr "Geçerli boyama renginin açıklığını azalt."
 
-#: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
-msgstr "Tonu Saat Yönünün Tersine Değiştir"
-
-#: ../po/tmp/resources.xml.h:48
-msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
-msgstr "Boya renginin tonunu renk tekerleğinde saat yönünün tersine çevir."
-
-#: ../po/tmp/resources.xml.h:49
+#: ../po/tmp/resources.xml.h:57
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Change Hue Clockwise"
 msgstr "Tonu Saat Yönünde Değiştir"
 
-#: ../po/tmp/resources.xml.h:50
+#: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
 msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr "Boya renginin tonunu renk tekerleğinde saat yönünde çevir."
 
-#: ../po/tmp/resources.xml.h:51
+#: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr "Tonu Saat Yönünün Tersine Değiştir"
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr "Boya renginin tonunu renk tekerleğinde saat yönünün tersine çevir."
+
+#: ../po/tmp/resources.xml.h:61
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Increase Saturation"
 msgstr "Doygunluğu Artır"
 
-#: ../po/tmp/resources.xml.h:52
+#: ../po/tmp/resources.xml.h:62
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color more saturated (more colorful, purer)."
 msgstr "Boyama renginin doygunluğunu artır (daha renkli, daha saf)"
 
-#: ../po/tmp/resources.xml.h:53
+#: ../po/tmp/resources.xml.h:63
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Decrease Saturation"
 msgstr "Doygunluğu Azalt"
 
-#: ../po/tmp/resources.xml.h:54
+#: ../po/tmp/resources.xml.h:64
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color less saturated (grayer)."
 msgstr "Boyama renginin doygunluğunu azalt (daha gri)"
 
-#: ../po/tmp/resources.xml.h:55
+#: ../po/tmp/resources.xml.h:65
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Reload Brush Settings"
 msgstr "Fırça Ayarlarını Yeniden Yükle"
 
-#: ../po/tmp/resources.xml.h:56
+#: ../po/tmp/resources.xml.h:66
 msgctxt "Accel Editor (descriptions)"
 msgid "Restore all brush settings to the current brush’s saved values."
 msgstr "Tüm fırça ayarlarını geçerli fırçanın kayıtlı değerlerine geri yükle."
 
-#: ../po/tmp/resources.xml.h:57
+#: ../po/tmp/resources.xml.h:67
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Pick Stroke and Layer"
 msgstr "Darbe ve Katman Seç"
 
-#: ../po/tmp/resources.xml.h:58
+#: ../po/tmp/resources.xml.h:68
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
 msgstr "Tuvalden fırça darbesi seç: fırça, renk ve katmanı geri yükler."
 
-#: ../po/tmp/resources.xml.h:59
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr "Fırça Kısayol Tuşları Rengi Geri Yükler"
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
@@ -4104,214 +5054,265 @@ msgstr ""
 "Fırçayı kısayol tuşundan geri yüklemenin, kaydedilen rengi de geri yükleyip "
 "yüklemeyeceğini belirler."
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr "Fırçayı En Son Kısayola Kaydet"
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr "Fırça ayarlarını en son kullanılan kısayol tuşuna kaydet."
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "Katmanı Temizle"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr "Geçerli katmanın içeriğini temizle."
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+#, fuzzy
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr "Araç Seçenekleri"
+
+#: ../po/tmp/resources.xml.h:76
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr "Katmanı Çerçeveye Kırp"
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr "Geçerli katmanın çerçevesinin dışında kalan kısımlarını sil."
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr "Geçerli katmanın çerçevesinin dışında kalan kısımlarını sil."
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "Altına Yeni Katman Grubu"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "Altına Yeni Katman Grubu"
+
+#: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr "Katmanı Panoya Kopyala"
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr "Geçerli katmanın içeriğini panoya kopyala."
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr "Katmanı Panodan Yapıştır"
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr "Geçerli katmanı pano içeriğiyle değiştir."
 
-#: ../po/tmp/resources.xml.h:71
+#: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Edit Layer in External App…"
 msgstr "Katmanı Harici Uygulamayla Düzenle…"
 
-#: ../po/tmp/resources.xml.h:72
+#: ../po/tmp/resources.xml.h:90
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
+msgid "Edit the active layer in an external application."
 msgstr "Geçerli katmanı harici uygulamayla düzenlemeye başla."
 
-#: ../po/tmp/resources.xml.h:73
+#: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Update Layer with External Edits"
 msgstr "Katmanı Harici Düzenlemelerle Güncelle"
 
-#: ../po/tmp/resources.xml.h:74
+#: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
 msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 "Harici uygulamadan kaydedilen değişiklikleri ekle (normalde otomatik olarak "
 "yapılır)."
 
-#: ../po/tmp/resources.xml.h:75
+#: ../po/tmp/resources.xml.h:93
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer at Cursor"
 msgstr "İmleçteki Katmana Git"
 
-#: ../po/tmp/resources.xml.h:76
+#: ../po/tmp/resources.xml.h:94
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr "Üstünden bir nesne alarak katmn seç."
 
-#: ../po/tmp/resources.xml.h:77
+#: ../po/tmp/resources.xml.h:95
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Above"
 msgstr "Üstteki Katmana Git"
 
-#: ../po/tmp/resources.xml.h:78
+#: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer up in the layer stack."
 msgstr "Katman yığınında bir üst katmana git."
 
-#: ../po/tmp/resources.xml.h:79
+#: ../po/tmp/resources.xml.h:97
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Below"
 msgstr "Alttaki Katmana Git"
 
-#: ../po/tmp/resources.xml.h:80
+#: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer down in the layer stack."
 msgstr "Katman yığınında bir katman aşağı git."
 
-#: ../po/tmp/resources.xml.h:81
+#: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer"
 msgstr "Yeni Boyama Katmanı"
 
-#: ../po/tmp/resources.xml.h:82
+#: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer above the current layer."
 msgstr "Geçerli katmanın üzerine yeni boyama katmanı ekle."
 
-#: ../po/tmp/resources.xml.h:83
+#: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer…"
 msgstr "Yeni Vektör Katmanı…"
 
-#: ../po/tmp/resources.xml.h:84
+#: ../po/tmp/resources.xml.h:102
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer above the current layer, and begin editing it."
 msgstr "Geçerli katmanın üzerine bir vektör katmanı ekle ve düzenlemeye başla."
 
-#: ../po/tmp/resources.xml.h:85
+#: ../po/tmp/resources.xml.h:103
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group"
 msgstr "Yeni Katman Grubu"
 
-#: ../po/tmp/resources.xml.h:86
+#: ../po/tmp/resources.xml.h:104
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group above the current layer."
 msgstr "Geçerli katmanın üzerine yeni katman grubu ekle."
 
-#: ../po/tmp/resources.xml.h:87
+#: ../po/tmp/resources.xml.h:105
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer Below"
 msgstr "Altına Yeni Boyama Katmanı"
 
-#: ../po/tmp/resources.xml.h:88
+#: ../po/tmp/resources.xml.h:106
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer below the current layer."
 msgstr "Geçerli katmanın altına yeni boyama katmanı ekle."
 
-#: ../po/tmp/resources.xml.h:89
+#: ../po/tmp/resources.xml.h:107
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer Below…"
 msgstr "Altına Yeni Vektör Katmanı…"
 
-#: ../po/tmp/resources.xml.h:90
+#: ../po/tmp/resources.xml.h:108
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer below the current layer, and begin editing it."
 msgstr "Geçerli katmanın altına bir vektör katmanı ekle ve düzenlemeye başla."
 
-#: ../po/tmp/resources.xml.h:91
+#: ../po/tmp/resources.xml.h:109
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group Below"
 msgstr "Altına Yeni Katman Grubu"
 
-#: ../po/tmp/resources.xml.h:92
+#: ../po/tmp/resources.xml.h:110
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group below the current layer."
 msgstr "Geçerli katmanın altına yeni katman grubu ekle."
 
-#: ../po/tmp/resources.xml.h:93
+#: ../po/tmp/resources.xml.h:111
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Layer Down"
 msgstr "Katmanı Aşağı Birleştir"
 
-#: ../po/tmp/resources.xml.h:94
+#: ../po/tmp/resources.xml.h:112
 msgctxt "Accel Editor (descriptions)"
 msgid "Merge the current layer with the layer beneath it."
 msgstr "Geçerli katmanı altındaki katman ile birleştir."
 
-#: ../po/tmp/resources.xml.h:95
+#: ../po/tmp/resources.xml.h:113
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Visible Layers"
 msgstr "Görünür Katmanları Birleştir"
 
-#: ../po/tmp/resources.xml.h:96
+#: ../po/tmp/resources.xml.h:114
 msgctxt "Accel Editor (descriptions)"
 msgid "Consolidate all visible layers, and delete the originals."
 msgstr "Tüm görünür katmanları birleştir ve özgün katmanları sil."
 
-#: ../po/tmp/resources.xml.h:97
+#: ../po/tmp/resources.xml.h:115
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer from Visible"
 msgstr "Görünürden Yeni Katman"
 
-#: ../po/tmp/resources.xml.h:98
+#: ../po/tmp/resources.xml.h:116
 msgctxt "Accel Editor (descriptions)"
 msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
 msgstr "‘Görünür Katmanları Birleştir’ gibidir, fakat özgün katmanları silmez."
 
-#: ../po/tmp/resources.xml.h:99
+#: ../po/tmp/resources.xml.h:117
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Delete Layer"
 msgstr "Katmanı Sil"
 
-#: ../po/tmp/resources.xml.h:100
+#: ../po/tmp/resources.xml.h:118
 msgctxt "Accel Editor (descriptions)"
 msgid "Remove the current layer from the layer stack."
 msgstr "Geçerli katmanı katman yığınından kaldır."
 
-#: ../po/tmp/resources.xml.h:101
+#: ../po/tmp/resources.xml.h:119
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Convert to Normal Painting Layer"
 msgstr "Normal Boyama Katmanına Dönüştür"
 
-#: ../po/tmp/resources.xml.h:102
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
@@ -4320,561 +5321,650 @@ msgstr ""
 "Görünümünü koruyarak, geçerli katmanı veya grubu ‘Normal’ kipte boyama "
 "katmanına dönüştür."
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr "Katman Matlığını Artır"
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr "Katmanı daha az saydam yap."
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr "Katman matlığını Azalt"
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr "Katmanı daha fazla saydam yap."
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr "Katmanı Yükselt"
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr "Geçerli katmanı katman yığınında bir sıra yükselt."
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr "Katmanı Alçalt"
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr "Geçerli katmanı katman yığınında bir sıra alçalt."
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr "Katmanı Çoğalt"
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr "Geçerli katmanın tam bir kopyasını oluştur."
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
+#, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
-msgstr "Katmanı Yeniden Adlandır…"
+msgid "Layer Properties…"
+msgstr "Özellikler"
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
-msgstr "Geçerli katman için yeni ad gir."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr "Katman Kilitli"
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 "Geçerli katmanın kilit durumunu değiştir. Kilitli katmanlar değiştirilemez."
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr "Katman Görünür"
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr "Geçerli katmanın görünürlük durumunu değiştir ve onu gizle."
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr "Arkaplanı Göster"
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr "Arkaplan katmanının görünürlüğünü değiştir."
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr "Geçerli katmanı katman yığınından kaldır."
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr "Görünümü Sıfırla ve Ortala"
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 "Yakınlaştırmayı, Döndürmeyi ve Çevirmeyi sıfırla ve belgeyi yeniden ortala."
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr "Görünüme Sığdır"
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 "Ekrana sığdırılmış görünüm, çalışma konumunuz ve yakınlaştırma arasında "
 "geçiş yap."
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr "Sıfırla"
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr "Yakınlaştırmayı Sıfırla"
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr "Görünüm yakınlaştırmasını varsayılan değerlerine geri yükle."
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr "Döndürmeyi Sıfırla"
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr "Görünümün döndürmesini 0 dereceye sıfırla"
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr "Çevirmeyi Sıfırla"
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
-msgstr "Görünüm yansıtmasını kapat."
+msgid "Reset the view's mirroring."
+msgstr "Çevirmeyi Sıfırla"
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr "Yakınlaştır"
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr "Yaklaştırmayı artır."
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Uzaklaştır"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr "Yakınlaştırmayı azalt."
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
+#, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
-msgstr "Saat Yönünün Tersine Döndür"
+msgid "Pan Left"
+msgstr "Görünümü Kaydır"
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
-msgstr "Görünümü saat yönünün tersine çevir."
+msgid "Move your view of the canvas to the left."
+msgstr "Görünümü Döndür: tuval görünümünü eğ."
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr "Sert Işık"
+
+#: ../po/tmp/resources.xml.h:159
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr "Görünümü Kaydır: görünümü tuval üzerinde yatay ve dikey taşı."
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr "Görünümü Döndür: tuval görünümünü eğ."
+
+#: ../po/tmp/resources.xml.h:162
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr "Görünümü Kaydır"
+
+#: ../po/tmp/resources.xml.h:163
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr "Görünümü Döndür: tuval görünümünü eğ."
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr "Saat Yönünde Döndür"
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr "Görünümü saat yönünde çevir."
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr "Saat Yönünün Tersine Döndür"
+
+#: ../po/tmp/resources.xml.h:167
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr "Görünümü saat yönünün tersine çevir."
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr "Yatay Çevir"
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr "Görüntüyü soldan sağa çevir."
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr "Dikey Çevir"
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr "Görüntüyü baş aşağı çevir."
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr "Tek Katman"
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr "Yalnızca geçerli katmanın gösterilip gösterilmeyeceğini değiştir."
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr "Simetrik Boyamayı Etkinleştir"
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr "Simetri ekseni boyunca fırça darbelerini yansıt"
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr "Çerçeveyi Etkinleştir"
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr "Belge çerçevesinin görünürlüğünü değiştir."
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr "Fırça Girdi Değerlerini Uçbirime Yazdır"
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr "Fırça motorunun dahili olarak oluşturulan girdileri uçbirimde göster."
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr "İşlemeyi Görselleştir"
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr "Hata ayıklama için işleme güncellemelerini ekranda göster."
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr "Çift Tamponlama Yok"
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr "Normalde etkin olan GTK’nın çift tamponlamasını kapat."
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+#, fuzzy
+msgid "Delete Point"
+msgstr "Noktayı Sil"
+
+#: ../po/tmp/resources.xml.h:187
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr "Geçerli seçilmiş noktayı sil"
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr "Boyama Kipi"
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr "Boyama Kipi: Normal"
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr "Boyama sırasında normal şekilde renk uygula."
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr "Boyama Kipi: Silgi"
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr "Geçerli fırçayı kullanarak sil."
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr "Boyama Kipi: Alfayı Kilitle"
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr "Fırçayı uygulamak, katmanın matlığını değiştirmez."
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr "Boyama Kipi: Renklendir"
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr "Parlaklığını veya matlığını etkilemeden geçerli katmana renk uygula."
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Dosya"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "Çık"
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr "Ana pencereyi kapat ve uygulamadan çık."
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "Düzenle"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr "Geçerli Araç"
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "Renk"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr "Rengi Ayarla"
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr "Renk Geçmişi Açılır Penceresi"
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr "İmleç altında son renklerin zaman çizelgesini aç."
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr "Renk Ayrıntıları Penceresi"
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr "Renk ayrıntıları iletişim kutusunu metin girişiyle göster."
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr "Sonraki Palet Rengi"
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr "Boyama rengini paletteki sonraki renge ayarla."
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr "Önceki Palet Rengi"
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr "Boyama rengini paletteki önceki renge ayarla."
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr "Rengi Palete Ekle"
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr "Geçerli boyama rengini palete ekle."
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "Katman"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr "Matlık"
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr "Katmana Git"
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr "Altına Yeni Katman"
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr "Özellikler"
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr "Karalama Defteri"
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr "Yeni Karalama Defteri"
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 "Varsayılan karalama defterini yeni karalama defteri tuvali olarak yükle."
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr "Karalama Defteri Aç…"
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr "Diskteki bir görüntü dosyasını karalama defterine yükle."
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr "Karalama Defterini Kaydet"
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr "Karalama defterini diskteki varolan dosyasına kaydet."
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr "Karalama Defterini Farklı Kaydet…"
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr "Belirlediğin bir adla karalama defterini diske dışa aktar."
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr "Karalama Defterini Geri Döndür"
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr "Karalama defterini son kaydedildiği duruma geri döndür."
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr "Karalama Defterini Varsayılan Olarak Kaydet"
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 "Karalama defterini ‘Yeni Karalama Defteri’ için varsayılan olarak kaydet."
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr "Varsayılan Karalama Defterini Temizle"
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr "Varsayılan karalama defterini boş tuvale temizle."
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr "Ana Arkaplanı Karalama Defterine Kopyala"
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr "Arkaplan görüntüsünü çalışan belgeden Karalama Defteri'ne kopyala."
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "Pencere"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "Fırça"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr "Kısayol Tuşları"
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr "Fırça Kısayol Tuşları Yardımı"
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr "Kısayolların nasıl çalıştığını anlatan bir açıklama göster."
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "Fırça Değiştir…"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr "İmlecin altında bir fırça değiştirici göster."
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "Renk Değiştir…"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
@@ -4882,12 +5972,12 @@ msgstr ""
 "İmlecin altında, tüm renk seçicilerin listelendiği bir renk değiştirici "
 "göster."
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "Renk Değiştir (Hızlı Altküme)…"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
@@ -4896,210 +5986,214 @@ msgstr ""
 "İmlecin altında, sadece tek-tıklama seçicilerinin listelendiği bir renk "
 "değiştirici göster."
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr "Daha Fazla Fırça…"
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr "Mypaint wikiden fırça paketleri indir."
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr "Fırçaları İçe Aktar…"
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr "Diskten fırça paketi yükle."
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Yardım"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr "Çevirimiçi Yardım"
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr "Mypaint belgeleri wikisine git."
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "MyPaint Hakkında"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 "Mypaint'in lisansını, sürüm numarasını ve emeği geçenler listesini göster."
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Hata Ayıkla"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr "Bellek Taşması Verisini Uçbirime Yazdır (Yavaş!)"
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr "Bellek taşmasını hata ayıkla."
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr "Çöp Toplayıcısını Şimdi Çalıştır"
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr "Artık kullanılmayan Python nesneleri için kullanılan boş bellek."
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr "Profillemeyi Başlat/Durdur…"
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr "Python Profillemeyi Başlat veya Durdur (cProfile)"
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr "Çökmeyi Taklit Et…"
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 "Çökme iletişim penceresini test etmek için bir Python istisnası oluştur."
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "Görünüm"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr "Geri Bildirim"
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr "Görünümü Ayarla"
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
+#, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr "Menüyü Aç"
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr "Ana menüyü açılır pencere olarak göster."
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "Tam Ekran"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr "Tam ekran ve pencere kipi arasında geçiş yap."
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "Tercihleri Düzenle"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr "Mypaint'in genel ayarlarını değiştir."
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr "Girdi Aygıtını Test Et"
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 "Girdi aygıtının gönderdiği tüm olayları yakalayan bir iletişim kutusu göster."
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr "Arkaplan Seçici"
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr "Arkaplan kağıt dokusunu değiştir."
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr "Fırça Ayarları Düzenleyici"
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr "Etkin fırçanın ayarlarını düzenle."
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr "Fırça Simgesi Düzenleyici"
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr "Fırça simgelerini düzenle."
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr "Katman Paneli"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
-msgstr "Katmanlar rıhtımını değiştir (katmanları düzenle veya kipleri ata)."
+msgid "Dockable panel for managing layers."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr "Katman Panelini Göster"
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr "Katmanlar panelini göster (katmanları düzenle veya kip ata)."
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr "HCY Tekerleği"
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
@@ -5108,42 +6202,32 @@ msgstr ""
 "Sabitlenebilir silindir ton/renk saflığı/renk parlaklığı renk seçici. "
 "Dairesel dilimler eşittir."
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "Renk Paleti"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr "Sabitlenebilir palet renk seçici."
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr "HSV Tekerleği"
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr "Sabitlenebilir doygunluk ve Değer renk değiştirici."
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr "HSV Üçgeni"
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr "Sabitlenebilir renk seçici: eski GTK renk üçgeni."
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr "HSV Küpü"
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
@@ -5152,217 +6236,215 @@ msgstr ""
 "Sabitlenebilir renk seçici: farklı düzlem dilimlerini göstermek için "
 "döndürülebilir HSV küpü."
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr "HSV Karesi"
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
-msgstr ""
-"Sabitlenebilir renk seçici: farklı renk tonlarını göstermek için "
-"döndürülebilir HSV karesi."
+msgid "Dockable color selector: HSV square with Hue ring."
+msgstr "Eşmerkezli HSV halkalarından oluşan, sabitlenebilir renk seçici."
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr "Bileşen Sürgüleri"
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr "Rengin bağımsız bileşenlerini gösteren sabitlenebilir renk seçici."
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr "Sıvı Boya Tabakası"
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 "Birbirine yakın renkleri sıvı boya tabakası gibi gösteren, sabitlenebilir "
 "renk seçici."
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr "Eşmerkezli Halkalar"
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr "Eşmerkezli HSV halkalarından oluşan, sabitlenebilir renk seçici."
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr "Çapraz Kase"
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 "Radyal bir kabın üstünden geçen HSV rampalarından renk seçimi için "
 "sabitlenebilir panel."
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr "Karalama Paneli"
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
-msgstr "Karalama rıhtımını değiştir (renkleri karıştır ve eskiz çiz)."
+msgid "Dockable Panel for mixing colors and testing brushes."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr "Karalama Defteri Panelini Göster"
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr "Karalama panelini göster (renkleri karıştır ve eskiz çiz)."
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr "Önizleme Paneli"
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
-msgstr "Önizleme rıhtımını değiştir (tüm çizim alanının genel görünümü)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "Önizle"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr "Önizleme panelini göster (tüm çizim alanının genel görünümü)."
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr "Araç Seçenekleri Paneli"
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
-msgstr "Araç Seçenekleri rıhtımını değiştir (geçerli araç için seçenekler)."
+msgid "Dockable panel for adjusting the options with the activated tool."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr "Araç Seçenekleri Panelini Göster"
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr "Araç Seçenekleri panelini göster (geçerli araç için seçenekler)."
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr "Fırça ve Renk Geçmişi Paneli"
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
-msgstr "Geçmiş panelini göster/gizle (son kullanılan fırçalar ve renkler)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr "Son Fırçalar ve Renkler"
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr "Geçmiş panelini göster(son kullanılan fırçalar ve renkler)."
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr "Tam Ekranda Kontrolleri Gizle"
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr "Tam ekranda kullanıcı arayüzünün otomatik gizlenmesini aç/kapat."
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr "Yaklaştırma Seviyesini Göster"
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr "Yakınlaştırma seviyesi bilgisini göster/gizle."
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr "Son Boyama Konumunu Göster"
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr "Son darbesinin bittiği yerin gösterimini değiştir."
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr "Ekran Filtreleri"
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr "Renkleri Normal Göster"
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr "Renkleri filtrele: renkleri değiştirmeden göster."
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr "Renkleri Gri Tonlamada Göster"
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
-msgstr "Renkleri filtrele: sadece parlaklığı göster (HCY/YCbCr Renk Parlaklığı)"
+msgstr ""
+"Renkleri filtrele: sadece parlaklığı göster (HCY/YCbCr Renk Parlaklığı)"
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr "Renkleri Ters Çevir"
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 "Renkleri filtrele: renkleri tersine çevir. Siyahı beyaz, kırmızıyı camgöbeği "
 "yapar."
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr "Renkleri Kırmızı Duyarlılık Taklidiyle Göster"
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
@@ -5370,266 +6452,267 @@ msgstr ""
 "Renkleri döteranopiyi (yeşil körlüğü) taklit etmek için filtrele, renk "
 "körlüğünün yaygın bir şekli."
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr "Renkleri Yeşil Duyarlılık Taklidiyle Göster"
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 "Renkleri protanopiyi (kırmızı körlüğü) taklit etmek için filtrele, renk "
 "körlüğünün yaygın bir şekli."
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr "Renkleri Mavi Duyarlılık Taklidiyle Göster"
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 "Renkleri tritanopiyi (sarı-mavi körlüğü) taklit etmek için filtrele, renk "
 "körlüğünün nadir bir şekli."
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr "Serbest"
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr "Serbest"
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr "Serbestçe çiz ve boya, genel geometrik kısıtlar olmadan."
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr "Serbest"
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
-msgstr "Serbest çizim: serbestçe çiz ve boya, genel geometrik kısıtlar olmadan."
+msgstr ""
+"Serbest çizim: serbestçe çiz ve boya, genel geometrik kısıtlar olmadan."
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr "Görünümü Kaydır"
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr "Kaydır"
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr "Görünümü Kaydır: görünümü tuval üzerinde yatay ve dikey taşı."
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr "Görünümü Kaydır"
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr "Tuval görünümünü etkileşimli olarak yatay veya dikey taşı."
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr "Görünümü Döndür"
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr "Döndür"
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr "Görünümü Döndür: tuval görünümünü eğ."
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr "Görünümü Döndür"
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr "Tuval görünümünü etkileşimli olarak döndür."
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr "Görünümü Yakınlaştır"
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr "Yakınlaştırma"
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr "Görünümü Yakınlaştır: tuvale yakınlaştır veya uzaklaştır."
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr "Görünümü Yakınlaştır"
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr "Tuvali etkileşimli olarak yakınlaştır veya uzaklaştır."
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr "Çizgiler ve Eğriler"
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr "Çizgiler"
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr "Çizgiler ve Eğriler: düzgün veya eğri çizgiler çiz."
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr "Çizgiler ve Eğriler"
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr "Düzgün veya eğri çizgiler çiz."
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr "Bağlı Çizgiler"
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr "Bağ. Çizgiler"
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr "Bağlı Çizgiler: düzgün veya eğri çizgi parçaları çiz."
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr "Bağlı Çizgiler"
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr "Düzgün veya eğri çizgi parçaları çiz."
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr "Elipsler ve Daireler"
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr "Elips"
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr "Elipsler ve Daireler: yuvarlak şekiller çiz."
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr "Elipsler ve Daireler"
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr "Elipsler ve daireler çiz."
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr "Mürekkepleme"
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr "Mürekkep"
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr "Mürekkepleme: pürüzsüz denetimli çizgiler çiz."
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr "Mürekkepleme"
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr "Pürüzsüz denetimli çizgiler çiz."
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr "Katmanı Yeniden Konumlandır"
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr "Katman Poz."
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr "Katmanı Yeniden Konumlandır: geçerli katmanı tuval üzerinde taşı."
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr "Katmanı Yeniden Konumlandır"
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr "Geçerli katmanı tuval üzerinde etkileşimli olarak taşı."
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr "Çerçeveyi Düzenle"
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr "Çerçeve"
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
@@ -5637,12 +6720,12 @@ msgstr ""
 "Çerçeveyi Düzenle: Sonlu boyut vermek için belgenin etrafındaki kareyi "
 "etkileşimli olarak ayarla."
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr "Çerçeveyi Düzenle"
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
@@ -5650,78 +6733,283 @@ msgstr ""
 "Sonlu boyut vermek için belgenin etrafındaki kareyi etkileşimli olarak "
 "ayarla."
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Boyama Simetrisini Düzenle"
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr "Simetri"
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 "Boyama simetrisini düzenle: simetrik boyama için kullanılan ekseni ayarla."
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Boyama Simetrisini Düzenle"
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr "Simetrik boyama için kullanılan ekseni etkileşimli olarak ayarla."
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr "Renk Seç"
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr "Renk Seç"
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr "Renk Seç: ekran pikselinden boyama rengi seç."
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "Renk Seç"
+
+#: ../po/tmp/resources.xml.h:401
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr "Boyama rengini ekran piksellerinden seç."
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "Renk Seç"
+
+#: ../po/tmp/resources.xml.h:403
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr "Boyama rengini ekran piksellerinden seç."
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "Renk Seç"
+
+#: ../po/tmp/resources.xml.h:405
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr "Boyama rengini ekran piksellerinden seç."
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr "Renk Seç"
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr "Boyama rengini ekran piksellerinden seç."
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr "Akıcı Dolgu"
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr "Doldur"
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr "Akıcı Dolgu: alanı renkle doldur."
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr "Akıcı Dolgu"
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr "Bir bölgeyi renk ile doldur."
+
+#~ msgctxt "Accelerator map editor: action column markup"
+#~ msgid ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+#~ msgstr ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+
+#~ msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
+#~ msgid "{action_label} {action_desc} {accel_label}"
+#~ msgstr "{action_label} {action_desc} {accel_label}"
+
+#~ msgctxt "brush list context menu"
+#~ msgid "Delete"
+#~ msgstr "Sil"
+
+#~ msgctxt "brush list commands"
+#~ msgid "Really delete brush from disk?"
+#~ msgstr "Bu fırçayı diskten silmek istediğinize emin misiniz?"
+
+#~ msgid "HSV Triangle"
+#~ msgstr "HSV Üçgen"
+
+#~ msgid "The standard GTK color selector"
+#~ msgstr "Standard GTK renk seçici"
+
+#~ msgid "Pick a color from the screen"
+#~ msgstr "Ekrandan bir renk seç"
+
+#~ msgid "Layer Name"
+#~ msgstr "Katman Adı"
+
+#~ msgid ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+#~ msgstr ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+
+#~ msgid "Save..."
+#~ msgstr "Kaydet..."
+
+#~ msgid "Confirm"
+#~ msgstr "Onayla"
+
+#~ msgid "Open..."
+#~ msgstr "Aç..."
+
+#~ msgid "{default_name} at {path}"
+#~ msgstr "{default_name} : {path}"
+
+#~ msgid "Type"
+#~ msgstr "Tür"
+
+#~ msgid "Mode:"
+#~ msgstr "Mod:"
+
+#~ msgid ""
+#~ "Blending mode: how the current layer combines with the layers underneath "
+#~ "it."
+#~ msgstr ""
+#~ "Harmanlama kipi: geçerli katmanın altındaki katmanlarla nasıl "
+#~ "birleştirileceği."
+
+#~ msgid ""
+#~ "Layer opacity: how much of the current layer to use. Smaller values make "
+#~ "it more transparent."
+#~ msgstr ""
+#~ "Katman matlığı: geçerli katmanın ne kadarının kullanılacağı. Daha küçük "
+#~ "değerler daha saydam yapar."
+
+#~ msgid "%s: edit properties"
+#~ msgstr "%s: özellikleri düzenle"
+
+#~ msgctxt "layer unique names: match regex (leave untranslated if unsure)"
+#~ msgid "^(.*?)\\s*(\\d+)$"
+#~ msgstr "^(.*?)\\s*(\\d+)$"
+
+#~ msgctxt "layer default names"
+#~ msgid "Unknown Bitmap Layer"
+#~ msgstr "Bilinmeyen Bit Eşlem Katmanı"
+
+#~ msgctxt "Autosave Recovery dialog|"
+#~ msgid "_Ignore for Now"
+#~ msgstr "Şimdilik _Görmezden Gel"
+
+#~ msgid "Setting name:"
+#~ msgstr "Ayar adı:"
+
+#~ msgid "Base value:"
+#~ msgstr "Temel değer:"
+
+#~ msgid "Reset the base value to its default"
+#~ msgstr "Temel değeri varsayılanına sıfırla"
+
+#~ msgid "<ymin>"
+#~ msgstr "<ymin>"
+
+#~ msgid "<ymax>"
+#~ msgstr "<ymax>"
+
+#~ msgid "<xmin>"
+#~ msgstr "<xmin>"
+
+#~ msgid "<xmax>"
+#~ msgstr "<xmax>"
+
+#~ msgid "Edit Setting"
+#~ msgstr "Ayarı Düzenle"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Trim Layer to Frame"
+#~ msgstr "Katmanı Çerçeveye Kırp"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Rename Layer…"
+#~ msgstr "Katmanı Yeniden Adlandır…"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Enter a new name for the current layer."
+#~ msgstr "Geçerli katman için yeni ad gir."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Turn off mirroring of the view."
+#~ msgstr "Görünüm yansıtmasını kapat."
+
+#~ msgctxt "Menu→Edit (labels)"
+#~ msgid "Current Tool"
+#~ msgstr "Geçerli Araç"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+#~ msgstr "Katmanlar rıhtımını değiştir (katmanları düzenle veya kipleri ata)."
+
+#~ msgctxt "Menu→Color (labels), Accel Editor (labels)"
+#~ msgid "HSV Triangle"
+#~ msgstr "HSV Üçgeni"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Dockable color selector: the old GTK color triangle."
+#~ msgstr "Sabitlenebilir renk seçici: eski GTK renk üçgeni."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid ""
+#~ "Dockable color selector: HSV square which can be rotated to show "
+#~ "different hues."
+#~ msgstr ""
+#~ "Sabitlenebilir renk seçici: farklı renk tonlarını göstermek için "
+#~ "döndürülebilir HSV karesi."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+#~ msgstr "Karalama rıhtımını değiştir (renkleri karıştır ve eskiz çiz)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+#~ msgstr "Önizleme rıhtımını değiştir (tüm çizim alanının genel görünümü)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+#~ msgstr "Araç Seçenekleri rıhtımını değiştir (geçerli araç için seçenekler)."
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the History panel (recently used brushes and colors)."
+#~ msgstr "Geçmiş panelini göster/gizle (son kullanılan fırçalar ve renkler)."

--- a/po/tr.po
+++ b/po/tr.po
@@ -535,18 +535,18 @@ msgstr "MyPaint fırça paketi (*.zip)"
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
-msgstr "Yeni Grup..."
+msgid "New Group…"
+msgstr "Yeni Grup…"
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
-msgstr "Fırçaları İçe Aktar..."
+msgid "Import Brushes…"
+msgstr "Fırçaları İçe Aktar…"
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
-msgstr "Daha Fazla Fırça Edin..."
+msgid "Get More Brushes…"
+msgstr "Daha Fazla Fırça Edin…"
 
 #: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
@@ -1225,12 +1225,12 @@ msgstr "Tür"
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr "Kullanım Amacı"
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr "Kaydır"
 
 #. Name and preview column: will be indented
@@ -1454,8 +1454,8 @@ msgid "_Quit"
 msgstr "Çıkış"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
-msgstr "Fırça paketini içe aktar..."
+msgid "Import brush package…"
+msgstr "Fırça paketini içe aktar…"
 
 #: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
@@ -1513,8 +1513,8 @@ msgstr ""
 "hangi uygulamayı kullansın?"
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
-msgstr "Birlikte Aç..."
+msgid "Open With…"
+msgstr "Birlikte Aç…"
 
 #: ../gui/externalapp.py:123
 msgid "Icon"
@@ -1704,13 +1704,13 @@ msgstr "JPEG %90 kalite (*.jpg; *.jpeg)"
 
 #: ../gui/filehandling.py:576
 #, fuzzy
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr "Dışa Aktar…"
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Farklı Kaydet…"
 
@@ -1781,8 +1781,8 @@ msgstr "Aç"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
-msgstr "Karalama Defteri Aç..."
+msgid "Open Scratchpad…"
+msgstr "Karalama Defteri Aç…"
 
 #: ../gui/filehandling.py:1099
 #, fuzzy
@@ -2238,13 +2238,13 @@ msgstr ""
 "geliştiricilere bilgi verebilirsin."
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr "Hata Takipçisinde Ara"
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
-msgstr "Raporla..."
+msgid "Report…"
+msgstr "Raporla…"
 
 #: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
@@ -2255,8 +2255,8 @@ msgid "Quit MyPaint"
 msgstr "MyPaint'den Çık"
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
-msgstr "Ayrıntılar..."
+msgid "Details…"
+msgstr "Ayrıntılar…"
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
@@ -2461,8 +2461,8 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
-msgstr "Katmanı yığında taşı..."
+msgid "Move layer in stack…"
+msgstr "Katmanı yığında taşı…"
 
 #: ../gui/layerswindow.py:110
 msgid ""
@@ -2532,7 +2532,7 @@ msgid "Stroke trail-off beginning"
 msgstr "Başlangıçtan azalarak yok olan darbe"
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr "Basınç Çeşitliliği"
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-05-14 16:49+0000\n"
 "Last-Translator: prolinux ukraine <prolinux@ukr.net>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/mypaint/"
@@ -16,31 +16,11 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<="
-"4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 3.7-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr "<b>{action_label}</b><small>{action_desc}</small>"
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr "<big><b>{accel_label}</b></big>"
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr "{action_label} {action_desc} {accel_label}"
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "Дія"
 
@@ -48,32 +28,32 @@ msgstr "Дія"
 msgid "Key combination"
 msgstr "Комбінація клавіш"
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr "Редагувати клавіші для «%s»"
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "Дія:"
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "Шлях:"
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "Клавіша:"
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr "Натисніть клавіші, щоб оновити це призначення"
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "Невідома дія"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
@@ -82,7 +62,7 @@ msgstr ""
 "<b>{accel} — вже використовується для «{action}». Наявне призначення буде "
 "заміщено.</b>"
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr "Відкриту теку «{folder_basename}»…"
@@ -90,194 +70,204 @@ msgstr "Відкриту теку «{folder_basename}»…"
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "Гаразд"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr "Не знайдено резервних копій у кеші."
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr "Немає доступних резервних копій"
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr "Відкрити теку кешу…"
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr "Не вдалося відновити резервну копію"
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr "Відкрити теку з резервними копіями…"
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr "Відновлений файл з {iso_datetime}.ora"
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "Зберегти як типовий"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "Тло"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "Візерунок"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Колір"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "Додати колір до шаблонів"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr "Один або більше тлів неможливо завантажити"
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr "Помилка завантаження тлів"
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 "Вилучте файли, які неможливо завантажити, або перевірте пакунок libgdkpixbuf."
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr "Gdk-Pixbuf не може завантажити «{filename}», і повідомляє «{error}»"
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr "{filename} має нульовий розмір (w={w}, h={h})"
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr "Редактор параметрів пензля"
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr "Про програму"
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "Експериментальне"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr "Основне"
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr "Непрозорість"
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr "Мазки"
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "Заплямлення"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr "Швидкість"
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr ""
+
+#: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr "Стеження"
 
-#: ../gui/brusheditor.py:359
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "Штрих"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr "Колір"
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Власне"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr "Не вибрано пезля, натисніть «Додати як новий» натомість."
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr "Не вибрано жодного пензля!"
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "Перейменувати пензель"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "Пензель з такою назвою вже існує!"
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr "Не вибрано жодного пензля!"
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr "Вилучити пезель «{brush_name}» з диска?"
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr "(Неназваний пензель)"
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr "{brush_name} [не збежено]"
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr "Піктограма пензля"
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr "Піктограма пезля (редагування)"
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr "Не вибрано жодного пензля"
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -286,7 +276,7 @@ msgstr ""
 "<b>%s</b>\n"
 "<small>Спочатку виберіть дійсний пензель</small>"
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
@@ -295,7 +285,7 @@ msgstr ""
 "<b>%s</b> <i>(змінено)</i>\n"
 "<small>Зміни не збережено</small>"
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
@@ -304,7 +294,7 @@ msgstr ""
 "<b>%s</b> (редагування)\n"
 "<small>Малюйте з будь-яким пензлем і кольором</small>"
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -345,98 +335,138 @@ msgstr "Автоматично"
 msgid "Use the default icon"
 msgstr "Використати типову піктограму"
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Зберегти"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr "Зберегти піктограму й закінчити редагування"
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr "Втрачено й знайдено"
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr "Вилучено"
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr "Улюблені"
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr "Чорнило"
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr "Класичне"
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr "Набір#1"
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr "Набір#2"
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr "Набір#3"
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr "Набір#4"
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr "Набір#5"
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr "Експериментальне"
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Створити"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr "Невідомий пезель"
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr "Додати до улюблених"
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr "Вилучити з улюблених"
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr "Клонувати"
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr "Редагувати параметри пензля"
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
-msgstr "Вилучити"
+#: ../gui/brushselectionwindow.py:250
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
+msgstr "Перейменувати групу"
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
-msgstr "Вилучити пензель з диска?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, fuzzy, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
+msgstr "Вилучити пезель «{brush_name}» з диска?"
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
@@ -444,44 +474,44 @@ msgstr[0] "%d пензель"
 msgstr[1] "%d пензлі"
 msgstr[2] "%d пензлів"
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr "Група «{group_name}»"
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr "Перейменувати групу"
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr "Експортувати як запакований набір пензлів"
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr "Вилучити групу"
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr "Перейменувати групу"
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "Група з такою назвою вже існує!"
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr "Вилучити групу «{group_name}»?"
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -491,58 +521,58 @@ msgstr ""
 "Неможливо вилучити групу «{group_name}».\n"
 "Деякі певні групи неможливо вилучити."
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr "Експортувати пензлі"
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr "Пакунок пензлів MyPaint (*.zip)"
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "Створити групу…"
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr "Імпортувати пензлі…"
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr "Одержати більше пензлів…"
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "Створити групу"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr "Кнопка"
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr "Кнопка"
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr "Натиск кнопки"
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr "Додати нову зв'язку"
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr "Вилучити поточну зв'язку"
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr "Редагувати зв'язку для «%s»"
@@ -551,7 +581,7 @@ msgstr "Редагувати зв'язку для «%s»"
 msgid "Button press:"
 msgstr "Натиск кнопки:"
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
@@ -559,46 +589,74 @@ msgstr ""
 "Щоб створити прив’язування, затисніть клавіші-модифікатори та натисніть на "
 "кнопку над цим текстом."
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr "{button} не може бути прив’язаною без модифікаторів"
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr "{button_combination} уже прив’язана до дії ’{action_name}’"
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr "Обрати колір"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr "Обрати колір для малювання"
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+#, fuzzy
+msgid "Set the color Hue used for painting"
+msgstr "Обрати колір для малювання"
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "Взяти колір."
+
+#: ../gui/colorpicker.py:296
+#, fuzzy
+msgid "Set the color Chroma used for painting"
+msgstr "Обрати колір для малювання"
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+#, fuzzy
+msgid "Set the color Luma used for painting"
+msgstr "Обрати колір для малювання"
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr "Деталі  кольору"
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr "Поточний колір пензля та останній використаний колір"
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr "Маска Gamut активна"
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -608,137 +666,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr "Тон і насиченість HCY."
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr "Атмосферна тріада"
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr "Зсунута тріада"
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr "Зміщена до домінантного кольору."
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr "Додатковий колір"
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr "Активні"
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr "Довідка…"
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -746,162 +804,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -909,373 +959,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr "Гумка"
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Назва"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr "Перейменувати"
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr "Перейменувати всі"
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr "Відновити пензель %d"
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr "Зберегти до пензля %d"
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr "Відмінити %s"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Вернути"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr "Повторити %s"
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Повторити"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1285,324 +1332,706 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Відкрити"
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr "На повний екран"
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "На повний екран"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Вийти"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+#, fuzzy
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr "Справді вийти?"
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Вийти"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
+#: ../gui/filehandling.py:126
+#, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:130
+#, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:134
+#, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:138
+#, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:145
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "Зберегти як типовий"
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr "Відкрити недавні файли"
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: ../gui/filehandling.py:221
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
+msgstr "Помилка під час завантаження: “{basename}”."
+
+#: ../gui/filehandling.py:427
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "All Recognized Formats"
 msgstr "Всі формати, які можна розпізнати"
 
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
+#: ../gui/filehandling.py:432
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "OpenRaster (*.ora)"
 msgstr "OpenRaster (*.ora)"
 
-#: ../gui/filehandling.py:95
+#: ../gui/filehandling.py:437
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "PNG (*.png)"
 msgstr "PNG (*.png)"
 
-#: ../gui/filehandling.py:96
+#: ../gui/filehandling.py:442
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
 msgid "JPEG (*.jpg; *.jpeg)"
 msgstr "JPEG (*.jpg; *.jpeg)"
 
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
 msgid "By extension (prefer default format)"
 msgstr ""
 
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
+#: ../gui/filehandling.py:494
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
+#: ../gui/filehandling.py:502
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:506
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
 msgstr "PNG з прозорістю (*.png)"
 
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
+#: ../gui/filehandling.py:510
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
 msgstr "Серія прозорих PNG (*.XXX.png)"
 
-#: ../gui/filehandling.py:113
+#: ../gui/filehandling.py:514
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr "Серія прозорих PNG (*.XXX.png)"
+
+#: ../gui/filehandling.py:518
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
 msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr "JPEG 90% якості (*.jpg; *.jpeg)"
 
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr "Зберегти…"
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
 
-#: ../gui/filehandling.py:177
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Зберегти як…"
+
+#: ../gui/filehandling.py:601
+#, fuzzy
+msgctxt "save dialogs: formats and options: (label)"
 msgid "Format to save as:"
+msgstr "Не вдалося зберегти: %s"
+
+#: ../gui/filehandling.py:668
+#, fuzzy
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr "Справді вийти?"
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
 msgstr ""
 
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
-#, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
-msgstr ""
-
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
+#: ../gui/filehandling.py:705
+#, fuzzy
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
 msgstr "_Зберегти як чернетку"
 
-#: ../gui/filehandling.py:282
-#, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:734
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
 msgstr ""
 
-#: ../gui/filehandling.py:321
-#, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
 msgstr ""
 
-#: ../gui/filehandling.py:422
-#, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
 msgstr ""
 
-#: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
-msgstr ""
-
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
-msgstr ""
-
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
-msgstr ""
-
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
-msgstr ""
-
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
 msgstr "Відкрити…"
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Відкрити недавні файли"
+
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr "Відкрити чернетку..."
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
-msgstr "Файлів чернеток з назвою «%s» ще не існує."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Шари"
 
-#: ../gui/fill.py:75 ../lib/command.py:459
-msgid "Flood Fill"
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Відкрити"
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Відкрити недавні"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Відкрити"
+
+#: ../gui/filehandling.py:1446
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr "Файлів чернеток з назвою «%s» ще не існує."
+
+#: ../gui/filehandling.py:1455
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr "Відкрити наступну чернетку"
+
+#: ../gui/filehandling.py:1463
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr "Відкрити попередню чернетку"
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Відкрити"
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+#, fuzzy
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr "Повернути"
+
+#: ../gui/fill.py:121
+#, fuzzy
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
+msgid "Flood Fill"
+msgstr "Заливка"
+
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+#, fuzzy
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr "За розміром зображення"
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
-msgstr ""
+msgstr "Створити групу"
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Непрозорість:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "Видалити шар"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1610,130 +2039,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr "Колір:"
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr "Тиск:"
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr "Виявлено ваду"
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr "<big><b>Було виявлено помилку у програмі.</b></big>"
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1742,35 +2183,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr "Звіт…"
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr "Подробиці…"
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1794,45 +2235,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr "Тиск:"
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1840,155 +2285,223 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+#, fuzzy
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr "Властивості"
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Шари"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Шари"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Непрозорість:"
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "Перейменувати"
 
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr ""
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr ""
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr ""
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr ""
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 msgid "Stroke lead-in end"
 msgstr ""
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr ""
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
+#, fuzzy
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 "© Martin Renold і Команда розробників MyPaint,\n"
 "2005–2015"
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -2007,256 +2520,282 @@ msgstr ""
 "Ця програма поширюється у сподіванні, що вона буде корисною, але БЕЗ ЖОДНИХ "
 "ГАРАНТІЙ. Докладніше про це у файлі COPYING."
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr "програмування"
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr "придатність до портування"
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr "пензлі"
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr "піктограма стільниці"
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr "Взяти колір…"
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr "Параметри"
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
+msgstr "Симетрія"
+
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2264,188 +2803,214 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "Перейменувати групу"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr "Об'єднати з нижнім"
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Шари"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr "Помилка під час завантаження: “{basename}”."
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2454,13 +3019,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2470,7 +3035,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2480,13 +3045,13 @@ msgstr ""
 "Не вдалося зберегти “{filename}”: {err}\n"
 "Чи достатньо місця на вашому диску?"
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2494,7 +3059,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2504,7 +3069,7 @@ msgstr ""
 "{error_loading_common}\n"
 "У вас недостатньо прав для відкриття файла."
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2515,7 +3080,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2525,7 +3090,12 @@ msgstr ""
 "{error_loading_common}\n"
 "Невідоме розширення формату файлів: “{ext}”"
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2535,7 +3105,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2546,285 +3116,401 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
-msgctxt "layer default names"
-msgid "Vector Layer"
-msgstr ""
-
 #: ../lib/layer/data.py:1153
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Vectors"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
+#: ../lib/layer/data.py:1158
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Vector Layer"
+msgstr "Очистити шар"
+
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Data Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr "Невідома дія"
+
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "Новий шар"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "Створити групу"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+#, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "Перегляд"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+#, fuzzy
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr "Шари"
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr "Видимість шару"
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr "Екран"
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr "Темніше"
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr "Яскравіше"
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2834,7 +3520,28 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+#, fuzzy
+msgid "Rotational"
+msgstr "Обернути"
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2843,53 +3550,85 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr "Вилучити"
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
-msgstr "Перейменувати пензель"
+msgid "Save these settings to the brush"
+msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
 msgid "Edit Icon"
@@ -2910,18 +3649,16 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
-msgstr ""
+msgid "Rename this brush"
+msgstr "Перейменувати пензель"
 
 #: ../po/tmp/brusheditor.glade.h:13
 msgid "Brush Setting"
@@ -2949,113 +3686,89 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
-msgstr "Основне значення:"
-
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr "<ymin>"
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr "<ymax>"
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr "<xmin>"
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr "<xmax>"
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
 msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+#, fuzzy
+msgid "<big><b>No Brush Dynamics</b></big>"
+msgstr "<big><b>{accel_label}</b></big>"
 
 #: ../po/tmp/inktool.glade.h:1
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
@@ -3067,7 +3780,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr "Тиск:"
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3108,6 +3821,135 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Назва"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Непрозорість"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr "Вилучити поточну зв'язку"
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3477,56 +4319,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr "Перегляд"
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3534,12 +4396,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3548,7 +4410,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3559,28 +4421,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr "Колір"
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3642,769 +4504,947 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
-msgstr "Зберегти"
+msgid "Import Layers…"
+msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
-msgstr "Зберегти як…"
+msgid "Save"
+msgstr "Зберегти"
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
-msgstr ""
+msgid "Save As…"
+msgstr "Зберегти як…"
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
-msgstr "Зберегти як чернетку"
+msgid "Export…"
+msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
-msgstr "Відкрити попередню чернетку"
+msgid "Save As Scrap"
+msgstr "Зберегти як чернетку"
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
-msgstr "Відкрити наступну чернетку"
+msgid "Open Previous Scrap"
+msgstr "Відкрити попередню чернетку"
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Open Next Scrap"
+msgstr "Відкрити наступну чернетку"
+
+#: ../po/tmp/resources.xml.h:25
+msgctxt "Accel Editor (descriptions)"
+msgid "Load the scrap file after the current one."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Recover File from an Automated Backup…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:25
+#: ../po/tmp/resources.xml.h:27
 msgctxt "Accel Editor (descriptions)"
 msgid "Try to save and resume interrupted unsaved work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:26
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr "Пензлі"
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr "Кольори"
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "Очистити шар"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "Створити групу"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "Створити групу"
+
+#: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:71
+#: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Edit Layer in External App…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
-msgstr "Новий шар"
-
-#: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:85
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
-msgstr "Створити групу"
-
-#: ../po/tmp/resources.xml.h:86
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:87
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:88
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:89
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
-msgstr "Видалити шар"
+msgid "New Painting Layer"
+msgstr "Новий шар"
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr "Створити групу"
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr "Видалити шар"
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr "Збільшити прозорість шару"
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr "Зменшити прозорість шару"
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
+#, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
-msgstr ""
+msgid "Layer Properties…"
+msgstr "Властивості"
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr "Видимість шару"
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr "За розміром зображення"
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr "Збільшити"
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Зменшити"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
-msgstr "Обернути проти годинникової стрілки"
-
-#: ../po/tmp/resources.xml.h:137
-msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:157
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the left."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr "Обернути за годинниковою стрілкою"
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
-msgstr ""
+msgid "Rotate the canvas clockwise."
+msgstr "Обернути проти годинникової стрілки"
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr "Обернути проти годинникової стрілки"
+
+#: ../po/tmp/resources.xml.h:167
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr "Обернути проти годинникової стрілки"
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr "Візуалізувати відтворення"
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+#, fuzzy
+msgid "Delete Point"
+msgstr "Вилучити групу"
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr "Стирати активним пензлем."
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr "Режим Малювання: Альфа Зафіксоване"
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr "Застосування пензля не впливає на прозорість прошарку."
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr "Режим Малювання: Розфарбовування"
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
@@ -4412,1063 +5452,1124 @@ msgstr ""
 "Застосувати колір до поточного шару без впливу на його яскравість або "
 "прозорість."
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Файл"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "Вийти"
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr "Закрити головне вікно і вийти з програми."
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "Змінити"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr "Вибраний Інструмент"
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "Колір"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr "Коректувати Колір"
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr "Історія Вибору Кольорів"
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "Шари"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr "Непрозорість"
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr "Властивості"
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr "Записник"
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr "Відкрити чернетку…"
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr "Зберегти чернетку"
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr "Зберегти чернетку як типовий"
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "Вікно"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "Пензель"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "Зміна пензля…"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "Зміна кольору…"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "Зміна кольору (швидкий вибір)…"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr "Отримати більше пензлів…"
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Довідка"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr "Довідка"
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "Про MyPaint"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Зневаджування"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr "Вивести дані щодо витоку пам'яті до стандартного виводу (Повільно!)"
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr "Розпочати вилучення зайвих даних (сміття) зараз"
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "Перегляд"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "На повний екран"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "Параметри"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr "Редактор налаштування пензля"
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr "Шари"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr "Показати панель шарів"
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "Палітра"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr "Показати панель із записником"
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr "Панель огляду"
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "Огляд"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr "Налаштування інструментів"
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr "Показати налаштування інструментів"
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr "Історія пензлів та кольорів"
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr "Нещодавні пензлі та кольори"
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr "Від руки"
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr "Від руки"
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr "Обернути"
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr "Лінії та криві"
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr "З'єднані лінії"
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr "Еліпси та кола"
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr "чорнило"
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr "Контури"
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr "Перемістити шар"
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr "Змінити рамку"
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr "Симетрія"
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "Симетричне малювання"
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr "Взяти колір"
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr "Взяти колір."
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "Обрати колір"
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "Обрати колір"
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "Обрати колір"
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr "Піпетка"
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr "Заливка"
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""
+
+#~ msgctxt "Accelerator map editor: action column markup"
+#~ msgid ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+#~ msgstr "<b>{action_label}</b><small>{action_desc}</small>"
+
+#~ msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
+#~ msgid "{action_label} {action_desc} {accel_label}"
+#~ msgstr "{action_label} {action_desc} {accel_label}"
+
+#~ msgctxt "brush list commands"
+#~ msgid "Really delete brush from disk?"
+#~ msgstr "Вилучити пензель з диска?"
+
+#~ msgid "Save..."
+#~ msgstr "Зберегти…"
+
+#~ msgid "Open..."
+#~ msgstr "Відкрити…"
+
+#~ msgid "Base value:"
+#~ msgstr "Основне значення:"
+
+#~ msgid "<ymin>"
+#~ msgstr "<ymin>"
+
+#~ msgid "<ymax>"
+#~ msgstr "<ymax>"
+
+#~ msgid "<xmin>"
+#~ msgstr "<xmin>"
+
+#~ msgid "<xmax>"
+#~ msgstr "<xmax>"
+
+#~ msgctxt "Menu→Edit (labels)"
+#~ msgid "Current Tool"
+#~ msgstr "Вибраний Інструмент"
 
 #~ msgid "Add As New"
 #~ msgstr "додати як новий"
@@ -5569,9 +6670,6 @@ msgstr ""
 #~ "підказок. Щоб переглянути вміст підказок, достатньо навести вказівник на "
 #~ "відповідний елемент інтерфейсу програми. \n"
 
-#~ msgid "Open Recent files"
-#~ msgstr "Відкрити недавні файли"
-
 #, fuzzy
 #~ msgid "This will discard %d second of unsaved painting."
 #~ msgid_plural "This will discard %d seconds of unsaved painting."
@@ -5626,15 +6724,8 @@ msgstr ""
 #~ msgstr "зберегти налаштування"
 
 #, fuzzy
-#~ msgid "Add Layer"
-#~ msgstr "Шари"
-
-#, fuzzy
 #~ msgid "Change Layer Visibility"
 #~ msgstr "Видимість шару"
-
-#~ msgid "Unable to save: %s"
-#~ msgstr "Не вдалося зберегти: %s"
 
 #~ msgid "File does not exist: %s"
 #~ msgstr "Файла не існує: %s"

--- a/po/uk.po
+++ b/po/uk.po
@@ -533,17 +533,17 @@ msgstr "Пакунок пензлів MyPaint (*.zip)"
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr "Створити групу…"
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr "Імпортувати пензлі…"
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr "Одержати більше пензлів…"
 
 #: ../gui/brushselectionwindow.py:554
@@ -1211,12 +1211,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1434,7 +1434,7 @@ msgid "_Quit"
 msgstr "Вийти"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1484,7 +1484,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1674,13 +1674,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr "JPEG 90% якості (*.jpg; *.jpeg)"
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Зберегти як…"
 
@@ -1751,8 +1751,8 @@ msgstr "Відкрити недавні файли"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
-msgstr "Відкрити чернетку..."
+msgid "Open Scratchpad…"
+msgstr "Відкрити чернетку…"
 
 #: ../gui/filehandling.py:1099
 #, fuzzy
@@ -2184,12 +2184,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr "Звіт…"
 
 #: ../gui/gtkexcepthook.py:180
@@ -2201,7 +2201,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr "Подробиці…"
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2388,7 +2388,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2459,7 +2459,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/uz.po
+++ b/po/uz.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:19+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Uzbek <https://hosted.weblate.org/projects/mypaint/mypaint/uz/"
@@ -19,27 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -47,39 +27,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -87,214 +67,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Rang"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Boshqa"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -333,142 +323,177 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Saqlash"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Yangi"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -476,58 +501,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -536,51 +561,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -590,137 +639,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -728,162 +777,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -891,373 +932,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Nomi"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Bekor qilish"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Qaytarish"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1267,324 +1305,678 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Ochish..."
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr ""
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Chiqish"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Chiqish"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Ochish..."
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Saqlash"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr ""
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr ""
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Fayl"
+
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Ochish..."
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Yaqinda foydalanilganni ochish"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Ochish..."
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Ochish..."
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr ""
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1592,130 +1984,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1724,35 +2128,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1776,45 +2180,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1822,153 +2230,217 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr ""
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr ""
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr ""
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1980,256 +2452,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2237,188 +2734,212 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+msgid "Import Layers"
+msgstr ""
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2427,13 +2948,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2443,7 +2964,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2451,13 +2972,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2465,7 +2986,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2473,7 +2994,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2484,7 +3005,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2492,7 +3013,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2502,7 +3028,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2513,285 +3039,394 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr ""
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2801,7 +3436,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2810,52 +3465,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2877,17 +3563,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2916,112 +3600,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3034,7 +3693,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3075,6 +3734,133 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Nomi"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3444,56 +4230,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3501,12 +4307,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3515,7 +4321,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3526,28 +4332,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3609,1828 +4415,2018 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Kichiklashtirish"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Fayl"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Yordam"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/uz.po
+++ b/po/uz.po
@@ -513,17 +513,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1184,12 +1184,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1372,7 +1372,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Open dragged file confirm dialog: continue button"
 msgid "_Open"
-msgstr "Ochish..."
+msgstr "Ochish…"
 
 #: ../gui/drawwindow.py:486
 msgid "Set current color"
@@ -1406,7 +1406,7 @@ msgid "_Quit"
 msgstr "Chiqish"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1456,7 +1456,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1633,13 +1633,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Saqlash"
 
@@ -1705,7 +1705,7 @@ msgstr "Fayl"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -1722,7 +1722,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Ochish..."
+msgstr "Ochish…"
 
 #: ../gui/filehandling.py:1427
 #, fuzzy
@@ -1734,7 +1734,7 @@ msgstr "Yaqinda foydalanilganni ochish"
 #, fuzzy
 msgctxt "File→Open Most Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Ochish..."
+msgstr "Ochish…"
 
 #: ../gui/filehandling.py:1446
 msgctxt "File→Open Next/Prev Scrap: error message"
@@ -1755,7 +1755,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
 msgid "_Open"
-msgstr "Ochish..."
+msgstr "Ochish…"
 
 #: ../gui/filehandling.py:1487
 msgctxt "File→Revert: status message: canvas has no filename yet"
@@ -2129,12 +2129,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2146,7 +2146,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2331,7 +2331,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2401,7 +2401,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/vi.po
+++ b/po/vi.po
@@ -512,17 +512,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
-msgstr "Nhóm mới..."
+msgid "New Group…"
+msgstr "Nhóm mới…"
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1184,12 +1184,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1372,7 +1372,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Open dragged file confirm dialog: continue button"
 msgid "_Open"
-msgstr "Mở..."
+msgstr "Mở…"
 
 #: ../gui/drawwindow.py:486
 msgid "Set current color"
@@ -1407,7 +1407,7 @@ msgid "_Quit"
 msgstr "Thoát"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1457,7 +1457,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1644,13 +1644,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr "JPEG 90% chất lượng (*.jpg, *.jpeg)"
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Lưu"
 
@@ -1719,7 +1719,7 @@ msgstr "Tập tin"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr "Mở bản nháp tiếp theo"
 
 #: ../gui/filehandling.py:1099
@@ -1737,7 +1737,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Mở..."
+msgstr "Mở…"
 
 #: ../gui/filehandling.py:1427
 #, fuzzy
@@ -1749,7 +1749,7 @@ msgstr "Mở gần đây"
 #, fuzzy
 msgctxt "File→Open Most Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Mở..."
+msgstr "Mở…"
 
 #: ../gui/filehandling.py:1446
 #, fuzzy
@@ -1773,7 +1773,7 @@ msgstr "Mở bản nháp trước"
 #, fuzzy
 msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
 msgid "_Open"
-msgstr "Mở..."
+msgstr "Mở…"
 
 #: ../gui/filehandling.py:1487
 msgctxt "File→Revert: status message: canvas has no filename yet"
@@ -2147,13 +2147,13 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
-msgstr "Báo cáo..."
+msgid "Report…"
+msgstr "Báo cáo…"
 
 #: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
@@ -2164,8 +2164,8 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
-msgstr "Chi tiết..."
+msgid "Details…"
+msgstr "Chi tiết…"
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
@@ -2350,7 +2350,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2421,7 +2421,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-23 08:18+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Vietnamese <https://hosted.weblate.org/projects/mypaint/"
@@ -19,27 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -47,39 +27,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -87,214 +67,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "lưu thành mặc định"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "Nền"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "Mẫu"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Màu"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "thêm màu vào mẫu"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "loang"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr ""
+
+#: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr ""
 
-#: ../gui/brusheditor.py:359
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "Nét"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "Tùy chọn"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "Đổi tên chổi"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "Đã có chổi được đặt tên này rồi!"
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -333,141 +323,176 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Lưu"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Mới"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
-msgstr "Bạn có chắc muốn xóa chổi khỏi ổ đĩa?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
+msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "Đã có nhóm được đặt tên này rồi!"
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -475,58 +500,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "Nhóm mới..."
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "Tạo nhóm"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -535,51 +560,76 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr "Chọn màu"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "Chọn màu"
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -589,137 +639,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -727,162 +777,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -890,373 +932,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr "tẩy"
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "Tên"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr "Khôi phục chổi %d"
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr "Lưu thành chổi %d"
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Hồi lại"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Làm lại"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1266,324 +1305,696 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Mở..."
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Toàn màn hình"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Thoát"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+#, fuzzy
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr "Chắc chắn thoát?"
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Thoát"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr "Tất cả định dạng nhận được"
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr "OpenRaster (*.ora)"
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr "PNG (*.png)"
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr "JPEG (*.jpg; *.jpeg)"
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr "PNG trong suốt (*.png)"
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr "Multiple PNG transparent (*.XXX.png)"
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr "JPEG 90% chất lượng (*.jpg, *.jpeg)"
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr "_Lưu thành nháp"
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "lưu thành mặc định"
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
+msgstr "Tất cả định dạng nhận được"
+
+#: ../gui/filehandling.py:432
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:437
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:442
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
+msgstr "JPEG (*.jpg; *.jpeg)"
+
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:494
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:502
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:506
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr "PNG trong suốt (*.png)"
+
+#: ../gui/filehandling.py:510
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr "Multiple PNG transparent (*.XXX.png)"
+
+#: ../gui/filehandling.py:514
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr "Multiple PNG transparent (*.XXX.png)"
+
+#: ../gui/filehandling.py:518
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr "JPEG 90% chất lượng (*.jpg, *.jpeg)"
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Lưu"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:668
+#, fuzzy
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr "Chắc chắn thoát?"
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
+#: ../gui/filehandling.py:705
+#, fuzzy
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr "_Lưu thành nháp"
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr ""
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr ""
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Tập tin"
+
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
+msgid "Open Scratchpad..."
+msgstr "Mở bản nháp tiếp theo"
+
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "Lớp vẽ"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
 msgstr "Mở..."
 
-#: ../gui/filehandling.py:552
-msgid "Open Scratchpad..."
-msgstr ""
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Mở gần đây"
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Mở..."
+
+#: ../gui/filehandling.py:1446
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
 msgstr "Không có tập tin nháp với tên \"%s\"."
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1455
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr "Mở bản nháp tiếp theo"
+
+#: ../gui/filehandling.py:1463
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr "Mở bản nháp trước"
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Mở..."
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Độ mờ đục:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1591,130 +2002,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr "Phát hiện lỗi"
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr "<big><b>Đã phát hiện một lỗi lập trình.</b></big>"
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1723,35 +2146,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr "Báo cáo..."
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr "Chi tiết..."
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1775,45 +2198,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1821,153 +2248,219 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "Lớp vẽ"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "Lớp vẽ"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Độ mờ đục:"
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "Đổi tên chổi"
 
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr ""
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr ""
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr ""
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr ""
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr ""
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 msgid "Stroke lead-in end"
 msgstr ""
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr ""
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1986,256 +2479,281 @@ msgstr ""
 "This program is distributed in the hope that it will be useful, but WITHOUT "
 "ANY WARRANTY. See the COPYING file for more details."
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr "đang lập trình"
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr "Di chuyển được"
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr "biểu tượng màn hình nền"
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2243,188 +2761,214 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "Tạo nhóm"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr "Hợp nhất xuống dưới"
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "Lớp vẽ"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2433,13 +2977,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2449,7 +2993,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2457,13 +3001,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2471,7 +3015,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2479,7 +3023,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2490,7 +3034,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2498,7 +3042,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2508,7 +3057,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2519,285 +3068,395 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "Tạo nhóm"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2807,7 +3466,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2816,52 +3495,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2883,17 +3593,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2922,112 +3630,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3040,7 +3723,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3081,6 +3764,134 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "Tên"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Độ mờ đục:"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3450,56 +4261,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3507,12 +4338,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3521,7 +4352,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3532,28 +4363,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3615,1828 +4446,2028 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
-msgstr "Lưu thành bản nháp"
+msgid "Export…"
+msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
-msgstr "Mở bản nháp trước"
+msgid "Save As Scrap"
+msgstr "Lưu thành bản nháp"
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
-msgstr "Mở bản nháp tiếp theo"
+msgid "Open Previous Scrap"
+msgstr "Mở bản nháp trước"
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Open Next Scrap"
+msgstr "Mở bản nháp tiếp theo"
+
+#: ../po/tmp/resources.xml.h:25
+msgctxt "Accel Editor (descriptions)"
+msgid "Load the scrap file after the current one."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Recover File from an Automated Backup…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:25
+#: ../po/tmp/resources.xml.h:27
 msgctxt "Accel Editor (descriptions)"
 msgid "Try to save and resume interrupted unsaved work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:26
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Thu nhỏ"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
-msgstr "Xoay ngược chiều kim đồng hồ"
-
-#: ../po/tmp/resources.xml.h:137
-msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:157
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the left."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr "Xoay theo chiều kim đồng hồ"
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
-msgstr ""
+msgid "Rotate the canvas clockwise."
+msgstr "Xoay ngược chiều kim đồng hồ"
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr "Xoay ngược chiều kim đồng hồ"
+
+#: ../po/tmp/resources.xml.h:167
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr "Xoay ngược chiều kim đồng hồ"
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr "Lớp vẽ đơn"
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr "Biểu diễn hình ảnh"
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Tập tin"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "Chổi"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Trợ giúp"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "Giới thiệu về MyPaint"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "Tìm lỗi"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
-msgstr ""
+msgstr "Lớp vẽ"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "Chọn màu"
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "Chọn màu"
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "Chọn màu"
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""
+
+#~ msgctxt "brush list commands"
+#~ msgid "Really delete brush from disk?"
+#~ msgstr "Bạn có chắc muốn xóa chổi khỏi ổ đĩa?"

--- a/po/wa.po
+++ b/po/wa.po
@@ -513,17 +513,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1184,12 +1184,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1372,7 +1372,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Open dragged file confirm dialog: continue button"
 msgid "_Open"
-msgstr "Drovi..."
+msgstr "Drovi…"
 
 #: ../gui/drawwindow.py:486
 msgid "Set current color"
@@ -1406,7 +1406,7 @@ msgid "_Quit"
 msgstr "Cwiter"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1456,7 +1456,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1633,13 +1633,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "Schaper"
 
@@ -1705,7 +1705,7 @@ msgstr "Fitchî"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -1722,7 +1722,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Drovi..."
+msgstr "Drovi…"
 
 #: ../gui/filehandling.py:1427
 #, fuzzy
@@ -1734,7 +1734,7 @@ msgstr "Drovi les Dierins"
 #, fuzzy
 msgctxt "File→Open Most Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "Drovi..."
+msgstr "Drovi…"
 
 #: ../gui/filehandling.py:1446
 msgctxt "File→Open Next/Prev Scrap: error message"
@@ -1755,7 +1755,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
 msgid "_Open"
-msgstr "Drovi..."
+msgstr "Drovi…"
 
 #: ../gui/filehandling.py:1487
 msgctxt "File→Revert: status message: canvas has no filename yet"
@@ -2129,12 +2129,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2146,7 +2146,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2331,7 +2331,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2401,7 +2401,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/wa.po
+++ b/po/wa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:19+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Walloon <https://hosted.weblate.org/projects/mypaint/mypaint/"
@@ -19,27 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -47,39 +27,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -87,214 +67,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "Coleur"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "A vosse môde"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -333,142 +323,177 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "Schaper"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "Novea"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -476,58 +501,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -536,51 +561,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -590,137 +639,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -728,162 +777,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -891,373 +932,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "No"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "Disfé"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "Rifé "
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1267,324 +1305,678 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "Drovi..."
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "Forrimpli li purnea"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "Cwiter"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "Cwiter"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "Drovi..."
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "Schaper"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr ""
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr ""
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "Fitchî"
+
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Drovi..."
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "Drovi les Dierins"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "Drovi..."
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "Drovi..."
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "Zeroveyaedje:"
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1592,130 +1984,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1724,35 +2128,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1776,45 +2180,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1822,153 +2230,217 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr ""
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr ""
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "Zeroveyaedje:"
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1980,256 +2452,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2237,188 +2734,212 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+msgid "Import Layers"
+msgstr ""
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2427,13 +2948,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2443,7 +2964,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2451,13 +2972,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2465,7 +2986,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2473,7 +2994,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2484,7 +3005,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2492,7 +3013,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2502,7 +3028,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2513,285 +3039,394 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr ""
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2801,7 +3436,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2810,52 +3465,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2877,17 +3563,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2916,112 +3600,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3034,7 +3693,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3075,6 +3734,134 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "No"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "Zeroveyaedje:"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3444,56 +4231,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3501,12 +4308,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3515,7 +4322,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3526,28 +4333,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3609,1828 +4416,2018 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "Diszoumer"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "Fitchî"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "Aidance"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -89,7 +89,7 @@ msgstr "备份恢复失败"
 
 #: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
-msgstr "打开备份文件夹 …"
+msgstr "打开备份文件夹…"
 
 #: ../gui/autorecover.py:182
 #, python-brace-format
@@ -527,18 +527,18 @@ msgstr "MyPaint 笔刷套件 (*.zip)"
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
-msgstr "新建组..."
+msgid "New Group…"
+msgstr "新建组…"
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
-msgstr "导入笔刷..."
+msgid "Import Brushes…"
+msgstr "导入笔刷…"
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
-msgstr "获取更多笔刷..."
+msgid "Get More Brushes…"
+msgstr "获取更多笔刷…"
 
 #: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
@@ -1206,13 +1206,13 @@ msgstr "类型"
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
-msgstr "用作..."
+msgid "Use for…"
+msgstr "用作…"
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
-msgstr "滚动..."
+msgid "Scroll…"
+msgstr "滚动…"
 
 #. Name and preview column: will be indented
 #: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
@@ -1435,8 +1435,8 @@ msgid "_Quit"
 msgstr "离开"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
-msgstr "汇入笔刷套件..."
+msgid "Import brush package…"
+msgstr "汇入笔刷套件…"
 
 #: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
@@ -1488,8 +1488,8 @@ msgstr ""
 "MyPaint 应该使用什么应用程序编辑类型为“{type_name}” ({content_type})的文件？"
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
-msgstr "打开通过..."
+msgid "Open With…"
+msgstr "打开通过…"
 
 #: ../gui/externalapp.py:123
 msgid "Icon"
@@ -1681,13 +1681,13 @@ msgstr "JPEG 90% 品质 (*.jpg; *.jpeg)"
 
 #: ../gui/filehandling.py:576
 #, fuzzy
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr "导出…"
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "另存为…"
 
@@ -1758,8 +1758,8 @@ msgstr "开启最近的档案"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
-msgstr "开启便条纸..."
+msgid "Open Scratchpad…"
+msgstr "开启便条纸…"
 
 #: ../gui/filehandling.py:1099
 #, fuzzy
@@ -2207,13 +2207,13 @@ msgstr ""
 "如果还没有其他人报告过这个问题，请通过问题跟踪器把问题告诉开发人员。"
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
-msgstr "搜索跟踪器......"
+msgid "Search Tracker…"
+msgstr "搜索跟踪器...…"
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
-msgstr "报告中......"
+msgid "Report…"
+msgstr "报告中...…"
 
 #: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
@@ -2224,8 +2224,8 @@ msgid "Quit MyPaint"
 msgstr "退出 MyPaint"
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
-msgstr "详细资讯..."
+msgid "Details…"
+msgstr "详细资讯…"
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
@@ -2429,8 +2429,8 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
-msgstr "在栈中移动图层......"
+msgid "Move layer in stack…"
+msgstr "在栈中移动图层...…"
 
 #: ../gui/layerswindow.py:110
 msgid ""
@@ -2500,8 +2500,8 @@ msgid "Stroke trail-off beginning"
 msgstr "笔划开始逐渐消失"
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
-msgstr "压力变化......"
+msgid "Pressure variation…"
+msgstr "压力变化...…"
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
@@ -3665,7 +3665,7 @@ msgstr "从磁盘上删除此画笔"
 #, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid "_Recover & Save…"
-msgstr "恢复与保存..."
+msgstr "恢复与保存…"
 
 #: ../po/tmp/autorecover.glade.h:12
 #, fuzzy

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mypaint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2015-11-26 20:38+0000\n"
 "Last-Translator: Andrew Chadwick <a.t.chadwick@gmail.com>\n"
-"Language-Team: Chinese (China) "
-"<https://hosted.weblate.org/projects/mypaint/mypaint/zh_CN/>\n"
+"Language-Team: Chinese (China) <https://hosted.weblate.org/projects/mypaint/"
+"mypaint/zh_CN/>\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,29 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 2.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr "<big><b>{accel_label}</b></big>"
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr "{action_label} {action_desc} {accel_label}"
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "动作"
 
@@ -49,39 +27,39 @@ msgstr "动作"
 msgid "Key combination"
 msgstr "组合键"
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr "为'%s'编辑键"
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "动作："
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "路径："
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "键："
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr "按键以更新该分配"
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "不明的动作"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr "<b>{accel} 已被用于 '{action}'. 存在的绑定将被替换.</b>"
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr "打开文件夹 “{folder_basename}”…"
@@ -89,193 +67,203 @@ msgstr "打开文件夹 “{folder_basename}”…"
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "确定"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr "缓存中未发现备份。"
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr "无可用备份"
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr "打开缓存文件夹…"
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr "备份恢复失败"
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr "打开备份文件夹 …"
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr "已从 {iso_datetime}.ora恢复文件"
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "保存为默认值"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "背景"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "图案"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "颜色"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "加入颜色到图案"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr "一个或多个背景无法载入"
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr "载入背景时发生错误"
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr "请移除无法加载的文件，或者检查libgdkpixbuf是否已成功安装。"
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr "Gdk-Pixbuf 无法加载文件「{filename}」，并报告了错误「{error}」"
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr "文件 {filename} 大小为零 (w={w}, h={h})"
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr "笔刷设置编辑器"
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr "关于"
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "实验阶段"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr "基本"
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr "不透明度"
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr "笔触点"
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "涂抹"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr "笔速"
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr ""
+
+#: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr "跟踪"
 
-#: ../gui/brusheditor.py:359
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "笔触"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr "颜色"
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "自定义"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr "尚未选择任何笔刷，请改用「加入新笔刷」。"
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr "尚未选择笔刷！"
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "重命名笔刷"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "同名的笔刷已存在！"
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr "尚未选择笔刷！"
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr "确定要从硬盘中删除笔刷 “{brush_name}” 吗?"
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr "(未命名的笔刷)"
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr "{brush_name} [未保存]"
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr "笔刷图标"
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr "笔刷图标（编辑中）"
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr "尚未选择笔刷"
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -284,7 +272,7 @@ msgstr ""
 "<b>%s</b>\n"
 "<small>首先选择一个有效的笔刷</small>"
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
@@ -293,7 +281,7 @@ msgstr ""
 "<b>%s</b> <i>(已修改)</i>\n"
 "<small>修改尚未保存</small>"
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
@@ -302,7 +290,7 @@ msgstr ""
 "<b>%s</b> (编辑中)\n"
 "<small>用任意笔刷或颜色绘画</small>"
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -343,141 +331,181 @@ msgstr "自动"
 msgid "Use the default icon"
 msgstr "使用默认图标"
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "保存"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr "保存该预览图标，并结束编辑"
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr "回收站"
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr "已删除"
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr "收藏"
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr "墨水"
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr "经典"
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr "笔刷集#1"
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr "笔刷集#2"
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr "笔刷集#3"
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr "笔刷集#4"
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr "笔刷集#5"
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr "实验阶段"
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "新建"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr "不明的笔刷"
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr "添加至收藏夹"
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr "从收藏夹中移除"
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr "克隆"
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr "编辑笔刷设置"
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
-msgstr "删除"
+#: ../gui/brushselectionwindow.py:250
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
+msgstr "重命名组"
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
-msgstr "确定要从硬盘中删除笔刷？"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, fuzzy, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
+msgstr "确定要从硬盘中删除笔刷 “{brush_name}” 吗?"
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] "%d 笔刷"
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr "组 “{group_name}”"
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr "重命名组"
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr "导出为压缩的笔刷集"
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr "删除组"
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr "重命名组"
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "已存在同名的组！"
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr "确定要删除组 “{group_name}” 吗?"
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -487,58 +515,58 @@ msgstr ""
 "未能删除组 “{group_name}”。\n"
 "一些特别的组不能被删除。"
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr "导出笔刷"
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr "MyPaint 笔刷套件 (*.zip)"
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "新建组..."
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr "导入笔刷..."
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr "获取更多笔刷..."
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "创建组"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr "按钮"
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr "按钮"
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr "按键组合"
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr "增加一个新绑定"
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr "移除当前绑定"
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr "为 '%s' 修改绑定"
@@ -547,52 +575,80 @@ msgstr "为 '%s' 修改绑定"
 msgid "Button press:"
 msgstr "按键组合："
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr "按住修饰键并在这个文本上按下一个鼠标键以设置新绑定。"
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr "没有修饰键，鼠标键 {button} 不能绑定"
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr "{button_combination} 已被绑定到动作 '{action_name}'"
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr "选取颜色"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr "设置用于绘画的颜色"
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+#, fuzzy
+msgid "Set the color Hue used for painting"
+msgstr "设置用于绘画的颜色"
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "选取颜色"
+
+#: ../gui/colorpicker.py:296
+#, fuzzy
+msgid "Set the color Chroma used for painting"
+msgstr "设置用于绘画的颜色"
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+#, fuzzy
+msgid "Set the color Luma used for painting"
+msgstr "设置用于绘画的颜色"
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr "色彩详细资料"
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr "当前笔刷的颜色以及最近绘画使用的颜色"
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr "色域遮罩生效"
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr "为特定的气氛使用色域遮罩限制你的调色板。"
@@ -602,137 +658,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr "HCY 色相与浓度。"
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr "色域遮罩编辑器。点击中间创建、调整形状，或者使用圆盘的边缘旋转遮罩。"
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr "大气三色组"
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr "情绪化、主观的，通过一种主要的原色和两种强度略弱的原色定义。"
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr "可转移的三色组"
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr "更强烈地向主色加重。"
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr "互补色"
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr "对比对立，并通过色轮上的中央中性色在它们进行平衡。"
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr "心情和口音"
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr "一个主要的颜色范围，并针对变化和高光提供补充强调的颜色。"
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr "分列的互补色"
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr "两种类似的颜色以及它们的补色，它们当中没有间色。"
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr "从模板创建新色域遮罩"
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr "色域遮罩编辑器"
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr "有效的"
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr "帮助…"
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr "从模板创建蒙版。"
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr "从 GIMP 调色板文件加载遮罩。"
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr "保存遮罩到GIMP调色板文件。"
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr "擦除蒙版。"
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr "在web浏览器中打开该对话框的在线帮助。"
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr "保存遮罩为GIMP调色板"
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr "从 GIMP 调色板加载遮罩"
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr "设置色域蒙版。"
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr "HCY 色轮"
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -740,162 +796,154 @@ msgid ""
 msgstr "使用色相/色度/亮度空间圆柱设置颜色。圆片亮度是同等的。"
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr "HSV 色相"
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr "HSV 饱和度"
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr "HSV 明度"
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr "HSV 饱和度与明度"
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr "HSV 色相与明度"
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr "HSV 色相与饱和度"
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr "旋转立方体 (显示不同的轴)"
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr "HSV 立方体"
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr "HSV 立方体（旋转可显示不同的平面切片）。"
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr "HSV 方格"
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr "一个 HSV 正方形（旋转可显示不同的色相）。"
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr "HSV 三角形"
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr "标准 GTK 选色器"
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr "HSV 色轮"
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr "饱和度和明度颜色修改器。"
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr "调色板属性"
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr "调色板"
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr "通过一个可加载的、 可编辑的调色板设置颜色。"
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr "无标题调色板"
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr "调色板编辑器"
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr "从 GIMP 调色板加载"
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr "保存至 GIMP 调色板文件"
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr "添加一个新的空色板"
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr "移除当前样本"
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr "移除所有样本"
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr "标题:"
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr "调色板名称及描述"
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr "列:"
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr "列数"
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr "颜色名称："
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr "当前颜色名称"
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr "空调色板位置"
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr "加载调色板"
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr "保存调色板"
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -906,378 +954,376 @@ msgstr ""
 "放置颜色到这里，\n"
 "拖动以重新组织颜色。"
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr "空调色板位置（拖放颜色至此）"
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr "添加空位置"
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr "插入一行"
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr "插入一列"
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr "填补空白 (RGB)"
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr "填补空白 (HCY)"
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr "填补空白 (HSV)"
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "GIMP 调色板(*.gpl)"
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr "全部文件(*)"
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "GIMP 调色板文件(*.gpl)"
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr "全部文件(*)"
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr "从画面上选取颜色"
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr "R"
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr "G"
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr "B"
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr "H"
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr "C"
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr "Y"
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr "构成要素滚动条"
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr "调整颜色的单个构成要素。"
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr "RGB 红色"
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr "RGB 绿色"
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr "RGB 蓝色"
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr "HSV 色相"
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr "HSV 饱和度"
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr "HSV 明度"
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr "HCY 色相"
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr "HCY 色度"
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr "HCY 亮度 (Y')"
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr "液体清洗"
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr "使用像液体清洗附近的颜色的方式改变颜色。"
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr "同心环"
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr "通过HSV同心环改变颜色。"
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr "交叉碗"
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr "通过穿过辐射状的碗形颜色的HSV坡道改变颜色。"
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr "光标/冰球"
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr "橡皮擦"
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr "键盘"
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr "鼠标"
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr "钢笔"
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr "触摸板"
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr "触摸屏"
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr "忽略"
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr "任何任务"
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr "非绘画任务"
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr "仅作导航"
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr "缩放"
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr "平移工具"
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr "设备"
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr "轴线"
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr "类型"
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr "用作..."
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr "滚动..."
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "名称"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr "要覆写笔刷吗？"
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr "取代"
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr "重新命名"
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr "全部取代"
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr "全部重新命名"
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr "汇入的笔刷"
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr "现有的笔刷"
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 "<b>已经存在名称为「%s」的笔刷。</b>\n"
 "你想要取代原来笔刷，或重新命名为新的笔刷？"
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr "覆写笔刷群组？"
 
-#: ../gui/dialogs.py:190
-#, python-brace-format
+#: ../gui/dialogs.py:220
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 "<b>已经存在名称为“{groupname}”的组。</b>\n"
 "您想要取代已有的组还是重命名新组？\n"
-"若您选择取代已有的组，被取代的组里面的笔刷会被移动到名为“{deleted_groupname}”的组里。"
+"若您选择取代已有的组，被取代的组里面的笔刷会被移动到名"
+"为“{deleted_groupname}”的组里。"
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr "要汇入笔刷套件吗？"
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, fuzzy, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr "<b>你真的要汇入套件「%s」？</b>"
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr "从快捷方式位置 %d 加载笔刷设置"
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr "保存笔刷设置到快捷方式位置 %d"
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr "还原笔刷 %d"
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr "储存到笔刷 %d"
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr "复原 %s"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "复原"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr "取消复原 %s"
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "取消复原"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr "{button_combination} is {resultant_action}"
@@ -1287,306 +1333,615 @@ msgstr "{button_combination} is {resultant_action}"
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr "；  "
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr "按住 {modifiers} :  {button_actions}。"
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
-msgstr "图层名称"
-
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
-#, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
-"<b>{name}</b>\n"
-"{description}"
+
+#: ../gui/document.py:909
+#, python-brace-format
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
+msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr "%s - MyPaint"
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr "MyPaint"
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "打开"
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr "设定目前颜色"
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr "离开全萤幕模式"
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr "退出全屏模式"
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr "进入全萤幕模式"
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "全萤幕"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "离开"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+#, fuzzy
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr "确定要离开？"
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "离开"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr "汇入笔刷套件..."
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr "MyPaint 笔刷套件 (*.zip)"
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr "为编辑层 “{layer_name}” 已启动 {app_name}"
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr "错误: 无法为编辑层\"{layer_name}\"启动 {app_name}"
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr "编辑取消。您仍可以通过“图层”菜单编辑\"{layer_name}\"。"
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr "已使用外部编辑更新层 “{layer_name}”"
 
-#: ../gui/externalapp.py:46
-#, python-brace-format
-msgid ""
-"MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
-"application should it use?"
-msgstr "MyPaint 需要编辑类型为 \"{type_name}\"({content_type}) 的文件。应该使用什么应用程序?"
-
-#: ../gui/externalapp.py:50
-#, python-brace-format
-msgid ""
-"What application should MyPaint use for editing files of type "
-"“{type_name}” ({content_type})?"
-msgstr "MyPaint 应该使用什么应用程序编辑类型为“{type_name}” ({content_type})的文件？"
-
-#: ../gui/externalapp.py:56
-msgid "Open With..."
-msgstr "打开通过..."
-
-#: ../gui/externalapp.py:107
-msgid "Icon"
-msgstr "图标"
-
-#: ../gui/externalapp.py:150
-msgid "no description"
-msgstr "无描述"
-
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr "所有可辨识的格式"
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr "OpenRaster (*.ora)"
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr "PNG (*.png)"
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr "JPEG (*.jpg; *.jpeg)"
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr "根据副档名 (优先使用预设格式)"
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr "含带背景的 PNG (*.png)"
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr "PNG 透明图片 (*.png)"
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr "多个 PNG 透明图片"
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr "JPEG 90% 品质 (*.jpg; *.jpeg)"
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr "储存..."
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr "另存新档的格式："
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr "确认"
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr "确定要继续？"
-
-#: ../gui/filehandling.py:234
-#, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
-msgstr "这将放弃 {abbreviated_time} 的未保存的绘画"
-
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr "另存为作废稿(_S)"
-
-#: ../gui/filehandling.py:282
-#, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
-msgstr "正在加载\"{file_basename}\"…"
-
-#: ../gui/filehandling.py:296
+#: ../gui/externalapp.py:48
 #, python-brace-format
 msgctxt "file handling: open failed (statusbar)"
 msgid "Could not load “{file_basename}”."
 msgstr "无法加载\"{file_basename}\"。"
 
-#: ../gui/filehandling.py:321
+#: ../gui/externalapp.py:61
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
-msgstr "已加载\"{file_basename}\"。"
+msgid ""
+"MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
+"application should it use?"
+msgstr ""
+"MyPaint 需要编辑类型为 \"{type_name}\"({content_type}) 的文件。应该使用什么应"
+"用程序?"
 
-#: ../gui/filehandling.py:422
+#: ../gui/externalapp.py:65
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
-msgstr "导出到\"{file_basename}\"…"
+msgid ""
+"What application should MyPaint use for editing files of type "
+"“{type_name}” ({content_type})?"
+msgstr ""
+"MyPaint 应该使用什么应用程序编辑类型为“{type_name}” ({content_type})的文件？"
 
-#: ../gui/filehandling.py:427
+#: ../gui/externalapp.py:71
+msgid "Open With..."
+msgstr "打开通过..."
+
+#: ../gui/externalapp.py:123
+msgid "Icon"
+msgstr "图标"
+
+#: ../gui/externalapp.py:166
+msgid "no description"
+msgstr "无描述"
+
+#: ../gui/filehandling.py:126
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
+msgstr "正在加载\"{file_basename}\"…"
+
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:134
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr "正在保存\"{file_basename}\"…"
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:138
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
+msgstr "导出到\"{file_basename}\"…"
+
+#: ../gui/filehandling.py:145
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
 msgstr "未能导出到\"{file_basename}\"。"
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:149
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
 msgstr "未能成功保存\"{file_basename}\"。"
 
-#: ../gui/filehandling.py:476
+#: ../gui/filehandling.py:153
 #, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr "无法加载\"{file_basename}\"。"
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "保存调色板"
+
+#: ../gui/filehandling.py:168
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr "汇出成档案"
+
+#: ../gui/filehandling.py:172
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr "汇出成档案"
+
+#: ../gui/filehandling.py:176
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr "开启最近的档案"
+
+#: ../gui/filehandling.py:183
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
 msgstr "成功导出到\"{file_basename}\"。"
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:187
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
 msgstr "成功保存\"{file_basename}\"。"
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr "开启..."
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:195
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr "已加载\"{file_basename}\"。"
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+
+#: ../gui/filehandling.py:221
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
+msgstr "已加载\"{file_basename}\"。"
+
+#: ../gui/filehandling.py:427
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
+msgstr "所有可辨识的格式"
+
+#: ../gui/filehandling.py:432
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:437
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:442
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
+msgstr "JPEG (*.jpg; *.jpeg)"
+
+#: ../gui/filehandling.py:490
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
+msgstr "根据副档名 (优先使用预设格式)"
+
+#: ../gui/filehandling.py:494
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:498
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr "含带背景的 PNG (*.png)"
+
+#: ../gui/filehandling.py:502
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:506
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr "PNG 透明图片 (*.png)"
+
+#: ../gui/filehandling.py:510
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr "多个 PNG 透明图片"
+
+#: ../gui/filehandling.py:514
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr "多个 PNG 透明图片"
+
+#: ../gui/filehandling.py:518
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr "JPEG 90% 品质 (*.jpg; *.jpeg)"
+
+#: ../gui/filehandling.py:576
+#, fuzzy
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr "导出…"
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "另存为…"
+
+#: ../gui/filehandling.py:601
+#, fuzzy
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr "另存新档的格式："
+
+#: ../gui/filehandling.py:668
+#, fuzzy
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr "确定要继续？"
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+#, fuzzy
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr "另存为作废稿(_S)"
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, fuzzy, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr "这将放弃 {abbreviated_time} 的未保存的绘画"
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr "打开…"
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "开启最近的档案"
+
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr "开启便条纸..."
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "汇入的笔刷"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "打开"
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "打开最近的"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "打开"
+
+#: ../gui/filehandling.py:1446
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
 msgstr "还没有作废稿档命名为「%s」。"
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1455
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr "打开下一个废稿"
+
+#: ../gui/filehandling.py:1463
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr "打开上一个废稿"
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "打开"
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+#, fuzzy
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr "恢复"
+
+#: ../gui/fill.py:121
+#, fuzzy
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr "满水法填充"
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+#, fuzzy
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr "用颜色填充区域"
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+#, fuzzy
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr "限度："
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+#, fuzzy
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr "满水法填充拒绝填充前允许多少像素颜色与开始不同"
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+#, fuzzy
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr "源："
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
-msgstr "应被填充的那些可见图层"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
+msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+#, fuzzy
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr "合并的样本"
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+#, fuzzy
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr "当考虑填充区域时，临时合并当前图层下面所有的可见图层"
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+#, fuzzy
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr "适合视图"
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+#, fuzzy
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr "目标："
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+#, fuzzy
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr "输出到哪里"
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr "新图层（一次性）"
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+#, fuzzy
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
@@ -1594,21 +1949,108 @@ msgstr ""
 "为填充结果创建一个新图层。\n"
 "该图层在使用后自动关闭。"
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "不透明度："
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr "重置"
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+#, fuzzy
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr "重置选项为默认值"
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "选择图层"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr "<b>{brush_name}</b>"
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1618,130 +2060,142 @@ msgstr ""
 "<b>{brush_name}</b>\n"
 "{brush_desc}"
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr "编辑边框"
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr "调整文档边框"
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr "边框尺寸"
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr "像素"
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr "高度："
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr "宽度："
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr "解析度："
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr "DPI"
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr "点每英寸 (实际像素每英寸)"
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr "颜色："
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr "边框颜色"
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr "<b>边框尺寸</b>"
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr "<b>像素密度</b>"
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr "根据图层设置边框"
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr "将边框设置成根据当前图层的尺寸"
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr "根据文档设置边框"
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr "将边框设置为所有图层的合并的尺寸"
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr "根据边框修剪图层"
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr "修剪边框当前图层位于边框以外的部分"
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr "已启用"
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr "{width:g}×{height:g} {units}"
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr "英寸"
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr "公分"
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr "公厘"
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr "徒手绘图"
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr "绘画形式自由的画笔笔触"
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr "平滑度:"
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr "压力："
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr "侦测到程式错误"
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr "<big><b>已侦测到一个程式错误。</b></big>"
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1752,35 +2206,35 @@ msgstr ""
 "您可以忽略此错误并继续，但你应该尽快保存你的作品。\n"
 "如果还没有其他人报告过这个问题，请通过问题跟踪器把问题告诉开发人员。"
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr "搜索跟踪器......"
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr "报告中......"
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr "忽略错误"
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr "退出 MyPaint"
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr "详细资讯..."
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr "当分析例外时的例外。"
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1806,7 +2260,8 @@ msgstr ""
 "            #### 描述\n"
 "\n"
 "            为该报告提供一个简短的描述性的标题。\n"
-"            如果可以，请提供形如\"{feature-that-broke}: {what-went-wrong}\"的标题。\n"
+"            如果可以，请提供形如\"{feature-that-broke}: {what-went-wrong}\"的"
+"标题。\n"
 "            接着请把这个文本替换为一段长一些的缺陷描述。\n"
 "            有屏幕截图或者录屏也非常好！            \n"
 "\n"
@@ -1818,45 +2273,50 @@ msgstr ""
 "            #### 追踪\n"
 "        "
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr "墨迹作图"
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr "先画，然后调整成流程的线条"
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr "输入装置测试"
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr "(无压力感应)"
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr "压力："
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr "(无倾斜感应)"
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr "倾斜："
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr "(无装置)"
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
 msgstr "装置："
 
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+#, fuzzy
+msgid "Barrel Rotation:"
+msgstr "重置旋转"
+
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr "移动图层"
 
@@ -1864,155 +2324,225 @@ msgstr "移动图层"
 msgid "Move the current layer"
 msgstr "移动当前图层"
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
-msgstr "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
+msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
-msgstr "类型"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
+msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+#, fuzzy
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr "属性"
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr "可见性"
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "图层"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+#, fuzzy
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr "已锁定"
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+#, fuzzy
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ", "
+
+#: ../gui/layers.py:990
+#, fuzzy, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr "添加 {layer_default_name}"
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "图层"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr "安排图层并指定效果"
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr "图层不透明度：%d％"
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr "在栈中移动图层......"
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr "在栈中移动图层（拖放到一个一般图层中将创建一个新的组）"
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr "图层"
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
-msgstr "模式："
+#: ../gui/layervis.py:53
+#, fuzzy, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
+msgstr "<b>{brush_name}</b>"
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
-msgstr "混合模式：指定当前图层如何与它下面的图层合并。"
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
+msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "不透明度："
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "旋转视图"
 
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr "图层不透明度：指定使用当前图层的多少。较小的值使得图层更加透明。"
-
-#: ../gui/linemode.py:37
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr "起始压力"
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr "线条工具笔划起始压力"
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr "中点压力"
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr "线条工具笔划中间压力"
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr "结束压力"
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr "线条工具笔划结束压力"
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr "头"
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 msgid "Stroke lead-in end"
 msgstr "笔划引入末端"
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr "尾"
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr "笔划开始逐渐消失"
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr "压力变化......"
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr "直线和曲线"
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr "通用直线/曲线模式"
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr "绘制直线；Shift键加入曲线，Ctrl键限制角度"
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr "连接线"
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr "绘制一系列直线;Shift键添加曲线， Ctrl 键限制角度"
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr "椭圆形和圆形"
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr "绘制椭圆; Shift键旋转，Ctrl 键限制比例/角度"
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
+#, fuzzy
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 "著作权 (C) 2005-2015\n"
 "Martin Renold 和 MyPaint 开发团队"
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -2023,263 +2553,294 @@ msgid ""
 "This program is distributed in the hope that it will be useful, but WITHOUT "
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
-"此程序是免费软件;你可以将它重新分发和/或在GNU 通用公共许可的条款下修改并把它以自由软件基金会的名义出版；许可协议的版本 2，或 (由您选择) "
-"任何之后的版本。\n"
+"此程序是免费软件;你可以将它重新分发和/或在GNU 通用公共许可的条款下修改并把它"
+"以自由软件基金会的名义出版；许可协议的版本 2，或 (由您选择) 任何之后的版"
+"本。\n"
 "\n"
 "希望此程序的分发是令人满意的，但没有任何担保。请参阅版权文件获取更多细节。"
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr "编程"
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr "可移植性"
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr "项目管理"
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr "笔刷"
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr "模式"
 
 # ../gui/drawwindow.py:867
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr "工具图标"
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr "桌面图标"
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr "调色板"
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr "文档"
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr "支持"
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr "外联"
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr "社区"
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ", "
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr "翻译者信誉"
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr "大小:"
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr "不透明度:"
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr "尖锐："
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr "增益:"
 
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
 # ../gui/drawwindow.py:867
-#: ../gui/optionspanel.py:46
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr "工具选项"
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr "当前编辑工具的专门设置"
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr "<b>{mode_name}</b>"
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr "<i>没有可用的选项</i>"
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr "缩放：%.01f%%"
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr "选取笔触设置，笔触颜色，以及图层…"
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr "选取颜色…"
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr "偏好设定"
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr "预览"
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr "显示整个绘图区域的预览"
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr "显示取景器"
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr "暂存区"
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr "在另外的废弃页面上混合颜色或者绘制草图"
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr "上一个项目"
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr "下一个项目"
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
 msgstr "(没有东西可显示)"
 
-#: ../gui/symmetry.py:76
+#: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Place axis"
 msgstr "放置轴"
 
-#: ../gui/symmetry.py:80
+#: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Move axis"
 msgstr "移动轴"
 
-#: ../gui/symmetry.py:84
+#: ../gui/symmetry.py:88
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr "移除轴"
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr "编辑对称轴"
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr "调整绘画对称轴。"
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
+#, fuzzy
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr "位置:"
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr "位置:"
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr "无"
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr "%d px"
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr "Alpha:"
 
-#: ../gui/symmetry.py:352
+#: ../gui/symmetry.py:376
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
+msgstr "对称轴"
+
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+#, fuzzy
 msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+msgid "X axis Position"
 msgstr "轴的位置"
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:477
+#, fuzzy
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr "轴的位置"
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr "已启用"
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr "档案处理"
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr "作废稿切换器"
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr "复原和取消复原"
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr "混合模式"
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr "直线模式"
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr "视图 (主)"
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr "视图 (替代/辅助)"
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr "视图 (重置)"
 
@@ -2287,188 +2848,214 @@ msgstr "视图 (重置)"
 msgid "<b>MyPaint</b>"
 msgstr "<b>MyPaint</b>"
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr "滚动视图"
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr "拖动画布视图"
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr "缩放视图"
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr "缩放画布视图"
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr "旋转视图"
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr "旋转画布视图"
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, fuzzy, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr "%s: 关闭标签"
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
-msgstr "%s: 编辑属性"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
+msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr "未知的命令"
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr "未定义的 (命令尚未启动)"
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr "用笔刷 {brush_name} 绘制了{seconds:.01f}秒"
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr "满水法填充"
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr "修剪图层"
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "重命名组"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr "清除图层"
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr "粘贴图层"
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr "新建可见图层"
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr "合并可见图层"
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr "向下合并"
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr "正常化图层模式"
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "汇入的笔刷"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr "添加 {layer_default_name}"
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr "移除图层"
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr "选择图层"
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr "复制图层"
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr "向上移动图层"
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr "向下移动图层"
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr "在栈中移动图层"
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr "重新命名图层"
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr "将图层设为显现状态"
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr "将图层设为隐形状态"
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr "锁定图层"
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr "解除锁定图层"
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr "设置图层不透明度: %0.1f%%"
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr "未知的模式"
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr "设置图层模式: %s"
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr "启用边框"
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr "禁用边框"
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr "更新边框"
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr "通过外部工具编辑图层"
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr "加载\"{basename}\"时出错。"
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr "日志可能会有关于此错误的更多细节。"
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr "从现在开始"
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr "以前"
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2480,13 +3067,13 @@ msgstr ""
 "你在运行超过一个MyPaint实例吗？\n"
 "关闭应用程序并等待{cache_update_interval}秒后重试。"
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr "不兼容的备份（更新自 {last_modified_time} {ago}）"
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2499,7 +3086,7 @@ msgstr ""
 "大小: {autosave.width}×{autosave.height} 像素，图层: {autosave.num_layers} \n"
 "包含 {unsaved_time} 的未保存的绘画。"
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2509,13 +3096,13 @@ msgstr ""
 "无法写入文件“{filename}”: {err}\n"
 "你的设备上有足够的剩余空间吗?"
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr "无法写入文件 “{filename}”: {err}"
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2525,7 +3112,7 @@ msgstr ""
 "{error_loading_common}\n"
 "文件不存在。"
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2535,7 +3122,7 @@ msgstr ""
 "{error_loading_common}\n"
 "你没有打开此文件所需的权限。"
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2551,7 +3138,7 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2561,7 +3148,13 @@ msgstr ""
 "{error_loading_common}\n"
 "未知的文件格式扩展名: “{ext}”"
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+#, fuzzy
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr "汇入的笔刷"
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2572,9 +3165,10 @@ msgid ""
 msgstr ""
 "无法另存为 JPEG: {original_msg} \n"
 "\n"
-"如果你的机器没有大量的内存，尝试保存成PNG 格式。MyPaint 的PNG保存功能更加高效。"
+"如果你的机器没有大量的内存，尝试保存成PNG 格式。MyPaint 的PNG保存功能更加高"
+"效。"
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2590,285 +3184,408 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/helpers.py:402
-#, python-brace-format
+#: ../lib/floodfill.py:131
+#, fuzzy
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr "填充"
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr "{days}天{hours}小时"
 
-#: ../lib/helpers.py:404
-#, python-brace-format
+#: ../lib/helpers.py:537
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr "{hours}小时{minutes}分钟"
 
-#: ../lib/helpers.py:406
-#, python-brace-format
+#: ../lib/helpers.py:539
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr "{minutes}分钟{seconds}秒"
 
-#: ../lib/helpers.py:408
-#, python-brace-format
+#: ../lib/helpers.py:541
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr "{seconds}秒"
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr "图层"
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr "%(name)s %(number)d"
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr "^(.*?)\\s*(\\d+)$"
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
+#, fuzzy
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr "矢量图层"
+
+#: ../lib/layer/data.py:1158
+#, fuzzy
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr "矢量图层"
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
-msgstr "未知的位图图层"
+msgid "Bitmap"
+msgstr ""
 
-#: ../lib/layer/data.py:1169
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1244
 msgctxt "layer default names"
-msgid "Unknown Data Layer"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
 msgstr "未知的数据图层"
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "新建绘画图层"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr "组"
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "新建图层组"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr "占位符"
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr "根"
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ", "
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+#, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "视图"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+#, fuzzy
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr "加入图层"
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+#, fuzzy
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr "移除图层"
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr "锁定图层"
+
+#: ../lib/layervis.py:697
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr "解除锁定图层"
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr "传递"
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr "组内容直接应用于组的背景"
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr "标准"
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr "仅限最顶部图层，没有混合颜色。"
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr "色彩增值"
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr "类似于加载两个幻灯片到投影仪并投影合并后的结果。"
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr "滤色"
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
-msgstr "就像将两个不同幻灯片的投影仪同时投影到屏幕上。这个效果与“正片叠底”相反。"
+msgstr ""
+"就像将两个不同幻灯片的投影仪同时投影到屏幕上。这个效果与“正片叠底”相反。"
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr "叠加"
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr "叠加背景与上面的图层，保留背景的高光和阴影。此效果与“强光”相反。"
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr "变暗"
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr "顶部图层被使用在比背景暗的地方。"
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr "变亮"
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr "顶部图层被使用在比背景亮的地方。"
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr "加亮颜色"
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
-msgstr "通过顶部图层照亮背景。效果类似于同名的摄影暗室技术，用来在阴影中增强对比。"
+msgstr ""
+"通过顶部图层照亮背景。效果类似于同名的摄影暗室技术，用来在阴影中增强对比。"
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr "加深颜色"
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
-msgstr "通过顶部图层使背景变暗。效果类似于同名的摄影暗室技术，用来降低过亮的高光。"
+msgstr ""
+"通过顶部图层使背景变暗。效果类似于同名的摄影暗室技术，用来降低过亮的高光。"
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr "强光"
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr "类似于用聚光灯照射到背景上。"
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr "柔光"
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr "就像用漫射聚光灯照射到背景上。"
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr "差异"
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr "从两个当中的较亮颜色中减去较暗的颜色。"
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr "排除"
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr "类似于 '差异' 模式，但对比度较低。"
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr "色相"
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr "结合顶部图层的色相和背景的饱和度与亮度。"
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr "饱和度"
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr "将顶部图层颜色的饱和度应用到背景的色相和亮度上。"
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr "将顶部图层的色相和饱和度应用到背景的亮度上。"
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr "光亮度"
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr "将顶部图层的亮度应用到背景的色相和饱和度上。"
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr "加号"
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr "该图层和它的背景图层简单地相加在一起。"
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr "目标入口"
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr "仅把背景使用在该图层已覆盖的地方。其他的一切都忽略掉。"
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr "目标出口"
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr "仅把背景使用在该图层没有覆盖的地方。其他的一切都忽略掉。"
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr "来源顶上"
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr "用与目标重叠的来源替换目标。放置目标在其他地方。"
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr "目标顶上"
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr "用与来源重叠的目标替换来源。把来源放置在其他地方。"
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, fuzzy, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr "%(name)s %(number)d"
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr "无法构建一个重要的内部对象。您的系统可能没有足够的内存来执行此操作。"
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2882,7 +3599,30 @@ msgstr ""
 "原因: {err}\n"
 "目标文件夹: “{dirname}”。"
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+#, fuzzy
+msgid "Vertical"
+msgstr "纵向镜像"
+
+#: ../lib/tiledsurface.py:49
+#, fuzzy
+msgid "Horizontal"
+msgstr "横向镜像"
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+#, fuzzy
+msgid "Rotational"
+msgstr "重置旋转"
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr "PNG 读入失败: %s"
@@ -2891,53 +3631,91 @@ msgstr "PNG 读入失败: %s"
 msgid "Recover interrupted work?"
 msgstr "恢复被中断的工作吗?"
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
-msgstr "恢复与保存..."
+msgid "_Look for backups at startup"
+msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr "删除"
+
+#: ../po/tmp/autorecover.glade.h:9
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr "从磁盘上删除此画笔"
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr "恢复与保存..."
+
+#: ../po/tmp/autorecover.glade.h:12
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr "将此备份保存到磁盘，然后继续处理它。"
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
-msgstr "暂时忽略"
+msgid "Decide _Later"
+msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr "在新的画布上开始工作。这些备份将被保留。"
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
+#, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
-msgstr "MyPaint崩溃（有未保存的工作），但是它保存了备份。你现在可以从一个文件恢复，或者随它去直至你再次启动MyPaint。"
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
+msgstr ""
+"MyPaint崩溃（有未保存的工作），但是它保存了备份。你现在可以从一个文件恢复，或"
+"者随它去直至你再次启动MyPaint。"
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr "缩略图"
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr "描述"
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
-msgstr "通过复制新建"
+msgid "Live update"
+msgstr "实时更新"
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
-msgstr "把这些设置和当前笔刷的图标复制到一个新的笔刷中"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
+msgstr "实时地用此窗口中的设置更新画布上的最后一个笔触"
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
-msgstr "重命名此笔刷"
+msgid "Save these settings to the brush"
+msgstr "将这些设置保存到笔刷"
 
 #: ../po/tmp/brusheditor.glade.h:5
 msgid "Edit Icon"
@@ -2958,18 +3736,16 @@ msgid "Delete this brush from the disk"
 msgstr "从磁盘上删除此画笔"
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
-msgstr "实时更新"
+msgid "Copy to New"
+msgstr "通过复制新建"
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
-msgstr "实时地用此窗口中的设置更新画布上的最后一个笔触"
+msgid "Copy these settings and the current brush's icon to a new brush"
+msgstr "把这些设置和当前笔刷的图标复制到一个新的笔刷中"
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
-msgstr "将这些设置保存到笔刷"
+msgid "Rename this brush"
+msgstr "重命名此笔刷"
 
 #: ../po/tmp/brusheditor.glade.h:13
 msgid "Brush Setting"
@@ -2997,30 +3773,22 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr "备注:"
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr "设置名称:"
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr "此画笔设置的起始值。下面的笔刷动态效果基于该设置。"
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
-msgstr "基准值："
+#: ../po/tmp/brusheditor.glade.h:22
+#, fuzzy
+msgid "Value:"
+msgstr "HSV 明度"
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr "重置基准值为默认值"
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr "重置此输入以对此设置无影响"
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
@@ -3028,11 +3796,7 @@ msgstr ""
 "输出轴的最小值。\n"
 "可以通过 {dname} 的主滚动条设置。"
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr "<ymin>"
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
@@ -3040,27 +3804,23 @@ msgstr ""
 "输出轴的最大值。\n"
 "可以通过 {dname} 的主滚动条设置。"
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr "<ymax>"
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr "输出"
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr "输入"
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr "调整最大值"
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr "调整最小值"
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
@@ -3068,11 +3828,7 @@ msgstr ""
 "输入轴的最小值。\n"
 "使用弹出比例尺调整。"
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr "<xmin>"
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
@@ -3080,38 +3836,36 @@ msgstr ""
 "输入轴的最大值。\n"
 "使用弹出比例尺调整。"
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr "<xmax>"
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr "基准值的变化（基于触控笔输入以及其他标准）"
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr "笔刷动态效果"
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr "此设置的基本详细信息"
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr "编辑设置"
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr "详细地调整此输入映射"
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr "{tooltip}"
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
 msgstr "{dname}:"
+
+#: ../po/tmp/brusheditor.glade.h:42
+#, fuzzy
+msgid "Brush dynamics are not available for this setting."
+msgstr "此设置的基本详细信息"
+
+#: ../po/tmp/brusheditor.glade.h:43
+#, fuzzy
+msgid "<big><b>No Brush Dynamics</b></big>"
+msgstr "<big><b>{accel_label}</b></big>"
 
 #: ../po/tmp/inktool.glade.h:1
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
@@ -3123,7 +3877,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr "按键："
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3168,6 +3922,141 @@ msgstr "删除点"
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
 msgstr "删除当前选中的点"
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+#, fuzzy
+msgid "Insert Point"
+msgstr "插入一行"
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+#, fuzzy
+msgid "Cull Points"
+msgstr "删除点"
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "名称"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr "模式"
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "不透明度"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr "当前图层的混合模式。"
+
+#: ../po/tmp/layervis.glade.h:2
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr "旋转画布视图"
+
+#: ../po/tmp/layervis.glade.h:3
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr "旋转画布视图"
+
+#: ../po/tmp/layervis.glade.h:4
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr "应被填充的那些可见图层"
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
+msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
 msgctxt "footer: color picker button: tooltip"
@@ -3305,7 +4194,9 @@ msgctxt "Prefs Dialog|Devices|"
 msgid ""
 "Here you can restrict pointing devices to specific tasks on the canvas, or "
 "have them ignored completely if they glitch your drawing."
-msgstr "这里你可以在画布上限制指针设备到特定的任务上，或者如果它们干扰了你的绘画，你可以完全忽略它们。"
+msgstr ""
+"这里你可以在画布上限制指针设备到特定的任务上，或者如果它们干扰了你的绘画，你"
+"可以完全忽略它们。"
 
 #: ../po/tmp/preferenceswindow.glade.h:29
 msgctxt "Prefs Dialog|Button|"
@@ -3387,11 +4278,12 @@ msgid ""
 "monitors. If you know your display is radically different from this, use the "
 "\"no automatic conversions or tagging\" setting instead."
 msgstr ""
-"当MyPaint加载图片时，包含<i>完整</i>色彩空间信息的图片将被转换成sRGB。当MyPaint保存图片时，会在图片中加入提示从而其他程序能够用合"
-"适的方式渲染图片。\n"
+"当MyPaint加载图片时，包含<i>完整</i>色彩空间信息的图片将被转换成sRGB。当"
+"MyPaint保存图片时，会在图片中加入提示从而其他程序能够用合适的方式渲染图片。\n"
 "\n"
-"基于的假设是显示器校准为接近sRGB "
-"（针对网页以及大多数个人电脑显示器的悲观近似的标准色彩空间）。如果你知道你的显示器根本不同于此，使用“无自动转换或标注”设置以替代。"
+"基于的假设是显示器校准为接近sRGB （针对网页以及大多数个人电脑显示器的悲观近似"
+"的标准色彩空间）。如果你知道你的显示器根本不同于此，使用“无自动转换或标注”设"
+"置以替代。"
 
 #: ../po/tmp/preferenceswindow.glade.h:47
 msgctxt "Prefs Dialog|Load & Save|Color Management|"
@@ -3434,7 +4326,9 @@ msgid ""
 "Backs up work incrementally in the background to MyPaint's disk cache. If "
 "the program crashes, you'll have a chance to restore what you were working "
 "on."
-msgstr "在后台增量地备份工作到MyPaint的磁盘缓冲区。如果程序崩溃，你将有机会从你之前正工作的内容中恢复。"
+msgstr ""
+"在后台增量地备份工作到MyPaint的磁盘缓冲区。如果程序崩溃，你将有机会从你之前正"
+"工作的内容中恢复。"
 
 #: ../po/tmp/preferenceswindow.glade.h:56
 msgctxt "Prefs Dialog|Load & Save|Automated Backups|interval label"
@@ -3487,7 +4381,9 @@ msgctxt "Prefs Dialog|View|Interface|Dark theme variant|checkbox tooltip"
 msgid ""
 "Use a light-on-dark theme variant, when it's supported by the GTK theme. "
 "This is generally sensible for image editors and media viewers."
-msgstr "当GTK主题支持时，使用“亮光在黑暗之上”主题变种。这对图像编辑者以及媒体观众一般说来是明智的。"
+msgstr ""
+"当GTK主题支持时，使用“亮光在黑暗之上”主题变种。这对图像编辑者以及媒体观众一般"
+"说来是明智的。"
 
 #: ../po/tmp/preferenceswindow.glade.h:67
 msgid "Some of these settings require MyPaint to be restarted."
@@ -3546,7 +4442,8 @@ msgid ""
 "Scrolling to pan the view needs this setting to be turned on, and for your "
 "device to be configured to send bidirectional scroll events."
 msgstr ""
-"平滑滚动支持使得来自一些设备的滚动手势以及滚轮事件平滑而不是分步的。该设置适应于触摸板，但使用鼠标滚动时会感到不适。\n"
+"平滑滚动支持使得来自一些设备的滚动手势以及滚轮事件平滑而不是分步的。该设置适"
+"应于触摸板，但使用鼠标滚动时会感到不适。\n"
 "\n"
 "如果支持平滑滚动，可用通过在滚动时按住Shift键简单地调回到逐步滚动。\n"
 "\n"
@@ -3556,13 +4453,34 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr "绘画时隐藏光标"
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+#, fuzzy
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr "已启用"
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr "视图"
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
@@ -3571,56 +4489,60 @@ msgstr ""
 "磁盘式色轮上显示为主要的色彩集。\n"
 "不同的传统有不同颜色和谐方式。"
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr "主色是："
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr "标准数字红/绿/蓝"
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr "红绿蓝（计算机监视器的主色）均匀地围绕圆圈排列。绿色对着洋红色。"
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr "红绿蓝（计算机监视器的主色）均匀地围绕圆圈排列。绿色对着洋红色。"
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr "传统艺术家的红/黄/蓝"
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
-msgstr "按传统排列的红/黄/蓝色色轮从18世纪就被众多艺术家所使用。纯显示颜色以接近均匀地方式围绕圆圈排列。绿色对着红色。"
+msgstr ""
+"按传统排列的红/黄/蓝色色轮从18世纪就被众多艺术家所使用。纯显示颜色以接近均匀"
+"地方式围绕圆圈排列。绿色对着红色。"
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
-msgstr "按传统排列的红/黄/蓝色色轮从18世纪就被众多艺术家所使用。纯显示颜色以接近均匀地方式围绕圆圈排列。绿色对着红色。"
+msgstr ""
+"按传统排列的红/黄/蓝色色轮从18世纪就被众多艺术家所使用。纯显示颜色以接近均匀"
+"地方式围绕圆圈排列。绿色对着红色。"
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr "红绿和蓝黄对立配对"
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3628,10 +4550,11 @@ msgid ""
 "and yellow is opposite blue. CIECAM02 and NCS present a similar model. Here "
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
-"据说使用了四种“心理学主色”或“独特色相”的色轮的“快而脏”的近似，颜色在重要的点上成对对立排列。红色对着绿色，黄色对着蓝色。CIECAM02 和 "
-"NCS表达了类似的模型。这里我们用到了纯显示红，黄等作为四种主色。"
+"据说使用了四种“心理学主色”或“独特色相”的色轮的“快而脏”的近似，颜色在重要的点"
+"上成对对立排列。红色对着绿色，黄色对着蓝色。CIECAM02 和 NCS表达了类似的模型。"
+"这里我们用到了纯显示红，黄等作为四种主色。"
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3640,32 +4563,33 @@ msgid ""
 "blue. CIECAM02 and NCS present a similar model. Here we use pure display "
 "red, yellow etc. as the four primaries."
 msgstr ""
-"据说使用了四种“心理学主色”或“独特色相”的色轮的“快而脏”的近似，颜色在重要的点上成对对立排列。红色对着绿色，黄色对着蓝色。CIECAM02 和 "
-"NCS表达了类似的模型。这里我们用到了纯显示红，黄等作为四种主色。"
+"据说使用了四种“心理学主色”或“独特色相”的色轮的“快而脏”的近似，颜色在重要的点"
+"上成对对立排列。红色对着绿色，黄色对着蓝色。CIECAM02 和 NCS表达了类似的模型。"
+"这里我们用到了纯显示红，黄等作为四种主色。"
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr "<b>色轮</b>"
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr "颜色"
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr "屏幕 (正常)"
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr "禁用 (没有压力敏感性)"
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr "窗口 (不推荐)"
@@ -3726,1832 +4650,2222 @@ msgid "Reload the file your current work was loaded from."
 msgstr "重新加载你加载当前工作使用的文件。"
 
 #: ../po/tmp/resources.xml.h:12
+#, fuzzy
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Import Layers…"
+msgstr "导入笔刷…"
+
+#: ../po/tmp/resources.xml.h:13
+msgctxt "Accel Editor (descriptions)"
+msgid "Import layers from one or more files."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save"
 msgstr "保存"
 
-#: ../po/tmp/resources.xml.h:13
+#: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file."
 msgstr "将您的工作保存到文件。"
 
-#: ../po/tmp/resources.xml.h:14
+#: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As…"
 msgstr "另存为…"
 
-#: ../po/tmp/resources.xml.h:15
+#: ../po/tmp/resources.xml.h:17
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file, assigning it a new name."
 msgstr "将你的文件保存到文件，并分配一个新名字。"
 
-#: ../po/tmp/resources.xml.h:16
+#: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Export…"
 msgstr "导出…"
 
-#: ../po/tmp/resources.xml.h:17
+#: ../po/tmp/resources.xml.h:19
 msgid "Export your work to a file, but keep working on the same file."
 msgstr "把你的工作导出到文件，但在同一个文件上继续工作。"
 
-#: ../po/tmp/resources.xml.h:18
+#: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As Scrap"
 msgstr "另存为废稿"
 
-#: ../po/tmp/resources.xml.h:19
+#: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
 msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr "保存为新废稿文件，或者如果废稿已存在，保存它的新修订版本。"
 
-#: ../po/tmp/resources.xml.h:20
+#: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Previous Scrap"
 msgstr "打开上一个废稿"
 
-#: ../po/tmp/resources.xml.h:21
+#: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file before the current one."
 msgstr "在当前文档前加载废稿文件。"
 
-#: ../po/tmp/resources.xml.h:22
+#: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Next Scrap"
 msgstr "打开下一个废稿"
 
-#: ../po/tmp/resources.xml.h:23
+#: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file after the current one."
 msgstr "在当前文档后面加载废稿文件。"
 
-#: ../po/tmp/resources.xml.h:24
+#: ../po/tmp/resources.xml.h:26
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Recover File from an Automated Backup…"
 msgstr "从自动备份中恢复文件…"
 
-#: ../po/tmp/resources.xml.h:25
+#: ../po/tmp/resources.xml.h:27
 msgctxt "Accel Editor (descriptions)"
 msgid "Try to save and resume interrupted unsaved work."
 msgstr "尝试保存并恢复中断未保存的工作。"
 
-#: ../po/tmp/resources.xml.h:26
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr "笔刷组"
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr "笔刷"
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr "笔刷组列表。"
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr "颜色调节器"
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr "颜色"
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr "可用的颜色调节器。"
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr "模式"
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr "模式"
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr "当前图层的混合模式。"
 
-#: ../po/tmp/resources.xml.h:35
+#: ../po/tmp/resources.xml.h:37
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Pressure"
+msgstr "起始压力"
+
+#: ../po/tmp/resources.xml.h:38
+msgctxt "Accel Editor (descriptions)"
+msgid "Send harder pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:39
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Pressure"
+msgstr "起始压力"
+
+#: ../po/tmp/resources.xml.h:40
+msgctxt "Accel Editor (descriptions)"
+msgid "Send softer pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:41
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Rotation"
+msgstr "提高饱和度"
+
+#: ../po/tmp/resources.xml.h:42
+msgctxt "Accel Editor (descriptions)"
+msgid "Increase barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:43
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
+msgstr "降低色彩饱和度"
+
+#: ../po/tmp/resources.xml.h:44
+msgctxt "Accel Editor (descriptions)"
+msgid "Decrease barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:45
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Size"
 msgstr "增加笔刷大小"
 
-#: ../po/tmp/resources.xml.h:36
+#: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush bigger."
 msgstr "使正在使用的笔刷变大。"
 
-#: ../po/tmp/resources.xml.h:37
+#: ../po/tmp/resources.xml.h:47
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Size"
 msgstr "减小笔刷大小"
 
-#: ../po/tmp/resources.xml.h:38
+#: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush smaller."
 msgstr "使正在使用的笔刷变小。"
 
-#: ../po/tmp/resources.xml.h:39
+#: ../po/tmp/resources.xml.h:49
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Opacity"
 msgstr "增加笔刷不透明度"
 
-#: ../po/tmp/resources.xml.h:40
+#: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush more opaque."
 msgstr "使正在使用的笔刷更不透明。"
 
-#: ../po/tmp/resources.xml.h:41
+#: ../po/tmp/resources.xml.h:51
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Opacity"
 msgstr "降低笔刷不透明度"
 
-#: ../po/tmp/resources.xml.h:42
+#: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush less opaque."
 msgstr "使正在使用的笔刷更透明。"
 
-#: ../po/tmp/resources.xml.h:43
+#: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Lighten Painting Color"
 msgstr "提高绘画色彩的亮度"
 
-#: ../po/tmp/resources.xml.h:44
+#: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase the lightness of the current painting color."
 msgstr "提高当前绘画色彩的明度。"
 
-#: ../po/tmp/resources.xml.h:45
+#: ../po/tmp/resources.xml.h:55
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Darken Painting Color"
 msgstr "使绘画色彩变暗"
 
-#: ../po/tmp/resources.xml.h:46
+#: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease the lightness of the current painting color."
 msgstr "降低当前绘画色彩的明度。"
 
-#: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
-msgstr "逆时针改变色相"
-
-#: ../po/tmp/resources.xml.h:48
-msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
-msgstr "在色轮上逆时针旋转绘画色彩的色相。"
-
-#: ../po/tmp/resources.xml.h:49
+#: ../po/tmp/resources.xml.h:57
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Change Hue Clockwise"
 msgstr "顺时针旋转改变色相"
 
-#: ../po/tmp/resources.xml.h:50
+#: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
 msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr "在色轮上顺时针旋转绘画色彩的色相。"
 
-#: ../po/tmp/resources.xml.h:51
+#: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr "逆时针改变色相"
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr "在色轮上逆时针旋转绘画色彩的色相。"
+
+#: ../po/tmp/resources.xml.h:61
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Increase Saturation"
 msgstr "提高饱和度"
 
-#: ../po/tmp/resources.xml.h:52
+#: ../po/tmp/resources.xml.h:62
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color more saturated (more colorful, purer)."
 msgstr "使得绘画色彩更加饱和（色彩更鲜艳，更纯）。"
 
-#: ../po/tmp/resources.xml.h:53
+#: ../po/tmp/resources.xml.h:63
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Decrease Saturation"
 msgstr "降低色彩饱和度"
 
-#: ../po/tmp/resources.xml.h:54
+#: ../po/tmp/resources.xml.h:64
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color less saturated (grayer)."
 msgstr "降低绘画色彩的饱和（色彩更灰）。"
 
-#: ../po/tmp/resources.xml.h:55
+#: ../po/tmp/resources.xml.h:65
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Reload Brush Settings"
 msgstr "重新加载画笔设置"
 
-#: ../po/tmp/resources.xml.h:56
+#: ../po/tmp/resources.xml.h:66
 msgctxt "Accel Editor (descriptions)"
 msgid "Restore all brush settings to the current brush’s saved values."
 msgstr "将画笔的所有设置都恢复到当前画笔保存的值。"
 
-#: ../po/tmp/resources.xml.h:57
+#: ../po/tmp/resources.xml.h:67
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Pick Stroke and Layer"
 msgstr "选取笔触和图层"
 
-#: ../po/tmp/resources.xml.h:58
+#: ../po/tmp/resources.xml.h:68
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
 msgstr "从画布上选取笔触：恢复笔刷，颜色和图层。"
 
-#: ../po/tmp/resources.xml.h:59
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr "通过笔刷快捷键恢复颜色"
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr "切换是否通过快捷键恢复画笔以及保存的颜色。"
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr "将画笔保存到最近使用的快捷键"
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr "将画笔设置保存到最近使用的快捷键。"
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "清除图层"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr "清除当前图层的内容。"
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+# ../gui/drawwindow.py:867
+#: ../po/tmp/resources.xml.h:75
+#, fuzzy
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr "工具选项"
+
+#: ../po/tmp/resources.xml.h:76
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr "根据边框修剪图层"
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr "擦除当前图层位于边框以外的部分。"
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr "擦除当前图层位于边框以外的部分。"
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "在下面新建图层组"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "在下面新建图层组"
+
+#: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr "将图层复制到剪贴板"
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr "将当前图层的内容复制到剪贴板。"
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr "从剪贴板粘帖图层"
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr "用剪贴板中的内容替换当前图层。"
 
-#: ../po/tmp/resources.xml.h:71
+#: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Edit Layer in External App…"
 msgstr "在外部工具中编辑图层…"
 
-#: ../po/tmp/resources.xml.h:72
+#: ../po/tmp/resources.xml.h:90
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
+msgid "Edit the active layer in an external application."
 msgstr "开始在外部应用程序中编辑当前图层。"
 
-#: ../po/tmp/resources.xml.h:73
+#: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Update Layer with External Edits"
 msgstr "使用外部编辑更新图层"
 
-#: ../po/tmp/resources.xml.h:74
+#: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
 msgid "Commit changes saved from the external app (normally automatic)."
 msgstr "提交从外部应用程序保存的更改 (通常是自动的)。"
 
-#: ../po/tmp/resources.xml.h:75
+#: ../po/tmp/resources.xml.h:93
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer at Cursor"
 msgstr "转到光标所在的图层"
 
-#: ../po/tmp/resources.xml.h:76
+#: ../po/tmp/resources.xml.h:94
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr "通过选择图层上一个对象选择图层。"
 
-#: ../po/tmp/resources.xml.h:77
+#: ../po/tmp/resources.xml.h:95
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Above"
 msgstr "转到上面的图层"
 
-#: ../po/tmp/resources.xml.h:78
+#: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer up in the layer stack."
 msgstr "在图层栈中转到上面一个图层。"
 
-#: ../po/tmp/resources.xml.h:79
+#: ../po/tmp/resources.xml.h:97
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Below"
 msgstr "转到下面的图层"
 
-#: ../po/tmp/resources.xml.h:80
+#: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer down in the layer stack."
 msgstr "在图层栈中转到下面一个图层。"
 
-#: ../po/tmp/resources.xml.h:81
+#: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer"
 msgstr "新建绘画图层"
 
-#: ../po/tmp/resources.xml.h:82
+#: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer above the current layer."
 msgstr "在当前图层上面添加一个新绘画图层。"
 
-#: ../po/tmp/resources.xml.h:83
+#: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer…"
 msgstr "新建矢量图层…"
 
-#: ../po/tmp/resources.xml.h:84
+#: ../po/tmp/resources.xml.h:102
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer above the current layer, and begin editing it."
 msgstr "在当前图层上面添加一个新矢量图层，并开始编辑它。"
 
-#: ../po/tmp/resources.xml.h:85
+#: ../po/tmp/resources.xml.h:103
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group"
 msgstr "新建图层组"
 
-#: ../po/tmp/resources.xml.h:86
+#: ../po/tmp/resources.xml.h:104
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group above the current layer."
 msgstr "在当前图层上面添加一个新的图层组。"
 
-#: ../po/tmp/resources.xml.h:87
+#: ../po/tmp/resources.xml.h:105
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer Below"
 msgstr "在下面新建绘画图层"
 
-#: ../po/tmp/resources.xml.h:88
+#: ../po/tmp/resources.xml.h:106
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer below the current layer."
 msgstr "在当前图层下面添加一个新绘画图层。"
 
-#: ../po/tmp/resources.xml.h:89
+#: ../po/tmp/resources.xml.h:107
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer Below…"
 msgstr "在下面新建矢量图层…"
 
-#: ../po/tmp/resources.xml.h:90
+#: ../po/tmp/resources.xml.h:108
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer below the current layer, and begin editing it."
 msgstr "在当前图层下面添加一个新矢量图层，并开始编辑它。"
 
-#: ../po/tmp/resources.xml.h:91
+#: ../po/tmp/resources.xml.h:109
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group Below"
 msgstr "在下面新建图层组"
 
-#: ../po/tmp/resources.xml.h:92
+#: ../po/tmp/resources.xml.h:110
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group below the current layer."
 msgstr "在当前图层下面添加一个新的图层组。"
 
-#: ../po/tmp/resources.xml.h:93
+#: ../po/tmp/resources.xml.h:111
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Layer Down"
 msgstr "向下合并图层"
 
-#: ../po/tmp/resources.xml.h:94
+#: ../po/tmp/resources.xml.h:112
 msgctxt "Accel Editor (descriptions)"
 msgid "Merge the current layer with the layer beneath it."
 msgstr "合并当前图层与下面的图层。"
 
-#: ../po/tmp/resources.xml.h:95
+#: ../po/tmp/resources.xml.h:113
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Visible Layers"
 msgstr "合并可见图层"
 
-#: ../po/tmp/resources.xml.h:96
+#: ../po/tmp/resources.xml.h:114
 msgctxt "Accel Editor (descriptions)"
 msgid "Consolidate all visible layers, and delete the originals."
 msgstr "合并所有可见图层，并删除原始图层。"
 
-#: ../po/tmp/resources.xml.h:97
+#: ../po/tmp/resources.xml.h:115
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer from Visible"
 msgstr "从可见内容新建图层"
 
-#: ../po/tmp/resources.xml.h:98
+#: ../po/tmp/resources.xml.h:116
 msgctxt "Accel Editor (descriptions)"
 msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
 msgstr "类似于“合并可见图层”，但不删除原始图层。"
 
-#: ../po/tmp/resources.xml.h:99
+#: ../po/tmp/resources.xml.h:117
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Delete Layer"
 msgstr "删除图层"
 
-#: ../po/tmp/resources.xml.h:100
+#: ../po/tmp/resources.xml.h:118
 msgctxt "Accel Editor (descriptions)"
 msgid "Remove the current layer from the layer stack."
 msgstr "从图层堆栈中移除当前图层。"
 
-#: ../po/tmp/resources.xml.h:101
+#: ../po/tmp/resources.xml.h:119
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Convert to Normal Painting Layer"
 msgstr "转换为正常绘画图层"
 
-#: ../po/tmp/resources.xml.h:102
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr "将当前图层或组转换为“正常”模式的绘画图层，并保留它本来的样子。"
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr "增加图层的不透明度"
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr "使图层透明度较低。"
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr "降低图层的不透明度"
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr "使图层更透明。"
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr "上移图层"
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr "把当前图层在堆栈中向上移动一格。"
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr "下移图层"
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr "把当前图层在堆栈中向下移动一格。"
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr "复制图层"
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr "创建当前图层的一个精确克隆。"
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
+#, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
-msgstr "重命名图层…"
+msgid "Layer Properties…"
+msgstr "属性"
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
-msgstr "为当前图层输入一个新名字。"
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr "图层已锁定"
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr "切换当前图层的锁定状态。被锁定的图层不能修改。"
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr "图层可见性"
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr "切换当前图层的可见性状态，使它隐藏。"
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr "显示背景"
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr "切换背景图层的可见性。"
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr "从图层堆栈中移除当前图层。"
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr "重置和中心视图"
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr "重置缩放，旋转和镜像并将文档居中。"
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr "适合视图"
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr "在合适的视图，工作位置以及缩放间切换。"
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr "重置"
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr "重置缩放"
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr "恢复视图的缩放为其默认值。"
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr "重置旋转"
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr "恢复视图的旋转值到 0 °"
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr "重置镜像"
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
-msgstr "关闭视图镜像。"
+msgid "Reset the view's mirroring."
+msgstr "重置镜像"
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr "放大"
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr "提高放大倍数。"
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "缩小"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr "减小放大倍数。"
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
+#, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
-msgstr "逆时针旋转"
+msgid "Pan Left"
+msgstr "平移视图"
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
-msgstr "逆时针旋转视图。"
+msgid "Move your view of the canvas to the left."
+msgstr "旋转视图: 倾斜你画布上的视图。"
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr "强光"
+
+#: ../po/tmp/resources.xml.h:159
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr "平移视图：水平或者垂直地移动画布的视图。"
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr "旋转视图: 倾斜你画布上的视图。"
+
+#: ../po/tmp/resources.xml.h:162
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr "平移视图"
+
+#: ../po/tmp/resources.xml.h:163
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr "旋转视图: 倾斜你画布上的视图。"
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr "顺时针旋转"
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr "顺时针旋转视图。"
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr "逆时针旋转"
+
+#: ../po/tmp/resources.xml.h:167
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr "逆时针旋转视图。"
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr "横向镜像"
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr "左右翻转视图。"
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr "纵向镜像"
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr "上下翻转视图。"
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr "图层独显"
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr "切换是否只显示当前图层。"
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr "对称绘画激活"
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr "沿对称轴镜像笔触"
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr "启用边框"
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr "切换文档边框的可见性。"
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr "向控制台打印笔刷的输入值"
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr "在控制台上显示画笔引擎内部生成的输入。"
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr "可视化渲染"
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr "在屏幕上显示渲染更新（用于调试）。"
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr "禁用双重缓冲"
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr "关闭GTK的双重缓冲（一般是打开的）。"
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+#, fuzzy
+msgid "Delete Point"
+msgstr "删除点"
+
+#: ../po/tmp/resources.xml.h:187
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr "删除当前选中的点"
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr "绘画模式"
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr "绘制模式: 正常"
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr "绘画时正常地应用颜色。"
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr "绘制模式: 橡皮擦"
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr "使用当前画笔擦除。"
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr "绘画模式: 锁定alpha"
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr "应用笔刷时不改变图层的不透明度。"
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr "绘制模式: 着色"
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr "在当前图层上应用色彩，但不影响它的亮度和不透明度。"
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "文件"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "退出"
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr "关闭主窗口并退出应用程序。"
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "编辑"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr "当前工具"
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "颜色"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr "调整颜色"
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr "颜色历史弹出式菜单"
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr "在光标下面弹出按时间线排列最近使用的颜色。"
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr "颜色详细信息对话框"
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr "显示带有文字描述的颜色详细信息对话框。"
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr "下一个调色板颜色"
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr "把绘画颜色设置为调色板上的下一个颜色。"
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr "上一个调色板颜色"
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr "把绘画颜色设置为调色板上的上一个颜色。"
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr "添加颜色到调色板"
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr "追加当前绘画颜色到调色板。"
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "图层"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr "不透明度"
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr "切换图层"
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr "在下面新建图层"
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr "属性"
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr "暂存区"
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr "新建便笺"
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr "加载默认暂存区作为新的暂存区画布。"
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr "打开暂存区…"
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr "加载磁盘上图片文件到暂存区。"
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr "保存暂存区"
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr "保存暂存区到磁盘上已存在的文件中。"
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr "导出暂存区为…"
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr "用你指定的文件名导出暂存区到磁盘。"
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr "恢复暂存区"
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr "恢复暂存区到最后一次保存的状态。"
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr "将暂存区作为默认值保存"
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr "将暂存区作为“新建暂存区”的默认值保存。"
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr "清除默认暂存区"
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr "清除默认暂存区为空白画布。"
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr "复制主背景到暂存区"
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr "复制工作文档的背景图片到暂存区内。"
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "窗口"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "笔刷"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr "快捷键"
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr "笔刷快捷键帮助"
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr "显示快捷键如何使用的解释。"
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "改变笔刷…"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr "在光标处弹出笔刷修改器。"
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "改变颜色…"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr "在光标处弹出颜色修改器，并罗列全部的颜色选择器。"
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "改变颜色 (快速子集)…"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr "在光标处弹出颜色修改器，仅罗列单击的颜色选择器。"
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr "获取更多笔刷…"
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr "从MyPaint wiki下载笔刷包。"
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr "导入笔刷…"
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr "从磁盘加载笔刷包。"
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "帮助"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr "在线帮助"
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr "跳转到MyPaint文档 wiki。"
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "关于 MyPaint"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr "显示MyPaint的许可证，版本号以及信用。"
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "调试"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr "打印内存泄漏信息到控制台 (慢！)"
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr "调试内存泄漏。"
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr "立即运行垃圾回收"
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr "过期Python对象占用的空闲内存。"
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr "启动/停止性能分析…"
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr "启动/停止 Python 性能分析 (cProfile)"
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr "模拟应用崩溃…"
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr "抛出一个Python异常以测试崩溃对话框。"
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "视图"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr "反馈"
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr "调整视图"
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
+#, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr "弹出菜单"
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr "以弹出方式显示主菜单。"
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "全屏"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr "在全屏与窗口模式之间切换。"
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "偏好设定"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr "编辑 MyPaint 的全局设置。"
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr "测试输入设备"
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr "显示用来捕捉输入设备发送的所有事件的对话框。"
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr "背景选择器"
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr "改变背景纸张纹理。"
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr "笔刷设定值编辑器"
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr "编辑使用中笔刷的设置。"
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr "笔刷图标编辑器"
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr "编辑笔刷图标。"
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr "图层面板"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
-msgstr "切换到图层停靠面板（排列图层，或者分配模式）。"
+msgid "Dockable panel for managing layers."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr "显示图层面板"
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr "显示图层停靠面板（排列图层，或者分配模式）。"
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr "HCY 色轮"
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr "可停靠的柱状色相/色度/亮度颜色选择器。圆形片是亮度等值的。"
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "颜色调色板"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr "可停靠的调色板颜色选择器。"
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr "HSV 色轮"
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr "可停靠的饱和度明度颜色选择器。"
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr "HSV 三角形"
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr "可停靠的颜色选择器：旧式GTK颜色三角形。"
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr "HSV 立方体"
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr "可停靠的颜色选择器：HSV立方体旋转以显示不同的平面切片。"
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr "HSV 正方形"
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
-msgstr "可停靠的颜色选择器: HSV 正方形可以旋转以显示不同的色相。"
+msgid "Dockable color selector: HSV square with Hue ring."
+msgstr "可停靠的颜色选择器，带有HSV 同心环。"
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr "构成要素滚动条"
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr "可停靠的颜色选择器：显示颜色的单一要素。"
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr "液体清洗"
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr "可停靠的颜色选择器，用来显示附近颜色液体清洗效果。"
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr "同心环"
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr "可停靠的颜色选择器，带有HSV 同心环。"
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr "交叉碗"
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr "可停靠的颜色选择器，带有穿过辐射状的碗形颜色的HSV坡道。"
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr "暂存区面板"
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
-msgstr "切换暂存区可停靠面板 (混合颜色以及绘制草图)。"
+msgid "Dockable Panel for mixing colors and testing brushes."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr "显示暂存区面板"
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr "显示暂存区可停靠面板 (混合颜色以及绘制草图)。"
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr "预览面板"
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
-msgstr "切换到预览可停靠面板 (通览整个绘图区域)。"
+msgid "Dockable panel for an overview and navigation of the whole canvas."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "预览"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr "显示预览可停靠面板 (通览整个绘图区域)。"
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr "工具选项面板"
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
-msgstr "切换到工具选项可停靠面板(当前工具的选项)。"
+msgid "Dockable panel for adjusting the options with the activated tool."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr "显示工具选项面板"
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr "显示工具选项可停靠面板(当前工具的选项)。"
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr "笔刷和颜色历史记录面板"
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
-msgstr "切换历史记录面板（最近使用的笔刷和颜色）。"
+msgid "Dockable panel for viewing recently changed colors and brushes."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr "最近使用的笔刷和颜色"
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr "显示历史记录面板 (最近使用的画笔和颜色)。"
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr "在全屏模式隐藏控制面板"
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr "切换到全屏模式下的用户界面自动隐藏。"
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr "显示缩放级别"
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr "切换缩放级别反馈。"
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr "显示最后一个绘画位置"
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr "切换用来显示最后一个笔触结束位置的反馈。"
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr "显示过滤"
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr "正常显示颜色"
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr "过滤颜色: 显示未改变过的颜色。"
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr "以灰度方式显示颜色"
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr "过滤颜色: 只显示亮度 (HCY/YCbCr 亮度)"
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr "反转显示颜色"
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr "过滤颜色: 反转视频。黑色反转为白色，红色反转为青色。"
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr "用模拟的对红色不敏感方式显示颜色"
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr "过滤颜色以模拟绿色盲（色盲的常见类型）。"
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr "用模拟的对绿色不敏感方式显示颜色"
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr "过滤颜色以模拟红色盲（色盲的常见类型）。"
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr "用模拟的对蓝色不敏感方式显示颜色"
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr "过滤颜色以模拟蓝色盲（色盲中的罕见类型）。"
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr "徒手绘图"
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr "徒手绘图"
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr "徒手绘图：自由地不受几何限制地绘画。"
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr "徒手绘图"
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr "自由地不受几何限制地绘画。"
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr "平移视图"
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr "平移工具"
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr "平移视图：水平或者垂直地移动画布的视图。"
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr "平移视图"
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr "水平或垂直地以交互方式移动你的画布上的视图。"
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr "旋转视图"
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr "旋转"
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr "旋转视图: 倾斜你画布上的视图。"
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr "旋转视图"
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr "以交互方式旋转画布的视图。"
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr "缩放视图"
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr "缩放"
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr "缩放视图: 放大或缩小画布。"
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr "缩放视图"
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr "以交互方式放大或缩小画布。"
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr "直线和曲线"
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr "线条"
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr "直线和曲线: 绘制直的或弯曲的线。"
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr "直线和曲线"
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr "绘制直的或弯曲的线。"
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr "连续线段"
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr "连续线段"
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr "连续线段: 绘制直线或曲线的序列。"
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr "连续线段"
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr "绘制直线或曲线的序列。"
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr "椭圆形和圆形"
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr "椭圆形"
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr "椭圆形和圆形: 绘制圆角的形状。"
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr "圆形与椭圆"
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr "绘制圆和椭圆。"
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr "墨迹作图"
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr "墨水"
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr "墨迹作图: 绘制平滑受控的线。"
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr "墨迹作图"
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr "绘制平滑受控的线。"
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr "重新放置图层"
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr "图层位置。"
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr "重新放置图层：在画布上移动当前图层。"
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr "重新放置图层"
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr "在画布上以交互方式移动当前图层。"
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr "编辑边框"
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr "边框"
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr "编辑边框: 围绕文档定义一个边框以给它一个有限的大小。"
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr "编辑边框"
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr "围绕文档定义一个边框以给它一个有限的大小。"
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "编辑绘画对称性"
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr "对称轴"
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr "编辑绘画对称性: 调整用于对称绘画的轴线。"
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "编辑绘画对称性"
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr "以交互的方式调整用于对称绘画的轴线。"
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr "选取颜色"
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr "选取颜色"
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr "选取颜色: 用来自屏幕像素的颜色设置绘画色彩。"
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "选取颜色"
+
+#: ../po/tmp/resources.xml.h:401
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr "用来自屏幕像素的颜色设置绘画色彩。"
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "选取颜色"
+
+#: ../po/tmp/resources.xml.h:403
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr "用来自屏幕像素的颜色设置绘画色彩。"
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "选取颜色"
+
+#: ../po/tmp/resources.xml.h:405
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr "用来自屏幕像素的颜色设置绘画色彩。"
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr "选取颜色"
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr "用来自屏幕像素的颜色设置绘画色彩。"
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr "满水法填充"
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr "填充"
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr "满水法填充: 用颜色填充一块区域。"
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr "满水法填充"
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr "用颜色填充一块区域。"
+
+#~ msgctxt "Accelerator map editor: action column markup"
+#~ msgid ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+#~ msgstr ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+
+#~ msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
+#~ msgid "{action_label} {action_desc} {accel_label}"
+#~ msgstr "{action_label} {action_desc} {accel_label}"
+
+#~ msgctxt "brush list context menu"
+#~ msgid "Delete"
+#~ msgstr "删除"
+
+#~ msgctxt "brush list commands"
+#~ msgid "Really delete brush from disk?"
+#~ msgstr "确定要从硬盘中删除笔刷？"
+
+#~ msgid "HSV Triangle"
+#~ msgstr "HSV 三角形"
+
+#~ msgid "The standard GTK color selector"
+#~ msgstr "标准 GTK 选色器"
+
+#~ msgid "Pick a color from the screen"
+#~ msgstr "从画面上选取颜色"
+
+#~ msgid "Layer Name"
+#~ msgstr "图层名称"
+
+#~ msgid ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+#~ msgstr ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+
+#~ msgid "Save..."
+#~ msgstr "储存..."
+
+#~ msgid "Confirm"
+#~ msgstr "确认"
+
+#~ msgid "Open..."
+#~ msgstr "开启..."
+
+#~ msgid "{default_name} at {path}"
+#~ msgstr "{default_name} at {path}"
+
+#~ msgid "Type"
+#~ msgstr "类型"
+
+#~ msgid "Mode:"
+#~ msgstr "模式："
+
+#~ msgid ""
+#~ "Blending mode: how the current layer combines with the layers underneath "
+#~ "it."
+#~ msgstr "混合模式：指定当前图层如何与它下面的图层合并。"
+
+#~ msgid ""
+#~ "Layer opacity: how much of the current layer to use. Smaller values make "
+#~ "it more transparent."
+#~ msgstr "图层不透明度：指定使用当前图层的多少。较小的值使得图层更加透明。"
+
+#~ msgid "%s: edit properties"
+#~ msgstr "%s: 编辑属性"
+
+#~ msgctxt "layer unique names: match regex (leave untranslated if unsure)"
+#~ msgid "^(.*?)\\s*(\\d+)$"
+#~ msgstr "^(.*?)\\s*(\\d+)$"
+
+#~ msgctxt "layer default names"
+#~ msgid "Unknown Bitmap Layer"
+#~ msgstr "未知的位图图层"
+
+#~ msgctxt "Autosave Recovery dialog|"
+#~ msgid "_Ignore for Now"
+#~ msgstr "暂时忽略"
+
+#~ msgid "Setting name:"
+#~ msgstr "设置名称:"
+
+#~ msgid "Base value:"
+#~ msgstr "基准值："
+
+#~ msgid "Reset the base value to its default"
+#~ msgstr "重置基准值为默认值"
+
+#~ msgid "<ymin>"
+#~ msgstr "<ymin>"
+
+#~ msgid "<ymax>"
+#~ msgstr "<ymax>"
+
+#~ msgid "<xmin>"
+#~ msgstr "<xmin>"
+
+#~ msgid "<xmax>"
+#~ msgstr "<xmax>"
+
+#~ msgid "Edit Setting"
+#~ msgstr "编辑设置"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Trim Layer to Frame"
+#~ msgstr "根据边框修剪图层"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Rename Layer…"
+#~ msgstr "重命名图层…"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Enter a new name for the current layer."
+#~ msgstr "为当前图层输入一个新名字。"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Turn off mirroring of the view."
+#~ msgstr "关闭视图镜像。"
+
+#~ msgctxt "Menu→Edit (labels)"
+#~ msgid "Current Tool"
+#~ msgstr "当前工具"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+#~ msgstr "切换到图层停靠面板（排列图层，或者分配模式）。"
+
+#~ msgctxt "Menu→Color (labels), Accel Editor (labels)"
+#~ msgid "HSV Triangle"
+#~ msgstr "HSV 三角形"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Dockable color selector: the old GTK color triangle."
+#~ msgstr "可停靠的颜色选择器：旧式GTK颜色三角形。"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid ""
+#~ "Dockable color selector: HSV square which can be rotated to show "
+#~ "different hues."
+#~ msgstr "可停靠的颜色选择器: HSV 正方形可以旋转以显示不同的色相。"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+#~ msgstr "切换暂存区可停靠面板 (混合颜色以及绘制草图)。"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+#~ msgstr "切换到预览可停靠面板 (通览整个绘图区域)。"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+#~ msgstr "切换到工具选项可停靠面板(当前工具的选项)。"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the History panel (recently used brushes and colors)."
+#~ msgstr "切换历史记录面板（最近使用的笔刷和颜色）。"
 
 #~ msgid "Add As New"
 #~ msgstr "加入新笔刷"
@@ -5648,9 +6962,6 @@ msgstr "用颜色填充一块区域。"
 #~ "\n"
 #~ "关於笔刷设定值 (不透明度、硬度等) 和输入 (压力、速度等) 会有工具提示。将您"
 #~ "的滑鼠移到标签的上方可看见这些提示。\n"
-
-#~ msgid "Open Recent files"
-#~ msgstr "开启最近的档案"
 
 #~ msgid "This will discard %d second of unsaved painting."
 #~ msgid_plural "This will discard %d seconds of unsaved painting."
@@ -5752,9 +7063,6 @@ msgstr "用颜色填充一块区域。"
 #~ msgid "Brush Blend Mode"
 #~ msgstr "笔刷混合模式"
 
-#~ msgid "Add Layer"
-#~ msgstr "加入图层"
-
 #~ msgid "Move Layer on Canvas"
 #~ msgstr "移动画布上的图层"
 
@@ -5792,9 +7100,6 @@ msgstr "用颜色填充一块区域。"
 #~ msgctxt "Menu|File|"
 #~ msgid "Save"
 #~ msgstr "储存"
-
-#~ msgid "Export to a file"
-#~ msgstr "汇出成档案"
 
 #, fuzzy
 #~ msgid ""

--- a/po/zh_Hant_HK.po
+++ b/po/zh_Hant_HK.po
@@ -512,17 +512,17 @@ msgstr ""
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
+msgid "New Group…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
+msgid "Import Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
+msgid "Get More Brushes…"
 msgstr ""
 
 #: ../gui/brushselectionwindow.py:554
@@ -1183,12 +1183,12 @@ msgstr ""
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr ""
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr ""
 
 #. Name and preview column: will be indented
@@ -1404,7 +1404,7 @@ msgid "_Quit"
 msgstr "結束"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
+msgid "Import brush package…"
 msgstr ""
 
 #: ../gui/drawwindow.py:698
@@ -1454,7 +1454,7 @@ msgid ""
 msgstr ""
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
+msgid "Open With…"
 msgstr ""
 
 #: ../gui/externalapp.py:123
@@ -1630,13 +1630,13 @@ msgid "JPEG 90% quality (*.jpg; *.jpeg)"
 msgstr ""
 
 #: ../gui/filehandling.py:576
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr ""
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "儲存"
 
@@ -1702,7 +1702,7 @@ msgstr "檔案"
 
 #: ../gui/filehandling.py:1057
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
+msgid "Open Scratchpad…"
 msgstr ""
 
 #: ../gui/filehandling.py:1099
@@ -2123,12 +2123,12 @@ msgid ""
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
+msgid "Search Tracker…"
 msgstr ""
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
+msgid "Report…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:180
@@ -2140,7 +2140,7 @@ msgid "Quit MyPaint"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
+msgid "Details…"
 msgstr ""
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
@@ -2326,7 +2326,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr ""
 
 #: ../gui/layerswindow.py:110
@@ -2396,7 +2396,7 @@ msgid "Stroke trail-off beginning"
 msgstr ""
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
+msgid "Pressure variation…"
 msgstr ""
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777

--- a/po/zh_Hant_HK.po
+++ b/po/zh_Hant_HK.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2019-02-27 14:18+0000\n"
 "Last-Translator: glixx <roman_romul@mail.ru>\n"
 "Language-Team: Chinese (Hong Kong) <https://hosted.weblate.org/projects/"
@@ -19,27 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 3.5-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr ""
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr ""
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr ""
 
@@ -47,39 +27,39 @@ msgstr ""
 msgid "Key combination"
 msgstr ""
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr ""
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr ""
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr ""
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr ""
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr ""
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr ""
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr ""
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr ""
@@ -87,214 +67,224 @@ msgstr ""
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr ""
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr ""
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr ""
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr ""
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr ""
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "顏色"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr ""
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr ""
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr ""
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr ""
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr ""
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr ""
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr ""
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr ""
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr ""
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr ""
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
 msgctxt "brush settings list: setting group"
-msgid "Tracking"
-msgstr ""
-
-#: ../gui/brusheditor.py:359
-msgctxt "brush settings list: setting group"
-msgid "Stroke"
+msgid "Directional Offsets"
 msgstr ""
 
 #: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
+msgid "Tracking"
+msgstr ""
+
+#: ../gui/brusheditor.py:381
+msgctxt "brush settings list: setting group"
+msgid "Stroke"
+msgstr ""
+
+#: ../gui/brusheditor.py:392
+msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr ""
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "自選"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr ""
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr ""
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr ""
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr ""
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr ""
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr ""
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
 "<small>Select a valid brush first</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
 "<small>Changes are not yet saved</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
 "<small>Paint with any brush or color</small>"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -333,141 +323,176 @@ msgstr ""
 msgid "Use the default icon"
 msgstr ""
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "儲存"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr ""
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr ""
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr ""
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr ""
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr ""
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr ""
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr ""
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr ""
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr ""
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr ""
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr ""
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr ""
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr ""
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
+#: ../gui/brushselectionwindow.py:250
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
 msgstr ""
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] ""
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -475,58 +500,58 @@ msgid ""
 "Some special groups cannot be deleted."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr ""
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr ""
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr ""
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr ""
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr ""
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr ""
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr ""
@@ -535,51 +560,75 @@ msgstr ""
 msgid "Button press:"
 msgstr ""
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr ""
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr ""
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr ""
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr ""
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+msgid "Set the color Hue used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:293
+msgid "Pick Chroma"
+msgstr ""
+
+#: ../gui/colorpicker.py:296
+msgid "Set the color Chroma used for painting"
+msgstr ""
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+msgid "Set the color Luma used for painting"
+msgstr ""
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr ""
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr ""
@@ -589,137 +638,137 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -727,162 +776,154 @@ msgid ""
 msgstr ""
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr ""
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr ""
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr ""
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr ""
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -890,373 +931,370 @@ msgid ""
 "drag them to organize."
 msgstr ""
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr ""
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr ""
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr ""
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr ""
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr ""
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr ""
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr ""
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr ""
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr ""
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr ""
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr ""
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr ""
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr ""
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr ""
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr ""
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr ""
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr ""
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr ""
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr ""
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr ""
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr ""
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr ""
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr ""
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr ""
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr ""
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr ""
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr ""
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr ""
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr ""
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr ""
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr ""
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr ""
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr ""
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr ""
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr ""
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr ""
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "名稱"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr ""
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr ""
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr ""
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr ""
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr ""
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr ""
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr ""
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr ""
 
-#: ../gui/dialogs.py:190
+#: ../gui/dialogs.py:220
 #, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr ""
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr ""
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr ""
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr ""
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr ""
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr ""
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "復原"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr ""
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "取消復原"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr ""
@@ -1266,324 +1304,673 @@ msgstr ""
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr ""
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr ""
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
 
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
+#: ../gui/document.py:909
 #, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
 msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr ""
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr ""
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr ""
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr ""
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "全螢幕"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "結束"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr ""
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "結束"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr ""
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr ""
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr ""
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr ""
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr ""
 
-#: ../gui/externalapp.py:46
+#: ../gui/externalapp.py:48
+#, python-brace-format
+msgctxt "file handling: open failed (statusbar)"
+msgid "Could not load “{file_basename}”."
+msgstr ""
+
+#: ../gui/externalapp.py:61
 #, python-brace-format
 msgid ""
 "MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
 "application should it use?"
 msgstr ""
 
-#: ../gui/externalapp.py:50
+#: ../gui/externalapp.py:65
 #, python-brace-format
 msgid ""
 "What application should MyPaint use for editing files of type "
 "“{type_name}” ({content_type})?"
 msgstr ""
 
-#: ../gui/externalapp.py:56
+#: ../gui/externalapp.py:71
 msgid "Open With..."
 msgstr ""
 
-#: ../gui/externalapp.py:107
+#: ../gui/externalapp.py:123
 msgid "Icon"
 msgstr ""
 
-#: ../gui/externalapp.py:150
+#: ../gui/externalapp.py:166
 msgid "no description"
 msgstr ""
 
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr ""
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr ""
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr ""
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr ""
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr ""
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr ""
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr ""
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr ""
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr ""
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr ""
-
-#: ../gui/filehandling.py:234
+#: ../gui/filehandling.py:126
 #, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr ""
-
-#: ../gui/filehandling.py:282
+#: ../gui/filehandling.py:130
 #, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:296
+#: ../gui/filehandling.py:134
 #, python-brace-format
-msgctxt "file handling: open failed (statusbar)"
-msgid "Could not load “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:321
+#: ../gui/filehandling.py:138
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
 msgstr ""
 
-#: ../gui/filehandling.py:422
+#: ../gui/filehandling.py:145
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:149
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:164
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr ""
+
+#: ../gui/filehandling.py:168
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr ""
+
+#: ../gui/filehandling.py:172
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr ""
+
+#: ../gui/filehandling.py:176
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr ""
+
+#: ../gui/filehandling.py:183
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:187
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr ""
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+
+#: ../gui/filehandling.py:221
+#, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
 msgstr ""
 
 #: ../gui/filehandling.py:427
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
+msgstr ""
+
+#: ../gui/filehandling.py:432
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:437
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:442
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:490
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
+msgstr ""
+
+#: ../gui/filehandling.py:494
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr ""
+
+#: ../gui/filehandling.py:498
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:502
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:506
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:510
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:514
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr ""
+
+#: ../gui/filehandling.py:518
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr ""
+
+#: ../gui/filehandling.py:576
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr ""
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "儲存"
+
+#: ../gui/filehandling.py:601
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr ""
+
+#: ../gui/filehandling.py:668
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr ""
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr ""
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
 #, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
 msgstr ""
 
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
 msgstr ""
 
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
 msgstr ""
 
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
+#: ../gui/filehandling.py:1007
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
 msgstr ""
 
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
-msgstr ""
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "檔案"
 
-#: ../gui/filehandling.py:552
+#: ../gui/filehandling.py:1057
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr ""
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "圖層"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
 msgstr ""
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1412
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1427
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1432
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1446
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
+msgstr ""
+
+#: ../gui/filehandling.py:1455
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1463
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr ""
+
+#: ../gui/filehandling.py:1472
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr ""
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr ""
+
+#: ../gui/fill.py:121
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr ""
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr ""
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr ""
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr ""
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
 msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr ""
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
 "underneath the current layer"
 msgstr ""
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr ""
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr ""
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr ""
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr ""
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
 msgstr ""
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr ""
+
+#: ../gui/fill.py:706
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr ""
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr ""
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr ""
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr ""
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr ""
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1591,130 +1978,142 @@ msgid ""
 "{brush_desc}"
 msgstr ""
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr ""
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr ""
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr ""
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr ""
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr ""
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr ""
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr ""
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr ""
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr ""
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr ""
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr ""
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr ""
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr ""
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr ""
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr ""
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr ""
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr ""
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr ""
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr ""
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr ""
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr ""
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr ""
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr ""
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1723,35 +2122,35 @@ msgid ""
 "has reported it yet."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr ""
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr ""
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr ""
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1775,45 +2174,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr ""
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr ""
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr ""
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+msgid "Barrel Rotation:"
 msgstr ""
 
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr ""
 
@@ -1821,153 +2224,218 @@ msgstr ""
 msgid "Move the current layer"
 msgstr ""
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
 msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
 msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr ""
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr ""
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "圖層"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr ""
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ""
+
+#: ../gui/layers.py:990
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr ""
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "圖層"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr ""
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr ""
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr ""
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr ""
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr ""
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
+#: ../gui/layervis.py:53
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
 msgstr ""
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
 msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr ""
-
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr ""
-
-#: ../gui/linemode.py:37
-msgid "Entrance Pressure"
-msgstr ""
-
-#: ../gui/linemode.py:38
-msgid "Stroke entrance pressure for line tools"
-msgstr ""
-
-#: ../gui/linemode.py:39
-msgid "Midpoint Pressure"
+#: ../gui/layervis.py:187
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
 msgstr ""
 
 #: ../gui/linemode.py:40
-msgid "Mid-Stroke pressure for line tools"
+msgid "Entrance Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:41
-msgid "Exit Pressure"
+msgid "Stroke entrance pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:42
-msgid "Stroke exit pressure for line tools"
+msgid "Midpoint Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:43
-msgid "Head"
+msgid "Mid-Stroke pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:44
-msgid "Stroke lead-in end"
+msgid "Exit Pressure"
 msgstr ""
 
 #: ../gui/linemode.py:45
-msgid "Tail"
+msgid "Stroke exit pressure for line tools"
 msgstr ""
 
 #: ../gui/linemode.py:46
+msgid "Head"
+msgstr ""
+
+#: ../gui/linemode.py:47
+msgid "Stroke lead-in end"
+msgstr ""
+
+#: ../gui/linemode.py:48
+msgid "Tail"
+msgstr ""
+
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr ""
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr ""
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr ""
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr ""
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr ""
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
 msgstr ""
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr ""
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -1979,256 +2447,281 @@ msgid ""
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr ""
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr ""
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr ""
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr ""
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr ""
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr ""
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr ""
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr ""
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr ""
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr ""
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr ""
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr ""
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ""
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr ""
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr ""
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr ""
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr ""
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr ""
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr ""
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr ""
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr ""
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr ""
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr ""
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr ""
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr ""
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr ""
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr ""
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr ""
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr ""
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr ""
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr ""
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr ""
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr ""
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
-msgstr ""
-
-#: ../gui/symmetry.py:76
-msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
-msgid "Move axis"
+msgid "Place axis"
 msgstr ""
 
 #: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
+msgid "Move axis"
+msgstr ""
+
+#: ../gui/symmetry.py:88
+msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr ""
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr ""
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr ""
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr ""
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr ""
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr ""
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr ""
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr ""
 
-#: ../gui/symmetry.py:352
-msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+#: ../gui/symmetry.py:376
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
 msgstr ""
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "X axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:477
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr ""
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr ""
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr ""
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr ""
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr ""
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr ""
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr ""
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr ""
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr ""
 
@@ -2236,188 +2729,213 @@ msgstr ""
 msgid "<b>MyPaint</b>"
 msgstr ""
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr ""
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr ""
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr ""
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr ""
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr ""
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr ""
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
 msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr ""
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr ""
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr ""
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr ""
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr ""
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+msgid "Refactor Group"
+msgstr ""
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr ""
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr ""
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr ""
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr ""
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr ""
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr ""
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "圖層"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr ""
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr ""
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr ""
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr ""
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr ""
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr ""
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr ""
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr ""
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr ""
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr ""
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr ""
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr ""
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr ""
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr ""
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr ""
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr ""
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr ""
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr ""
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr ""
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr ""
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr ""
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr ""
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2426,13 +2944,13 @@ msgid ""
 "Close app and wait {cache_update_interval}s to retry."
 msgstr ""
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr ""
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2442,7 +2960,7 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2450,13 +2968,13 @@ msgid ""
 "Do you have enough space left on the device?"
 msgstr ""
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr ""
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2464,7 +2982,7 @@ msgid ""
 "The file does not exist."
 msgstr ""
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2472,7 +2990,7 @@ msgid ""
 "You do not have the permissions needed to open this file."
 msgstr ""
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2483,7 +3001,7 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2491,7 +3009,12 @@ msgid ""
 "Unknown file format extension: “{ext}”"
 msgstr ""
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr ""
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2501,7 +3024,7 @@ msgid ""
 "memory. MyPaint’s PNG save function is more efficient."
 msgstr ""
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2512,285 +3035,394 @@ msgid ""
 "{see_logs}"
 msgstr ""
 
-#: ../lib/helpers.py:402
+#: ../lib/floodfill.py:131
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr ""
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr ""
 
-#: ../lib/helpers.py:404
+#: ../lib/helpers.py:537
 #, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr ""
 
-#: ../lib/helpers.py:406
+#: ../lib/helpers.py:539
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr ""
 
-#: ../lib/helpers.py:408
+#: ../lib/helpers.py:541
 #, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr ""
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr ""
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr ""
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr ""
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr ""
+
+#: ../lib/layer/data.py:1158
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr ""
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
+msgid "Bitmap"
 msgstr ""
 
-#: ../lib/layer/data.py:1169
-msgctxt "layer default names"
-msgid "Unknown Data Layer"
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
 msgstr ""
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1244
+msgctxt "layer default names"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1300
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr ""
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr ""
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr ""
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr ""
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr ""
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ""
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr ""
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr ""
+
+#: ../lib/layervis.py:697
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr ""
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr ""
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr ""
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr ""
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr ""
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr ""
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr ""
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr ""
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr ""
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr ""
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr ""
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr ""
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr ""
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr ""
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
 msgstr ""
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr ""
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
 msgstr ""
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr ""
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr ""
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr ""
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr ""
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr ""
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr ""
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr ""
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr ""
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr ""
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr ""
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr ""
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr ""
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr ""
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr ""
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr ""
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr ""
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr ""
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr ""
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr ""
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr ""
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr ""
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr ""
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2800,7 +3432,27 @@ msgid ""
 "Target folder: “{dirname}”."
 msgstr ""
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+msgid "Vertical"
+msgstr ""
+
+#: ../lib/tiledsurface.py:49
+msgid "Horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+msgid "Rotational"
+msgstr ""
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr ""
@@ -2809,52 +3461,83 @@ msgstr ""
 msgid "Recover interrupted work?"
 msgstr ""
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
+msgid "_Look for backups at startup"
 msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:9
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr ""
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr ""
+
+#: ../po/tmp/autorecover.glade.h:12
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
+msgid "Decide _Later"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
+msgid "Live update"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
+msgid "Save these settings to the brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:5
@@ -2876,17 +3559,15 @@ msgid "Delete this brush from the disk"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
+msgid "Copy to New"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
+msgid "Copy these settings and the current brush's icon to a new brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
+msgid "Rename this brush"
 msgstr ""
 
 #: ../po/tmp/brusheditor.glade.h:13
@@ -2915,112 +3596,87 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr ""
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr ""
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
+#: ../po/tmp/brusheditor.glade.h:22
+msgid "Value:"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr ""
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr ""
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr ""
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:42
+msgid "Brush dynamics are not available for this setting."
+msgstr ""
+
+#: ../po/tmp/brusheditor.glade.h:43
+msgid "<big><b>No Brush Dynamics</b></big>"
 msgstr ""
 
 #: ../po/tmp/inktool.glade.h:1
@@ -3033,7 +3689,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr ""
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3074,6 +3730,133 @@ msgstr ""
 #: ../po/tmp/inktool.glade.h:13
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+msgid "Insert Point"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+msgid "Cull Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "名稱"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:2
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:3
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:4
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
 msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
@@ -3443,56 +4226,76 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr ""
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr ""
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
 "Different traditions have different color harmonies."
 msgstr ""
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
@@ -3500,12 +4303,12 @@ msgid ""
 "arranged around the circle. Green is opposite red."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3514,7 +4317,7 @@ msgid ""
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3525,28 +4328,28 @@ msgid ""
 msgstr ""
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr ""
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr ""
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr ""
@@ -3608,1828 +4411,2019 @@ msgstr ""
 
 #: ../po/tmp/resources.xml.h:12
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save"
+msgid "Import Layers…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:13
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file."
+msgid "Import layers from one or more files."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As…"
+msgid "Save"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
-msgid "Save your work to a file, assigning it a new name."
+msgid "Save your work to a file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Export…"
+msgid "Save As…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:17
-msgid "Export your work to a file, but keep working on the same file."
+msgctxt "Accel Editor (descriptions)"
+msgid "Save your work to a file, assigning it a new name."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Save As Scrap"
+msgid "Export…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:19
-msgctxt "Accel Editor (descriptions)"
-msgid "Save to a new scrap file, or save a new revision if already a scrap."
+msgid "Export your work to a file, but keep working on the same file."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Previous Scrap"
+msgid "Save As Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file before the current one."
+msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Open Next Scrap"
+msgid "Open Previous Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
-msgid "Load the scrap file after the current one."
+msgid "Load the scrap file before the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
-msgid "Recover File from an Automated Backup…"
+msgid "Open Next Scrap"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
-msgid "Try to save and resume interrupted unsaved work."
+msgid "Load the scrap file after the current one."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:26
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Recover File from an Automated Backup…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:27
+msgctxt "Accel Editor (descriptions)"
+msgid "Try to save and resume interrupted unsaved work."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:35
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Size"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:36
-msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush bigger."
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:37
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Size"
+msgid "Increase Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:38
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush smaller."
+msgid "Send harder pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:39
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Increase Brush Opacity"
+msgid "Decrease Fake Pressure"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:40
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush more opaque."
+msgid "Send softer pressure for devices that don't support pressure input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:41
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Decrease Brush Opacity"
+msgid "Increase Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:42
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the working brush less opaque."
+msgid "Increase barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:43
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Lighten Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:44
 msgctxt "Accel Editor (descriptions)"
-msgid "Increase the lightness of the current painting color."
+msgid "Decrease barrel rotation for devices that don't support rotation input."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:45
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Darken Painting Color"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
-msgid "Decrease the lightness of the current painting color."
+msgid "Make the working brush bigger."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Size"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgid "Make the working brush smaller."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:49
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Clockwise"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue clockwise on the color wheel."
+msgid "Make the working brush more opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:51
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Increase Saturation"
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Brush Opacity"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color more saturated (more colorful, purer)."
+msgid "Make the working brush less opaque."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Decrease Saturation"
+msgid "Lighten Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
-msgid "Make the painting color less saturated (grayer)."
+msgid "Increase the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:55
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Reload Brush Settings"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Darken Painting Color"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore all brush settings to the current brush’s saved values."
+msgid "Decrease the lightness of the current painting color."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:57
-msgctxt "Menu→Brush (labels), Accel Editor (labels)"
-msgid "Pick Stroke and Layer"
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Clockwise"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:61
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Increase Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:62
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color more saturated (more colorful, purer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:63
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Decrease Saturation"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:64
+msgctxt "Accel Editor (descriptions)"
+msgid "Make the painting color less saturated (grayer)."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:65
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Reload Brush Settings"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:66
+msgctxt "Accel Editor (descriptions)"
+msgid "Restore all brush settings to the current brush’s saved values."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:67
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Pick Stroke and Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:68
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:76
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:67
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Copy Layer to Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:68
-msgctxt "Accel Editor (descriptions)"
-msgid "Copy the current layer’s contents to the clipboard."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:69
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Paste Layer from Clipboard"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:70
-msgctxt "Accel Editor (descriptions)"
-msgid "Replaces the current layer with the clipboard’s contents."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:71
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Edit Layer in External App…"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:72
-msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:73
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Update Layer with External Edits"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:74
-msgctxt "Accel Editor (descriptions)"
-msgid "Commit changes saved from the external app (normally automatic)."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:75
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer at Cursor"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:76
-msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:77
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Above"
-msgstr ""
-
 #: ../po/tmp/resources.xml.h:78
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer up in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:79
-msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
-msgid "Go to Layer Below"
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:80
-msgctxt "Accel Editor (descriptions)"
-msgid "Go one layer down in the layer stack."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:81
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:82
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer above the current layer."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:83
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer…"
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:84
-msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer above the current layer, and begin editing it."
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group"
+msgid "Copy Layer to Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group above the current layer."
+msgid "Copy the current layer’s contents to the clipboard."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Painting Layer Below"
+msgid "Paste Layer from Clipboard"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new painting layer below the current layer."
+msgid "Replaces the current layer with the clipboard’s contents."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Vector Layer Below…"
+msgid "Edit Layer in External App…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:90
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new vector layer below the current layer, and begin editing it."
+msgid "Edit the active layer in an external application."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer Group Below"
+msgid "Update Layer with External Edits"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
-msgid "Add a new layer group below the current layer."
+msgid "Commit changes saved from the external app (normally automatic)."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:93
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Layer Down"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer at Cursor"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:94
 msgctxt "Accel Editor (descriptions)"
-msgid "Merge the current layer with the layer beneath it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:95
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Merge Visible Layers"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Above"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
-msgid "Consolidate all visible layers, and delete the originals."
+msgid "Go one layer up in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:97
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "New Layer from Visible"
+msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
+msgid "Go to Layer Below"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
-msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgid "Go one layer down in the layer stack."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Delete Layer"
+msgid "New Painting Layer"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
-msgid "Remove the current layer from the layer stack."
+msgid "Add a new painting layer above the current layer."
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Convert to Normal Painting Layer"
+msgid "New Vector Layer…"
 msgstr ""
 
 #: ../po/tmp/resources.xml.h:102
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer above the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:103
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:104
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group above the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:105
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Painting Layer Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:106
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new painting layer below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:107
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Vector Layer Below…"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:108
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new vector layer below the current layer, and begin editing it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:109
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer Group Below"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:110
+msgctxt "Accel Editor (descriptions)"
+msgid "Add a new layer group below the current layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:111
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Layer Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:112
+msgctxt "Accel Editor (descriptions)"
+msgid "Merge the current layer with the layer beneath it."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:113
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Merge Visible Layers"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:114
+msgctxt "Accel Editor (descriptions)"
+msgid "Consolidate all visible layers, and delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:115
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "New Layer from Visible"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:116
+msgctxt "Accel Editor (descriptions)"
+msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:117
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Delete Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:118
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove the current layer from the layer stack."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:119
+msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+msgid "Convert to Normal Painting Layer"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
+msgid "Layer Properties…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
+msgid "Reset the view's mirroring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "拉遠"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
+msgid "Pan Left"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
+msgid "Move your view of the canvas to the left."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:159
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:162
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:163
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:167
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+msgid "Delete Point"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:187
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "檔案"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "求助"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "偵錯"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
-msgstr ""
+msgstr "圖層"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+msgid "Dockable panel for managing layers."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr ""
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
+msgid "Dockable color selector: HSV square with Hue ring."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+msgid "Dockable Panel for mixing colors and testing brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+msgid "Dockable panel for an overview and navigation of the whole canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+msgid "Dockable panel for adjusting the options with the activated tool."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
+msgid "Dockable panel for viewing recently changed colors and brushes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:401
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:402
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:403
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:404
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:405
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr ""
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr ""

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -528,18 +528,18 @@ msgstr "MyPaint 筆刷包 (*.zip)"
 
 #: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
-msgid "New Group..."
-msgstr "新增類組..."
+msgid "New Group…"
+msgstr "新增類組…"
 
 #: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
-msgid "Import Brushes..."
-msgstr "匯入筆刷..."
+msgid "Import Brushes…"
+msgstr "匯入筆刷…"
 
 #: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
-msgid "Get More Brushes..."
-msgstr "取得更多筆刷..."
+msgid "Get More Brushes…"
+msgstr "取得更多筆刷…"
 
 #: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
@@ -1208,12 +1208,12 @@ msgstr "種類"
 
 #: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
-msgid "Use for..."
+msgid "Use for…"
 msgstr "給使用…"
 
 #: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
-msgid "Scroll..."
+msgid "Scroll…"
 msgstr "捲動…"
 
 #. Name and preview column: will be indented
@@ -1401,7 +1401,7 @@ msgstr ""
 #, fuzzy
 msgctxt "Open dragged file confirm dialog: continue button"
 msgid "_Open"
-msgstr "開啟..."
+msgstr "開啟…"
 
 #: ../gui/drawwindow.py:486
 msgid "Set current color"
@@ -1436,8 +1436,8 @@ msgid "_Quit"
 msgstr "退出"
 
 #: ../gui/drawwindow.py:697
-msgid "Import brush package..."
-msgstr "匯入筆刷包..."
+msgid "Import brush package…"
+msgstr "匯入筆刷包…"
 
 #: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
@@ -1489,8 +1489,8 @@ msgstr ""
 "MyPaint 應該用哪個應用程式來編輯 “{type_name}” ({content_type}) 種類的檔案？"
 
 #: ../gui/externalapp.py:71
-msgid "Open With..."
-msgstr "開啟..."
+msgid "Open With…"
+msgstr "開啟…"
 
 #: ../gui/externalapp.py:123
 msgid "Icon"
@@ -1516,13 +1516,13 @@ msgstr ""
 #, fuzzy, python-brace-format
 msgctxt "Document I/O: message shown while working"
 msgid "Saving {files_summary}…"
-msgstr "儲存「{file_basename}」 …"
+msgstr "儲存「{file_basename}」…"
 
 #: ../gui/filehandling.py:138
 #, fuzzy, python-brace-format
 msgctxt "Document I/O: message shown while working"
 msgid "Exporting to {files_summary}…"
-msgstr "匯出至「{file_basename}」 …"
+msgstr "匯出至「{file_basename}」…"
 
 #: ../gui/filehandling.py:145
 #, fuzzy, python-brace-format
@@ -1682,13 +1682,13 @@ msgstr "JPEG 90% 品質 (*.jpg; *.jpeg)"
 
 #: ../gui/filehandling.py:576
 #, fuzzy
-msgctxt "Dialogs (window title): File→Export..."
+msgctxt "Dialogs (window title): File→Export…"
 msgid "Export"
 msgstr "匯出…"
 
 #: ../gui/filehandling.py:581
 #, fuzzy
-msgctxt "Dialogs (window title): File→Save As..."
+msgctxt "Dialogs (window title): File→Save As…"
 msgid "Save As"
 msgstr "另存為…"
 
@@ -1759,8 +1759,8 @@ msgstr "開啟最近的檔案"
 #: ../gui/filehandling.py:1057
 #, fuzzy
 msgctxt "load dialogs: title"
-msgid "Open Scratchpad..."
-msgstr "開啟便條紙..."
+msgid "Open Scratchpad…"
+msgstr "開啟便條紙…"
 
 #: ../gui/filehandling.py:1099
 #, fuzzy
@@ -1777,7 +1777,7 @@ msgstr ""
 #, fuzzy
 msgctxt "File→Open Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "開啟..."
+msgstr "開啟…"
 
 #: ../gui/filehandling.py:1427
 #, fuzzy
@@ -1789,7 +1789,7 @@ msgstr "開啟最新近"
 #, fuzzy
 msgctxt "File→Open Most Recent→* confirm dialog: continue button"
 msgid "_Open"
-msgstr "開啟..."
+msgstr "開啟…"
 
 #: ../gui/filehandling.py:1446
 #, fuzzy
@@ -1813,7 +1813,7 @@ msgstr "開啟上一個圖料"
 #, fuzzy
 msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
 msgid "_Open"
-msgstr "開啟..."
+msgstr "開啟…"
 
 #: ../gui/filehandling.py:1487
 msgctxt "File→Revert: status message: canvas has no filename yet"
@@ -2213,13 +2213,13 @@ msgstr ""
 "如果還未有人報告這個問題，請使用問題追蹤系統告知開發人員。"
 
 #: ../gui/gtkexcepthook.py:176
-msgid "Search Tracker..."
-msgstr "尋找追蹤系統 …"
+msgid "Search Tracker…"
+msgstr "尋找追蹤系統…"
 
 #. only development and prereleases
 #: ../gui/gtkexcepthook.py:178
-msgid "Report..."
-msgstr "報告..."
+msgid "Report…"
+msgstr "報告…"
 
 #: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
@@ -2230,8 +2230,8 @@ msgid "Quit MyPaint"
 msgstr "離開 MyPaint"
 
 #: ../gui/gtkexcepthook.py:191
-msgid "Details..."
-msgstr "詳細資訊..."
+msgid "Details…"
+msgstr "詳細資訊…"
 
 #: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
@@ -2436,7 +2436,7 @@ msgstr ""
 
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
 #: ../gui/layerswindow.py:109
-msgid "Move layer in stack..."
+msgid "Move layer in stack…"
 msgstr "移動堆疊中的圖層…"
 
 #: ../gui/layerswindow.py:110
@@ -2507,8 +2507,8 @@ msgid "Stroke trail-off beginning"
 msgstr "筆劃結尾開端"
 
 #: ../gui/linemode.py:173
-msgid "Pressure variation..."
-msgstr "壓力變化 …"
+msgid "Pressure variation…"
+msgstr "壓力變化…"
 
 #: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
@@ -3673,7 +3673,7 @@ msgstr "從磁碟中刪除筆刷"
 #, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid "_Recover & Save…"
-msgstr "_回復並儲存..."
+msgstr "_回復並儲存…"
 
 #: ../po/tmp/autorecover.glade.h:12
 #, fuzzy
@@ -4627,7 +4627,7 @@ msgstr "開啟…"
 #: ../po/tmp/resources.xml.h:5
 msgctxt "Toolbar (short labels)"
 msgid "Open"
-msgstr "開啟..."
+msgstr "開啟…"
 
 #: ../po/tmp/resources.xml.h:6
 msgctxt "Toolbar (tooltips), Accel Editor (descriptions)"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mypaint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-11 21:24+0100\n"
+"POT-Creation-Date: 2019-09-08 22:53+0200\n"
 "PO-Revision-Date: 2017-08-02 06:48+0000\n"
 "Last-Translator: Jeff Huang <s8321414@gmail.com>\n"
-"Language-Team: Chinese (Traditional) "
-"<https://hosted.weblate.org/projects/mypaint/mypaint/zh_Hant/>\n"
+"Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
+"mypaint/mypaint/zh_Hant/>\n"
 "Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,29 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 2.16-dev\n"
 
-#: ../gui/accelmap.py:55
-#, python-brace-format
-msgctxt "Accelerator map editor: action column markup"
-msgid ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-msgstr ""
-"<b>{action_label}</b><small>\n"
-"{action_desc}</small>"
-
-#: ../gui/accelmap.py:59
-#, python-brace-format
-msgctxt "Accelerator map editor: accelerator key column markup"
-msgid "<big><b>{accel_label}</b></big>"
-msgstr "<big><b>{accel_label}</b></big>"
-
-#: ../gui/accelmap.py:63
-#, python-brace-format
-msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
-msgid "{action_label} {action_desc} {accel_label}"
-msgstr "{action_label} {action_desc} {accel_label}"
-
-#: ../gui/accelmap.py:99 ../gui/buttonmap.py:278
+#: ../gui/accelmap.py:99 ../gui/buttonmap.py:280
 msgid "Action"
 msgstr "動作"
 
@@ -49,39 +27,39 @@ msgstr "動作"
 msgid "Key combination"
 msgstr "按鍵組合"
 
-#: ../gui/accelmap.py:270
+#: ../gui/accelmap.py:295
 #, python-format
 msgid "Edit Key for '%s'"
 msgstr "編輯「%s」的按鍵綁定"
 
-#: ../gui/accelmap.py:301 ../gui/buttonmap.py:493
+#: ../gui/accelmap.py:326 ../gui/buttonmap.py:491
 msgid "Action:"
 msgstr "動作："
 
-#: ../gui/accelmap.py:314
+#: ../gui/accelmap.py:339
 msgid "Path:"
 msgstr "路徑："
 
-#: ../gui/accelmap.py:325
+#: ../gui/accelmap.py:350
 msgid "Key:"
 msgstr "按鍵："
 
-#: ../gui/accelmap.py:363
+#: ../gui/accelmap.py:388
 msgid "Press keys to update this assignment"
 msgstr "按任何鍵更新此設置"
 
-#: ../gui/accelmap.py:416
+#: ../gui/accelmap.py:443
 msgid "Unknown Action"
 msgstr "未知動作"
 
-#: ../gui/accelmap.py:425
+#: ../gui/accelmap.py:452
 #, python-brace-format
 msgid ""
 "<b>{accel} is already in use for '{action}'. The existing assignment will be "
 "replaced.</b>"
 msgstr "<b>{accel} 經已被 「{action}」 使用，現存配置將會被取代。</b>"
 
-#: ../gui/application.py:634
+#: ../gui/application.py:702
 #, python-brace-format
 msgid "Open Folder “{folder_basename}”…"
 msgstr "開啟資料夾「{folder_basename}」…"
@@ -89,193 +67,204 @@ msgstr "開啟資料夾「{folder_basename}」…"
 #. ... so that the main actions end up in the bottom-right of the
 #. dialog (reversed for rtl scripts), where the eye ends up
 #. naturally at the end of the flow.
-#: ../gui/application.py:642
+#: ../gui/application.py:710
 msgid "OK"
 msgstr "確定"
 
-#: ../gui/autorecover.py:70
+#: ../gui/autorecover.py:138
 msgid "No backups were found in the cache."
 msgstr "緩衝儲存中沒有發現任何備份。"
 
-#: ../gui/autorecover.py:71
+#: ../gui/autorecover.py:139
 msgid "No Available Backups"
 msgstr "沒有有效備份"
 
-#: ../gui/autorecover.py:74
+#: ../gui/autorecover.py:142
 msgid "Open the Cache Folder…"
 msgstr "開啟快取資料夾…"
 
-#: ../gui/autorecover.py:120
+#: ../gui/autorecover.py:171
 msgid "Backup Recovery Failed"
 msgstr "備份還原失敗"
 
-#: ../gui/autorecover.py:123
+#: ../gui/autorecover.py:174
 msgid "Open the Backup’s Folder…"
 msgstr "開啟備份的資料夾…"
 
-#: ../gui/autorecover.py:130
+#: ../gui/autorecover.py:182
 #, python-brace-format
 msgid "Recovered file from {iso_datetime}.ora"
 msgstr "從 {iso_datetime}.ora 還原檔案"
 
-#: ../gui/backgroundwindow.py:51
+#: ../gui/backgroundwindow.py:56
 msgid "Save as Default"
 msgstr "儲存為預設"
 
-#: ../gui/backgroundwindow.py:57
+#: ../gui/backgroundwindow.py:62
 msgid "Background"
 msgstr "背景"
 
-#: ../gui/backgroundwindow.py:75
+#: ../gui/backgroundwindow.py:80
 msgid "Pattern"
 msgstr "圖樣"
 
-#: ../gui/backgroundwindow.py:87 ../lib/modes.py:96
+#: ../gui/backgroundwindow.py:91 ../lib/modes.py:102
 msgid "Color"
 msgstr "色彩"
 
-#: ../gui/backgroundwindow.py:93
+#: ../gui/backgroundwindow.py:97
 msgid "Add color to Patterns"
 msgstr "將色彩加入到圖樣"
 
-#: ../gui/backgroundwindow.py:255
+#: ../gui/backgroundwindow.py:261
 msgid "One or more backgrounds could not be loaded"
 msgstr "無法載入一個或多個背景"
 
-#: ../gui/backgroundwindow.py:256
+#: ../gui/backgroundwindow.py:262
 msgid "Error loading backgrounds"
 msgstr "載入背景發生錯誤"
 
-#: ../gui/backgroundwindow.py:257
+#: ../gui/backgroundwindow.py:263
 msgid ""
 "Please remove the unloadable files, or check your libgdkpixbuf installation."
 msgstr "請移除無法載入的檔案，或是檢查您的 libgdkpixbuf 安裝是否完整。"
 
-#: ../gui/backgroundwindow.py:359
+#: ../gui/backgroundwindow.py:377
 #, python-brace-format
 msgid "Gdk-Pixbuf couldn't load \"{filename}\", and reported \"{error}\""
 msgstr "Gdk-Pixbuf 無法載入「{filename}」，並回報「{error}」"
 
-#: ../gui/backgroundwindow.py:369
+#: ../gui/backgroundwindow.py:387
 #, python-brace-format
 msgid "{filename} has zero size (w={w}, h={h})"
 msgstr "{filename} 的大小為零 (w={w}, h={h})"
 
-#: ../gui/brusheditor.py:80
+#: ../gui/brusheditor.py:90
 msgctxt "brush settings editor: subwindow title"
 msgid "Brush Settings Editor"
 msgstr "筆刷設定編輯器"
 
-#: ../gui/brusheditor.py:264
+#: ../gui/brusheditor.py:267
 msgctxt "brush settings list: brush metadata texts group"
 msgid "About"
 msgstr "關於"
 
-#: ../gui/brusheditor.py:275
+#: ../gui/brusheditor.py:278
 msgctxt "brush settings list: setting group"
 msgid "Experimental"
 msgstr "實驗性"
 
-#: ../gui/brusheditor.py:282
+#: ../gui/brusheditor.py:285
 msgctxt "brush settings list: setting group"
 msgid "Basic"
 msgstr "基本"
 
-#: ../gui/brusheditor.py:300
+#: ../gui/brusheditor.py:304
 msgctxt "brush settings list: setting group"
 msgid "Opacity"
 msgstr "不透明度"
 
-#: ../gui/brusheditor.py:312
+#: ../gui/brusheditor.py:316
 msgctxt "brush settings list: setting group"
 msgid "Dabs"
 msgstr "筆觸"
 
-#: ../gui/brusheditor.py:323
+#: ../gui/brusheditor.py:327
 msgctxt "brush settings list: setting group"
 msgid "Smudge"
 msgstr "塗抹"
 
-#: ../gui/brusheditor.py:334
+#: ../gui/brusheditor.py:338
 msgctxt "brush settings list: setting group"
 msgid "Speed"
 msgstr "速度"
 
-#: ../gui/brusheditor.py:348
+#: ../gui/brusheditor.py:352
+#, fuzzy
+msgctxt "brush settings list: setting group"
+msgid "Directional Offsets"
+msgstr "方向過濾"
+
+#: ../gui/brusheditor.py:370
 msgctxt "brush settings list: setting group"
 msgid "Tracking"
 msgstr "追跡"
 
-#: ../gui/brusheditor.py:359
+#: ../gui/brusheditor.py:381
 msgctxt "brush settings list: setting group"
 msgid "Stroke"
 msgstr "筆劃"
 
-#: ../gui/brusheditor.py:370
+#: ../gui/brusheditor.py:392
 msgctxt "brush settings list: setting group"
 msgid "Color"
 msgstr "色彩"
 
-#: ../gui/brusheditor.py:385
+#: ../gui/brusheditor.py:407
+msgctxt "brush settings list: setting group"
+msgid "GridMap"
+msgstr ""
+
+#: ../gui/brusheditor.py:418
 msgctxt "brush settings list: setting group"
 msgid "Custom"
 msgstr "自訂"
 
-#: ../gui/brusheditor.py:454
+#: ../gui/brusheditor.py:484
 msgctxt "brush settings editor: save brush: error message"
 msgid "No brush selected, please use “Add As New” instead."
 msgstr "尚未選取筆刷，請改用「加入為新筆刷」。"
 
-#: ../gui/brusheditor.py:479
+#: ../gui/brusheditor.py:509
 msgctxt "brush settings editor: rename brush: error message"
 msgid "No brush selected!"
 msgstr "沒有選擇筆刷！"
 
-#: ../gui/brusheditor.py:488
+#: ../gui/brusheditor.py:518
 msgctxt "brush settings editor: rename brush: dialog title"
 msgid "Rename Brush"
 msgstr "重新命名筆刷"
 
-#: ../gui/brusheditor.py:505
+#: ../gui/brusheditor.py:536
 msgctxt "brush settings editor: rename brush: error message"
 msgid "A brush with this name already exists!"
 msgstr "已經存在相同名稱的筆刷！"
 
-#: ../gui/brusheditor.py:539
+#: ../gui/brusheditor.py:570
 msgctxt "brush settings editor: delete brush: error message"
 msgid "No brush selected!"
 msgstr "沒有選擇筆刷！"
 
-#: ../gui/brusheditor.py:545
+#: ../gui/brusheditor.py:576
 #, python-brace-format
 msgctxt "brush settings editor: delete brush: confirm dialog question"
 msgid "Really delete brush “{brush_name}” from disk?"
 msgstr "確定要從磁碟中刪除「{brush_name}」筆刷？"
 
-#: ../gui/brusheditor.py:664
+#: ../gui/brusheditor.py:695
 msgctxt "brush settings editor: header: fallback name"
 msgid "(Unnamed brush)"
 msgstr "(未命名的筆刷)"
 
-#: ../gui/brusheditor.py:671
+#: ../gui/brusheditor.py:702
 #, python-brace-format
 msgctxt "brush settings editor: header: is-modified hint"
 msgid "{brush_name} [unsaved]"
 msgstr "{brush_name} [未儲存]"
 
-#: ../gui/brushiconeditor.py:37
+#: ../gui/brushiconeditor.py:36
 msgid "Brush Icon"
 msgstr "筆刷圖示"
 
-#: ../gui/brushiconeditor.py:38
+#: ../gui/brushiconeditor.py:37
 msgid "Brush Icon (editing)"
 msgstr "筆刷圖示 (編輯中)"
 
-#: ../gui/brushiconeditor.py:75
+#: ../gui/brushiconeditor.py:74
 msgid "No brush selected"
 msgstr "未有選擇筆刷"
 
-#: ../gui/brushiconeditor.py:77
+#: ../gui/brushiconeditor.py:76
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -284,7 +273,7 @@ msgstr ""
 "<b>%s</b>\n"
 "<small>請先選擇有效筆刷</small>"
 
-#: ../gui/brushiconeditor.py:80
+#: ../gui/brushiconeditor.py:79
 #, python-format
 msgid ""
 "<b>%s</b> <i>(modified)</i>\n"
@@ -293,7 +282,7 @@ msgstr ""
 "<b>%s</b> <i>(已變更)</i>\n"
 "<small>變更還未儲存</small>"
 
-#: ../gui/brushiconeditor.py:83
+#: ../gui/brushiconeditor.py:82
 #, python-format
 msgid ""
 "<b>%s</b> (editing)\n"
@@ -302,7 +291,7 @@ msgstr ""
 "<b>%s</b> (編輯中)\n"
 "<small>請用任何筆刷和色彩繪畫</small>"
 
-#: ../gui/brushiconeditor.py:86
+#: ../gui/brushiconeditor.py:85
 #, python-format
 msgid ""
 "<b>%s</b>\n"
@@ -343,141 +332,181 @@ msgstr "自動"
 msgid "Use the default icon"
 msgstr "使用預設圖示"
 
-#: ../gui/brushiconeditor.py:194 ../po/tmp/brusheditor.glade.h:11
+#: ../gui/brushiconeditor.py:190 ../po/tmp/brusheditor.glade.h:3
 msgid "Save"
 msgstr "儲存"
 
-#: ../gui/brushiconeditor.py:196
+#: ../gui/brushiconeditor.py:192
 msgid "Save this preview icon, and finish editing"
 msgstr "儲存此預覽圖示及完成編輯"
 
-#: ../gui/brushmanager.py:98
+#: ../gui/brushmanager.py:128
 msgid "Lost & Found"
 msgstr "遺失與尋回"
 
-#: ../gui/brushmanager.py:99
+#: ../gui/brushmanager.py:129
 msgid "Deleted"
 msgstr "刪除的"
 
-#: ../gui/brushmanager.py:100
+#: ../gui/brushmanager.py:130
 msgid "Favorites"
 msgstr "喜愛"
 
-#: ../gui/brushmanager.py:101
+#: ../gui/brushmanager.py:131
 msgid "Ink"
 msgstr "墨水"
 
-#: ../gui/brushmanager.py:102
+#: ../gui/brushmanager.py:132
 msgid "Classic"
 msgstr "經典"
 
-#: ../gui/brushmanager.py:103
+#: ../gui/brushmanager.py:133
 msgid "Set#1"
 msgstr "組#1"
 
-#: ../gui/brushmanager.py:104
+#: ../gui/brushmanager.py:134
 msgid "Set#2"
 msgstr "組#2"
 
-#: ../gui/brushmanager.py:105
+#: ../gui/brushmanager.py:135
 msgid "Set#3"
 msgstr "組#3"
 
-#: ../gui/brushmanager.py:106
+#: ../gui/brushmanager.py:136
 msgid "Set#4"
 msgstr "組#4"
 
-#: ../gui/brushmanager.py:107
+#: ../gui/brushmanager.py:137
 msgid "Set#5"
 msgstr "組#5"
 
-#: ../gui/brushmanager.py:108
+#: ../gui/brushmanager.py:138
 msgid "Experimental"
 msgstr "實驗性"
 
-#: ../gui/brushmanager.py:109
+#: ../gui/brushmanager.py:139
 msgid "New"
 msgstr "新增"
 
-#: ../gui/brushmanager.py:967
+#: ../gui/brushmanager.py:614
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid "No file named “{order_conf_file}”. This is not a brushpack."
+msgstr ""
+
+#: ../gui/brushmanager.py:639
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” is listed in “{order_conf_file}”, but it does not exist "
+"in the zipfile."
+msgstr ""
+
+#: ../gui/brushmanager.py:652
+#, python-brace-format
+msgctxt "brushpack import failure messages"
+msgid ""
+"Brush “{brush_name}” exists in the zipfile, but it is not listed in "
+"“{order_conf_file}”."
+msgstr ""
+
+#: ../gui/brushmanager.py:1258 ../gui/footer.py:62
 msgid "Unknown Brush"
 msgstr "未知筆刷"
 
-#: ../gui/brushselectionwindow.py:183
-msgctxt "brush list context menu"
-msgid "Add to favorites"
+#: ../gui/brushselectionwindow.py:220
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Add to Favorites"
 msgstr "加到我的最愛"
 
-#: ../gui/brushselectionwindow.py:187
-msgctxt "brush list context menu"
-msgid "Remove from favorites"
+#: ../gui/brushselectionwindow.py:227
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Favorites"
 msgstr "從我的最愛中移除"
 
-#: ../gui/brushselectionwindow.py:192
-msgctxt "brush list context menu"
+#: ../gui/brushselectionwindow.py:235
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
 msgid "Clone"
 msgstr "複製"
 
-#: ../gui/brushselectionwindow.py:196
-msgctxt "brush list context menu"
-msgid "Edit brush settings"
+#: ../gui/brushselectionwindow.py:242
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Edit Brush Settings"
 msgstr "編輯筆刷設定"
 
-#: ../gui/brushselectionwindow.py:201
-msgctxt "brush list context menu"
-msgid "Delete"
-msgstr "刪除"
+#: ../gui/brushselectionwindow.py:250
+#, fuzzy
+msgctxt "brush group: context menu for a single brush"
+msgid "Remove from Group"
+msgstr "重新命名群組"
 
-#: ../gui/brushselectionwindow.py:241
-msgctxt "brush list commands"
-msgid "Really delete brush from disk?"
-msgstr "確定要從磁碟中刪除筆刷？"
+#: ../gui/brushselectionwindow.py:290
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:299
+#, python-brace-format
+msgctxt "brush group: context menu: unique names for cloned brushes"
+msgid "{original_name} copy {n}"
+msgstr ""
+
+#: ../gui/brushselectionwindow.py:325
+#, fuzzy, python-brace-format
+msgctxt "brush group: context menu: remove from group"
+msgid "Really remove brush “{brush_name}” from group “{group_name}”?"
+msgstr "確定要從磁碟中刪除「{brush_name}」筆刷？"
 
 #. TRANSLATORS: number of brushes in a brush group, for tooltips
-#: ../gui/brushselectionwindow.py:295
+#: ../gui/brushselectionwindow.py:381
 #, python-format
 msgid "%d brush"
 msgid_plural "%d brushes"
 msgstr[0] "%d 筆刷"
 
-#: ../gui/brushselectionwindow.py:323
+#: ../gui/brushselectionwindow.py:407
 #, python-brace-format
 msgctxt "brush group properties dialog: title"
 msgid "Group “{group_name}”"
 msgstr "「{group_name}」 群組"
 
-#: ../gui/brushselectionwindow.py:332
+#: ../gui/brushselectionwindow.py:417
 msgctxt "brush group properties dialog: action buttons"
 msgid "Rename Group"
 msgstr "重新命名群組"
 
-#: ../gui/brushselectionwindow.py:338
+#: ../gui/brushselectionwindow.py:423
 msgctxt "brush group properties dialog: action buttons"
 msgid "Export as Zipped Brushset"
 msgstr "匯出成筆刷組壓縮檔"
 
-#: ../gui/brushselectionwindow.py:344
+#: ../gui/brushselectionwindow.py:429
 msgctxt "brush group properties dialog: action buttons"
 msgid "Delete Group"
 msgstr "刪除群組"
 
-#: ../gui/brushselectionwindow.py:364
+#: ../gui/brushselectionwindow.py:449
 msgctxt "brush group rename dialog: title"
 msgid "Rename Group"
 msgstr "重新命名群組"
 
-#: ../gui/brushselectionwindow.py:382
+#: ../gui/brushselectionwindow.py:467
 msgctxt "brush group rename"
 msgid "A group with this name already exists!"
 msgstr "已經存在相同名稱的群組！"
 
-#: ../gui/brushselectionwindow.py:391
+#: ../gui/brushselectionwindow.py:476
 #, python-brace-format
 msgctxt "brush group delete"
 msgid "Really delete group “{group_name}”?"
 msgstr "確定要刪除群組 「{group_name}」？"
 
-#: ../gui/brushselectionwindow.py:409
+#: ../gui/brushselectionwindow.py:494
 #, python-brace-format
 msgctxt "brush group delete"
 msgid ""
@@ -487,58 +516,58 @@ msgstr ""
 "無法刪除「{group_name}」。\n"
 "部份特殊群組無法被刪除。"
 
-#: ../gui/brushselectionwindow.py:420
+#: ../gui/brushselectionwindow.py:509
 msgctxt "brush group export dialog: title"
 msgid "Export Brushes"
 msgstr "匯出筆刷"
 
-#: ../gui/brushselectionwindow.py:425
+#: ../gui/brushselectionwindow.py:514
 msgctxt "brush group export dialog"
 msgid "MyPaint brush package (*.zip)"
 msgstr "MyPaint 筆刷包 (*.zip)"
 
-#: ../gui/brushselectionwindow.py:445
+#: ../gui/brushselectionwindow.py:534
 msgctxt "brush groups menu"
 msgid "New Group..."
 msgstr "新增類組..."
 
-#: ../gui/brushselectionwindow.py:448
+#: ../gui/brushselectionwindow.py:537
 msgctxt "brush groups menu"
 msgid "Import Brushes..."
 msgstr "匯入筆刷..."
 
-#: ../gui/brushselectionwindow.py:451
+#: ../gui/brushselectionwindow.py:540
 msgctxt "brush groups menu"
 msgid "Get More Brushes..."
 msgstr "取得更多筆刷..."
 
-#: ../gui/brushselectionwindow.py:465
+#: ../gui/brushselectionwindow.py:554
 msgctxt "new brush group dialog: title"
 msgid "Create Group"
 msgstr "建立類組"
 
-#: ../gui/buttonmap.py:56
+#: ../gui/buttonmap.py:58
 msgid "Button"
 msgstr "按鈕"
 
 #. TRANSLATORS: abbreviated "Button <number>" for forms like "Alt+Btn1"
-#: ../gui/buttonmap.py:59
+#: ../gui/buttonmap.py:61
 msgid "Btn"
 msgstr "按鈕"
 
-#: ../gui/buttonmap.py:293
+#: ../gui/buttonmap.py:295
 msgid "Button press"
 msgstr "按鈕按壓"
 
-#: ../gui/buttonmap.py:311
+#: ../gui/buttonmap.py:313
 msgid "Add a new binding"
 msgstr "加入新的按鍵綁定"
 
-#: ../gui/buttonmap.py:319
+#: ../gui/buttonmap.py:321
 msgid "Remove the current binding"
 msgstr "重新載入目前的按鍵綁定"
 
-#: ../gui/buttonmap.py:470
+#: ../gui/buttonmap.py:468
 #, python-format
 msgid "Edit binding for '%s'"
 msgstr "編輯「%s」的按鍵綁定"
@@ -547,52 +576,80 @@ msgstr "編輯「%s」的按鍵綁定"
 msgid "Button press:"
 msgstr "按鈕按壓："
 
-#: ../gui/buttonmap.py:537
+#: ../gui/buttonmap.py:541
 msgid ""
 "Hold down modifier keys, and press a button over this text to set a new "
 "binding."
 msgstr "按住修飾鍵不放，接著在此文字上按壓一個按鈕以設定新的按鍵綁定。"
 
-#: ../gui/buttonmap.py:559
+#: ../gui/buttonmap.py:569
 #, python-brace-format
 msgid ""
 "{button} cannot be bound without modifier keys (its meaning is fixed, sorry)"
 msgstr "{button} 必須與修飾鍵一同綁定 (對不起，其功能固定)"
 
-#: ../gui/buttonmap.py:574
+#: ../gui/buttonmap.py:584
 #, python-brace-format
 msgid "{button_combination} is already bound to the action '{action_name}'"
 msgstr "{button_combination} 已經與「{action_name}」動作綁定起來"
 
-#: ../gui/colorpicker.py:71
+#: ../gui/colorpicker.py:65
 msgid "Pick Color"
 msgstr "挑選顏色"
 
-#: ../gui/colorpicker.py:74
+#: ../gui/colorpicker.py:68
 msgid "Set the color used for painting"
 msgstr "設定用來繪畫的色彩"
 
-#: ../gui/colors/adjbases.py:707
+#: ../gui/colorpicker.py:270
+msgid "Pick Hue"
+msgstr ""
+
+#: ../gui/colorpicker.py:273
+#, fuzzy
+msgid "Set the color Hue used for painting"
+msgstr "設定用來繪畫的色彩"
+
+#: ../gui/colorpicker.py:293
+#, fuzzy
+msgid "Pick Chroma"
+msgstr "挑選顏色。"
+
+#: ../gui/colorpicker.py:296
+#, fuzzy
+msgid "Set the color Chroma used for painting"
+msgstr "設定用來繪畫的色彩"
+
+#: ../gui/colorpicker.py:316
+msgid "Pick Luma"
+msgstr ""
+
+#: ../gui/colorpicker.py:319
+#, fuzzy
+msgid "Set the color Luma used for painting"
+msgstr "設定用來繪畫的色彩"
+
+#: ../gui/colors/adjbases.py:699
 msgid "Color details"
 msgstr "色彩詳細資訊"
 
-#: ../gui/colors/adjbases.py:831
+#: ../gui/colors/adjbases.py:872
 msgid "Current brush color, and the color most recently used for painting"
 msgstr "目前筆刷的顏色，及最近使用於繪圖的顏色"
 
-#: ../gui/colors/hcywheel.py:48
+#: ../gui/colors/hcywheel.py:49
 msgctxt "Online help pages"
 msgid ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 msgstr ""
 "https://github.com/mypaint/mypaint/wiki/v1.2-HCY-Wheel-and-Gamut-Mask-Editor"
 
-#: ../gui/colors/hcywheel.py:86
+#: ../gui/colors/hcywheel.py:87
 msgctxt "Color Wheels: activity toggle: action title"
 msgid "Gamut Mask Active"
 msgstr "色域遮罩作用中"
 
-#: ../gui/colors/hcywheel.py:90
+#: ../gui/colors/hcywheel.py:91
 msgctxt "Color Wheels: activity toggle: action tooltip"
 msgid "Limit your palette for specific moods using a gamut mask."
 msgstr "使用色域遮罩來將您的調色盤限制在特定色調上。"
@@ -602,137 +659,138 @@ msgctxt "HCY Color Wheel: tooltip"
 msgid "HCY hue and chroma."
 msgstr "HCY 色相與彩度。"
 
-#: ../gui/colors/hcywheel.py:411
+#: ../gui/colors/hcywheel.py:412
 msgctxt "HCY Mask Editor Wheel: tooltip"
 msgid ""
 "Gamut mask editor. Click in the middle to create or manipulate shapes, or "
 "rotate the mask using the edges of the disc."
-msgstr "色域遮罩編輯器。按一下中間可建立或操控外形，或是使用圓盤的邊緣來旋轉遮罩。"
+msgstr ""
+"色域遮罩編輯器。按一下中間可建立或操控外形，或是使用圓盤的邊緣來旋轉遮罩。"
 
-#: ../gui/colors/hcywheel.py:893
+#: ../gui/colors/hcywheel.py:910
 msgctxt "HCY Gamut Mask template name"
 msgid "Atmospheric Triad"
 msgstr "氣氛三角"
 
-#: ../gui/colors/hcywheel.py:897
+#: ../gui/colors/hcywheel.py:914
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Moody and subjective, defined by one dominant primary and two primaries "
 "which are less intense."
 msgstr "富情緒、主觀，由一個首要主色與兩個較不強烈的主色定義而成。"
 
-#: ../gui/colors/hcywheel.py:905
+#: ../gui/colors/hcywheel.py:922
 msgctxt "HCY Gamut Mask template name"
 msgid "Shifted Triad"
 msgstr "轉移三角"
 
-#: ../gui/colors/hcywheel.py:909
+#: ../gui/colors/hcywheel.py:926
 msgctxt "HCY Gamut Mask template description"
 msgid "Weighted more strongly towards the dominant color."
 msgstr "更強烈加重主色。"
 
-#: ../gui/colors/hcywheel.py:920
+#: ../gui/colors/hcywheel.py:937
 msgctxt "HCY Gamut Mask template name"
 msgid "Complementary"
 msgstr "互補"
 
-#: ../gui/colors/hcywheel.py:924
+#: ../gui/colors/hcywheel.py:941
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Contrasting opposites, balanced by having central neutrals between them on "
 "the color wheel."
 msgstr "具對比的相對色，色輪間有中央的中立色在這些色彩間達成平衡。"
 
-#: ../gui/colors/hcywheel.py:940
+#: ../gui/colors/hcywheel.py:957
 msgctxt "HCY Gamut Mask template name"
 msgid "Mood and Accent"
 msgstr "基調與強調"
 
-#: ../gui/colors/hcywheel.py:944
+#: ../gui/colors/hcywheel.py:961
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "One main range of colors, with a complementary accent for variation and "
 "highlights."
 msgstr "一個主要的色彩範圍，加上變化、醒目的互補強調。"
 
-#: ../gui/colors/hcywheel.py:953
+#: ../gui/colors/hcywheel.py:970
 msgctxt "HCY Gamut Mask template name"
 msgid "Split Complementary"
 msgstr "切分補色"
 
-#: ../gui/colors/hcywheel.py:957
+#: ../gui/colors/hcywheel.py:974
 msgctxt "HCY Gamut Mask template description"
 msgid ""
 "Two analogous colors and a complement to them, with no secondary colors "
 "between them."
 msgstr "兩個類比色與一個前兩者的互補色，它們之間沒有次色。"
 
-#: ../gui/colors/hcywheel.py:969
+#: ../gui/colors/hcywheel.py:985
 msgctxt "HCY Gamut Mask new-from-template dialog: window title"
 msgid "New Gamut Mask from Template"
 msgstr "從樣板添加新色域遮罩"
 
-#: ../gui/colors/hcywheel.py:1038
+#: ../gui/colors/hcywheel.py:1054
 msgctxt "HCY Gamut Mask Editor dialog: window title"
 msgid "Gamut Mask Editor"
 msgstr "色域遮罩編輯器"
 
-#: ../gui/colors/hcywheel.py:1061
+#: ../gui/colors/hcywheel.py:1078
 msgctxt "HCY Gamut Mask Editor dialog: mask-is-active checkbox"
 msgid "Active"
 msgstr "有效"
 
-#: ../gui/colors/hcywheel.py:1085
+#: ../gui/colors/hcywheel.py:1102
 msgctxt "HCY Mask Editor: action button labels"
 msgid "Help…"
 msgstr "幫助…"
 
-#: ../gui/colors/hcywheel.py:1091
+#: ../gui/colors/hcywheel.py:1108
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Create mask from template."
 msgstr "以樣板建立遮罩。"
 
-#: ../gui/colors/hcywheel.py:1095
+#: ../gui/colors/hcywheel.py:1112
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Load mask from a GIMP palette file."
 msgstr "從 GIMP 調色盤檔載入遮罩。"
 
-#: ../gui/colors/hcywheel.py:1099
+#: ../gui/colors/hcywheel.py:1116
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Save mask to a GIMP palette file."
 msgstr "將遮罩儲存至 GIMP 調色盤檔。"
 
-#: ../gui/colors/hcywheel.py:1103
+#: ../gui/colors/hcywheel.py:1120
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Erase the mask."
 msgstr "消除遮罩。"
 
-#: ../gui/colors/hcywheel.py:1107
+#: ../gui/colors/hcywheel.py:1124
 msgctxt "HCY Mask Editor: action button tooltips"
 msgid "Open the online help for this dialog in a web browser."
 msgstr "在瀏覽器中開啟此對話窗的線上幫助。"
 
-#: ../gui/colors/hcywheel.py:1174
+#: ../gui/colors/hcywheel.py:1191
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Save Mask as a GIMP Palette"
 msgstr "儲存遮罩作為一個 Gimp 調色盤"
 
-#: ../gui/colors/hcywheel.py:1191
+#: ../gui/colors/hcywheel.py:1208
 msgctxt "HCY Gamut Mask load dialog: window title"
 msgid "Load Mask from a GIMP Palette"
 msgstr "從 GIMP 調色盤載入遮罩"
 
-#: ../gui/colors/hcywheel.py:1257
+#: ../gui/colors/hcywheel.py:1275
 msgctxt "HCY Wheel color adjuster page: properties tooltip."
 msgid "Set gamut mask."
 msgstr "設定色域遮罩。"
 
-#: ../gui/colors/hcywheel.py:1275
+#: ../gui/colors/hcywheel.py:1293
 msgctxt "HCY Wheel color adjuster page: title for tooltips etc."
 msgid "HCY Wheel"
 msgstr "HCY 色輪"
 
-#: ../gui/colors/hcywheel.py:1282
+#: ../gui/colors/hcywheel.py:1300
 msgctxt "HCY Wheel color adjuster page: description for tooltips etc."
 msgid ""
 "Set the color using cylindrical hue/chroma/luma space. The circular slices "
@@ -740,162 +798,154 @@ msgid ""
 msgstr "使用色相/彩度/明度空間圓柱體設定色彩。圓形切塊皆為相等。"
 
 #. Tooltip mappings, indexed by whatever the slider currently represents
-#: ../gui/colors/hsvcube.py:37 ../gui/colors/hsvsquare.py:129
+#: ../gui/colors/hsvcube.py:46 ../gui/colors/hsvsquare.py:133
 msgid "HSV Hue"
 msgstr "HSV 色相"
 
-#: ../gui/colors/hsvcube.py:38
+#: ../gui/colors/hsvcube.py:47
 msgid "HSV Saturation"
 msgstr "HSV 飽和度"
 
-#: ../gui/colors/hsvcube.py:39
+#: ../gui/colors/hsvcube.py:48
 msgid "HSV Value"
 msgstr "HSV 明度"
 
-#: ../gui/colors/hsvcube.py:40 ../gui/colors/hsvsquare.py:130
+#: ../gui/colors/hsvcube.py:49 ../gui/colors/hsvsquare.py:134
 msgid "HSV Saturation and Value"
 msgstr "HSV 飽和度與明度"
 
-#: ../gui/colors/hsvcube.py:41
+#: ../gui/colors/hsvcube.py:50
 msgid "HSV Hue and Value"
 msgstr "HSV 色相與明度"
 
-#: ../gui/colors/hsvcube.py:42 ../gui/colors/hsvwheel.py:33
+#: ../gui/colors/hsvcube.py:51 ../gui/colors/hsvwheel.py:31
 msgid "HSV Hue and Saturation"
 msgstr "HSV 色相與飽和度"
 
-#: ../gui/colors/hsvcube.py:54
+#: ../gui/colors/hsvcube.py:59
 msgid "Rotate cube (show different axes)"
 msgstr "旋轉方塊 (顯示不同的軸)"
 
-#: ../gui/colors/hsvcube.py:74
+#: ../gui/colors/hsvcube.py:86
 msgid "HSV Cube"
 msgstr "HSV 方塊"
 
-#: ../gui/colors/hsvcube.py:78
+#: ../gui/colors/hsvcube.py:90
 msgid "An HSV cube which can be rotated to show different planar slices."
 msgstr "可以旋轉 HSV 方塊來顯示不同的平面切塊。"
 
-#: ../gui/colors/hsvsquare.py:57
+#: ../gui/colors/hsvsquare.py:56
 msgid "HSV Square"
 msgstr "HSV 方塊"
 
-#: ../gui/colors/hsvsquare.py:61
+#: ../gui/colors/hsvsquare.py:60
 msgid "An HSV Square which can be rotated to show different hues."
 msgstr "HSV 方塊可以旋轉來顯示不同色相。"
 
-#: ../gui/colors/hsvtriangle.py:47
-msgid "HSV Triangle"
-msgstr "HSV 三角"
-
-#: ../gui/colors/hsvtriangle.py:51
-msgid "The standard GTK color selector"
-msgstr "標準 GTK 撿色器"
-
-#: ../gui/colors/hsvwheel.py:89
+#: ../gui/colors/hsvwheel.py:91
 msgid "HSV Wheel"
 msgstr "HSV 色輪"
 
-#: ../gui/colors/hsvwheel.py:93
+#: ../gui/colors/hsvwheel.py:95
 msgid "Saturation and Value color changer."
 msgstr "飽和度與明度的換色器。"
 
-#: ../gui/colors/paletteview.py:72
+#: ../gui/colors/paletteview.py:67
 msgctxt "palette panel: properties button tooltip"
 msgid "Palette properties"
 msgstr "調色盤屬性"
 
-#: ../gui/colors/paletteview.py:81
+#: ../gui/colors/paletteview.py:76
 msgctxt "palette panel tab tooltip title"
 msgid "Palette"
 msgstr "調色盤"
 
-#: ../gui/colors/paletteview.py:87
+#: ../gui/colors/paletteview.py:82
 msgctxt "palette panel tab tooltip description"
 msgid "Set the color from a loadable, editable palette."
 msgstr "從一個可載入、可編輯的調色盤設定色彩。"
 
-#: ../gui/colors/paletteview.py:113
+#: ../gui/colors/paletteview.py:108
 msgctxt "palette editor dialog: palette name entry"
 msgid "Untitled Palette"
 msgstr "無標題調色盤"
 
-#: ../gui/colors/paletteview.py:120
+#: ../gui/colors/paletteview.py:115
 msgctxt "palette editor dialog: title"
 msgid "Palette Editor"
 msgstr "調色盤編輯器"
 
-#: ../gui/colors/paletteview.py:166
+#: ../gui/colors/paletteview.py:161
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Load from a GIMP palette file"
 msgstr "從一個 GIMP 調色盤檔載入"
 
-#: ../gui/colors/paletteview.py:170
+#: ../gui/colors/paletteview.py:165
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Save to a GIMP palette file"
 msgstr "儲存到一個 GIMP 調色盤檔"
 
-#: ../gui/colors/paletteview.py:174
+#: ../gui/colors/paletteview.py:169
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Add a new empty swatch"
 msgstr "加入新的空白色票"
 
-#: ../gui/colors/paletteview.py:178
+#: ../gui/colors/paletteview.py:173
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove the current swatch"
 msgstr "移除目前的色票"
 
-#: ../gui/colors/paletteview.py:182
+#: ../gui/colors/paletteview.py:177
 msgctxt "palette editor dialog: action buttons: tooltips"
 msgid "Remove all swatches"
 msgstr "移除所有色票"
 
-#: ../gui/colors/paletteview.py:196
+#: ../gui/colors/paletteview.py:191
 msgctxt "palette editor dialog: palette name/title entry: label"
 msgid "Title:"
 msgstr "標題："
 
-#: ../gui/colors/paletteview.py:200
+#: ../gui/colors/paletteview.py:195
 msgctxt "palette editor dialog: palette name/title entry: tooltip"
 msgid "Name or description for this palette"
 msgstr "此調色盤的名稱或描述"
 
-#: ../gui/colors/paletteview.py:212
+#: ../gui/colors/paletteview.py:207
 msgctxt "palette editor dialog: number-of-columns spinbutton: title"
 msgid "Columns:"
 msgstr "欄："
 
-#: ../gui/colors/paletteview.py:216
+#: ../gui/colors/paletteview.py:211
 msgctxt "palette editor dialog: number-of-columns spinbutton: tooltip"
 msgid "Number of columns"
 msgstr "欄數"
 
-#: ../gui/colors/paletteview.py:233
+#: ../gui/colors/paletteview.py:228
 msgctxt "palette editor dialog: color name entry: label"
 msgid "Color name:"
 msgstr "色彩名稱："
 
-#: ../gui/colors/paletteview.py:237
+#: ../gui/colors/paletteview.py:232
 msgctxt "palette editor dialog: color name entry: tooltip"
 msgid "Current color's name"
 msgstr "目前色彩的名稱"
 
-#: ../gui/colors/paletteview.py:328
+#: ../gui/colors/paletteview.py:323
 msgctxt "palette editor dialog: color name entry"
 msgid "Empty palette slot"
 msgstr "清空調色盤槽"
 
-#: ../gui/colors/paletteview.py:384
+#: ../gui/colors/paletteview.py:379
 msgctxt "palette load dialog: title"
 msgid "Load palette"
 msgstr "載入調色盤"
 
-#: ../gui/colors/paletteview.py:397
+#: ../gui/colors/paletteview.py:392
 msgctxt "palette save dialog: title"
 msgid "Save palette"
 msgstr "儲存調色盤"
 
-#: ../gui/colors/paletteview.py:549
+#: ../gui/colors/paletteview.py:544
 msgctxt "palette view"
 msgid ""
 "Color swatch palette.\n"
@@ -906,378 +956,375 @@ msgstr ""
 "將色彩拖放至此處，\n"
 "可四處拖曳進行整理。"
 
-#: ../gui/colors/paletteview.py:704
+#: ../gui/colors/paletteview.py:699
 msgctxt "palette view"
 msgid "Empty palette slot (drag a color here)"
 msgstr "淨空調色盤內的槽 (請將色彩拖曳至此)"
 
-#: ../gui/colors/paletteview.py:792
+#: ../gui/colors/paletteview.py:786
 msgctxt "palette view: context menu"
 msgid "Add Empty Slot"
 msgstr "加入空槽"
 
-#: ../gui/colors/paletteview.py:798
+#: ../gui/colors/paletteview.py:792
 msgctxt "palette view: context menu"
 msgid "Insert Row"
 msgstr "插入橫列"
 
-#: ../gui/colors/paletteview.py:804
+#: ../gui/colors/paletteview.py:798
 msgctxt "palette view: context menu"
 msgid "Insert Column"
 msgstr "插入直欄"
 
-#: ../gui/colors/paletteview.py:812
+#: ../gui/colors/paletteview.py:806
 msgctxt "palette view: context menu"
 msgid "Fill Gap (RGB)"
 msgstr "填充空隙 (RGB)"
 
-#: ../gui/colors/paletteview.py:818
+#: ../gui/colors/paletteview.py:812
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HCY)"
 msgstr "填充空隙 (HCY)"
 
-#: ../gui/colors/paletteview.py:824
+#: ../gui/colors/paletteview.py:818
 msgctxt "palette view: context menu"
 msgid "Fill Gap (HSV)"
 msgstr "填充空隙 (HSV)"
 
-#: ../gui/colors/paletteview.py:1282
+#: ../gui/colors/paletteview.py:1276
 msgctxt "palette load dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "GIMP 調色盤檔 (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1289
+#: ../gui/colors/paletteview.py:1283
 msgctxt "palette load dialog: filters"
 msgid "All files (*)"
 msgstr "所有檔案 (*)"
 
-#: ../gui/colors/paletteview.py:1331
+#: ../gui/colors/paletteview.py:1325
 msgctxt "palette save dialog: filters"
 msgid "GIMP palette file (*.gpl)"
 msgstr "GIMP 調色盤檔 (*.gpl)"
 
-#: ../gui/colors/paletteview.py:1338
+#: ../gui/colors/paletteview.py:1332
 msgctxt "palette save dialog: filters"
 msgid "All files (*)"
 msgstr "所有檔案 (*)"
 
-#: ../gui/colors/picker.py:100
-msgid "Pick a color from the screen"
-msgstr "從畫面中挑選顏色"
-
-#: ../gui/colors/sliders.py:44
+#: ../gui/colors/sliders.py:45
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "R"
 msgstr "R"
 
-#: ../gui/colors/sliders.py:48
+#: ../gui/colors/sliders.py:49
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "G"
 msgstr "G"
 
-#: ../gui/colors/sliders.py:52
+#: ../gui/colors/sliders.py:53
 msgctxt "color sliders panel: red/green/blue: slider label"
 msgid "B"
 msgstr "B"
 
-#: ../gui/colors/sliders.py:56
+#: ../gui/colors/sliders.py:57
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "H"
 msgstr "H"
 
-#: ../gui/colors/sliders.py:60
+#: ../gui/colors/sliders.py:61
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "C"
 msgstr "C"
 
-#: ../gui/colors/sliders.py:64
+#: ../gui/colors/sliders.py:65
 msgctxt "color sliders panel: hue/chroma/luma: slider label"
 msgid "Y"
 msgstr "Y"
 
-#: ../gui/colors/sliders.py:108
+#: ../gui/colors/sliders.py:109
 msgctxt "color sliders panel: tab title (in tooltip)"
 msgid "Component Sliders"
 msgstr "成份滑桿"
 
-#: ../gui/colors/sliders.py:115
+#: ../gui/colors/sliders.py:116
 msgctxt "color sliders panel: tab description (in tooltip)"
 msgid "Adjust individual components of the color."
 msgstr "調整色彩的各別成份。"
 
-#: ../gui/colors/sliders.py:160
+#: ../gui/colors/sliders.py:161
 msgctxt "color component slider: tooltip"
 msgid "RGB Red"
 msgstr "RGB 紅"
 
-#: ../gui/colors/sliders.py:177
+#: ../gui/colors/sliders.py:178
 msgctxt "color component slider: tooltip"
 msgid "RGB Green"
 msgstr "RGB 綠"
 
-#: ../gui/colors/sliders.py:194
+#: ../gui/colors/sliders.py:195
 msgctxt "color component slider: tooltip"
 msgid "RGB Blue"
 msgstr "RGB 藍"
 
-#: ../gui/colors/sliders.py:211
+#: ../gui/colors/sliders.py:212
 msgctxt "color component slider: tooltip"
 msgid "HSV Hue"
 msgstr "HSV 色相"
 
-#: ../gui/colors/sliders.py:224
+#: ../gui/colors/sliders.py:227
 msgctxt "color component slider: tooltip"
 msgid "HSV Saturation"
 msgstr "HSV 飽和度"
 
-#: ../gui/colors/sliders.py:236
+#: ../gui/colors/sliders.py:240
 msgctxt "color component slider: tooltip"
 msgid "HSV Value"
 msgstr "HSV 明度"
 
-#: ../gui/colors/sliders.py:248
+#: ../gui/colors/sliders.py:252
 msgctxt "color component slider: tooltip"
 msgid "HCY Hue"
 msgstr "HCY 色相"
 
-#: ../gui/colors/sliders.py:262
+#: ../gui/colors/sliders.py:266
 msgctxt "color component slider: tooltip"
 msgid "HCY Chroma"
 msgstr "HCY 彩度"
 
-#: ../gui/colors/sliders.py:275
+#: ../gui/colors/sliders.py:281
 msgctxt "color component slider: tooltip"
 msgid "HCY Luma (Y')"
 msgstr "HCY 明度 (Y')"
 
-#: ../gui/colortools.py:148
+#: ../gui/colortools.py:141
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Liquid Wash"
 msgstr "液體洗滌"
 
-#: ../gui/colortools.py:152
+#: ../gui/colortools.py:145
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using a liquid-like wash of nearby colors."
 msgstr "變更顏色，使用像液體洗滌般附近的顏色。"
 
-#: ../gui/colortools.py:162
+#: ../gui/colortools.py:155
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Concentric Rings"
 msgstr "同心色環"
 
-#: ../gui/colortools.py:166
+#: ../gui/colortools.py:159
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color using concentric HSV rings."
 msgstr "變更顏色，使用同心 HSV 色環。"
 
-#: ../gui/colortools.py:176
+#: ../gui/colortools.py:169
 msgctxt "color changer dock panels: tab tooltip title"
 msgid "Crossed Bowl"
 msgstr "跨越碗"
 
-#: ../gui/colortools.py:180
+#: ../gui/colortools.py:173
 msgctxt "color changer dock panels: tab tooltip description"
 msgid "Change color with HSV ramps crossing a radial bowl of color."
 msgstr "變更顏色，用 HSV 斜面跨越一徑向碗的顏色。"
 
-#: ../gui/device.py:46
+#: ../gui/device.py:47
 msgctxt "prefs: device's type label"
 msgid "Cursor/puck"
 msgstr "游標/puck"
 
-#: ../gui/device.py:50
+#: ../gui/device.py:51
 msgctxt "prefs: device's type label"
 msgid "Eraser"
 msgstr "橡皮擦"
 
-#: ../gui/device.py:54
+#: ../gui/device.py:55
 msgctxt "prefs: device's type label"
 msgid "Keyboard"
 msgstr "鍵盤"
 
-#: ../gui/device.py:58
+#: ../gui/device.py:59
 msgctxt "prefs: device's type label"
 msgid "Mouse"
 msgstr "滑鼠"
 
-#: ../gui/device.py:62
+#: ../gui/device.py:63
 msgctxt "prefs: device's type label"
 msgid "Pen"
 msgstr "繪圖筆"
 
-#: ../gui/device.py:66
+#: ../gui/device.py:67
 msgctxt "prefs: device's type label"
 msgid "Touchpad"
 msgstr "觸控板"
 
-#: ../gui/device.py:70
+#: ../gui/device.py:71
 msgctxt "prefs: device's type label"
 msgid "Touchscreen"
 msgstr "觸控螢幕"
 
-#: ../gui/device.py:90
+#: ../gui/device.py:91
 msgctxt "device settings: allowed usage"
 msgid "Ignore"
 msgstr "忽略"
 
-#: ../gui/device.py:94
+#: ../gui/device.py:95
 msgctxt "device settings: allowed usage"
 msgid "Any Task"
 msgstr "任何任務"
 
-#: ../gui/device.py:98
+#: ../gui/device.py:99
 msgctxt "device settings: allowed usage"
 msgid "Non-painting tasks"
 msgstr "非繪畫任務"
 
-#: ../gui/device.py:102
+#: ../gui/device.py:103
 msgctxt "device settings: allowed usage"
 msgid "Navigation only"
 msgstr "純瀏覽"
 
-#: ../gui/device.py:127
+#: ../gui/device.py:128
 msgctxt "device settings: unmodified scroll action"
 msgid "Zoom"
 msgstr "放大縮小"
 
-#: ../gui/device.py:128
+#: ../gui/device.py:129
 msgctxt "device settings: unmodified scroll action"
 msgid "Pan"
 msgstr "移動"
 
-#: ../gui/device.py:405
+#: ../gui/device.py:430
 msgctxt "prefs: devices table: column header"
 msgid "Device"
 msgstr "裝置"
 
-#: ../gui/device.py:419
+#: ../gui/device.py:444
 msgctxt "prefs: devices table: column header"
 msgid "Axes"
 msgstr "軸"
 
-#: ../gui/device.py:433
+#: ../gui/device.py:458
 msgctxt "prefs: devices table: column header"
 msgid "Type"
 msgstr "種類"
 
-#: ../gui/device.py:456
+#: ../gui/device.py:481
 msgctxt "prefs: devices table: column header"
 msgid "Use for..."
 msgstr "給使用…"
 
-#: ../gui/device.py:486
+#: ../gui/device.py:511
 msgctxt "prefs: devices table: column header"
 msgid "Scroll..."
 msgstr "捲動…"
 
-#: ../gui/dialogs.py:67 ../gui/externalapp.py:120 ../gui/layers.py:364
+#. Name and preview column: will be indented
+#: ../gui/dialogs.py:74 ../gui/externalapp.py:136 ../gui/layers.py:405
 msgid "Name"
 msgstr "名稱"
 
-#: ../gui/dialogs.py:109
+#: ../gui/dialogs.py:126
 msgid "Overwrite brush?"
 msgstr "要覆寫筆刷嗎？"
 
-#: ../gui/dialogs.py:118 ../gui/dialogs.py:177
+#: ../gui/dialogs.py:134 ../gui/dialogs.py:204
 msgid "Replace"
 msgstr "取代"
 
-#: ../gui/dialogs.py:121 ../gui/dialogs.py:180 ../po/tmp/brusheditor.glade.h:3
+#: ../gui/dialogs.py:137 ../gui/dialogs.py:207 ../po/tmp/brusheditor.glade.h:11
 msgid "Rename"
 msgstr "重新命名"
 
-#: ../gui/dialogs.py:124
+#: ../gui/dialogs.py:140
 msgid "Replace all"
 msgstr "全部取代"
 
-#: ../gui/dialogs.py:126
+#: ../gui/dialogs.py:142
 msgid "Rename all"
 msgstr "重新命名全部"
 
-#: ../gui/dialogs.py:141
+#: ../gui/dialogs.py:162
 msgid "Imported brush"
 msgstr "匯入的筆刷"
 
-#: ../gui/dialogs.py:142
+#: ../gui/dialogs.py:163
 msgid "Existing brush"
 msgstr "現有的筆刷"
 
-#: ../gui/dialogs.py:144
-#, python-format
+#: ../gui/dialogs.py:166
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A brush named `%s' already exists.</b>\n"
+"<b>A brush named “{brush_name}” already exists.</b>\n"
 "Do you want to replace it, or should the new brush be renamed?"
 msgstr ""
 "<b>名為「%s」的筆刷已經存在。</b>\n"
 "您想要取代它，抑或是重新命名新筆刷呢？"
 
-#: ../gui/dialogs.py:168
+#: ../gui/dialogs.py:196
 msgid "Overwrite brush group?"
 msgstr "要覆寫筆刷類組嗎？"
 
-#: ../gui/dialogs.py:190
-#, python-brace-format
+#: ../gui/dialogs.py:220
+#, fuzzy, python-brace-format
 msgid ""
-"<b>A group named `{groupname}' already exists.</b>\n"
+"<b>A group named “{groupname}” already exists.</b>\n"
 "Do you want to replace it, or should the new group be renamed?\n"
 "If you replace it, the brushes may be moved to a group called "
-"`{deleted_groupname}'."
+"“{deleted_groupname}”."
 msgstr ""
 "<b>名為「{groupname}」的類組已經存在。</b>\n"
 "您想要取代它，或是重新命名新類組呢？\n"
 "若您取代它的話，這些筆刷會移動至名為「{deleted_groupname}」的類組。"
 
-#: ../gui/dialogs.py:282
+#: ../gui/dialogs.py:326
 msgid "Import brush package?"
 msgstr "要匯入筆刷包嗎？"
 
-#: ../gui/dialogs.py:299
-#, python-format
-msgid "<b>Do you really want to import package `%s'?</b>"
+#: ../gui/dialogs.py:357
+#, fuzzy, python-brace-format
+msgid "<b>Do you really want to import package “{brushpack_name}”?</b>"
 msgstr "<b>您真的想要匯入「%s」套件嗎？</b>"
 
-#: ../gui/document.py:436
+#: ../gui/document.py:453
 #, python-format
 msgid "Load brush settings from shortcut slot %d"
 msgstr "從%d快捷列中載入筆刷設定"
 
-#: ../gui/document.py:437
+#: ../gui/document.py:454
 #, python-format
 msgid "Store brush settings in shortcut slot %d"
 msgstr "儲存筆刷設定於%d快捷列"
 
-#: ../gui/document.py:438
+#: ../gui/document.py:455
 #, python-format
 msgid "Restore Brush %d"
 msgstr "還原筆刷 %d"
 
-#: ../gui/document.py:440
+#: ../gui/document.py:457
 #, python-format
 msgid "Save to Brush %d"
 msgstr "儲存到筆刷 %d"
 
-#: ../gui/document.py:538
+#: ../gui/document.py:555
 #, python-format
 msgid "Undo %s"
 msgstr "取消動作 %s"
 
-#: ../gui/document.py:540
+#: ../gui/document.py:557
 msgid "Undo"
 msgstr "取消動作"
 
-#: ../gui/document.py:550
+#: ../gui/document.py:567
 #, python-format
 msgid "Redo %s"
 msgstr "再次動作 %s"
 
-#: ../gui/document.py:552
+#: ../gui/document.py:569
 msgid "Redo"
 msgstr "再次動作"
 
 #. TRANSLATORS: Statusbar message explaining button and modifier
 #. TRANSLATORS: combinations used to access modes/tools/actions.
 #. TRANSLATORS: "With <current-modifiers> held down: <list>"
-#: ../gui/document.py:818
+#: ../gui/document.py:862
 #, python-brace-format
 msgid "{button_combination} is {resultant_action}"
 msgstr "{button_combination} 是 {resultant_action}"
@@ -1287,287 +1334,565 @@ msgstr "{button_combination} 是 {resultant_action}"
 #. TRANSLATORS: as the English "and", so use appropriate punctuation or
 #. TRANSLATORS: wording for the separator. Also a little more spacing
 #. TRANSLATORS: than normal looks good here.
-#: ../gui/document.py:830
+#: ../gui/document.py:874
 msgid ";  "
 msgstr "；  "
 
-#: ../gui/document.py:831
+#: ../gui/document.py:875
 #, python-brace-format
 msgid "With {modifiers} held down:  {button_actions}."
 msgstr "長按 {modifiers} ： {button_actions}。"
 
-#: ../gui/document.py:1244
-msgid "Layer Name"
-msgstr "圖層名稱"
-
-#. TRANSLATORS: footer icon tooltip markup for the current mode
-#. TRANSLATORS: tooltip for the layer mode dropdown (markup)
-#: ../gui/drawwindow.py:106 ../gui/layerswindow.py:81
-#, python-brace-format
-msgid ""
-"<b>{name}</b>\n"
-"{description}"
+#: ../gui/document.py:897
+msgctxt "Statusbar message: copy result"
+msgid "Empty document, nothing copied."
 msgstr ""
-"<b>{name}</b>\n"
-"{description}"
+
+#: ../gui/document.py:909
+#, python-brace-format
+msgctxt "Statusbar message: copy result"
+msgid "Copied layer as {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:926
+msgctxt "Statusbar message: paste result"
+msgid "Nothing on clipboard."
+msgstr ""
+
+#: ../gui/document.py:935
+msgctxt "Statusbar message: paste result"
+msgid "Clipboard does not contain an image."
+msgstr ""
+
+#: ../gui/document.py:946
+msgctxt "Statusbar message: paste result"
+msgid "Cannot paste into this type of layer."
+msgstr ""
+
+#: ../gui/document.py:951
+#, python-brace-format
+msgctxt "Statusbar message: paste result"
+msgid "Pasted {w}×{h} image."
+msgstr ""
+
+#: ../gui/document.py:2037
+#, python-brace-format
+msgctxt "Statusbar message: vacuum document"
+msgid "Vacuum: discarded {removed} of {total} tiles."
+msgstr ""
 
 #. TRANSLATORS: window title for use with a filename
-#: ../gui/drawwindow.py:298
+#: ../gui/drawwindow.py:269
 #, python-format
 msgid "%s - MyPaint"
 msgstr "%s - MyPaint"
 
 #. TRANSLATORS: window title for use without a filename
-#: ../gui/drawwindow.py:301 ../po/tmp/mypaint.glade.h:1
+#: ../gui/drawwindow.py:272 ../po/tmp/mypaint.glade.h:1
 msgid "MyPaint"
 msgstr "MyPaint"
 
-#: ../gui/drawwindow.py:564
+#: ../gui/drawwindow.py:289
+msgctxt "Open dragged file confirm dialog: title"
+msgid "Open Dragged File?"
+msgstr ""
+
+#: ../gui/drawwindow.py:293
+#, fuzzy
+msgctxt "Open dragged file confirm dialog: continue button"
+msgid "_Open"
+msgstr "開啟..."
+
+#: ../gui/drawwindow.py:486
 msgid "Set current color"
 msgstr "設定目前色彩"
 
-#: ../gui/drawwindow.py:607
+#: ../gui/drawwindow.py:531
 msgid "Leave Fullscreen Mode"
 msgstr "離開全螢幕模式"
 
-#: ../gui/drawwindow.py:608
+#: ../gui/drawwindow.py:532
 msgid "Leave Fullscreen"
 msgstr "離開全螢幕"
 
-#: ../gui/drawwindow.py:611
+#: ../gui/drawwindow.py:535
 msgid "Enter Fullscreen Mode"
 msgstr "進入全螢幕模式"
 
-#: ../gui/drawwindow.py:612
+#: ../gui/drawwindow.py:536
 msgid "Fullscreen"
 msgstr "全螢幕"
 
-#. FIXME: should do this periodically, not only on quit
-#: ../gui/drawwindow.py:740
-msgid "Quit"
-msgstr "退出"
-
-#: ../gui/drawwindow.py:740
+#: ../gui/drawwindow.py:675
+#, fuzzy
+msgctxt "Quit confirm dialog: title"
 msgid "Really Quit?"
 msgstr "確定要退出？"
 
-#: ../gui/drawwindow.py:754
+#: ../gui/drawwindow.py:679
+#, fuzzy
+msgctxt "Quit confirm dialog: continue button"
+msgid "_Quit"
+msgstr "退出"
+
+#: ../gui/drawwindow.py:697
 msgid "Import brush package..."
 msgstr "匯入筆刷包..."
 
-#: ../gui/drawwindow.py:755
+#: ../gui/drawwindow.py:698
 msgid "MyPaint brush package (*.zip)"
 msgstr "MyPaint 筆刷包 (*.zip)"
 
 #. # UI string consts
-#: ../gui/externalapp.py:31
+#: ../gui/externalapp.py:36
 #, python-brace-format
 msgid "Launched {app_name} to edit layer “{layer_name}”"
 msgstr "啟動 {app_name} 編輯圖層 「{layer_name}」"
 
-#: ../gui/externalapp.py:32
+#: ../gui/externalapp.py:37
 #, python-brace-format
 msgid "Error: failed to launch {app_name} to edit layer “{layer_name}”"
 msgstr "錯誤：無法起動 {app_name} 去編輯「{layer_name}」圖層"
 
-#: ../gui/externalapp.py:34
+#: ../gui/externalapp.py:39
 #, python-brace-format
 msgid ""
 "Editing cancelled. You can still edit “{layer_name}” from the Layers menu."
 msgstr "編輯已被取消。您仍然可以在圖層選單中編輯「{layer_name}」。"
 
-#: ../gui/externalapp.py:36
+#: ../gui/externalapp.py:41
 #, python-brace-format
 msgid "Updated layer “{layer_name}” with external edits"
 msgstr "「{layer_name}」圖層已被外部編輯更新"
 
-#: ../gui/externalapp.py:46
-#, python-brace-format
-msgid ""
-"MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
-"application should it use?"
-msgstr "MyPaint 需要編輯 “{type_name}” ({content_type}) 種類的檔案，應該要使用哪個應用程式？"
-
-#: ../gui/externalapp.py:50
-#, python-brace-format
-msgid ""
-"What application should MyPaint use for editing files of type "
-"“{type_name}” ({content_type})?"
-msgstr "MyPaint 應該用哪個應用程式來編輯 “{type_name}” ({content_type}) 種類的檔案？"
-
-#: ../gui/externalapp.py:56
-msgid "Open With..."
-msgstr "開啟..."
-
-#: ../gui/externalapp.py:107
-msgid "Icon"
-msgstr "圖示"
-
-#: ../gui/externalapp.py:150
-msgid "no description"
-msgstr "沒有描述"
-
-#. (name, patterns)
-#: ../gui/filehandling.py:93
-msgid "All Recognized Formats"
-msgstr "所有可辨識的格式"
-
-#: ../gui/filehandling.py:94 ../gui/filehandling.py:109
-msgid "OpenRaster (*.ora)"
-msgstr "OpenRaster (*.ora)"
-
-#: ../gui/filehandling.py:95
-msgid "PNG (*.png)"
-msgstr "PNG (*.png)"
-
-#: ../gui/filehandling.py:96
-msgid "JPEG (*.jpg; *.jpeg)"
-msgstr "JPEG (*.jpg; *.jpeg)"
-
-#. (name, extension, options)
-#: ../gui/filehandling.py:108
-msgid "By extension (prefer default format)"
-msgstr "依副檔名 (偏好預設格式)"
-
-#: ../gui/filehandling.py:110
-msgid "PNG solid with background (*.png)"
-msgstr "PNG 不透明背景 (*.png)"
-
-#: ../gui/filehandling.py:111
-msgid "PNG transparent (*.png)"
-msgstr "PNG 透明圖片 (*.png)"
-
-#: ../gui/filehandling.py:112
-msgid "Multiple PNG transparent (*.XXX.png)"
-msgstr "多張 PNG 透明圖片 (*.XXX.png)"
-
-#: ../gui/filehandling.py:113
-msgid "JPEG 90% quality (*.jpg; *.jpeg)"
-msgstr "JPEG 90% 品質 (*.jpg; *.jpeg)"
-
-#: ../gui/filehandling.py:166
-msgid "Save..."
-msgstr "儲存..."
-
-#: ../gui/filehandling.py:177
-msgid "Format to save as:"
-msgstr "要另存的格式："
-
-#: ../gui/filehandling.py:203
-msgid "Confirm"
-msgstr "確認"
-
-#: ../gui/filehandling.py:204
-msgid "Really continue?"
-msgstr "真的要繼續嗎？"
-
-#: ../gui/filehandling.py:234
-#, python-brace-format
-msgid "This will discard {abbreviated_time} of unsaved painting"
-msgstr "這將會丟棄 {abbreviated_time} 分鐘內尚未儲存的作畫"
-
-#: ../gui/filehandling.py:243
-msgid "_Save as Scrap"
-msgstr "儲存為圖料(_S)"
-
-#: ../gui/filehandling.py:282
-#, python-brace-format
-msgctxt "file handling: open: during load (statusbar)"
-msgid "Loading “{file_basename}”…"
-msgstr "「{file_basename}」載入中…"
-
-#: ../gui/filehandling.py:296
+#: ../gui/externalapp.py:48
 #, python-brace-format
 msgctxt "file handling: open failed (statusbar)"
 msgid "Could not load “{file_basename}”."
 msgstr "無法載入「{file_basename}」。"
 
-#: ../gui/filehandling.py:321
+#: ../gui/externalapp.py:61
 #, python-brace-format
-msgctxt "file handling: open success (statusbar)"
-msgid "Loaded “{file_basename}”."
-msgstr "「{file_basename}」已被載入。"
+msgid ""
+"MyPaint needs to edit a file of type “{type_name}” ({content_type}). What "
+"application should it use?"
+msgstr ""
+"MyPaint 需要編輯 “{type_name}” ({content_type}) 種類的檔案，應該要使用哪個應"
+"用程式？"
 
-#: ../gui/filehandling.py:422
+#: ../gui/externalapp.py:65
 #, python-brace-format
-msgctxt "file handling: during export (statusbar)"
-msgid "Exporting to “{file_basename}”…"
-msgstr "匯出至「{file_basename}」 …"
+msgid ""
+"What application should MyPaint use for editing files of type "
+"“{type_name}” ({content_type})?"
+msgstr ""
+"MyPaint 應該用哪個應用程式來編輯 “{type_name}” ({content_type}) 種類的檔案？"
 
-#: ../gui/filehandling.py:427
-#, python-brace-format
-msgctxt "file handling: during save (statusbar)"
-msgid "Saving “{file_basename}”…"
-msgstr "儲存「{file_basename}」 …"
-
-#: ../gui/filehandling.py:449
-#, python-brace-format
-msgctxt "file handling: export failure (statusbar)"
-msgid "Failed to export to “{file_basename}”."
-msgstr "無法匯出至「{file_basename}」。"
-
-#: ../gui/filehandling.py:454
-#, python-brace-format
-msgctxt "file handling: save failure (statusbar)"
-msgid "Failed to save “{file_basename}”."
-msgstr "無法儲存至「{file_basename}」。"
-
-#: ../gui/filehandling.py:476
-#, python-brace-format
-msgctxt "file handling: export success (statusbar)"
-msgid "Exported to “{file_basename}” successfully."
-msgstr "成功匯出至「{file_basename}」。"
-
-#: ../gui/filehandling.py:481
-#, python-brace-format
-msgctxt "file handling: save success (statusbar)"
-msgid "Saved “{file_basename}” successfully."
-msgstr "成功儲存「{file_basename}」。"
-
-#: ../gui/filehandling.py:503 ../gui/filehandling.py:520
-msgid "Open..."
+#: ../gui/externalapp.py:71
+msgid "Open With..."
 msgstr "開啟..."
 
-#: ../gui/filehandling.py:552
+#: ../gui/externalapp.py:123
+msgid "Icon"
+msgstr "圖示"
+
+#: ../gui/externalapp.py:166
+msgid "no description"
+msgstr "沒有描述"
+
+#: ../gui/filehandling.py:126
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Loading {files_summary}…"
+msgstr "「{file_basename}」載入中…"
+
+#: ../gui/filehandling.py:130
+#, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Importing layers from {files_summary}…"
+msgstr ""
+
+#: ../gui/filehandling.py:134
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Saving {files_summary}…"
+msgstr "儲存「{file_basename}」 …"
+
+#: ../gui/filehandling.py:138
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: message shown while working"
+msgid "Exporting to {files_summary}…"
+msgstr "匯出至「{file_basename}」 …"
+
+#: ../gui/filehandling.py:145
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to export to {files_summary}."
+msgstr "無法匯出至「{file_basename}」。"
+
+#: ../gui/filehandling.py:149
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Failed to save {files_summary}."
+msgstr "無法儲存至「{file_basename}」。"
+
+#: ../gui/filehandling.py:153
+#, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not import layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:157
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: fail message"
+msgid "Could not load {files_summary}."
+msgstr "無法載入「{file_basename}」。"
+
+#: ../gui/filehandling.py:164
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Save failed"
+msgstr "儲存調色盤"
+
+#: ../gui/filehandling.py:168
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Export failed"
+msgstr "匯出至檔案"
+
+#: ../gui/filehandling.py:172
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Import Layers failed"
+msgstr "匯出至檔案"
+
+#: ../gui/filehandling.py:176
+#, fuzzy
+msgctxt "Document I/O: fail dialog title"
+msgid "Open failed"
+msgstr "開啟最近的檔案"
+
+#: ../gui/filehandling.py:183
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Exported to {files_summary} successfully."
+msgstr "成功匯出至「{file_basename}」。"
+
+#: ../gui/filehandling.py:187
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Saved {files_summary} successfully."
+msgstr "成功儲存「{file_basename}」。"
+
+#: ../gui/filehandling.py:191
+#, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Imported layers from {files_summary}."
+msgstr ""
+
+#: ../gui/filehandling.py:195
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: success"
+msgid "Loaded {files_summary}."
+msgstr "「{file_basename}」已被載入。"
+
+#: ../gui/filehandling.py:213
+#, python-brace-format
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+
+#: ../gui/filehandling.py:221
+#, fuzzy, python-brace-format
+msgctxt "Document I/O: the {files_summary} for a single file"
+msgid "“{basename}”"
+msgstr "「{file_basename}」已被載入。"
+
+#: ../gui/filehandling.py:427
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "All Recognized Formats"
+msgstr "所有可辨識的格式"
+
+#: ../gui/filehandling.py:432
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:437
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "PNG (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:442
+#, fuzzy
+msgctxt "save/load dialogs: filter patterns"
+msgid "JPEG (*.jpg; *.jpeg)"
+msgstr "JPEG (*.jpg; *.jpeg)"
+
+#: ../gui/filehandling.py:490
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "By extension (prefer default format)"
+msgstr "依副檔名 (偏好預設格式)"
+
+#: ../gui/filehandling.py:494
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "OpenRaster (*.ora)"
+msgstr "OpenRaster (*.ora)"
+
+#: ../gui/filehandling.py:498
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, respecting “Show Background” (*.png)"
+msgstr "PNG 不透明背景 (*.png)"
+
+#: ../gui/filehandling.py:502
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, solid RGB (*.png)"
+msgstr "PNG (*.png)"
+
+#: ../gui/filehandling.py:506
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "PNG, transparent RGBA (*.png)"
+msgstr "PNG 透明圖片 (*.png)"
+
+#: ../gui/filehandling.py:510
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by layer (*.NUM.png)"
+msgstr "多張 PNG 透明圖片 (*.XXX.png)"
+
+#: ../gui/filehandling.py:514
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "Multiple PNGs, by view (*.NAME.png)"
+msgstr "多張 PNG 透明圖片 (*.XXX.png)"
+
+#: ../gui/filehandling.py:518
+#, fuzzy
+msgctxt "save dialogs: save formats and options"
+msgid "JPEG 90% quality (*.jpg; *.jpeg)"
+msgstr "JPEG 90% 品質 (*.jpg; *.jpeg)"
+
+#: ../gui/filehandling.py:576
+#, fuzzy
+msgctxt "Dialogs (window title): File→Export..."
+msgid "Export"
+msgstr "匯出…"
+
+#: ../gui/filehandling.py:581
+#, fuzzy
+msgctxt "Dialogs (window title): File→Save As..."
+msgid "Save As"
+msgstr "另存為…"
+
+#: ../gui/filehandling.py:601
+#, fuzzy
+msgctxt "save dialogs: formats and options: (label)"
+msgid "Format to save as:"
+msgstr "要另存的格式："
+
+#: ../gui/filehandling.py:668
+#, fuzzy
+msgctxt ""
+"Destructive action confirm dialog: fallback title (normally overridden)"
+msgid "Really Continue?"
+msgstr "真的要繼續嗎？"
+
+#: ../gui/filehandling.py:701
+msgctxt "Destructive action confirm dialog: cancel button"
+msgid "_Cancel"
+msgstr ""
+
+#: ../gui/filehandling.py:705
+#, fuzzy
+msgctxt "Destructive action confirm dialog: save checkbox"
+msgid "_Save to Scraps first"
+msgstr "儲存為圖料(_S)"
+
+#: ../gui/filehandling.py:711
+msgctxt ""
+"Destructive action confirm dialog: fallback continue button (normally "
+"overridden)"
+msgid "Co_ntinue"
+msgstr ""
+
+#: ../gui/filehandling.py:734
+#, fuzzy, python-brace-format
+msgctxt "Destructive action confirm dialog: warning message"
+msgid "You risk losing {abbreviated_time} of unsaved painting."
+msgstr "這將會丟棄 {abbreviated_time} 分鐘內尚未儲存的作畫"
+
+#: ../gui/filehandling.py:799
+msgctxt "File→New: confirm dialog: title question"
+msgid "New Canvas?"
+msgstr ""
+
+#: ../gui/filehandling.py:803
+msgctxt "File→New: confirm dialog: continue button"
+msgid "_New Canvas"
+msgstr ""
+
+#: ../gui/filehandling.py:1003
+msgctxt "File→Open: confirm dialog: title question"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1007
+#, fuzzy
+msgctxt "File→Open: confirm dialog: continue button"
+msgid "_Open…"
+msgstr "開啟…"
+
+#: ../gui/filehandling.py:1015
+#, fuzzy
+msgctxt "File→Open: file chooser dialog: title"
+msgid "Open File"
+msgstr "開啟最近的檔案"
+
+#: ../gui/filehandling.py:1057
+#, fuzzy
+msgctxt "load dialogs: title"
 msgid "Open Scratchpad..."
 msgstr "開啟便條紙..."
 
-#: ../gui/filehandling.py:845
-#, python-format
-msgid "There are no scrap files named \"%s\" yet."
+#: ../gui/filehandling.py:1099
+#, fuzzy
+msgctxt "Layers→Import Layers: files-chooser dialog: title"
+msgid "Import Layers"
+msgstr "匯入的筆刷"
+
+#: ../gui/filehandling.py:1408
+msgctxt "File→Open Recent→* confirm dialog: title"
+msgid "Open File?"
+msgstr ""
+
+#: ../gui/filehandling.py:1412
+#, fuzzy
+msgctxt "File→Open Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "開啟..."
+
+#: ../gui/filehandling.py:1427
+#, fuzzy
+msgctxt "File→Open Most Recent confirm dialog: title"
+msgid "Open Most Recent File?"
+msgstr "開啟最新近"
+
+#: ../gui/filehandling.py:1432
+#, fuzzy
+msgctxt "File→Open Most Recent→* confirm dialog: continue button"
+msgid "_Open"
+msgstr "開啟..."
+
+#: ../gui/filehandling.py:1446
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap: error message"
+msgid "There are no scrap files yet. Try saving one first."
 msgstr "還沒有圖料檔命名為「%s」。"
 
-#: ../gui/fill.py:75 ../lib/command.py:459
+#: ../gui/filehandling.py:1455
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Next Scrap?"
+msgstr "開啟下一個圖料"
+
+#: ../gui/filehandling.py:1463
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: title"
+msgid "Open Previous Scrap?"
+msgstr "開啟上一個圖料"
+
+#: ../gui/filehandling.py:1472
+#, fuzzy
+msgctxt "File→Open Next/Prev Scrap confirm dialog: continue button"
+msgid "_Open"
+msgstr "開啟..."
+
+#: ../gui/filehandling.py:1487
+msgctxt "File→Revert: status message: canvas has no filename yet"
+msgid "Cannot revert: canvas has not been saved to a file yet."
+msgstr ""
+
+#: ../gui/filehandling.py:1494
+msgctxt "File→Revert confirm dialog: title"
+msgid "Revert Changes?"
+msgstr ""
+
+#: ../gui/filehandling.py:1499
+#, fuzzy
+msgctxt "File→Revert confirm dialog: continue button"
+msgid "_Revert"
+msgstr "回復"
+
+#: ../gui/fill.py:121
+#, fuzzy
+msgctxt ""
+"Name of the fill mode\n"
+"In other software, 'Flood Fill' is also known as 'Bucket Fill' or just 'Fill'"
 msgid "Flood Fill"
 msgstr "填充"
 
-#: ../gui/fill.py:78
+#: ../gui/fill.py:127
+#, fuzzy
+msgctxt "Usage description of the Flood Fill mode"
 msgid "Fill areas with color"
 msgstr "在區域中填充顏色"
 
-#: ../gui/fill.py:183
+#: ../gui/fill.py:508
+#, fuzzy
+msgctxt ""
+"fill options: numeric value that determines whether tested pixels will be "
+"included in the fill, based on color difference"
 msgid "Tolerance:"
 msgstr "容差："
 
-#: ../gui/fill.py:185
+#: ../gui/fill.py:513
+#, fuzzy
+msgctxt ""
+"fill options: Tolerance (tooltip) Note: 'the start' refers to the color of "
+"the starting point (pixel) of the fill"
 msgid ""
 "How much pixel colors are allowed to vary from the start\n"
 "before Flood Fill will refuse to fill them"
 msgstr "容許多少像素色彩從開始改變直至填充無法填上色彩"
 
-#: ../gui/fill.py:205
+#: ../gui/fill.py:537
+#, fuzzy
+msgctxt ""
+"fill options: option category (label) Options under this category relate to "
+"what the fill isbased on, not where the actual fill ends up."
 msgid "Source:"
 msgstr "來源："
 
-#: ../gui/fill.py:206
-msgid "Which visible layers should be filled"
-msgstr "哪些可看見的圖層應被填充"
+#: ../gui/fill.py:540
+msgctxt "fill options: 'Source:' category (tooltip)"
+msgid "The input that the fill will be based on"
+msgstr ""
 
-#: ../gui/fill.py:211
+#: ../gui/fill.py:584
+msgctxt "fill options: 'Source' category: Layer dropdown (tooltip)"
+msgid "Select a specific layer you want the fill to be based on"
+msgstr ""
+
+#: ../gui/fill.py:602
+#, fuzzy
+msgctxt ""
+"fill options: 'Source:' category: toggle (label)\n"
+"When this option is enabled, the fill is based\n"
+"on the combination of all visible layers"
 msgid "Sample Merged"
 msgstr "結合抽樣"
 
-#: ../gui/fill.py:214
+#: ../gui/fill.py:606
+#, fuzzy
+msgctxt "fill options: Sample Merged (tooltip)"
 msgid ""
 "When considering which area to fill, use a\n"
 "temporary merge of all the visible layers\n"
@@ -1577,19 +1902,50 @@ msgstr ""
 "暫時合併目前圖層以下的所\n"
 "有可看見的圖層作參考"
 
-#: ../gui/fill.py:226
+#: ../gui/fill.py:622
+#, fuzzy
+msgctxt "fill options: toggle whether the fill will be limited by the viewport"
+msgid "Limit to View"
+msgstr "配合視圖大小"
+
+#: ../gui/fill.py:628
+msgctxt ""
+"fill options: Limit to View (tooltip)\n"
+"Note: 'that can fit the view' is equivalent to: 'in which the entire visible "
+"part of the canvas can fit"
+msgid ""
+"Limit the area that can be filled, based on the viewport.\n"
+"If the view is rotated, the fill will be limited to the\n"
+"smallest canvas-aligned rectangle that can fit the view."
+msgstr ""
+
+#: ../gui/fill.py:645
+#, fuzzy
+msgctxt ""
+"fill options: option category (label)\n"
+"Options under this category relate to where the fill will end up (default: "
+"the active layer) and how it will be combined with that layer."
 msgid "Target:"
 msgstr "目標："
 
-#: ../gui/fill.py:227
+#: ../gui/fill.py:648
+#, fuzzy
+msgctxt "fill options: 'Target:' category (tooltip)"
 msgid "Where the output should go"
 msgstr "輸出到哪裡"
 
-#: ../gui/fill.py:232
+#: ../gui/fill.py:657
+#, fuzzy
+msgctxt ""
+"fill options: Target | toggle (label)\n"
+"When this option is enabled, the fill will be placed on a new\n"
+"layer above the active layer. Option resets after each fill."
 msgid "New Layer (once)"
 msgstr "新圖層 (一次性)"
 
-#: ../gui/fill.py:235
+#: ../gui/fill.py:662
+#, fuzzy
+msgctxt "fill options: Target | New Layer (tooltip)"
 msgid ""
 "Create a new layer with the results of the fill.\n"
 "This is turned off automatically after use."
@@ -1597,21 +1953,109 @@ msgstr ""
 "以填充的結果創建新圖層。\n"
 "使用後這會被自動關閉。"
 
-#: ../gui/fill.py:245 ../gui/mode.py:605
+#: ../gui/fill.py:674
+msgctxt "fill options: Target | Blend Mode dropdown - warning text"
+msgid "This mode does nothing when alpha locking is enabled!"
+msgstr ""
+
+#: ../gui/fill.py:688
+msgctxt "fill options: Target | Blend Mode dropdown (tooltip)"
+msgid "Blend mode used when filling"
+msgstr ""
+
+#: ../gui/fill.py:703
+msgid "Opacity:"
+msgstr "不透明度："
+
+#: ../gui/fill.py:706
+#, fuzzy
+msgctxt "fill options: Opacity slider (tooltip)"
+msgid "Opacity of the fill"
+msgstr "不透明度相乘"
+
+#: ../gui/fill.py:729
+msgctxt "fill options: numeric option - grow/shrink fill (label)"
+msgid "Offset:"
+msgstr ""
+
+#: ../gui/fill.py:745
+msgctxt "fill options: Offset (tooltip)"
+msgid "The distance in pixels to grow or shrink the fill"
+msgstr ""
+
+#: ../gui/fill.py:756
+msgctxt "fill options: numeric option for blurring fill (label)"
+msgid "Feather:"
+msgstr ""
+
+#: ../gui/fill.py:771
+msgctxt "fill options: Feather (tooltip)"
+msgid "The amount of blur to apply to the fill"
+msgstr ""
+
+#: ../gui/fill.py:787
+msgctxt "fill options: gap detection toggle (label)"
+msgid "Use Gap Detection"
+msgstr ""
+
+#: ../gui/fill.py:792
+msgctxt "fill options: Use Gap Detection (tooltip)"
+msgid ""
+"Try to detect gaps and not fill past them.\n"
+"Note: This can be a lot slower than the regular fill, only enable when you "
+"need it."
+msgstr ""
+
+#: ../gui/fill.py:810
+msgctxt "fill options: gap-detection sub-option, numeric setting (label)"
+msgid "Max Gap Size:"
+msgstr ""
+
+#: ../gui/fill.py:825
+msgctxt "fill options: Max Gap Size (tooltip)"
+msgid ""
+"The size of the largest gaps that can be detected.\n"
+"Using large values can make the fill run a lot slower."
+msgstr ""
+
+#: ../gui/fill.py:838
+msgctxt ""
+"fill options: on/off sub-option, numeric (label)\n"
+"When enabled, if the fill stops after going past a detected gap, it 'pulls' "
+"the fill back out of the gap to the other side of it."
+msgid "Prevent seeping"
+msgstr ""
+
+#: ../gui/fill.py:845
+msgctxt "fill options: Prevent seeping (tooltip)"
+msgid ""
+"Try to prevent the fill from seeping into the gaps.\n"
+"If a fill starts in a detected gap, this option will do nothing."
+msgstr ""
+
+#: ../gui/fill.py:855 ../gui/mode.py:627
 msgid "Reset"
 msgstr "重設"
 
-#: ../gui/fill.py:247
+#: ../gui/fill.py:859
+#, fuzzy
+msgctxt "fill options: Reset button (tooltip)"
 msgid "Reset options to their defaults"
 msgstr "重設選項至其預設值"
 
-#: ../gui/footer.py:181
+#: ../gui/fill.py:1037
+#, fuzzy
+msgctxt "fill option: default option in the Source Layer dropdown"
+msgid "Selected Layer"
+msgstr "選取圖層"
+
+#: ../gui/footer.py:191
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (no-description case)"
 msgid "<b>{brush_name}</b>"
 msgstr "<b>{brush_name}</b>"
 
-#: ../gui/footer.py:186
+#: ../gui/footer.py:196
 #, python-brace-format
 msgctxt "current brush indicator: tooltip (description case)"
 msgid ""
@@ -1621,130 +2065,142 @@ msgstr ""
 "<b>{brush_name}</b>\n"
 "{brush_desc}"
 
-#: ../gui/framewindow.py:93
+#: ../gui/framewindow.py:99
 msgid "Edit Frame"
 msgstr "編輯畫框"
 
-#: ../gui/framewindow.py:96
+#: ../gui/framewindow.py:102
 msgid "Adjust the document frame"
 msgstr "調整文件的畫框"
 
-#: ../gui/framewindow.py:445
+#: ../gui/framewindow.py:466
 msgid "Frame Size"
 msgstr "畫框大小"
 
-#. unit :  (conversion_factor, upper, lower, step_incr, page_incr, digits)
-#: ../gui/framewindow.py:448 ../gui/framewindow.py:512
-#: ../gui/framewindow.py:883 ../gui/framewindow.py:895
-#: ../gui/framewindow.py:896 ../gui/framewindow.py:948
-#: ../gui/framewindow.py:953
+#. {unit: (conv_factor, upper, lower, step_incr, page_incr, digits)}
+#: ../gui/framewindow.py:469 ../gui/framewindow.py:535
+#: ../gui/framewindow.py:908 ../gui/framewindow.py:920
+#: ../gui/framewindow.py:921 ../gui/framewindow.py:973
+#: ../gui/framewindow.py:978
 msgid "px"
 msgstr "px"
 
-#: ../gui/framewindow.py:450
+#: ../gui/framewindow.py:471
 msgid "Height:"
 msgstr "高："
 
-#: ../gui/framewindow.py:451
+#: ../gui/framewindow.py:472
 msgid "Width:"
 msgstr "寬："
 
-#: ../gui/framewindow.py:452
+#: ../gui/framewindow.py:473
 msgid "Resolution:"
 msgstr "解析度："
 
-#: ../gui/framewindow.py:454
+#: ../gui/framewindow.py:475
 msgid "DPI"
 msgstr "DPI"
 
-#: ../gui/framewindow.py:458
+#: ../gui/framewindow.py:480
 msgid "Dots Per Inch (really Pixels Per Inch)"
 msgstr "Dots Per Inch (每吋所含像素數目)"
 
-#: ../gui/framewindow.py:460
+#: ../gui/framewindow.py:483
 msgid "Color:"
 msgstr "色彩："
 
-#: ../gui/framewindow.py:497
+#: ../gui/framewindow.py:520
 msgid "Frame Color"
 msgstr "畫框顏色"
 
-#: ../gui/framewindow.py:520
+#: ../gui/framewindow.py:543
 msgid "<b>Frame dimensions</b>"
 msgstr "<b>畫框尺寸</b>"
 
-#: ../gui/framewindow.py:534
+#: ../gui/framewindow.py:557
 msgid "<b>Pixel density</b>"
 msgstr "<b>像素密度</b>"
 
-#: ../gui/framewindow.py:562
+#: ../gui/framewindow.py:585
 msgid "Set Frame to Layer"
 msgstr "設定畫框至圖層"
 
-#: ../gui/framewindow.py:563
+#: ../gui/framewindow.py:586
 msgid "Set frame to the extents of the current layer"
 msgstr "設定畫框至目前圖層的範圍"
 
-#: ../gui/framewindow.py:565
+#: ../gui/framewindow.py:588
 msgid "Set Frame to Document"
 msgstr "設定畫框至文件呎吋"
 
-#: ../gui/framewindow.py:566
+#: ../gui/framewindow.py:589
 msgid "Set frame to the combination of all layers"
 msgstr "設定畫框至結合全部圖層"
 
-#: ../gui/framewindow.py:576
+#: ../gui/framewindow.py:599
 msgid "Trim Layer to Frame"
 msgstr "裁切圖層至畫框"
 
-#: ../gui/framewindow.py:577
+#: ../gui/framewindow.py:600
 msgid "Trim parts of the current layer which lie outside the frame"
 msgstr "裁切目前圖層於畫框以外的部份"
 
-#: ../gui/framewindow.py:583
+#: ../gui/framewindow.py:606
 msgid "Enabled"
 msgstr "已啟用"
 
-#: ../gui/framewindow.py:695
+#: ../gui/framewindow.py:718
 #, python-brace-format
 msgid "{width:g}×{height:g} {units}"
 msgstr "{width:g}×{height:g} {units}"
 
-#: ../gui/framewindow.py:884
+#: ../gui/framewindow.py:909
 msgid "inch"
 msgstr "英吋"
 
-#: ../gui/framewindow.py:885
+#: ../gui/framewindow.py:910
 msgid "cm"
 msgstr "cm"
 
-#: ../gui/framewindow.py:886
+#: ../gui/framewindow.py:911
 msgid "mm"
 msgstr "mm"
 
-#: ../gui/freehand.py:120
+#: ../gui/freehand.py:86
 msgid "Freehand Drawing"
 msgstr "徒手繪畫"
 
-#: ../gui/freehand.py:123
+#: ../gui/freehand.py:89
 msgid "Paint free-form brush strokes"
 msgstr "繪畫自由形狀的筆畫"
 
 #. TRANSLATORS: Short alias for "Slow position tracking". This is
 #. TRANSLATORS: used on the options panel.
-#: ../gui/freehand.py:685
+#: ../gui/freehand.py:581
 msgid "Smooth:"
 msgstr "平滑："
 
-#: ../gui/gtkexcepthook.py:152
+#. TRANSLATORS: Short alias for "Fake Pressure (for mouse)". This is
+#. TRANSLATORS: used on the options panel.
+#: ../gui/freehand.py:596 ../gui/inputtestwindow.py:62
+msgid "Pressure:"
+msgstr "壓力："
+
+#. TRANSLATORS: Short alias for "Fake Barrel Rotation (for mouse)".
+#. TRANSLATORS: This is used on the options panel.
+#: ../gui/freehand.py:614
+msgid "Twist:"
+msgstr ""
+
+#: ../gui/gtkexcepthook.py:162
 msgid "Bug Detected"
 msgstr "偵測到臭蟲"
 
-#: ../gui/gtkexcepthook.py:155
+#: ../gui/gtkexcepthook.py:165
 msgid "<big><b>A programming error has been detected.</b></big>"
 msgstr "<big><b>已偵測到一個程式設計上的錯誤。</b></big>"
 
-#: ../gui/gtkexcepthook.py:158
+#: ../gui/gtkexcepthook.py:168
 msgid ""
 "You may be able to ignore this error and carry on working, but you should "
 "probably save your work soon.\n"
@@ -1756,35 +2212,35 @@ msgstr ""
 "\n"
 "如果還未有人報告這個問題，請使用問題追蹤系統告知開發人員。"
 
-#: ../gui/gtkexcepthook.py:166
+#: ../gui/gtkexcepthook.py:176
 msgid "Search Tracker..."
 msgstr "尋找追蹤系統 …"
 
 #. only development and prereleases
-#: ../gui/gtkexcepthook.py:168
+#: ../gui/gtkexcepthook.py:178
 msgid "Report..."
 msgstr "報告..."
 
-#: ../gui/gtkexcepthook.py:170
+#: ../gui/gtkexcepthook.py:180
 msgid "Ignore Error"
 msgstr "無視錯誤"
 
-#: ../gui/gtkexcepthook.py:171
+#: ../gui/gtkexcepthook.py:181
 msgid "Quit MyPaint"
 msgstr "離開 MyPaint"
 
-#: ../gui/gtkexcepthook.py:181
+#: ../gui/gtkexcepthook.py:191
 msgid "Details..."
 msgstr "詳細資訊..."
 
-#: ../gui/gtkexcepthook.py:208 ../gui/gtkexcepthook.py:211
+#: ../gui/gtkexcepthook.py:218 ../gui/gtkexcepthook.py:221
 msgid "Exception while analyzing the exception."
 msgstr "當分析例外時的例外。"
 
 #. TRANSLATORS: Crash report template for github, preceding a traceback.
 #. TRANSLATORS: Please ask users kindly to supply at least an English
 #. TRANSLATORS: title if they are able.
-#: ../gui/gtkexcepthook.py:260
+#: ../gui/gtkexcepthook.py:270
 msgid ""
 "            #### Description\n"
 "\n"
@@ -1824,45 +2280,50 @@ msgstr ""
 "            #### 過去追蹤\n"
 "        "
 
-#: ../gui/inktool.py:88 ../gui/inktool.py:452
+#: ../gui/inktool.py:96 ../gui/inktool.py:473
 msgid "Inking"
 msgstr "描線"
 
-#: ../gui/inktool.py:91
+#: ../gui/inktool.py:99
 msgid "Draw, and then adjust smooth lines"
 msgstr "先繪畫，然後再調整平滑線條"
 
-#: ../gui/inputtestwindow.py:30
+#: ../gui/inputtestwindow.py:32
 msgid "Input Device Test"
 msgstr "輸入裝置測試"
 
-#: ../gui/inputtestwindow.py:57
+#: ../gui/inputtestwindow.py:61
 msgid "(no pressure)"
 msgstr "(無壓力)"
 
-#: ../gui/inputtestwindow.py:58
-msgid "Pressure:"
-msgstr "壓力："
-
-#: ../gui/inputtestwindow.py:60
+#: ../gui/inputtestwindow.py:64
 msgid "(no tilt)"
 msgstr "(無傾斜)"
 
-#: ../gui/inputtestwindow.py:61
+#: ../gui/inputtestwindow.py:65
 msgid "Tilt:"
 msgstr "傾斜："
 
-#: ../gui/inputtestwindow.py:66
+#: ../gui/inputtestwindow.py:70
 msgid "(no device)"
 msgstr "(無裝置)"
 
-#: ../gui/inputtestwindow.py:67
+#: ../gui/inputtestwindow.py:71
 msgid "Device:"
 msgstr "裝置："
 
+#: ../gui/inputtestwindow.py:73
+msgid "(No Barrel Rotation)"
+msgstr ""
+
+#: ../gui/inputtestwindow.py:74
+#, fuzzy
+msgid "Barrel Rotation:"
+msgstr "重設旋轉"
+
 #. TRANSLATORS: Command to move a layer in the horizontal plane,
 #. TRANSLATORS: preserving its position in the stack.
-#: ../gui/layermanip.py:47 ../lib/command.py:899
+#: ../gui/layermanip.py:47 ../lib/command.py:1052
 msgid "Move Layer"
 msgstr "移動圖層"
 
@@ -1870,155 +2331,226 @@ msgstr "移動圖層"
 msgid "Move the current layer"
 msgstr "移動目前圖層"
 
-#. # Module vars
-#. TRANSLATORS: Display name template for otherwise anonymous layers
-#: ../gui/layers.py:35
-#, python-brace-format
-msgid "{default_name} at {path}"
-msgstr "{path}中的{default_name}"
+#: ../gui/layerprops.py:356
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer names cannot be empty."
+msgstr ""
 
-#: ../gui/layers.py:353
-msgid "Type"
-msgstr "種類"
+#: ../gui/layerprops.py:361
+msgctxt "layer properties dialog: name entry: icon tooltip"
+msgid "Layer name is not unique."
+msgstr ""
 
-#: ../gui/layers.py:375
+#: ../gui/layerprops.py:377
+#, fuzzy
+msgctxt "layer properties dialog: title"
+msgid "Layer Properties"
+msgstr "屬性"
+
+#: ../gui/layerprops.py:381
+msgctxt "layer properties dialog: done button"
+msgid "Done"
+msgstr ""
+
+#. Visibility flag column
+#: ../gui/layers.py:394
 msgid "Visible"
 msgstr "可見"
 
-#: ../gui/layers.py:384
+#. Other flags column
+#: ../gui/layers.py:426
+msgid "Flags"
+msgstr ""
+
+#: ../gui/layers.py:925
+#, fuzzy
+msgctxt "Layers: description: no layer (\"never happens\" condition!)"
+msgid "?layer"
+msgstr "圖層"
+
+#: ../gui/layers.py:945
+msgctxt "Layers: description parts: unknown mode (fallback str!)"
+msgid "?mode"
+msgstr ""
+
+#: ../gui/layers.py:952
+msgctxt "Layers: description parts: layer hidden"
+msgid "Hidden"
+msgstr ""
+
+#: ../gui/layers.py:957
+#, python-format
+msgctxt "Layers: description parts: opacity percentage"
+msgid "%d%% opaque"
+msgstr ""
+
+#: ../gui/layers.py:964
+#, fuzzy
+msgctxt "Layers dockable: description parts: layer locked flag"
 msgid "Locked"
 msgstr "已上鎖"
 
-#: ../gui/layerswindow.py:77
+#: ../gui/layers.py:975
+msgctxt "Layers: description parts: unknown type (fallback str!)"
+msgid "?type"
+msgstr ""
+
+#: ../gui/layers.py:982
+#, fuzzy
+msgctxt "Layers dockable: description parts joiner text"
+msgid ", "
+msgstr ", "
+
+#: ../gui/layers.py:990
+#, fuzzy, python-brace-format
+msgctxt "Layers dockable: markup for a layer with no description"
+msgid "{layer_name}"
+msgstr "新增 {layer_default_name}"
+
+#: ../gui/layers.py:995
+#, python-brace-format
+msgctxt "Layers dockable: markup for a layer with a description"
+msgid ""
+"<span size=\"smaller\">{layer_name}\n"
+"<span size=\"smaller\" alpha=\"50%\">{layer_description}</span></span>"
+msgstr ""
+
+#: ../gui/layerswindow.py:95
 msgid "Layers"
 msgstr "圖層"
 
-#: ../gui/layerswindow.py:78
+#: ../gui/layerswindow.py:96
 msgid "Arrange layers and assign effects"
 msgstr "編排圖層與指定效果"
 
 #. TRANSLATORS: tooltip for the opacity slider (text)
-#: ../gui/layerswindow.py:84
+#: ../gui/layerswindow.py:101
 #, python-format
 msgid "Layer opacity: %d%%"
 msgstr "圖層不透明度：%d%%"
 
+#: ../gui/layerswindow.py:102
+#, python-format
+msgid "%d%%"
+msgstr ""
+
 #. TRANSLATORS: status bar messages for drag, without/with modifiers
-#: ../gui/layerswindow.py:91
+#: ../gui/layerswindow.py:109
 msgid "Move layer in stack..."
 msgstr "移動堆疊中的圖層…"
 
-#: ../gui/layerswindow.py:92
+#: ../gui/layerswindow.py:110
 msgid ""
 "Move layer in stack (dropping into a regular layer will create a new group)"
 msgstr "移動堆疊中的圖層 (投在普通圖層上會建立新群組)"
 
-#: ../gui/layerswindow.py:131
+#: ../gui/layerswindow.py:151
 msgid "Layer"
 msgstr "圖層"
 
-#: ../gui/layerswindow.py:145
-msgid "Mode:"
-msgstr "模式："
+#: ../gui/layervis.py:53
+#, fuzzy, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "<i>{builtin_view_name}</i>"
+msgstr "<b>{brush_name}</b>"
 
-#: ../gui/layerswindow.py:147
-msgid ""
-"Blending mode: how the current layer combines with the layers underneath it."
-msgstr "混合模式：目前的圖層要如何與其下的圖層結合。"
+#: ../gui/layervis.py:125
+#, python-brace-format
+msgctxt "view controls: dropdown: item markup"
+msgid "{user_chosen_view_name}"
+msgstr ""
 
-#: ../gui/layerswindow.py:171
-msgid "Opacity:"
-msgstr "不透明度："
+#: ../gui/layervis.py:187
+#, fuzzy
+msgctxt "view controls: rename view dialog"
+msgid "Rename View"
+msgstr "旋轉視圖"
 
-#: ../gui/layerswindow.py:173
-msgid ""
-"Layer opacity: how much of the current layer to use. Smaller values make it "
-"more transparent."
-msgstr "圖層不透明度：目前圖層要顯現的程度有多少。較小的值會變得較透明。"
-
-#: ../gui/linemode.py:37
+#: ../gui/linemode.py:40
 msgid "Entrance Pressure"
 msgstr "開端壓力"
 
-#: ../gui/linemode.py:38
+#: ../gui/linemode.py:41
 msgid "Stroke entrance pressure for line tools"
 msgstr "線條工具的筆劃開端壓力"
 
-#: ../gui/linemode.py:39
+#: ../gui/linemode.py:42
 msgid "Midpoint Pressure"
 msgstr "中點壓力"
 
-#: ../gui/linemode.py:40
+#: ../gui/linemode.py:43
 msgid "Mid-Stroke pressure for line tools"
 msgstr "線條工具的筆劃中段壓力"
 
-#: ../gui/linemode.py:41
+#: ../gui/linemode.py:44
 msgid "Exit Pressure"
 msgstr "編輯壓力"
 
-#: ../gui/linemode.py:42
+#: ../gui/linemode.py:45
 msgid "Stroke exit pressure for line tools"
 msgstr "線條工具的筆劃結尾壓力"
 
-#: ../gui/linemode.py:43
+#: ../gui/linemode.py:46
 msgid "Head"
 msgstr "頭"
 
-#: ../gui/linemode.py:44
+#: ../gui/linemode.py:47
 msgid "Stroke lead-in end"
 msgstr "筆劃起頭末端"
 
-#: ../gui/linemode.py:45
+#: ../gui/linemode.py:48
 msgid "Tail"
 msgstr "尾"
 
-#: ../gui/linemode.py:46
+#: ../gui/linemode.py:49
 msgid "Stroke trail-off beginning"
 msgstr "筆劃結尾開端"
 
-#: ../gui/linemode.py:169
+#: ../gui/linemode.py:173
 msgid "Pressure variation..."
 msgstr "壓力變化 …"
 
-#: ../gui/linemode.py:215 ../gui/linemode.py:744
+#: ../gui/linemode.py:219 ../gui/linemode.py:777
 msgid "Lines and Curves"
 msgstr "線條與曲線"
 
 #. TRANSLATORS: users should never see this message
-#: ../gui/linemode.py:219
+#: ../gui/linemode.py:223
 msgid "Generic line/curve mode"
 msgstr "一般線條/曲線模式"
 
-#: ../gui/linemode.py:747
+#: ../gui/linemode.py:780
 msgid "Draw straight lines; Shift adds curves, Ctrl constrains angle"
 msgstr "畫直線；按 Shift 鍵可調整為曲線，畫線時按 Ctrl 鍵則會限制角度"
 
-#: ../gui/linemode.py:756
+#: ../gui/linemode.py:790
 msgid "Connected Lines"
 msgstr "連接的線條"
 
-#: ../gui/linemode.py:759
+#: ../gui/linemode.py:793
 msgid "Draw a sequence of lines; Shift adds curves, Ctrl constrains angle"
-msgstr "畫依照順序的線條；按 Shift 鍵可調整為曲線，劃線時按 Ctrl 鍵則會限制角度"
+msgstr ""
+"畫依照順序的線條；按 Shift 鍵可調整為曲線，劃線時按 Ctrl 鍵則會限制角度"
 
-#: ../gui/linemode.py:768
+#: ../gui/linemode.py:803
 msgid "Ellipses and Circles"
 msgstr "橢圓形與圓形"
 
-#: ../gui/linemode.py:771
+#: ../gui/linemode.py:806
 msgid "Draw ellipses; Shift rotates, Ctrl constrains ratio/angle"
 msgstr "畫橢圓形；按 Shift 鍵可旋轉，按 Ctrl 鍵可限制比例/角度"
 
-#: ../gui/meta.py:30
+#: ../gui/meta.py:39
+#, fuzzy
 msgctxt "About dialog: copyright statement"
 msgid ""
-"Copyright (C) 2005-2015\n"
+"Copyright (C) 2005-2017\n"
 "Martin Renold and the MyPaint Development Team"
 msgstr ""
 "著作權 (C) 2005-2012\n"
 "Martin Renold 和 MyPaint 開發團隊"
 
-#: ../gui/meta.py:36
+#: ../gui/meta.py:45
 msgctxt "About dialog: license summary"
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
@@ -2029,261 +2561,293 @@ msgid ""
 "This program is distributed in the hope that it will be useful, but WITHOUT "
 "ANY WARRANTY. See the COPYING file for more details."
 msgstr ""
-"此程式是自由軟體；您可以在遵守由自由軟體基金會發佈的 GNU 通用公共授權條款的情形下重新發行和 (或) 修改這個程式；授權第二版或任何之後的版本 "
-"(根據您的選擇)。\n"
+"此程式是自由軟體；您可以在遵守由自由軟體基金會發佈的 GNU 通用公共授權條款的情"
+"形下重新發行和 (或) 修改這個程式；授權第二版或任何之後的版本 (根據您的選"
+"擇)。\n"
 "\n"
-"這個程式發佈的目的是希望它對人們有所幫助，但沒有任何保證。詳情請看 COPYING 檔案，以獲得更多資訊。"
+"這個程式發佈的目的是希望它對人們有所幫助，但沒有任何保證。詳情請看 COPYING 檔"
+"案，以獲得更多資訊。"
 
-#: ../gui/meta.py:51
+#: ../gui/meta.py:60
 msgctxt "About dialog: credits: tasks"
 msgid "programming"
 msgstr "程式設計"
 
-#: ../gui/meta.py:55
+#: ../gui/meta.py:64
 msgctxt "About dialog: credits: tasks"
 msgid "portability"
 msgstr "可移植性"
 
-#: ../gui/meta.py:59
+#: ../gui/meta.py:68
 msgctxt "About dialog: credits: tasks"
 msgid "project management"
 msgstr "專案管理"
 
-#: ../gui/meta.py:63
+#: ../gui/meta.py:72
 msgctxt "About dialog: credits: tasks: brush presets and icons"
 msgid "brushes"
 msgstr "筆刷"
 
-#: ../gui/meta.py:67
+#: ../gui/meta.py:76
 msgctxt "About dialog: credits: tasks: background paper textures"
 msgid "patterns"
 msgstr "圖樣"
 
-#: ../gui/meta.py:71
+#: ../gui/meta.py:80
 msgctxt "About dialog: credits: tasks: icons for internal tools"
 msgid "tool icons"
 msgstr "工具圖示"
 
-#: ../gui/meta.py:75
+#: ../gui/meta.py:84
 msgctxt "About dialog: credits: tasks: the main application icon"
 msgid "desktop icon"
 msgstr "桌面圖示"
 
-#: ../gui/meta.py:79
+#: ../gui/meta.py:88
 msgctxt "About dialog: credits: tasks: palettes"
 msgid "palettes"
 msgstr "調色盤"
 
-#: ../gui/meta.py:84
+#: ../gui/meta.py:93
 msgctxt "About dialog: credits: tasks: docs, manuals and HOWTOs"
 msgid "documentation"
 msgstr "文件"
 
-#: ../gui/meta.py:88
+#: ../gui/meta.py:97
 msgctxt "About dialog: credits: tasks: user support"
 msgid "support"
 msgstr "支援"
 
-#: ../gui/meta.py:92
+#: ../gui/meta.py:101
 msgctxt "About dialog: credits: tasks: outreach (social media, ads?)"
 msgid "outreach"
 msgstr "擴展"
 
-#: ../gui/meta.py:96
+#: ../gui/meta.py:105
 msgctxt "About dialog: credits: tasks: running or building a community"
 msgid "community"
 msgstr "社群"
 
-#: ../gui/meta.py:101
+#: ../gui/meta.py:110
 msgctxt "About dialog: credits: tasks: joiner punctuation"
 msgid ", "
 msgstr ", "
 
-#: ../gui/meta.py:163
+#: ../gui/meta.py:208
 msgctxt "About dialog: credits: translator credits (your name(s) here!)"
 msgid "translator-credits"
 msgstr "translator-credits"
 
-#. TRANSLATORS: "Brush radius" for the options panel. Short.
-#: ../gui/mode.py:562
+#. TRANSLATORS:"Brush radius" for the options panel. Short.
+#: ../gui/mode.py:582
 msgid "Size:"
 msgstr "大小："
 
-#. TRANSLATORS: "Brush opacity" for the options panel. Short.
-#: ../gui/mode.py:564
+#. TRANSLATORS:"Brush opacity" for the options panel. Short.
+#: ../gui/mode.py:584
 msgid "Opaque:"
 msgstr "不透明度："
 
-#. TRANSLATORS: "Brush hardness/sharpness" for the options panel. Short.
-#: ../gui/mode.py:566
+#. TRANSLATORS:"Brush hardness/sharpness" for the options panel. Short.
+#: ../gui/mode.py:586
 msgid "Sharp:"
 msgstr "軟硬度："
 
-#. TRANSLATORS: "Additional pressure gain" for the options panel. Short.
-#: ../gui/mode.py:568
+#. TRANSLATORS:"Additional pressure gain" for the options panel. Short.
+#: ../gui/mode.py:588
 msgid "Gain:"
 msgstr "增益："
 
-#: ../gui/optionspanel.py:46
+#. TRANSLATORS:"Paint Pigment Mode" for the options panel. Short.
+#: ../gui/mode.py:590
+msgid "Pigment:"
+msgstr ""
+
+#: ../gui/optionspanel.py:47
 msgctxt "options panel: tab tooltip: title"
 msgid "Tool Options"
 msgstr "工具選項"
 
-#: ../gui/optionspanel.py:50
+#: ../gui/optionspanel.py:51
 msgctxt "options panel: tab tooltip: description"
 msgid "Specialized settings for the current editing tool"
 msgstr "目前編輯工具的專屬設定"
 
-#: ../gui/optionspanel.py:57
+#: ../gui/optionspanel.py:58
 #, python-brace-format
 msgctxt "options panel: header"
 msgid "<b>{mode_name}</b>"
 msgstr "<b>{mode_name}</b>"
 
-#: ../gui/optionspanel.py:61
+#: ../gui/optionspanel.py:62
 msgctxt "options panel: body"
 msgid "<i>No options available</i>"
 msgstr "<i>沒有可用的選項</i>"
 
-#: ../gui/overlays.py:160
+#: ../gui/overlays.py:161
 #, python-format
 msgid "Zoom: %.01f%%"
 msgstr "縮放：%.01f%%"
 
-#: ../gui/picker.py:457
+#: ../gui/picker.py:458
 msgctxt "context picker: statusbar text during grab"
 msgid "Pick brushstroke settings, stroke color, and layer…"
 msgstr "挑選筆刷筆劃設定、筆劃顏色，及圖層…"
 
-#: ../gui/picker.py:495
+#: ../gui/picker.py:496
 msgctxt "color picker: statusbar text during grab"
 msgid "Pick color…"
 msgstr "挑選顏色…"
 
-#: ../gui/preferenceswindow.py:40
+#: ../gui/preferenceswindow.py:38
 msgid "Preferences"
 msgstr "偏好設定"
 
 #. TRANSLATORS: title of panel showing an overview of the whole canvas
-#: ../gui/previewwindow.py:199
+#: ../gui/previewwindow.py:202
 msgid "Preview"
 msgstr "預覽"
 
-#: ../gui/previewwindow.py:201
+#: ../gui/previewwindow.py:204
 msgid "Show preview of the whole drawing area"
 msgstr "顯示整個繪圖區域的預覽"
 
 #. TRANSLATORS: The preview panel shows where the "camera" of the
 #. TRANSLATORS: main view is pointing.
-#: ../gui/previewwindow.py:259
+#: ../gui/previewwindow.py:264
 msgid "Show Viewfinder"
 msgstr "顯示取景器"
 
-#: ../gui/scratchwindow.py:36
+#: ../gui/scratchwindow.py:35
 msgid "Scratchpad"
 msgstr "便條紙"
 
-#: ../gui/scratchwindow.py:38
+#: ../gui/scratchwindow.py:37
 msgid "Mix colors and make sketches on separate scrap pages"
 msgstr "在各個圖料頁上調色與畫草圖"
 
-#: ../gui/spinbox.py:32
+#: ../gui/spinbox.py:35
 msgid "Previous item"
 msgstr "上一個項目"
 
-#: ../gui/spinbox.py:35
+#: ../gui/spinbox.py:39
 msgid "Next item"
 msgstr "下一個項目"
 
-#: ../gui/spinbox.py:97
+#: ../gui/spinbox.py:102
 msgid "(Nothing to show)"
 msgstr "(沒有可以顯示的)"
 
-#: ../gui/symmetry.py:76
+#: ../gui/symmetry.py:80
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Place axis"
 msgstr "設置軸線"
 
-#: ../gui/symmetry.py:80
+#: ../gui/symmetry.py:84
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Move axis"
 msgstr "移動軸線"
 
-#: ../gui/symmetry.py:84
+#: ../gui/symmetry.py:88
 msgctxt "symmetry axis edit mode: instructions shown in statusbar"
 msgid "Remove axis"
 msgstr "移除軸線"
 
-#: ../gui/symmetry.py:96
+#: ../gui/symmetry.py:100
 msgctxt "symmetry axis edit mode: mode name (tooltips)"
 msgid "Edit Symmetry Axis"
 msgstr "編輯對稱軸"
 
-#: ../gui/symmetry.py:102
+#: ../gui/symmetry.py:106
 msgctxt "symmetry axis edit mode: mode description (tooltips)"
 msgid "Adjust the painting symmetry axis."
 msgstr "調整繪畫對稱軸。"
 
-#: ../gui/symmetry.py:307
+#: ../gui/symmetry.py:356
+#, fuzzy
 msgctxt "symmetry axis options panel: labels"
-msgid "Position:"
+msgid "X Position:"
 msgstr "位置："
 
-#: ../gui/symmetry.py:311
+#: ../gui/symmetry.py:360
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Y Position:"
+msgstr "位置："
+
+#: ../gui/symmetry.py:364
 msgctxt "symmetry axis options panel: position button: no axis pos."
 msgid "None"
 msgstr "無"
 
-#: ../gui/symmetry.py:315
+#: ../gui/symmetry.py:368
 #, python-format
 msgctxt "symmetry axis options panel: position button: axis pos. in pixels"
 msgid "%d px"
 msgstr "%d 像素"
 
-#: ../gui/symmetry.py:319
+#: ../gui/symmetry.py:372
 msgctxt "symmetry axis options panel: labels"
 msgid "Alpha:"
 msgstr "Alpha："
 
-#: ../gui/symmetry.py:352
+#: ../gui/symmetry.py:376
+#, fuzzy
+msgctxt "symmetry axis options panel: labels"
+msgid "Symmetry Type:"
+msgstr "對稱性"
+
+#: ../gui/symmetry.py:380
+msgctxt "symmetry axis options panel: labels"
+msgid "Rotational lines:"
+msgstr ""
+
+#: ../gui/symmetry.py:446
+#, fuzzy
 msgctxt "symmetry axis options panel: axis position dialog: window title"
-msgid "Axis Position"
+msgid "X axis Position"
 msgstr "軸線位置"
 
-#: ../gui/symmetry.py:424
+#: ../gui/symmetry.py:477
+#, fuzzy
+msgctxt "symmetry axis options panel: axis position dialog: window title"
+msgid "Y axis Position"
+msgstr "軸線位置"
+
+#: ../gui/symmetry.py:605
 msgctxt "symmetry axis options panel: axis active checkbox"
 msgid "Enabled"
 msgstr "已啟用"
 
-#: ../gui/toolbar.py:32
+#: ../gui/toolbar.py:28
 msgid "File handling"
 msgstr "檔案處理"
 
-#: ../gui/toolbar.py:33
+#: ../gui/toolbar.py:29
 msgid "Scraps switcher"
 msgstr "圖料切換器"
 
-#: ../gui/toolbar.py:34
+#: ../gui/toolbar.py:30
 msgid "Undo and Redo"
 msgstr "取消動作與再次動作"
 
-#: ../gui/toolbar.py:35
+#: ../gui/toolbar.py:31
 msgid "Blend Modes"
 msgstr "混合模式"
 
-#: ../gui/toolbar.py:36
+#: ../gui/toolbar.py:32
 msgid "Line Modes"
 msgstr "線條模式"
 
-#: ../gui/toolbar.py:37
+#: ../gui/toolbar.py:33
 msgid "View (Main)"
 msgstr "檢視 (主要)"
 
-#: ../gui/toolbar.py:38
+#: ../gui/toolbar.py:35
 msgid "View (Alternative/Secondary)"
 msgstr "檢視 (替代/第二)"
 
-#: ../gui/toolbar.py:39
+#: ../gui/toolbar.py:37
 msgid "View (Resetting)"
 msgstr "檢視 (重設)"
 
@@ -2291,188 +2855,214 @@ msgstr "檢視 (重設)"
 msgid "<b>MyPaint</b>"
 msgstr "<b>MyPaint</b>"
 
-#: ../gui/viewmanip.py:39
+#: ../gui/viewmanip.py:40
 msgid "Scroll View"
 msgstr "捲動視圖"
 
-#: ../gui/viewmanip.py:42
+#: ../gui/viewmanip.py:43
 msgid "Drag the canvas view"
 msgstr "拖曳畫布視圖"
 
-#: ../gui/viewmanip.py:77
+#: ../gui/viewmanip.py:78
 msgid "Zoom View"
 msgstr "縮放視圖"
 
-#: ../gui/viewmanip.py:80
+#: ../gui/viewmanip.py:81
 msgid "Zoom the canvas view"
 msgstr "縮放畫布視圖"
 
-#: ../gui/viewmanip.py:119
+#: ../gui/viewmanip.py:120
 msgid "Rotate View"
 msgstr "旋轉視圖"
 
-#: ../gui/viewmanip.py:122
+#: ../gui/viewmanip.py:123
 msgid "Rotate the canvas view"
 msgstr "旋轉畫布視圖"
 
-#: ../gui/workspace.py:1211
-#, python-format
-msgid "%s: close tab"
+#: ../gui/workspace.py:1313
+#, fuzzy, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: close tab"
 msgstr "%s: 關閉分頁"
 
-#: ../gui/workspace.py:1213
-#, python-format
-msgid "%s: edit properties"
-msgstr "%s: 編輯屬性"
+#: ../gui/workspace.py:1317
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: tab options and properties"
+msgstr ""
 
-#: ../lib/command.py:158
+#: ../gui/workspace.py:1321
+#, python-brace-format
+msgctxt "workspace: sidebar tabs: button tooltips"
+msgid "{tab_title}: move tab to other sidebar"
+msgstr ""
+
+#: ../lib/command.py:181
 msgid "Unknown Command"
 msgstr "未知指命"
 
-#: ../lib/command.py:272
+#: ../lib/command.py:324
 msgid "Undefined (command not started yet)"
 msgstr "未被定義 (指命尚未被啟動)"
 
 #. TRANSLATORS: A short time spent painting / making brushwork.
 #. TRANSLATORS: This can correspond to zero or more touches of
 #. TRANSLATORS: the physical stylus to the tablet.
-#: ../lib/command.py:279
+#: ../lib/command.py:331
 #, python-brace-format
 msgid "{seconds:.01f}s of painting with {brush_name}"
 msgstr "用 {brush_name} 筆刷繪圖 {seconds:.01f} 秒"
 
-#: ../lib/command.py:522
+#: ../lib/command.py:529
+msgid "Flood Fill"
+msgstr "填充"
+
+#: ../lib/command.py:616
 msgid "Trim Layer"
 msgstr "裁切圖層"
 
-#: ../lib/command.py:542
+#: ../lib/command.py:636
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../lib/command.py:659
+#, fuzzy
+msgid "Refactor Group"
+msgstr "重新命名群組"
+
+#: ../lib/command.py:682
 msgid "Clear Layer"
 msgstr "清除圖層"
 
 #. This is used by Paste layer as well as when loading from a PNG
 #. file. However in the latter case, the undo stack is reset
 #. immediately afterward.
-#: ../lib/command.py:566
+#: ../lib/command.py:706
 msgid "Paste Layer"
 msgstr "貼上圖層"
 
-#: ../lib/command.py:589
+#: ../lib/command.py:729
 msgid "New Layer from Visible"
 msgstr "從可看見的圖層建立新的"
 
-#: ../lib/command.py:631
+#: ../lib/command.py:771
 msgid "Merge Visible Layers"
 msgstr "合併可看見的圖層"
 
-#: ../lib/command.py:705
+#: ../lib/command.py:845
 msgid "Merge Down"
 msgstr "向下合併"
 
-#: ../lib/command.py:754
+#: ../lib/command.py:894
 msgid "Normalize Layer Mode"
 msgstr "標準化圖層模式"
 
-#: ../lib/command.py:797
+#: ../lib/command.py:947
+#, fuzzy
+msgid "Import Layers"
+msgstr "匯入的筆刷"
+
+#: ../lib/command.py:949
 #, python-brace-format
 msgid "Add {layer_default_name}"
 msgstr "新增 {layer_default_name}"
 
-#: ../lib/command.py:820
+#: ../lib/command.py:973
 msgid "Remove Layer"
 msgstr "移除圖層"
 
-#: ../lib/command.py:867
+#: ../lib/command.py:1020
 msgid "Select Layer"
 msgstr "選取圖層"
 
-#: ../lib/command.py:996
+#: ../lib/command.py:1149
 msgid "Duplicate Layer"
 msgstr "製作圖層副本"
 
-#: ../lib/command.py:1019
+#: ../lib/command.py:1173
 msgid "Move Layer Up"
 msgstr "向上移動圖層"
 
-#: ../lib/command.py:1033
+#: ../lib/command.py:1187
 msgid "Move Layer Down"
 msgstr "向下移動圖層"
 
-#: ../lib/command.py:1060
+#: ../lib/command.py:1214
 msgid "Move Layer in Stack"
 msgstr "移動堆疊中的圖層"
 
-#: ../lib/command.py:1181
+#: ../lib/command.py:1333
 msgid "Rename Layer"
 msgstr "重新命名圖層"
 
-#: ../lib/command.py:1232
+#: ../lib/command.py:1391
 msgid "Make Layer Visible"
 msgstr "讓圖層看得見"
 
-#: ../lib/command.py:1234
+#: ../lib/command.py:1393
 msgid "Make Layer Invisible"
 msgstr "讓圖層看不見"
 
-#: ../lib/command.py:1272
+#: ../lib/command.py:1431
 msgid "Lock Layer"
 msgstr "鎖定圖層"
 
-#: ../lib/command.py:1274
+#: ../lib/command.py:1433
 msgid "Unlock Layer"
 msgstr "解除圖層鎖"
 
-#: ../lib/command.py:1292
+#: ../lib/command.py:1451
 #, python-format
 msgid "Set Layer Opacity: %0.1f%%"
 msgstr "設定圖層不透明度： %0.1f%%"
 
-#: ../lib/command.py:1331
+#: ../lib/command.py:1490
 msgid "Unknown Mode"
 msgstr "未知模式"
 
-#: ../lib/command.py:1332
+#: ../lib/command.py:1491
 #, python-format
 msgid "Set Layer Mode: %s"
 msgstr "設定圖層模式： %s"
 
-#: ../lib/command.py:1356
+#: ../lib/command.py:1515
 msgid "Enable Frame"
 msgstr "啟用畫框"
 
-#: ../lib/command.py:1358
+#: ../lib/command.py:1517
 msgid "Disable Frame"
 msgstr "停用畫框"
 
-#: ../lib/command.py:1376
+#: ../lib/command.py:1535
 msgid "Update Frame"
 msgstr "更新畫框"
 
-#: ../lib/command.py:1405
+#: ../lib/command.py:1564
 msgid "Edit Layer Externally"
 msgstr "從外部編輯圖層"
 
-#: ../lib/document.py:70
+#: ../lib/document.py:71
 #, python-brace-format
 msgctxt "Document IO: common error strings: {error_loading_common}"
 msgid "Error loading “{basename}”."
 msgstr "載入「{basename}」時發生錯誤。"
 
-#: ../lib/document.py:74
+#: ../lib/document.py:75
 msgctxt "Document IO: common error strings: {see_logs}"
 msgid "The logs may have more detail about this error."
 msgstr "在記錄中可能會有更多關於此錯誤的詳情。"
 
-#: ../lib/document.py:183
+#: ../lib/document.py:194
 msgctxt "Document autosave descriptions: the {ago} string: future"
 msgid "from now"
 msgstr "由現在開始"
 
-#: ../lib/document.py:188
+#: ../lib/document.py:199
 msgctxt "Document autosave descriptions: the {ago} string: past"
 msgid "ago"
 msgstr "之前"
 
-#: ../lib/document.py:196
+#: ../lib/document.py:207
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2484,13 +3074,13 @@ msgstr ""
 "您是否同時運行多於一個 MyPaint 程式？\n"
 "請關閉程式及等候 {cache_update_interval} 秒再試。"
 
-#: ../lib/document.py:203
+#: ../lib/document.py:214
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid "Incomplete backup updated {last_modified_time} {ago}"
 msgstr "已在 {last_modified_time} {ago} 更新不完整的備份"
 
-#: ../lib/document.py:208
+#: ../lib/document.py:219
 #, python-brace-format
 msgctxt "Document autosave descriptions"
 msgid ""
@@ -2500,10 +3090,11 @@ msgid ""
 "Contains {unsaved_time} of unsaved painting."
 msgstr ""
 "已在 {last_modified_time} {ago} 更新備份\n"
-"大小： {autosave.width}×{autosave.height} 像素，圖層數目： {autosave.num_layers}\n"
+"大小： {autosave.width}×{autosave.height} 像素，圖層數目： {autosave."
+"num_layers}\n"
 "包括 {unsaved_time} 的未儲存繪畫。"
 
-#: ../lib/document.py:1209
+#: ../lib/document.py:1426
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2513,13 +3104,13 @@ msgstr ""
 "無法寫入 “{filename}”： {err}\n"
 "您的裝置上有足夠剩餘空間嗎？"
 
-#: ../lib/document.py:1215 ../lib/document.py:1225
+#: ../lib/document.py:1432 ../lib/document.py:1442
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid "Unable to write “{filename}”: {err}"
 msgstr "無法寫入 “{filename}”： {err}"
 
-#: ../lib/document.py:1257
+#: ../lib/document.py:1478
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2529,7 +3120,7 @@ msgstr ""
 "{error_loading_common}\n"
 "檔案不存在。"
 
-#: ../lib/document.py:1264
+#: ../lib/document.py:1485
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2539,7 +3130,7 @@ msgstr ""
 "{error_loading_common}\n"
 "您沒有開啟此檔案所需的權限。"
 
-#: ../lib/document.py:1289
+#: ../lib/document.py:1510
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2555,7 +3146,7 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/document.py:1313
+#: ../lib/document.py:1534
 #, python-brace-format
 msgctxt "Document IO: loading errors"
 msgid ""
@@ -2565,7 +3156,13 @@ msgstr ""
 "{error_loading_common}\n"
 "不明檔案格式的檔案副檔名: “{ext}”"
 
-#: ../lib/document.py:1384
+#: ../lib/document.py:1565
+#, fuzzy
+msgctxt "Document IO: group name for Import Layers"
+msgid "Imported layers"
+msgstr "匯入的筆刷"
+
+#: ../lib/document.py:1732
 #, python-brace-format
 msgctxt "Document IO: hint templates for user-facing exceptions"
 msgid ""
@@ -2576,9 +3173,10 @@ msgid ""
 msgstr ""
 "無法儲存為 JPEG： {original_msg}\n"
 "\n"
-"如果您的電腦沒有大容量記憶體，請嘗試儲存成 PNG 格式。 MyPaint 的 PNG 儲存功能更有率效。"
+"如果您的電腦沒有大容量記憶體，請嘗試儲存成 PNG 格式。 MyPaint 的 PNG 儲存功能"
+"更有率效。"
 
-#: ../lib/document.py:1493
+#: ../lib/document.py:1862
 #, python-brace-format
 msgctxt "Document autosave: restoring: errors"
 msgid ""
@@ -2593,285 +3191,409 @@ msgstr ""
 "\n"
 "{see_logs}"
 
-#: ../lib/helpers.py:402
-#, python-brace-format
+#: ../lib/floodfill.py:131
+#, fuzzy
+msgctxt "floodfill status message: use active tense"
+msgid "Filling"
+msgstr "填充"
+
+#: ../lib/floodfill.py:132
+msgctxt "floodfill status message: use active tense"
+msgid "Morphing"
+msgstr ""
+
+#: ../lib/floodfill.py:133
+msgctxt "floodfill status message: use active tense"
+msgid "Blurring"
+msgstr ""
+
+#: ../lib/floodfill.py:134
+msgctxt "floodfill status message: use active tense"
+msgid "Compositing"
+msgstr ""
+
+#: ../lib/floodfill.py:135
+msgctxt "floodfill status message: use active tense"
+msgid "Finishing up"
+msgstr ""
+
+#: ../lib/floodfill.py:137
+msgctxt "uniform square region of pixels, plural noun"
+msgid "tiles"
+msgstr ""
+
+#: ../lib/helpers.py:535
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{days}d{hours}h"
 msgstr "{days}天{hours}小時"
 
-#: ../lib/helpers.py:404
-#, python-brace-format
+#: ../lib/helpers.py:537
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviations"
 msgid "{hours}h{minutes}m"
 msgstr "{hours}小時{minutes}分"
 
-#: ../lib/helpers.py:406
-#, python-brace-format
+#: ../lib/helpers.py:539
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{minutes}m{seconds}s"
 msgstr "{minutes}分{seconds}秒"
 
-#: ../lib/helpers.py:408
-#, python-brace-format
+#: ../lib/helpers.py:541
+#, fuzzy, python-brace-format
+msgctxt "Time period abbreviation"
 msgid "{seconds}s"
 msgstr "{seconds}秒"
 
-#: ../lib/layer/core.py:73 ../lib/layer/data.py:1221
+#: ../lib/layer/core.py:66 ../lib/layer/data.py:1295
 msgctxt "layer default names"
 msgid "Layer"
 msgstr "圖層"
 
-#: ../lib/layer/core.py:85
-#, python-format
-msgctxt "layer unique names: template (leave untranslated if unsure)"
-msgid "%(name)s %(number)d"
-msgstr "%(name)s %(number)d"
-
-#: ../lib/layer/core.py:89
-msgctxt "layer unique names: match regex (leave untranslated if unsure)"
-msgid "^(.*?)\\s*(\\d+)$"
-msgstr "^(.*?)\\s*(\\d+)$"
-
-#: ../lib/layer/data.py:1107
+#: ../lib/layer/data.py:1153
+#, fuzzy
 msgctxt "layer default names"
+msgid "Vectors"
+msgstr "向量圖層"
+
+#: ../lib/layer/data.py:1158
+#, fuzzy
+msgctxt "layer type descriptions"
 msgid "Vector Layer"
 msgstr "向量圖層"
 
-#: ../lib/layer/data.py:1153
+#: ../lib/layer/data.py:1223
 msgctxt "layer default names"
-msgid "Unknown Bitmap Layer"
-msgstr "不明點陣圖層"
+msgid "Bitmap"
+msgstr ""
 
-#: ../lib/layer/data.py:1169
+#: ../lib/layer/data.py:1228
+msgctxt "layer type descriptions"
+msgid "Bitmap Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1244
 msgctxt "layer default names"
-msgid "Unknown Data Layer"
+msgid "Data"
+msgstr ""
+
+#: ../lib/layer/data.py:1249
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Unknown Data"
 msgstr "不明數據圖層"
 
-#: ../lib/layer/group.py:59
+#: ../lib/layer/data.py:1300
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Painting Layer"
+msgstr "新增繪畫圖層"
+
+#: ../lib/layer/group.py:69
 msgctxt "layer default names"
 msgid "Group"
 msgstr "群組"
 
-#: ../lib/layer/tree.py:53
+#: ../lib/layer/group.py:74
+#, fuzzy
+msgctxt "layer type descriptions"
+msgid "Layer Group"
+msgstr "新增圖層群組"
+
+#: ../lib/layer/tree.py:70
 msgctxt "layer default names"
 msgid "Placeholder"
 msgstr "占位符"
 
-#: ../lib/layer/tree.py:92
+#: ../lib/layer/tree.py:109
 msgctxt "layer default names"
 msgid "Root"
 msgstr "Root"
 
-#: ../lib/layer/tree.py:1684 ../lib/layer/tree.py:1738
+#: ../lib/layer/tree.py:2133 ../lib/layer/tree.py:2199
 msgctxt "layer default names: joiner punctuation for merged layers"
 msgid ", "
 msgstr ", "
 
-#: ../lib/modes.py:36
+#: ../lib/layer/tree.py:2321
+msgctxt "layer default names: refactor: name of the common areas layer"
+msgid "Common"
+msgstr ""
+
+#: ../lib/layervis.py:44
+#, fuzzy
+msgctxt "layer visibility sets: default name for a user-managed view"
+msgid "View"
+msgstr "檢視"
+
+#: ../lib/layervis.py:49
+msgctxt "layer visibility sets: text shown when no user-managed view is active"
+msgid "No active view"
+msgstr ""
+
+#: ../lib/layervis.py:579
+#, fuzzy
+msgctxt "layer views: commands: add"
+msgid "Add Layer View"
+msgstr "加入圖層"
+
+#: ../lib/layervis.py:604 ../lib/layervis.py:633
+#, fuzzy
+msgctxt "layer views: commands: remove"
+msgid "Remove Layer View"
+msgstr "移除圖層"
+
+#: ../lib/layervis.py:663
+#, python-brace-format
+msgctxt "layer views: commands: activate"
+msgid "Activate Layer View “{name}”"
+msgstr ""
+
+#: ../lib/layervis.py:692
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Lock Layer View"
+msgstr "鎖定圖層"
+
+#: ../lib/layervis.py:697
+#, fuzzy
+msgctxt "layer views: commands: set active view's lock flag"
+msgid "Unlock Layer View"
+msgstr "解除圖層鎖"
+
+#: ../lib/modes.py:38
 msgid "Pass-through"
 msgstr "通過"
 
-#: ../lib/modes.py:37
+#: ../lib/modes.py:39
 msgid "Group contents apply directly to the group's backdrop"
 msgstr "群組內容會直接應用到群組的背幕"
 
-#: ../lib/modes.py:41
+#: ../lib/modes.py:43
 msgid "Normal"
 msgstr "正常"
 
-#: ../lib/modes.py:42
+#: ../lib/modes.py:44
 msgid "The top layer only, without blending colors."
 msgstr "僅頂圖層，不混合色彩。"
 
-#: ../lib/modes.py:44
+#: ../lib/modes.py:46
+msgid "Pigment"
+msgstr ""
+
+#: ../lib/modes.py:47
+msgid ""
+"Similar to mixing actual pigments by upsampling to 10 spectral channels."
+msgstr ""
+
+#: ../lib/modes.py:50
 msgid "Multiply"
 msgstr "疊加"
 
-#: ../lib/modes.py:45
+#: ../lib/modes.py:51
 msgid ""
 "Similar to loading two slides into a projector and projecting the combined "
 "result."
 msgstr "類似將兩張幻燈片載入投影機，然後投影出合併的影像。"
 
-#: ../lib/modes.py:48
+#: ../lib/modes.py:54
 msgid "Screen"
 msgstr "螢幕"
 
-#: ../lib/modes.py:49
+#: ../lib/modes.py:55
 msgid ""
 "Like shining two separate slide projectors onto a screen simultaneously. "
 "This is the inverse of 'Multiply'."
 msgstr "像是同時將兩臺獨立的幻燈片投影機照在一個螢幕上。這是「疊加」的反轉。"
 
-#: ../lib/modes.py:52
+#: ../lib/modes.py:58
 msgid "Overlay"
 msgstr "覆蓋"
 
-#: ../lib/modes.py:53
+#: ../lib/modes.py:59
 msgid ""
 "Overlays the backdrop with the top layer, preserving the backdrop's "
 "highlights and shadows. This is the inverse of 'Hard Light'."
 msgstr "疊加頂層與背幕，但保留背幕的高亮與陰影。這是「強光」的反轉。"
 
-#: ../lib/modes.py:57
+#: ../lib/modes.py:63
 msgid "Darken"
 msgstr "變暗"
 
-#: ../lib/modes.py:58
+#: ../lib/modes.py:64
 msgid "The top layer is used where it is darker than the backdrop."
 msgstr "在頂層較背幕暗的地方會使用頂層。"
 
-#: ../lib/modes.py:61
+#: ../lib/modes.py:67
 msgid "Lighten"
 msgstr "變亮"
 
-#: ../lib/modes.py:62
+#: ../lib/modes.py:68
 msgid "The top layer is used where it is lighter than the backdrop."
 msgstr "在頂層較背幕亮的地方使用頂層。"
 
-#: ../lib/modes.py:65
+#: ../lib/modes.py:71
 msgid "Dodge"
 msgstr "減淡"
 
-#: ../lib/modes.py:66
+#: ../lib/modes.py:72
 msgid ""
 "Brightens the backdrop using the top layer. The effect is similar to the "
 "photographic darkroom technique of the same name which is used for improving "
 "contrast in shadows."
-msgstr "使用頂圖層減淡背幕。效果看起來類似攝影中同名的暗房技巧，用來改善陰影區的對比程度。"
+msgstr ""
+"使用頂圖層減淡背幕。效果看起來類似攝影中同名的暗房技巧，用來改善陰影區的對比"
+"程度。"
 
-#: ../lib/modes.py:70
+#: ../lib/modes.py:76
 msgid "Burn"
 msgstr "加深"
 
-#: ../lib/modes.py:71
+#: ../lib/modes.py:77
 msgid ""
 "Darkens the backdrop using the top layer. The effect looks similar to the "
 "photographic darkroom technique of the same name which is used for reducing "
 "over-bright highlights."
-msgstr "使用頂圖層加深背幕。效果看起來類似攝影中同名的暗房技巧，用來減少高亮度區的過亮程度。"
+msgstr ""
+"使用頂圖層加深背幕。效果看起來類似攝影中同名的暗房技巧，用來減少高亮度區的過"
+"亮程度。"
 
-#: ../lib/modes.py:75
+#: ../lib/modes.py:81
 msgid "Hard Light"
 msgstr "強光"
 
-#: ../lib/modes.py:76
+#: ../lib/modes.py:82
 msgid "Similar to shining a harsh spotlight onto the backdrop."
 msgstr "類似將刺眼的聚光照在背幕上。"
 
-#: ../lib/modes.py:78
+#: ../lib/modes.py:84
 msgid "Soft Light"
 msgstr "柔光"
 
-#: ../lib/modes.py:79
+#: ../lib/modes.py:85
 msgid "Like shining a diffuse spotlight onto the backdrop."
 msgstr "類似將擴散的聚光照在背幕上。"
 
-#: ../lib/modes.py:81
+#: ../lib/modes.py:87
 msgid "Difference"
 msgstr "差異"
 
-#: ../lib/modes.py:82
+#: ../lib/modes.py:88
 msgid "Subtracts the darker color from the lighter of the two."
 msgstr "兩者中較亮者減去較暗者的色彩。"
 
-#: ../lib/modes.py:84
+#: ../lib/modes.py:90
 msgid "Exclusion"
 msgstr "排除"
 
-#: ../lib/modes.py:85
+#: ../lib/modes.py:91
 msgid "Similar to the 'Difference' mode, but lower in contrast."
 msgstr "類似「差異」模式，但對比較少。"
 
-#: ../lib/modes.py:88
+#: ../lib/modes.py:94
 msgid "Hue"
 msgstr "色相"
 
-#: ../lib/modes.py:89
+#: ../lib/modes.py:95
 msgid ""
 "Combines the hue of the top layer with the saturation and luminosity of the "
 "backdrop."
 msgstr "將頂圖層的色相與背幕的飽和度、明度相結合。"
 
-#: ../lib/modes.py:92
+#: ../lib/modes.py:98
 msgid "Saturation"
 msgstr "飽和度"
 
-#: ../lib/modes.py:93
+#: ../lib/modes.py:99
 msgid ""
 "Applies the saturation of the top layer's colors to the hue and luminosity "
 "of the backdrop."
 msgstr "將頂圖層色彩的飽和度套用至背幕的色相與明度上。"
 
-#: ../lib/modes.py:97
+#: ../lib/modes.py:103
 msgid ""
 "Applies the hue and saturation of the top layer to the luminosity of the "
 "backdrop."
 msgstr "將頂圖層的色相與飽和度套用至背幕的明度上。"
 
-#: ../lib/modes.py:100
+#: ../lib/modes.py:106
 msgid "Luminosity"
 msgstr "明度"
 
-#: ../lib/modes.py:101
+#: ../lib/modes.py:107
 msgid ""
 "Applies the luminosity of the top layer to the hue and saturation of the "
 "backdrop."
 msgstr "將頂圖層的明度套用至背幕的色相與飽和度上。"
 
-#: ../lib/modes.py:105
+#: ../lib/modes.py:111
 msgid "Plus"
 msgstr "相加"
 
-#: ../lib/modes.py:106
+#: ../lib/modes.py:112
 msgid "This layer and its backdrop are simply added together."
 msgstr "此圖層會與其背幕相加。"
 
-#: ../lib/modes.py:108
+#: ../lib/modes.py:114
 msgid "Destination In"
 msgstr "目標以內"
 
-#: ../lib/modes.py:109
+#: ../lib/modes.py:115
 msgid ""
 "Uses the backdrop only where this layer covers it. Everything else is "
 "ignored."
 msgstr "只在此圖層所涵蓋的範圍之內使用背幕，其餘部分會被忽略。"
 
-#: ../lib/modes.py:112
+#: ../lib/modes.py:118
 msgid "Destination Out"
 msgstr "目標以外"
 
-#: ../lib/modes.py:113
+#: ../lib/modes.py:119
 msgid ""
 "Uses the backdrop only where this layer doesn't cover it. Everything else is "
 "ignored."
 msgstr "只在此圖層所涵蓋的範圍之外使用背幕，其餘部分會被忽略。"
 
-#: ../lib/modes.py:116
+#: ../lib/modes.py:122
 msgid "Source Atop"
 msgstr "來源從上"
 
-#: ../lib/modes.py:117
+#: ../lib/modes.py:123
 msgid ""
 "Source which overlaps the destination, replaces the destination. Destination "
 "is placed elsewhere."
 msgstr "「來源」與「目標」重疊的部份將會取代「目標」。「目標」會被放到別處。"
 
-#: ../lib/modes.py:120
+#: ../lib/modes.py:126
 msgid "Destination Atop"
 msgstr "目標從上"
 
-#: ../lib/modes.py:121
+#: ../lib/modes.py:127
 msgid ""
 "Destination which overlaps the source replaces the source. Source is placed "
 "elsewhere."
 msgstr "「目標」與「來源」重疊的部份將會取代「來源」。「來源」會被放到別處。"
 
-#: ../lib/pixbufsurface.py:35
+#: ../lib/naming.py:22
+#, fuzzy, python-brace-format
+msgctxt "unique names: serial number needed: template"
+msgid "{name} {number}"
+msgstr "%(name)s %(number)d"
+
+#: ../lib/naming.py:29
+msgctxt "unique names: regex matching a string with a serial number"
+msgid "^(?P<name>.*?)\\s+(?P<number>\\d+)$"
+msgstr ""
+
+#: ../lib/pixbufsurface.py:38
 msgctxt "user-facing error texts"
 msgid ""
 "Unable to construct a vital internal object. Your system may not have enough "
 "memory to perform this operation."
 msgstr "無法建立一個重要的內部物件。您的系統可能沒有足夠的記憶體來執行此操作。"
 
-#: ../lib/surface.py:325
+#: ../lib/surface.py:300
 #, python-brace-format
 msgctxt "low-level PNG writer failure report (dialog)"
 msgid ""
@@ -2885,7 +3607,30 @@ msgstr ""
 "原因： {err}\n"
 "目標資料夾： “{dirname}”."
 
-#: ../lib/tiledsurface.py:542
+#: ../lib/tiledsurface.py:48
+#, fuzzy
+msgid "Vertical"
+msgstr "垂直鏡像"
+
+#: ../lib/tiledsurface.py:49
+#, fuzzy
+msgid "Horizontal"
+msgstr "水平鏡像"
+
+#: ../lib/tiledsurface.py:50
+msgid "Vertical and horizontal"
+msgstr ""
+
+#: ../lib/tiledsurface.py:51
+#, fuzzy
+msgid "Rotational"
+msgstr "重設旋轉"
+
+#: ../lib/tiledsurface.py:52
+msgid "Snowflake"
+msgstr ""
+
+#: ../lib/tiledsurface.py:627
 #, python-format
 msgid "PNG reader failed: %s"
 msgstr "PNG 閱讀器失效： %s"
@@ -2894,53 +3639,91 @@ msgstr "PNG 閱讀器失效： %s"
 msgid "Recover interrupted work?"
 msgstr "回復被中斷的作業？"
 
-#. Recover in the sense or retreival or salvage from a backup file; Save in the sense of saving it to disk immediately you click this button.
+#. Whether to show the dialog when MyPaint starts
 #: ../po/tmp/autorecover.glade.h:3
 msgctxt "Autosave Recovery dialog|"
-msgid "_Recover and Save..."
-msgstr "_回復並儲存..."
+msgid "_Look for backups at startup"
+msgstr ""
 
 #: ../po/tmp/autorecover.glade.h:4
-msgctxt "Autosave Recovery dialog|Recover and Save|"
+msgctxt "Autosave Recovery dialog|Show Dialog at Startup checkbutton|"
+msgid ""
+"Run this autosave recovery dialog when MyPaint starts, if there are files to "
+"recover.\n"
+"\n"
+"You can always launch this dialog from the ‘File’ menu when MyPaint is "
+"running."
+msgstr ""
+
+#. Deletes the selected autosave backup file.
+#: ../po/tmp/autorecover.glade.h:8
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Delete…"
+msgstr "刪除"
+
+#: ../po/tmp/autorecover.glade.h:9
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Delete button|"
+msgid "Delete this backup from the disk."
+msgstr "從磁碟中刪除筆刷"
+
+#. Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.
+#: ../po/tmp/autorecover.glade.h:11
+#, fuzzy
+msgctxt "Autosave Recovery dialog|"
+msgid "_Recover & Save…"
+msgstr "_回復並儲存..."
+
+#: ../po/tmp/autorecover.glade.h:12
+#, fuzzy
+msgctxt "Autosave Recovery dialog|Recover button|"
 msgid "Save this backup to disk, then continue working on it."
 msgstr "儲存此備份到磁碟，然後繼續當中的作業。"
 
-#: ../po/tmp/autorecover.glade.h:5
+#. Do not recover any autosaves; take no action.
+#: ../po/tmp/autorecover.glade.h:14
 msgctxt "Autosave Recovery dialog|"
-msgid "_Ignore for Now"
-msgstr "_現在忽略"
+msgid "Decide _Later"
+msgstr ""
 
-#: ../po/tmp/autorecover.glade.h:6
+#: ../po/tmp/autorecover.glade.h:15
 msgctxt "Autosave Recovery dialog|Cancel button|"
 msgid "Start work on a new canvas. These backups will be retained."
 msgstr "在新畫布上開始作業。這些備份會被保留。"
 
-#: ../po/tmp/autorecover.glade.h:7
+#: ../po/tmp/autorecover.glade.h:16
+#, fuzzy
 msgctxt "Autosave Recovery dialog|"
 msgid ""
-"MyPaint crashed with unsaved work, but it made backups. You can recover a "
-"file now, or leave it till you start MyPaint again."
-msgstr "MyPaint 在未儲存作業的狀態下當機，但是會生成備份。您可以現在就回復檔案，或者將之留置到下次再啟動 MyPaint 。"
+"MyPaint crashed with unsaved work, but it makes rolling backups. You can "
+"recover a working file from one of these automated backups now. You’ll be "
+"asked where to save it before continuing."
+msgstr ""
+"MyPaint 在未儲存作業的狀態下當機，但是會生成備份。您可以現在就回復檔案，或者"
+"將之留置到下次再啟動 MyPaint 。"
 
-#: ../po/tmp/autorecover.glade.h:8
+#: ../po/tmp/autorecover.glade.h:17
 msgid "Thumbnail"
 msgstr "略圖"
 
-#: ../po/tmp/autorecover.glade.h:9
+#: ../po/tmp/autorecover.glade.h:18
 msgid "Description"
 msgstr "描述"
 
 #: ../po/tmp/brusheditor.glade.h:1
-msgid "Copy to New"
-msgstr "複製成新"
+msgid "Live update"
+msgstr "實時更新"
 
 #: ../po/tmp/brusheditor.glade.h:2
-msgid "Copy these settings and the current brush's icon to a new brush"
-msgstr "複製這些設定及目前筆刷的圖示至新筆刷"
+msgid ""
+"Update the last stroke on the canvas with the settings in this window, in "
+"real time"
+msgstr "以此視窗中的設定實時更新畫布上最後的筆畫"
 
 #: ../po/tmp/brusheditor.glade.h:4
-msgid "Rename this brush"
-msgstr "重新命名筆刷"
+msgid "Save these settings to the brush"
+msgstr "儲存這些設定至筆刷"
 
 #: ../po/tmp/brusheditor.glade.h:5
 msgid "Edit Icon"
@@ -2961,18 +3744,16 @@ msgid "Delete this brush from the disk"
 msgstr "從磁碟中刪除筆刷"
 
 #: ../po/tmp/brusheditor.glade.h:9
-msgid "Live update"
-msgstr "實時更新"
+msgid "Copy to New"
+msgstr "複製成新"
 
 #: ../po/tmp/brusheditor.glade.h:10
-msgid ""
-"Update the last stroke on the canvas with the settings in this window, in "
-"real time"
-msgstr "以此視窗中的設定實時更新畫布上最後的筆畫"
+msgid "Copy these settings and the current brush's icon to a new brush"
+msgstr "複製這些設定及目前筆刷的圖示至新筆刷"
 
 #: ../po/tmp/brusheditor.glade.h:12
-msgid "Save these settings to the brush"
-msgstr "儲存這些設定至筆刷"
+msgid "Rename this brush"
+msgstr "重新命名筆刷"
 
 #: ../po/tmp/brusheditor.glade.h:13
 msgid "Brush Setting"
@@ -3000,30 +3781,22 @@ msgctxt "brush editor|metadata settings|labels|"
 msgid "Notes:"
 msgstr "註釋："
 
-#. field label (non-editable)
-#: ../po/tmp/brusheditor.glade.h:21
-msgid "Setting name:"
-msgstr "設定名稱："
-
-#: ../po/tmp/brusheditor.glade.h:22
+#: ../po/tmp/brusheditor.glade.h:20
 msgid ""
 "Starting value for this brush setting. The brush dynamics below act on this."
 msgstr "此筆刷設定的起始值。以下的筆刷動態將會在此之上作動。"
 
 #. field label
-#: ../po/tmp/brusheditor.glade.h:24
-msgid "Base value:"
-msgstr "基礎值："
+#: ../po/tmp/brusheditor.glade.h:22
+#, fuzzy
+msgid "Value:"
+msgstr "HSV 明度"
 
-#: ../po/tmp/brusheditor.glade.h:25
-msgid "Reset the base value to its default"
-msgstr "重設基礎值至其預設值"
-
-#: ../po/tmp/brusheditor.glade.h:26
+#: ../po/tmp/brusheditor.glade.h:23
 msgid "Reset this input to have no effect on the setting"
 msgstr "重設此輸入至沒有任何效果"
 
-#: ../po/tmp/brusheditor.glade.h:27
+#: ../po/tmp/brusheditor.glade.h:24
 msgid ""
 "Minimum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
@@ -3031,11 +3804,7 @@ msgstr ""
 "輸出軸的最小值。\n"
 "這可以利用 {dname} 的主滑桿來設定。"
 
-#: ../po/tmp/brusheditor.glade.h:29
-msgid "<ymin>"
-msgstr "<ymin>"
-
-#: ../po/tmp/brusheditor.glade.h:30
+#: ../po/tmp/brusheditor.glade.h:26
 msgid ""
 "Maximum value for the output axis.\n"
 "This can be set using the main slider for {dname}."
@@ -3043,27 +3812,23 @@ msgstr ""
 "輸出軸的最大值。\n"
 "這可以利用 {dname} 的主滑桿來設定。"
 
-#: ../po/tmp/brusheditor.glade.h:32
-msgid "<ymax>"
-msgstr "<ymax>"
-
-#: ../po/tmp/brusheditor.glade.h:33
+#: ../po/tmp/brusheditor.glade.h:28
 msgid "Output"
 msgstr "輸出"
 
-#: ../po/tmp/brusheditor.glade.h:34
+#: ../po/tmp/brusheditor.glade.h:29
 msgid "Input"
 msgstr "輸入"
 
-#: ../po/tmp/brusheditor.glade.h:35
+#: ../po/tmp/brusheditor.glade.h:30
 msgid "Adjusts the maximum value"
 msgstr "調整最大值"
 
-#: ../po/tmp/brusheditor.glade.h:36
+#: ../po/tmp/brusheditor.glade.h:31
 msgid "Adjusts the minimum value"
 msgstr "調整最小值"
 
-#: ../po/tmp/brusheditor.glade.h:37
+#: ../po/tmp/brusheditor.glade.h:32
 msgid ""
 "Minimum value for the input axis.\n"
 "Use the popup scale to adjust this."
@@ -3071,11 +3836,7 @@ msgstr ""
 "輸入軸的最小值。\n"
 "請使用起跳比例來調整此設定。"
 
-#: ../po/tmp/brusheditor.glade.h:39
-msgid "<xmin>"
-msgstr "<xmin>"
-
-#: ../po/tmp/brusheditor.glade.h:40
+#: ../po/tmp/brusheditor.glade.h:34
 msgid ""
 "Maximum value for the input axis.\n"
 "Use the popup scale to adjust this."
@@ -3083,38 +3844,36 @@ msgstr ""
 "輸入軸的最大值。\n"
 "請使用起跳比例來調整此設定。"
 
-#: ../po/tmp/brusheditor.glade.h:42
-msgid "<xmax>"
-msgstr "<xmax>"
-
-#: ../po/tmp/brusheditor.glade.h:43
+#: ../po/tmp/brusheditor.glade.h:36
 msgid "Variation of the base value by stylus input and other criteria"
 msgstr "筆桿輸入與其他標準的基礎值差異"
 
-#: ../po/tmp/brusheditor.glade.h:44
+#: ../po/tmp/brusheditor.glade.h:37
 msgid "Brush Dynamics"
 msgstr "筆刷動態"
 
-#: ../po/tmp/brusheditor.glade.h:45
-msgid "Basic details for this setting"
-msgstr "此設定的基本詳情"
-
-#: ../po/tmp/brusheditor.glade.h:46
-msgid "Edit Setting"
-msgstr "編輯設定"
-
-#: ../po/tmp/brusheditor.glade.h:47
+#: ../po/tmp/brusheditor.glade.h:38
 msgid "Adjust this input mapping in detail"
 msgstr "詳細調整此輸入對應"
 
-#: ../po/tmp/brusheditor.glade.h:48
+#: ../po/tmp/brusheditor.glade.h:39
 msgid "{tooltip}"
 msgstr "{tooltip}"
 
 #. field name (template)
-#: ../po/tmp/brusheditor.glade.h:50
+#: ../po/tmp/brusheditor.glade.h:41
 msgid "{dname}:"
 msgstr "{dname}:"
+
+#: ../po/tmp/brusheditor.glade.h:42
+#, fuzzy
+msgid "Brush dynamics are not available for this setting."
+msgstr "此設定的基本詳情"
+
+#: ../po/tmp/brusheditor.glade.h:43
+#, fuzzy
+msgid "<big><b>No Brush Dynamics</b></big>"
+msgstr "<big><b>{accel_label}</b></big>"
 
 #: ../po/tmp/inktool.glade.h:1
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
@@ -3126,7 +3885,7 @@ msgctxt "Inking tool options: point value sliders: labels"
 msgid "Press:"
 msgstr "按壓："
 
-#. The meaning of negative values is *not* affected by text direction.&#10;The widget's RTL/LTR layout, however, *is* affected.&#10;The value (and signs) *is* shown.
+#. The meaning of negative values is *not* affected by text direction.&#10;The widget
 #: ../po/tmp/inktool.glade.h:4
 msgctxt "Inking tool options: point value sliders: labels: tooltips"
 msgid ""
@@ -3171,6 +3930,141 @@ msgstr "刪除點"
 msgctxt "Inking tool options: node delete button: tooltip"
 msgid "Delete the currently selected point"
 msgstr "刪除目前已選擇的點"
+
+#: ../po/tmp/inktool.glade.h:14 ../po/tmp/resources.xml.h:184
+#, fuzzy
+msgid "Insert Point"
+msgstr "插入橫列"
+
+#: ../po/tmp/inktool.glade.h:15 ../po/tmp/resources.xml.h:188
+msgid "Simplify Points"
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:16
+msgid "Simplify the curve using the Reumann-Witkam algorithm."
+msgstr ""
+
+#: ../po/tmp/inktool.glade.h:17 ../po/tmp/resources.xml.h:190
+#, fuzzy
+msgid "Cull Points"
+msgstr "刪除點"
+
+#: ../po/tmp/inktool.glade.h:18
+msgid "Cull every other point from the curve."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:1
+msgctxt "Layer properties widget → Name → label tooltip"
+msgid "The layer’s unique name."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:2
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Name"
+msgstr "名稱"
+
+#. “Dropdown” = colloquial for a GtkComboBox control.
+#: ../po/tmp/layerprops.glade.h:4
+msgctxt "Layer properties widget → Mode → label tooltip"
+msgid ""
+"How the layer combines with what’s behind it.\n"
+"\n"
+"Each mode has a different visual effect. Refer to the dropdown’s tooltip for "
+"each one to discover what they all do."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:7
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Mode"
+msgstr "模式"
+
+#: ../po/tmp/layerprops.glade.h:9
+#, no-c-format
+msgctxt "Layer properties widget → Opacity → label tooltip"
+msgid ""
+"How much the layer combines with what’s behind it.\n"
+"\n"
+"At 0%, the layer doesn’t contribute at all."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:12
+#, fuzzy
+msgctxt "Layer properties widget → <category labels>"
+msgid "Opacity"
+msgstr "不透明度"
+
+#: ../po/tmp/layerprops.glade.h:13
+msgctxt "Layer properties widget → Flags → label tooltip"
+msgid ""
+"Special layer flags.\n"
+"\n"
+"Refer to each button’s tooltip to find out what each flag does."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:16
+msgctxt "Layer properties widget → <category labels>"
+msgid "Flags"
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:17
+msgctxt "Layer properties widget → Flags → Eye togglebutton → tooltip"
+msgid ""
+"Layer visible or hidden.\n"
+"\n"
+"An open eye icon here indicates that the layer is visible.\n"
+"\n"
+"When the eye icon is closed, the layer is hidden. Hidden layers are "
+"completely invisible: they have no effect on what's displayed. You cannot "
+"paint to hidden layers, for safety.\n"
+"\n"
+"When a layer group is hidden, all of the layers inside it are made invisible "
+"too."
+msgstr ""
+
+#: ../po/tmp/layerprops.glade.h:24
+msgctxt "Layer properties widget → Flags → Padlock togglebutton → tooltip"
+msgid ""
+"Layer editable or locked.\n"
+"\n"
+"An open padlock icon indicates that the layer can be edited.\n"
+"\n"
+"When a layer is locked, you cannot paint to it or otherwise change its pixel "
+"content. You cannot pick strokes from it either, so this is useful when "
+"painting under a sketch.\n"
+"\n"
+"When a layer group is locked, none of the layers inside it can be edited."
+msgstr ""
+
+#: ../po/tmp/layervis.glade.h:1
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "The currently active view."
+msgstr "將畫框裁切至目前使用中的圖層尺寸"
+
+#: ../po/tmp/layervis.glade.h:2
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Rename the active view."
+msgstr "旋轉畫布視圖"
+
+#: ../po/tmp/layervis.glade.h:3
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Remove the active view."
+msgstr "旋轉畫布視圖"
+
+#: ../po/tmp/layervis.glade.h:4
+#, fuzzy
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Snapshot visible layers as a new view."
+msgstr "哪些可看見的圖層應被填充"
+
+#: ../po/tmp/layervis.glade.h:5
+msgctxt "Layers window: view list controls: tooltips"
+msgid "Lock or unlock the active view."
+msgstr ""
 
 #: ../po/tmp/mypaint.glade.h:2
 msgctxt "footer: color picker button: tooltip"
@@ -3308,7 +4202,9 @@ msgctxt "Prefs Dialog|Devices|"
 msgid ""
 "Here you can restrict pointing devices to specific tasks on the canvas, or "
 "have them ignored completely if they glitch your drawing."
-msgstr "在此您可以限制定點設備在畫布上進行特定任務，或是這些設備干擾您繪畫的話也可以在此將之完全忽略。"
+msgstr ""
+"在此您可以限制定點設備在畫布上進行特定任務，或是這些設備干擾您繪畫的話也可以"
+"在此將之完全忽略。"
 
 #: ../po/tmp/preferenceswindow.glade.h:29
 msgctxt "Prefs Dialog|Button|"
@@ -3390,11 +4286,12 @@ msgid ""
 "monitors. If you know your display is radically different from this, use the "
 "\"no automatic conversions or tagging\" setting instead."
 msgstr ""
-"包含 <i>完整</i> 色彩空間資訊的圖像在載入 MyPaint 時會被轉換至 sRGB 。當 MyPaint "
-"儲存圖像時將會加入提示，使其他程式都能夠正確地渲染。\n"
+"包含 <i>完整</i> 色彩空間資訊的圖像在載入 MyPaint 時會被轉換至 sRGB 。當 "
+"MyPaint 儲存圖像時將會加入提示，使其他程式都能夠正確地渲染。\n"
 "\n"
-"這是假設顯示器是被較正至接近 sRGB "
-"的輸出，亦即是網路應用的標準色彩空間與及普遍電腦顯示器的悲觀估算值。如果您了解自己的顯示器與此有大幅差異的話，可以改為使用「不進行自動轉換或標籤」的設定。"
+"這是假設顯示器是被較正至接近 sRGB 的輸出，亦即是網路應用的標準色彩空間與及普"
+"遍電腦顯示器的悲觀估算值。如果您了解自己的顯示器與此有大幅差異的話，可以改為"
+"使用「不進行自動轉換或標籤」的設定。"
 
 #: ../po/tmp/preferenceswindow.glade.h:47
 msgctxt "Prefs Dialog|Load & Save|Color Management|"
@@ -3437,7 +4334,9 @@ msgid ""
 "Backs up work incrementally in the background to MyPaint's disk cache. If "
 "the program crashes, you'll have a chance to restore what you were working "
 "on."
-msgstr "在背景遞進地備份作業至 MyPaint 的磁碟緩衝儲存。萬一遇上程式當機，您有機會可以回復進行中的作業。"
+msgstr ""
+"在背景遞進地備份作業至 MyPaint 的磁碟緩衝儲存。萬一遇上程式當機，您有機會可以"
+"回復進行中的作業。"
 
 #: ../po/tmp/preferenceswindow.glade.h:56
 msgctxt "Prefs Dialog|Load & Save|Automated Backups|interval label"
@@ -3489,7 +4388,9 @@ msgctxt "Prefs Dialog|View|Interface|Dark theme variant|checkbox tooltip"
 msgid ""
 "Use a light-on-dark theme variant, when it's supported by the GTK theme. "
 "This is generally sensible for image editors and media viewers."
-msgstr "如 GTK3 主題支援就使用「深中帶淺」的主題版本。一般來說這樣比較適合圖像編輯器及媒體播放器。"
+msgstr ""
+"如 GTK3 主題支援就使用「深中帶淺」的主題版本。一般來說這樣比較適合圖像編輯器"
+"及媒體播放器。"
 
 #: ../po/tmp/preferenceswindow.glade.h:67
 msgid "Some of these settings require MyPaint to be restarted."
@@ -3548,7 +4449,8 @@ msgid ""
 "Scrolling to pan the view needs this setting to be turned on, and for your "
 "device to be configured to send bidirectional scroll events."
 msgstr ""
-"「順滑捲動」支援能使部分裝置的捲動動作及滾輪事件變得順滑而非層級式。這適合使用於觸控板，但是如果您習慣滑鼠的捲動表現的話可能會感到不適應。\n"
+"「順滑捲動」支援能使部分裝置的捲動動作及滾輪事件變得順滑而非層級式。這適合使"
+"用於觸控板，但是如果您習慣滑鼠的捲動表現的話可能會感到不適應。\n"
 "\n"
 "當支援順滑捲動時，可以在捲動時長按 shift 鍵來暫時切換回層級式捲動。\n"
 "\n"
@@ -3558,13 +4460,34 @@ msgstr ""
 msgid "Hide cursor while painting"
 msgstr "在繪畫時隱藏游標"
 
-#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:82
+#, fuzzy
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox label"
+msgid "Enabled"
+msgstr "已啟用"
+
 #: ../po/tmp/preferenceswindow.glade.h:83
+msgctxt ""
+"Prefs Dialog|View|Interface|Blink layers on creation/selection|checkbox "
+"tooltip"
+msgid ""
+"When a layer is created or selected, show only that layer for a short time "
+"period."
+msgstr ""
+
+#: ../po/tmp/preferenceswindow.glade.h:84
+msgctxt "Prefs Dialog|View|Interface|"
+msgid "Blink layers on creation/selection:"
+msgstr ""
+
+#. Tab label in preferences dialog&#10;
+#: ../po/tmp/preferenceswindow.glade.h:86
 msgctxt "Prefs Dialog|"
 msgid "View"
 msgstr "檢視"
 
-#: ../po/tmp/preferenceswindow.glade.h:84
+#: ../po/tmp/preferenceswindow.glade.h:87
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid ""
 "The set of colors to show as primary on disk-style color wheels.\n"
@@ -3573,56 +4496,63 @@ msgstr ""
 "圓盤狀色輪上顯示之原色色彩集。\n"
 "不同的慣例採不同的色彩調和體系。"
 
-#. Arrangement of MyPaint's custom colour wheels
-#: ../po/tmp/preferenceswindow.glade.h:87
+#. Arrangement of MyPaint
+#: ../po/tmp/preferenceswindow.glade.h:90
 msgctxt "Prefs Dialog|Color|Color Wheel|"
 msgid "Primaries are:"
 msgstr "原色是："
 
-#: ../po/tmp/preferenceswindow.glade.h:88
+#: ../po/tmp/preferenceswindow.glade.h:91
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Standard digital Red/Green/Blue"
 msgstr "標準數位紅/綠/藍"
 
-#: ../po/tmp/preferenceswindow.glade.h:89
+#: ../po/tmp/preferenceswindow.glade.h:92
 msgid ""
 "The red, green, and blue &apos;computer monitor&apos; primaries, evenly "
 "arranged around the circle. Green is opposite magenta."
-msgstr "紅、綠、與藍 &apos;電腦螢幕&apos; 主要的，平均分布。綠色是洋紅色的補色。"
+msgstr ""
+"紅、綠、與藍 &apos;電腦螢幕&apos; 主要的，平均分布。綠色是洋紅色的補色。"
 
-#: ../po/tmp/preferenceswindow.glade.h:90
+#: ../po/tmp/preferenceswindow.glade.h:93
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RGB|"
 msgid ""
 "The red, green, and blue 'computer monitor' primaries, evenly arranged "
 "around the circle. Green is opposite magenta."
-msgstr "紅、綠、藍是「電腦螢幕」的三原色，平均地散佈在這個圓裡面。綠色是洋紅色的補色。"
+msgstr ""
+"紅、綠、藍是「電腦螢幕」的三原色，平均地散佈在這個圓裡面。綠色是洋紅色的補"
+"色。"
 
-#: ../po/tmp/preferenceswindow.glade.h:91
+#: ../po/tmp/preferenceswindow.glade.h:94
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Traditional artist's Red/Yellow/Blue"
 msgstr "傳統藝術家的紅/黃/藍"
 
-#: ../po/tmp/preferenceswindow.glade.h:92
+#: ../po/tmp/preferenceswindow.glade.h:95
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
-msgstr "18世紀以來，許多藝術家使用近似於紅／黃／藍輪子的傳統排列方式，近乎純粹的顏色排列於圓的四周。綠色在紅色對面。"
+msgstr ""
+"18世紀以來，許多藝術家使用近似於紅／黃／藍輪子的傳統排列方式，近乎純粹的顏色"
+"排列於圓的四周。綠色在紅色對面。"
 
-#: ../po/tmp/preferenceswindow.glade.h:93
+#: ../po/tmp/preferenceswindow.glade.h:96
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYB|"
 msgid ""
 "The traditionally arranged red/yellow/blue wheel as used by many artists "
 "since the 18th century, approximated with pure display colors evenly "
 "arranged around the circle. Green is opposite red."
-msgstr "18世紀以來，許多藝術家使用近似於紅／黃／藍輪子的傳統排列方式，近乎純粹的顏色排列於圓的四周。綠色在紅色對面。"
+msgstr ""
+"18世紀以來，許多藝術家使用近似於紅／黃／藍輪子的傳統排列方式，近乎純粹的顏色"
+"排列於圓的四周。綠色在紅色對面。"
 
-#: ../po/tmp/preferenceswindow.glade.h:94
+#: ../po/tmp/preferenceswindow.glade.h:97
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|"
 msgid "Red-Green and Blue-Yellow opponent pairs"
 msgstr "紅-綠及藍-黃心理互補色"
 
-#: ../po/tmp/preferenceswindow.glade.h:95
+#: ../po/tmp/preferenceswindow.glade.h:98
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
 "use four &apos;psychological primaries&apos; or &apos;unique hues&apos; "
@@ -3630,10 +4560,11 @@ msgid ""
 "and yellow is opposite blue. CIECAM02 and NCS present a similar model. Here "
 "we use pure display red, yellow etc. as the four primaries."
 msgstr ""
-"透過使用&apos;四個心理原色&apos;，或在基點上相對排列的&apos;獨特色調&apos;的色彩理論，就可以快速近似原本的色彩輪。紅色在綠色對面，"
-"而黃色在藍色對面。CIECAM02 與 NCS 提供了類似的模型。這裡我們使用純粹顯示紅、黃等做為四個原色。"
+"透過使用&apos;四個心理原色&apos;，或在基點上相對排列的&apos;獨特色調&apos;的"
+"色彩理論，就可以快速近似原本的色彩輪。紅色在綠色對面，而黃色在藍色對面。"
+"CIECAM02 與 NCS 提供了類似的模型。這裡我們使用純粹顯示紅、黃等做為四個原色。"
 
-#: ../po/tmp/preferenceswindow.glade.h:96
+#: ../po/tmp/preferenceswindow.glade.h:99
 msgctxt "Prefs Dialog|Color|Color Wheel|Primaries|RYGB|"
 msgid ""
 "Quick and dirty approximation of wheels informed by theories of  color which "
@@ -3642,32 +4573,33 @@ msgid ""
 "blue. CIECAM02 and NCS present a similar model. Here we use pure display "
 "red, yellow etc. as the four primaries."
 msgstr ""
-"透過使用四個心理原色，或在基點上相對排列的獨特色調的色彩理論，就可以快速近似原本的色彩輪。紅色在綠色對面，而黃色在藍色對面。CIECAM02 與 NCS "
-"提供了類似的模型。這裡我們使用純粹顯示紅、黃等做為四個原色。"
+"透過使用四個心理原色，或在基點上相對排列的獨特色調的色彩理論，就可以快速近似"
+"原本的色彩輪。紅色在綠色對面，而黃色在藍色對面。CIECAM02 與 NCS 提供了類似的"
+"模型。這裡我們使用純粹顯示紅、黃等做為四個原色。"
 
 #. Options affecting color wheels
-#: ../po/tmp/preferenceswindow.glade.h:98
+#: ../po/tmp/preferenceswindow.glade.h:101
 msgctxt "Prefs Dialog|Color|"
 msgid "<b>Color Wheel</b>"
 msgstr "<b>色輪</b>"
 
 #. Tab label in preferences dialog
-#: ../po/tmp/preferenceswindow.glade.h:100
+#: ../po/tmp/preferenceswindow.glade.h:103
 msgctxt "Prefs Dialog|"
 msgid "Color"
 msgstr "色彩"
 
-#: ../po/tmp/preferenceswindow.glade.h:101
+#: ../po/tmp/preferenceswindow.glade.h:104
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Screen (normal)"
 msgstr "螢幕 (一般)"
 
-#: ../po/tmp/preferenceswindow.glade.h:102
+#: ../po/tmp/preferenceswindow.glade.h:105
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Disabled (no pressure sensitivity)"
 msgstr "停用 (無壓力感應)"
 
-#: ../po/tmp/preferenceswindow.glade.h:103
+#: ../po/tmp/preferenceswindow.glade.h:106
 msgctxt "Prefs Dialog|Pen Input|Mode|"
 msgid "Window (not recommended)"
 msgstr "視窗 (不建議使用)"
@@ -3728,1832 +4660,2221 @@ msgid "Reload the file your current work was loaded from."
 msgstr "重新載入您正在進行作業的檔案。"
 
 #: ../po/tmp/resources.xml.h:12
+#, fuzzy
+msgctxt "Menu→File (labels), Accel Editor (labels)"
+msgid "Import Layers…"
+msgstr "匯入筆刷…"
+
+#: ../po/tmp/resources.xml.h:13
+msgctxt "Accel Editor (descriptions)"
+msgid "Import layers from one or more files."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:14
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save"
 msgstr "儲存"
 
-#: ../po/tmp/resources.xml.h:13
+#: ../po/tmp/resources.xml.h:15
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file."
 msgstr "儲存您的作業至一個檔案。"
 
-#: ../po/tmp/resources.xml.h:14
+#: ../po/tmp/resources.xml.h:16
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As…"
 msgstr "另存為…"
 
-#: ../po/tmp/resources.xml.h:15
+#: ../po/tmp/resources.xml.h:17
 msgctxt "Accel Editor (descriptions)"
 msgid "Save your work to a file, assigning it a new name."
 msgstr "指定新的名稱來儲存您的作業至檔案。"
 
-#: ../po/tmp/resources.xml.h:16
+#: ../po/tmp/resources.xml.h:18
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Export…"
 msgstr "匯出…"
 
-#: ../po/tmp/resources.xml.h:17
+#: ../po/tmp/resources.xml.h:19
 msgid "Export your work to a file, but keep working on the same file."
 msgstr "將您的作業匯出至另一檔案，但繼續在相同檔案中進行作業。"
 
-#: ../po/tmp/resources.xml.h:18
+#: ../po/tmp/resources.xml.h:20
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Save As Scrap"
 msgstr "另存為圖料"
 
-#: ../po/tmp/resources.xml.h:19
+#: ../po/tmp/resources.xml.h:21
 msgctxt "Accel Editor (descriptions)"
 msgid "Save to a new scrap file, or save a new revision if already a scrap."
 msgstr "儲存至新圖料檔案，或圖料檔案已存在則儲存成新的修訂版本。"
 
-#: ../po/tmp/resources.xml.h:20
+#: ../po/tmp/resources.xml.h:22
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Previous Scrap"
 msgstr "開啟上一個圖料"
 
-#: ../po/tmp/resources.xml.h:21
+#: ../po/tmp/resources.xml.h:23
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file before the current one."
 msgstr "載入在目前圖料檔之前的圖料檔。"
 
-#: ../po/tmp/resources.xml.h:22
+#: ../po/tmp/resources.xml.h:24
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Open Next Scrap"
 msgstr "開啟下一個圖料"
 
-#: ../po/tmp/resources.xml.h:23
+#: ../po/tmp/resources.xml.h:25
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the scrap file after the current one."
 msgstr "載入在目前圖料檔之後的圖料檔。"
 
-#: ../po/tmp/resources.xml.h:24
+#: ../po/tmp/resources.xml.h:26
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Recover File from an Automated Backup…"
 msgstr "從自動化備份中回復檔案…"
 
-#: ../po/tmp/resources.xml.h:25
+#: ../po/tmp/resources.xml.h:27
 msgctxt "Accel Editor (descriptions)"
 msgid "Try to save and resume interrupted unsaved work."
 msgstr "嘗試儲存和恢復被中斷的未儲存作業。"
 
-#: ../po/tmp/resources.xml.h:26
+#: ../po/tmp/resources.xml.h:28
 msgctxt "Menu→Brush (label)"
 msgid "Brush Groups"
 msgstr "筆刷類組"
 
-#: ../po/tmp/resources.xml.h:27
+#: ../po/tmp/resources.xml.h:29
 msgctxt "Toolbar (short labels)"
 msgid "Brushes"
 msgstr "筆刷"
 
-#: ../po/tmp/resources.xml.h:28
+#: ../po/tmp/resources.xml.h:30
 msgctxt "Toolbar (tooltips)"
 msgid "List of brush groups."
 msgstr "筆刷類組清單。"
 
-#: ../po/tmp/resources.xml.h:29
+#: ../po/tmp/resources.xml.h:31
 msgctxt "Toolbar (label)"
 msgid "Color Adjusters"
 msgstr "色彩調整器"
 
-#: ../po/tmp/resources.xml.h:30
+#: ../po/tmp/resources.xml.h:32
 msgctxt "Toolbar (short labels)"
 msgid "Colors"
 msgstr "色彩"
 
-#: ../po/tmp/resources.xml.h:31
+#: ../po/tmp/resources.xml.h:33
 msgctxt "Toolbar (tooltips)"
 msgid "Available color adjusters."
 msgstr "可用的色彩調整器。"
 
-#: ../po/tmp/resources.xml.h:32
+#: ../po/tmp/resources.xml.h:34
 msgctxt "Menu→Layer→Properties (label)"
 msgid "Mode"
 msgstr "模式"
 
-#: ../po/tmp/resources.xml.h:33
+#: ../po/tmp/resources.xml.h:35
 msgctxt "Toolbar (short labels)"
 msgid "Mode"
 msgstr "模式"
 
-#: ../po/tmp/resources.xml.h:34
+#: ../po/tmp/resources.xml.h:36
 msgctxt "Toolbar (tooltips)"
 msgid "The current layer's compositing mode."
 msgstr "目前圖層的合成模式。"
 
-#: ../po/tmp/resources.xml.h:35
+#: ../po/tmp/resources.xml.h:37
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Pressure"
+msgstr "開端壓力"
+
+#: ../po/tmp/resources.xml.h:38
+msgctxt "Accel Editor (descriptions)"
+msgid "Send harder pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:39
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Pressure"
+msgstr "開端壓力"
+
+#: ../po/tmp/resources.xml.h:40
+msgctxt "Accel Editor (descriptions)"
+msgid "Send softer pressure for devices that don't support pressure input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:41
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Increase Fake Rotation"
+msgstr "提高色彩飽和度"
+
+#: ../po/tmp/resources.xml.h:42
+msgctxt "Accel Editor (descriptions)"
+msgid "Increase barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:43
+#, fuzzy
+msgctxt "Menu→Brush (labels), Accel Editor (labels)"
+msgid "Decrease Fake Rotation"
+msgstr "降低飽和度"
+
+#: ../po/tmp/resources.xml.h:44
+msgctxt "Accel Editor (descriptions)"
+msgid "Decrease barrel rotation for devices that don't support rotation input."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:45
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Size"
 msgstr "增大筆刷呎吋"
 
-#: ../po/tmp/resources.xml.h:36
+#: ../po/tmp/resources.xml.h:46
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush bigger."
 msgstr "令作業筆刷變得更大。"
 
-#: ../po/tmp/resources.xml.h:37
+#: ../po/tmp/resources.xml.h:47
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Size"
 msgstr "縮小筆刷呎吋"
 
-#: ../po/tmp/resources.xml.h:38
+#: ../po/tmp/resources.xml.h:48
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush smaller."
 msgstr "令作業筆刷變得更小。"
 
-#: ../po/tmp/resources.xml.h:39
+#: ../po/tmp/resources.xml.h:49
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Increase Brush Opacity"
 msgstr "增加筆刷不透明度"
 
-#: ../po/tmp/resources.xml.h:40
+#: ../po/tmp/resources.xml.h:50
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush more opaque."
 msgstr "令作業筆刷變得更不透明。"
 
-#: ../po/tmp/resources.xml.h:41
+#: ../po/tmp/resources.xml.h:51
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Decrease Brush Opacity"
 msgstr "減少筆刷不透明度"
 
-#: ../po/tmp/resources.xml.h:42
+#: ../po/tmp/resources.xml.h:52
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the working brush less opaque."
 msgstr "令作業筆刷變得更透明。"
 
-#: ../po/tmp/resources.xml.h:43
+#: ../po/tmp/resources.xml.h:53
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Lighten Painting Color"
 msgstr "加亮描繪色彩"
 
-#: ../po/tmp/resources.xml.h:44
+#: ../po/tmp/resources.xml.h:54
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase the lightness of the current painting color."
 msgstr "增加目前描繪色彩的亮度。"
 
-#: ../po/tmp/resources.xml.h:45
+#: ../po/tmp/resources.xml.h:55
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Darken Painting Color"
 msgstr "減暗描繪色彩"
 
-#: ../po/tmp/resources.xml.h:46
+#: ../po/tmp/resources.xml.h:56
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease the lightness of the current painting color."
 msgstr "減低目前描繪色彩的亮度。"
 
-#: ../po/tmp/resources.xml.h:47
-msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
-msgid "Change Hue Anticlockwise"
-msgstr "逆時針改變色相"
-
-#: ../po/tmp/resources.xml.h:48
-msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
-msgstr "將描繪色彩的色相在色輪上逆時針旋轉。"
-
-#: ../po/tmp/resources.xml.h:49
+#: ../po/tmp/resources.xml.h:57
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Change Hue Clockwise"
 msgstr "順時針改變色相"
 
-#: ../po/tmp/resources.xml.h:50
+#: ../po/tmp/resources.xml.h:58
 msgctxt "Accel Editor (descriptions)"
 msgid "Rotate the painting color’s hue clockwise on the color wheel."
 msgstr "將描繪色彩的色相在色輪上順時針旋轉。"
 
-#: ../po/tmp/resources.xml.h:51
+#: ../po/tmp/resources.xml.h:59
+msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
+msgid "Change Hue Anticlockwise"
+msgstr "逆時針改變色相"
+
+#: ../po/tmp/resources.xml.h:60
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the painting color’s hue anticlockwise on the color wheel."
+msgstr "將描繪色彩的色相在色輪上逆時針旋轉。"
+
+#: ../po/tmp/resources.xml.h:61
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Increase Saturation"
 msgstr "提高色彩飽和度"
 
-#: ../po/tmp/resources.xml.h:52
+#: ../po/tmp/resources.xml.h:62
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color more saturated (more colorful, purer)."
 msgstr "令描繪色彩更加飽和 (更鮮艷，更純淨)。"
 
-#: ../po/tmp/resources.xml.h:53
+#: ../po/tmp/resources.xml.h:63
 msgctxt "Menu→Color→Adjust Color (labels), Accel Editor (labels)"
 msgid "Decrease Saturation"
 msgstr "降低飽和度"
 
-#: ../po/tmp/resources.xml.h:54
+#: ../po/tmp/resources.xml.h:64
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the painting color less saturated (grayer)."
 msgstr "令描繪色彩較少飽和 (更灰淡)。"
 
-#: ../po/tmp/resources.xml.h:55
+#: ../po/tmp/resources.xml.h:65
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Reload Brush Settings"
 msgstr "重載筆刷設定"
 
-#: ../po/tmp/resources.xml.h:56
+#: ../po/tmp/resources.xml.h:66
 msgctxt "Accel Editor (descriptions)"
 msgid "Restore all brush settings to the current brush’s saved values."
 msgstr "復元所有筆刷設定至目前筆刷所儲存的設定值。"
 
-#: ../po/tmp/resources.xml.h:57
+#: ../po/tmp/resources.xml.h:67
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Pick Stroke and Layer"
 msgstr "挑選筆劃與圖層"
 
-#: ../po/tmp/resources.xml.h:58
+#: ../po/tmp/resources.xml.h:68
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Pick a brushstroke from the canvas: restores brush, color, and layer."
+msgid ""
+"Pick a brushstroke from the canvas, which restores brush, color, and layer."
 msgstr "在畫布中挑選一個筆刷筆劃：恢復筆刷、顏色和圖層。"
 
-#: ../po/tmp/resources.xml.h:59
+#: ../po/tmp/resources.xml.h:69
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Restore Color"
 msgstr "筆刷快捷鍵色彩復元"
 
-#: ../po/tmp/resources.xml.h:60
+#: ../po/tmp/resources.xml.h:70
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle whether restoring the brush from a shortcut key also restores the "
 "saved color."
 msgstr "切換是否由快捷鍵復元筆刷時同時復元被儲存的色彩。"
 
-#: ../po/tmp/resources.xml.h:61
+#: ../po/tmp/resources.xml.h:71
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Save Brush to Most Recent Shortcut Key"
 msgstr "儲存筆刷至最新近的快捷鍵"
 
-#: ../po/tmp/resources.xml.h:62
+#: ../po/tmp/resources.xml.h:72
 msgctxt "Accel Editor (descriptions)"
 msgid "Save brush settings to the most recently used shortcut key."
 msgstr "將筆刷設定儲存至最新近使用過的快捷鍵。"
 
-#: ../po/tmp/resources.xml.h:63
+#: ../po/tmp/resources.xml.h:73
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Clear Layer"
 msgstr "清空圖層"
 
-#: ../po/tmp/resources.xml.h:64
+#: ../po/tmp/resources.xml.h:74
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Clear the current layer’s content."
+msgid "Clear the active layer’s content."
 msgstr "清空目前圖層的內容。"
 
-#: ../po/tmp/resources.xml.h:65
-msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:75
+#, fuzzy
+msgctxt "Menu→Layer (labels)"
+msgid "Slice Operations"
+msgstr "工具選項"
+
+#: ../po/tmp/resources.xml.h:76
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
 msgid "Trim Layer to Frame"
 msgstr "裁切圖層至畫框"
 
-#: ../po/tmp/resources.xml.h:66
+#: ../po/tmp/resources.xml.h:77
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase parts of the current layer which lie outside the frame."
 msgstr "消除圖層中位於畫框以外的部分。"
 
-#: ../po/tmp/resources.xml.h:67
+#: ../po/tmp/resources.xml.h:78
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Pixels"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:79
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete parts of the current layer which do not vary from the backdrop."
+msgstr "消除圖層中位於畫框以外的部分。"
+
+#: ../po/tmp/resources.xml.h:80
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Uniquify Layer Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:81
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Delete whole tiles from the current layer which do not vary from the "
+"backdrop."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:82
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Pixels"
+msgstr "在下層新增圖層群組"
+
+#: ../po/tmp/resources.xml.h:83
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Normalize child layers, then factor out common parts to a new child layer."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:84
+#, fuzzy
+msgctxt "Menu→Layer→Slice (labels), Accel Editor (labels)"
+msgid "Refactor Layer Group Tiles"
+msgstr "在下層新增圖層群組"
+
+#: ../po/tmp/resources.xml.h:85
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Copy Layer to Clipboard"
 msgstr "複製圖層至剪貼簿"
 
-#: ../po/tmp/resources.xml.h:68
+#: ../po/tmp/resources.xml.h:86
 msgctxt "Accel Editor (descriptions)"
 msgid "Copy the current layer’s contents to the clipboard."
 msgstr "將目前圖層的內容複製至剪貼簿。"
 
-#: ../po/tmp/resources.xml.h:69
+#: ../po/tmp/resources.xml.h:87
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Paste Layer from Clipboard"
 msgstr "從剪貼簿貼至圖層"
 
-#: ../po/tmp/resources.xml.h:70
+#: ../po/tmp/resources.xml.h:88
 msgctxt "Accel Editor (descriptions)"
 msgid "Replaces the current layer with the clipboard’s contents."
 msgstr "以剪貼簿的內容置換目前圖層。"
 
-#: ../po/tmp/resources.xml.h:71
+#: ../po/tmp/resources.xml.h:89
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Edit Layer in External App…"
 msgstr "以外部程式編輯圖層…"
 
-#: ../po/tmp/resources.xml.h:72
+#: ../po/tmp/resources.xml.h:90
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Begin editing the current layer in an external application."
+msgid "Edit the active layer in an external application."
 msgstr "利用外部應用程式開始編輯目前的圖層。"
 
-#: ../po/tmp/resources.xml.h:73
+#: ../po/tmp/resources.xml.h:91
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Update Layer with External Edits"
 msgstr "更新圖層外部編輯"
 
-#: ../po/tmp/resources.xml.h:74
+#: ../po/tmp/resources.xml.h:92
 msgctxt "Accel Editor (descriptions)"
 msgid "Commit changes saved from the external app (normally automatic)."
 msgstr "適用外部應用程式所儲存的變動 (一般自動執行)。"
 
-#: ../po/tmp/resources.xml.h:75
+#: ../po/tmp/resources.xml.h:93
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer at Cursor"
 msgstr "前往游標下的圖層"
 
-#: ../po/tmp/resources.xml.h:76
+#: ../po/tmp/resources.xml.h:94
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Select a layer by picking an object on it."
+msgid "Select a layer by picking something [drawn] on it."
 msgstr "藉由挑選圖層上的物件來選取圖層。"
 
-#: ../po/tmp/resources.xml.h:77
+#: ../po/tmp/resources.xml.h:95
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Above"
 msgstr "前往上層圖層"
 
-#: ../po/tmp/resources.xml.h:78
+#: ../po/tmp/resources.xml.h:96
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer up in the layer stack."
 msgstr "前往圖層堆疊中的上一個圖層。"
 
-#: ../po/tmp/resources.xml.h:79
+#: ../po/tmp/resources.xml.h:97
 msgctxt "Menu→Layer→Go to Layer (labels), Accel Editor (labels)"
 msgid "Go to Layer Below"
 msgstr "前往下層圖層"
 
-#: ../po/tmp/resources.xml.h:80
+#: ../po/tmp/resources.xml.h:98
 msgctxt "Accel Editor (descriptions)"
 msgid "Go one layer down in the layer stack."
 msgstr "前往圖層堆疊中的下一個圖層。"
 
-#: ../po/tmp/resources.xml.h:81
+#: ../po/tmp/resources.xml.h:99
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer"
 msgstr "新增繪畫圖層"
 
-#: ../po/tmp/resources.xml.h:82
+#: ../po/tmp/resources.xml.h:100
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer above the current layer."
 msgstr "在目前圖層之上新增一個繪畫圖層。"
 
-#: ../po/tmp/resources.xml.h:83
+#: ../po/tmp/resources.xml.h:101
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer…"
 msgstr "新增向量圖層…"
 
-#: ../po/tmp/resources.xml.h:84
+#: ../po/tmp/resources.xml.h:102
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer above the current layer, and begin editing it."
 msgstr "在目前圖層之上新增一個向量圖層，並且開始編輯。"
 
-#: ../po/tmp/resources.xml.h:85
+#: ../po/tmp/resources.xml.h:103
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group"
 msgstr "新增圖層群組"
 
-#: ../po/tmp/resources.xml.h:86
+#: ../po/tmp/resources.xml.h:104
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group above the current layer."
 msgstr "在目前圖層之上新增一個圖層群組。"
 
-#: ../po/tmp/resources.xml.h:87
+#: ../po/tmp/resources.xml.h:105
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Painting Layer Below"
 msgstr "在下層新增繪畫圖層"
 
-#: ../po/tmp/resources.xml.h:88
+#: ../po/tmp/resources.xml.h:106
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new painting layer below the current layer."
 msgstr "在目前圖層之下新增一個繪畫圖層。"
 
-#: ../po/tmp/resources.xml.h:89
+#: ../po/tmp/resources.xml.h:107
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Vector Layer Below…"
 msgstr "在下層新增向量圖層…"
 
-#: ../po/tmp/resources.xml.h:90
+#: ../po/tmp/resources.xml.h:108
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new vector layer below the current layer, and begin editing it."
 msgstr "在目前圖層之下新增一個向量圖層，並且開始編輯。"
 
-#: ../po/tmp/resources.xml.h:91
+#: ../po/tmp/resources.xml.h:109
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer Group Below"
 msgstr "在下層新增圖層群組"
 
-#: ../po/tmp/resources.xml.h:92
+#: ../po/tmp/resources.xml.h:110
 msgctxt "Accel Editor (descriptions)"
 msgid "Add a new layer group below the current layer."
 msgstr "在目前圖層之下新增一個圖層群組。"
 
-#: ../po/tmp/resources.xml.h:93
+#: ../po/tmp/resources.xml.h:111
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Layer Down"
 msgstr "向下合併圖層"
 
-#: ../po/tmp/resources.xml.h:94
+#: ../po/tmp/resources.xml.h:112
 msgctxt "Accel Editor (descriptions)"
 msgid "Merge the current layer with the layer beneath it."
 msgstr "將目前圖層與底下的圖層合併。"
 
-#: ../po/tmp/resources.xml.h:95
+#: ../po/tmp/resources.xml.h:113
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Merge Visible Layers"
 msgstr "合併可看見的圖層"
 
-#: ../po/tmp/resources.xml.h:96
+#: ../po/tmp/resources.xml.h:114
 msgctxt "Accel Editor (descriptions)"
 msgid "Consolidate all visible layers, and delete the originals."
 msgstr "合併所有可看見的圖層，並刪除原來的。"
 
-#: ../po/tmp/resources.xml.h:97
+#: ../po/tmp/resources.xml.h:115
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "New Layer from Visible"
 msgstr "從可看見的圖層建立新的"
 
-#: ../po/tmp/resources.xml.h:98
+#: ../po/tmp/resources.xml.h:116
 msgctxt "Accel Editor (descriptions)"
 msgid "Like ‘Merge Visible Layers’, but doesn’t delete the originals."
 msgstr "和「合併可看見的圖層」相似，但不會將原來的圖層刪除。"
 
-#: ../po/tmp/resources.xml.h:99
+#: ../po/tmp/resources.xml.h:117
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Delete Layer"
 msgstr "刪除圖層"
 
-#: ../po/tmp/resources.xml.h:100
+#: ../po/tmp/resources.xml.h:118
 msgctxt "Accel Editor (descriptions)"
 msgid "Remove the current layer from the layer stack."
 msgstr "從圖層堆疊中移除目前的圖層。"
 
-#: ../po/tmp/resources.xml.h:101
+#: ../po/tmp/resources.xml.h:119
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Convert to Normal Painting Layer"
 msgstr "轉換成一般繪畫圖層"
 
-#: ../po/tmp/resources.xml.h:102
+#: ../po/tmp/resources.xml.h:120
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Convert the current layer or group to a painting layer in ‘Normal’ mode, "
 "preserving its appearance."
 msgstr "以目前圖層或群組的面貌轉換成「一般」模式的繪畫圖層。"
 
-#: ../po/tmp/resources.xml.h:103
+#: ../po/tmp/resources.xml.h:121
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Increase Layer’s Opacity"
 msgstr "增加圖層不透明度"
 
-#: ../po/tmp/resources.xml.h:104
+#: ../po/tmp/resources.xml.h:122
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer less transparent."
 msgstr "令圖層變得更不透明。"
 
-#: ../po/tmp/resources.xml.h:105
+#: ../po/tmp/resources.xml.h:123
 msgctxt "Menu→Layer→Opacity (labels), Accel Editor (labels)"
 msgid "Reduce Layer’s Opacity"
 msgstr "減少圖層不透明度"
 
-#: ../po/tmp/resources.xml.h:106
+#: ../po/tmp/resources.xml.h:124
 msgctxt "Accel Editor (descriptions)"
 msgid "Make the layer more transparent."
 msgstr "令圖層變得更加透明。"
 
-#: ../po/tmp/resources.xml.h:107
+#: ../po/tmp/resources.xml.h:125
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Raise Layer"
 msgstr "提昇圖層"
 
-#: ../po/tmp/resources.xml.h:108
+#: ../po/tmp/resources.xml.h:126
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise the current layer one step in the layer stack."
 msgstr "將目前圖層在圖層堆疊中提昇一級。"
 
-#: ../po/tmp/resources.xml.h:109
+#: ../po/tmp/resources.xml.h:127
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Lower Layer"
 msgstr "降低圖層"
 
-#: ../po/tmp/resources.xml.h:110
+#: ../po/tmp/resources.xml.h:128
 msgctxt "Accel Editor (descriptions)"
 msgid "Lower the current layer one step in the layer stack."
 msgstr "將目前圖層在圖層堆疊中降低一級。"
 
-#: ../po/tmp/resources.xml.h:111
+#: ../po/tmp/resources.xml.h:129
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Duplicate Layer"
 msgstr "製作圖層副本"
 
-#: ../po/tmp/resources.xml.h:112
+#: ../po/tmp/resources.xml.h:130
 msgctxt "Accel Editor (descriptions)"
 msgid "Make an exact clone of the current layer."
 msgstr "製作與目前圖層完全一致的副本。"
 
-#: ../po/tmp/resources.xml.h:113
+#: ../po/tmp/resources.xml.h:131
+#, fuzzy
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
-msgid "Rename Layer…"
-msgstr "重新命名圖層…"
+msgid "Layer Properties…"
+msgstr "屬性"
 
-#: ../po/tmp/resources.xml.h:114
+#: ../po/tmp/resources.xml.h:132
 msgctxt "Accel Editor (descriptions)"
-msgid "Enter a new name for the current layer."
-msgstr "為目前圖層輸入新的名稱。"
+msgid ""
+"Change the layer’s properties (name, mode, visibility, locked, opacity)."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:115
+#: ../po/tmp/resources.xml.h:133
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Locked"
 msgstr "圖層上鎖"
 
-#: ../po/tmp/resources.xml.h:116
+#: ../po/tmp/resources.xml.h:134
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Toggle the current layer’s locked state. Locked layers cannot be modified."
 msgstr "切換目前圖層的上鎖狀態。上鎖的圖層將無法被改動。"
 
-#: ../po/tmp/resources.xml.h:117
+#: ../po/tmp/resources.xml.h:135
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Layer Visible"
 msgstr "圖層可看見"
 
-#: ../po/tmp/resources.xml.h:118
+#: ../po/tmp/resources.xml.h:136
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the current layer’s visibility state, making it hidden."
 msgstr "切換圖層的可看見的狀態，讓圖層顯示或隱藏。"
 
-#: ../po/tmp/resources.xml.h:119
+#: ../po/tmp/resources.xml.h:137
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Show Background"
 msgstr "顯示背景"
 
-#: ../po/tmp/resources.xml.h:120
+#: ../po/tmp/resources.xml.h:138
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle the background layer’s visibility."
 msgstr "顯示或隱藏背景。"
 
-#: ../po/tmp/resources.xml.h:121
+#: ../po/tmp/resources.xml.h:139
+msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
+msgid "Vacuum Empty Tiles"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:140
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Remove empty tiles from the document."
+msgstr "從圖層堆疊中移除目前的圖層。"
+
+#: ../po/tmp/resources.xml.h:141
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Reset and Center View"
 msgstr "重設並置中檢視"
 
-#: ../po/tmp/resources.xml.h:122
+#: ../po/tmp/resources.xml.h:142
 msgctxt "Accel Editor (descriptions)"
 msgid "Reset Zoom, Rotation and Mirroring, and recenter the document."
 msgstr "重設視點的遠近、旋轉和鏡像，並且將文件重新置中。"
 
-#: ../po/tmp/resources.xml.h:123
+#: ../po/tmp/resources.xml.h:143
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fit to View"
 msgstr "配合視圖大小"
 
-#: ../po/tmp/resources.xml.h:124
+#: ../po/tmp/resources.xml.h:144
 msgctxt "Accel Editor (descriptions)"
 msgid "Switch between a fitted view and your working location and zoom."
 msgstr "在一適合的視圖與你的工作部位和縮放之間進行切換。"
 
-#: ../po/tmp/resources.xml.h:125
+#: ../po/tmp/resources.xml.h:145
 msgctxt "Menu→View (labels)"
 msgid "Reset"
 msgstr "重設"
 
-#: ../po/tmp/resources.xml.h:126
+#: ../po/tmp/resources.xml.h:146
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Zoom"
 msgstr "重設縮放"
 
-#: ../po/tmp/resources.xml.h:127
+#: ../po/tmp/resources.xml.h:147
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s zoom to its default."
+msgid "Reset view zoom level to default."
 msgstr "恢復視圖的縮放到其預設。"
 
-#: ../po/tmp/resources.xml.h:128
+#: ../po/tmp/resources.xml.h:148
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Rotation"
 msgstr "重設旋轉"
 
-#: ../po/tmp/resources.xml.h:129
+#: ../po/tmp/resources.xml.h:149
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Restore the view’s rotation to 0°"
+msgid "Reset the view’s rotation to 0°"
 msgstr "將視圖旋轉角度恢復到 0 度"
 
-#: ../po/tmp/resources.xml.h:130
+#: ../po/tmp/resources.xml.h:150
 msgctxt "Menu→View→Reset (labels), Accel Editor (labels)"
 msgid "Reset Mirroring"
 msgstr "重設鏡像"
 
-#: ../po/tmp/resources.xml.h:131
+#: ../po/tmp/resources.xml.h:151
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Turn off mirroring of the view."
-msgstr "關閉視圖的鏡像功能。"
+msgid "Reset the view's mirroring."
+msgstr "重設鏡像"
 
-#: ../po/tmp/resources.xml.h:132
+#: ../po/tmp/resources.xml.h:152
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom In"
 msgstr "放大"
 
-#: ../po/tmp/resources.xml.h:133
+#: ../po/tmp/resources.xml.h:153
 msgctxt "Accel Editor (descriptions)"
 msgid "Increase magnification."
 msgstr "提高放大倍數。"
 
-#: ../po/tmp/resources.xml.h:134
+#: ../po/tmp/resources.xml.h:154
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Zoom Out"
 msgstr "縮小"
 
-#: ../po/tmp/resources.xml.h:135
+#: ../po/tmp/resources.xml.h:155
 msgctxt "Accel Editor (descriptions)"
 msgid "Decrease magnification."
 msgstr "降低放大倍數。"
 
-#: ../po/tmp/resources.xml.h:136
+#: ../po/tmp/resources.xml.h:156
+#, fuzzy
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
-msgid "Rotate Counterclockwise"
-msgstr "逆時針旋轉"
+msgid "Pan Left"
+msgstr "平移視圖"
 
-#: ../po/tmp/resources.xml.h:137
+#: ../po/tmp/resources.xml.h:157
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view counterclockwise."
-msgstr "逆時針旋轉視圖。"
+msgid "Move your view of the canvas to the left."
+msgstr "旋轉視圖：傾斜你的畫布視圖。"
 
-#: ../po/tmp/resources.xml.h:138
+#: ../po/tmp/resources.xml.h:158
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Right"
+msgstr "強光"
+
+#: ../po/tmp/resources.xml.h:159
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas to the right."
+msgstr "平移視圖：水平或垂直移動您的的畫布視圖。"
+
+#: ../po/tmp/resources.xml.h:160
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Up"
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:161
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas upwards."
+msgstr "旋轉視圖：傾斜你的畫布視圖。"
+
+#: ../po/tmp/resources.xml.h:162
+#, fuzzy
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Pan Down"
+msgstr "平移視圖"
+
+#: ../po/tmp/resources.xml.h:163
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Move your view of the canvas downwards."
+msgstr "旋轉視圖：傾斜你的畫布視圖。"
+
+#: ../po/tmp/resources.xml.h:164
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Rotate Clockwise"
 msgstr "順時針旋轉"
 
-#: ../po/tmp/resources.xml.h:139
+#: ../po/tmp/resources.xml.h:165
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid "Rotate the view clockwise."
+msgid "Rotate the canvas clockwise."
 msgstr "順時針旋轉視圖。"
 
-#: ../po/tmp/resources.xml.h:140
+#: ../po/tmp/resources.xml.h:166
+msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
+msgid "Rotate Counterclockwise"
+msgstr "逆時針旋轉"
+
+#: ../po/tmp/resources.xml.h:167
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Rotate the canvas counter-clockwise."
+msgstr "逆時針旋轉視圖。"
+
+#: ../po/tmp/resources.xml.h:168
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Horizontal"
 msgstr "水平鏡像"
 
-#: ../po/tmp/resources.xml.h:141
+#: ../po/tmp/resources.xml.h:169
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view left to right."
 msgstr "將視圖左右翻轉。"
 
-#: ../po/tmp/resources.xml.h:142
+#: ../po/tmp/resources.xml.h:170
 msgctxt "Menu→View→Adjust View (labels), Accel Editor (labels)"
 msgid "Mirror Vertical"
 msgstr "垂直鏡像"
 
-#: ../po/tmp/resources.xml.h:143
+#: ../po/tmp/resources.xml.h:171
 msgctxt "Accel Editor (descriptions)"
 msgid "Flip the view upside-down."
 msgstr "將視圖上下顛倒。"
 
-#: ../po/tmp/resources.xml.h:144
+#: ../po/tmp/resources.xml.h:172
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Layer Solo"
 msgstr "單獨顯示圖層"
 
-#: ../po/tmp/resources.xml.h:145
+#: ../po/tmp/resources.xml.h:173
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle whether only the current layer is shown."
 msgstr "切換是否單獨顯示目前圖層。"
 
-#: ../po/tmp/resources.xml.h:146
+#: ../po/tmp/resources.xml.h:174
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Symmetrical Painting Active"
 msgstr "使用對稱繪畫"
 
-#: ../po/tmp/resources.xml.h:147
+#: ../po/tmp/resources.xml.h:175
 msgctxt "Accel Editor (descriptions)"
 msgid "Mirror brushstrokes along the axis of symmetry"
 msgstr "沿對稱軸鏡射筆刷筆劃"
 
-#: ../po/tmp/resources.xml.h:148
+#: ../po/tmp/resources.xml.h:176
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Frame Enabled"
 msgstr "啟用畫框"
 
-#: ../po/tmp/resources.xml.h:149
+#: ../po/tmp/resources.xml.h:177
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle visibility of the document frame."
 msgstr "顯示或隱藏畫框。"
 
-#: ../po/tmp/resources.xml.h:150
+#: ../po/tmp/resources.xml.h:178
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Brush Input Values to Console"
 msgstr "列印筆刷輸入值至主控臺"
 
-#: ../po/tmp/resources.xml.h:151
+#: ../po/tmp/resources.xml.h:179
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the brush engine’s internally generated inputs on the console."
 msgstr "在主控臺中顯示筆刷引擎的內部產生數值。"
 
-#: ../po/tmp/resources.xml.h:152
+#: ../po/tmp/resources.xml.h:180
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Visualize Rendering"
 msgstr "渲染視覺化"
 
-#: ../po/tmp/resources.xml.h:153
+#: ../po/tmp/resources.xml.h:181
 msgctxt "Accel Editor (descriptions)"
 msgid "Show rendering updates on-screen, for debugging."
 msgstr "於螢幕上顯示渲染的更新，除錯用。"
 
-#: ../po/tmp/resources.xml.h:154
+#: ../po/tmp/resources.xml.h:182
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "No Double Buffering"
 msgstr "停用雙倍緩衝"
 
-#: ../po/tmp/resources.xml.h:155
+#: ../po/tmp/resources.xml.h:183
 msgctxt "Accel Editor (descriptions)"
 msgid "Turn off GTK’s double buffering, normally enabled."
 msgstr "關閉 GTK 的雙倍緩衝，一般會被啟用。"
 
-#: ../po/tmp/resources.xml.h:156
+#: ../po/tmp/resources.xml.h:185
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Insert a point next to the currently selected point in the direction of the "
+"stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:186
+#, fuzzy
+msgid "Delete Point"
+msgstr "刪除點"
+
+#: ../po/tmp/resources.xml.h:187
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete currently selected point on the ink stroke."
+msgstr "刪除目前已選擇的點"
+
+#: ../po/tmp/resources.xml.h:189
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Simplify and delete points according to angle and distance between nodes."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:191
+msgctxt "Accel Editor (descriptions)"
+msgid "Delete every other point on the ink stroke."
+msgstr ""
+
+#: ../po/tmp/resources.xml.h:192
 msgctxt "Menu→Brush (labels)"
 msgid "Paint Mode"
 msgstr "繪圖模式"
 
-#: ../po/tmp/resources.xml.h:157
+#: ../po/tmp/resources.xml.h:193
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Normal"
 msgstr "繪圖模式：正常"
 
-#: ../po/tmp/resources.xml.h:158
+#: ../po/tmp/resources.xml.h:194
 msgctxt "Accel Editor (descriptions)"
 msgid "Apply color normally when painting."
 msgstr "繪圖時正常地套用顏色。"
 
-#: ../po/tmp/resources.xml.h:159
+#: ../po/tmp/resources.xml.h:195
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Eraser"
 msgstr "繪圖模式：橡皮擦"
 
-#: ../po/tmp/resources.xml.h:160
+#: ../po/tmp/resources.xml.h:196
 msgctxt "Accel Editor (descriptions)"
 msgid "Erase using the current brush."
 msgstr "使用目前的筆刷來擦除顏色。"
 
-#: ../po/tmp/resources.xml.h:161
+#: ../po/tmp/resources.xml.h:197
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Lock Alpha"
 msgstr "繪圖模式：Alpha 上鎖"
 
-#: ../po/tmp/resources.xml.h:162
+#: ../po/tmp/resources.xml.h:198
 msgctxt "Accel Editor (descriptions)"
 msgid "Applying the brush doesn't change the layer’s opacity."
 msgstr "使用筆刷時不會改變圖層的透明度。"
 
-#: ../po/tmp/resources.xml.h:163
+#: ../po/tmp/resources.xml.h:199
 msgctxt "Menu→Brush→Blend Mode (labels), Accel Editor (labels)"
 msgid "Paint Mode: Colorize"
 msgstr "繪圖模式：著色"
 
-#: ../po/tmp/resources.xml.h:164
+#: ../po/tmp/resources.xml.h:200
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Apply color to the current layer without affecting its brightness or opacity."
 msgstr "在目前圖層塗上色彩的同時保持原有的亮度和不透明度。"
 
-#: ../po/tmp/resources.xml.h:165
+#: ../po/tmp/resources.xml.h:201
 msgctxt "Menu (labels)"
 msgid "File"
 msgstr "檔案"
 
-#: ../po/tmp/resources.xml.h:166
+#: ../po/tmp/resources.xml.h:202
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Quit"
 msgstr "退出"
 
-#: ../po/tmp/resources.xml.h:167
+#: ../po/tmp/resources.xml.h:203
 msgctxt "Accel Editor (descriptions)"
 msgid "Close main window and exit the app."
 msgstr "關閉主視窗並且離開程式。"
 
-#: ../po/tmp/resources.xml.h:168
+#: ../po/tmp/resources.xml.h:204
 msgctxt "Menu (labels)"
 msgid "Edit"
 msgstr "編輯"
 
-#: ../po/tmp/resources.xml.h:169
-msgctxt "Menu→Edit (labels)"
-msgid "Current Tool"
-msgstr "目前工具"
-
-#: ../po/tmp/resources.xml.h:170
+#: ../po/tmp/resources.xml.h:205
 msgctxt "Menu (labels)"
 msgid "Color"
 msgstr "顏色"
 
-#: ../po/tmp/resources.xml.h:171
+#: ../po/tmp/resources.xml.h:206
 msgctxt "Menu→Color (labels)"
 msgid "Adjust Color"
 msgstr "調整色彩"
 
-#: ../po/tmp/resources.xml.h:172
+#: ../po/tmp/resources.xml.h:207
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color History Popup"
 msgstr "彈出顏色歷史"
 
-#: ../po/tmp/resources.xml.h:173
+#: ../po/tmp/resources.xml.h:208
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a timeline of recent colors under the cursor."
 msgstr "在游標下彈出一個「最近使用的顏色」之時間軸。"
 
-#: ../po/tmp/resources.xml.h:174
+#: ../po/tmp/resources.xml.h:209
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Details Dialog"
 msgstr "色彩細節對話框"
 
-#: ../po/tmp/resources.xml.h:175
+#: ../po/tmp/resources.xml.h:210
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a color details dialog with text entry."
 msgstr "顯示具有文字陳述的色彩細節對話框。"
 
-#: ../po/tmp/resources.xml.h:176
+#: ../po/tmp/resources.xml.h:211
 msgctxt "Menu→Color"
 msgid "Next Palette Color"
 msgstr "下一個調色盤色彩"
 
-#: ../po/tmp/resources.xml.h:177
+#: ../po/tmp/resources.xml.h:212
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the next color in the palette."
 msgstr "設定調色盤中的下一個色彩為繪圖色彩。"
 
-#: ../po/tmp/resources.xml.h:178
+#: ../po/tmp/resources.xml.h:213
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Previous Palette Color"
 msgstr "前一個調色盤色彩"
 
-#: ../po/tmp/resources.xml.h:179
+#: ../po/tmp/resources.xml.h:214
 msgctxt "Accel Editor (descriptions)"
 msgid "Set painting color to the previous color in the palette."
 msgstr "設定調色盤中的前一個色彩為繪圖色彩。"
 
-#: ../po/tmp/resources.xml.h:180
+#: ../po/tmp/resources.xml.h:215
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Add Color to Palette"
 msgstr "將顏色加入調色盤"
 
-#: ../po/tmp/resources.xml.h:181
+#: ../po/tmp/resources.xml.h:216
 msgctxt "Accel Editor (descriptions)"
 msgid "Append the current painting color to the palette."
 msgstr "添加目前繪圖顏色到調色盤。"
 
-#: ../po/tmp/resources.xml.h:182
+#: ../po/tmp/resources.xml.h:217
 msgctxt "Menu (labels)"
 msgid "Layer"
 msgstr "圖層"
 
-#: ../po/tmp/resources.xml.h:183
+#: ../po/tmp/resources.xml.h:218
 msgctxt "Menu→Layer→Properties (labels)"
 msgid "Opacity"
 msgstr "不透明度"
 
-#: ../po/tmp/resources.xml.h:184
+#: ../po/tmp/resources.xml.h:219
 msgctxt "Menu→Layer (labels)"
 msgid "Go to Layer"
 msgstr "前往圖層"
 
-#: ../po/tmp/resources.xml.h:185
+#: ../po/tmp/resources.xml.h:220
 msgctxt "Menu→Layer (labels)"
 msgid "New Layer Below"
 msgstr "在下層新增圖層"
 
-#: ../po/tmp/resources.xml.h:186
+#: ../po/tmp/resources.xml.h:221
 msgctxt "Menu→Layer (labels)"
 msgid "Properties"
 msgstr "屬性"
 
-#: ../po/tmp/resources.xml.h:187
+#: ../po/tmp/resources.xml.h:222
 msgctxt "Menu (labels)"
 msgid "Scratchpad"
 msgstr "便條紙"
 
-#: ../po/tmp/resources.xml.h:188
+#: ../po/tmp/resources.xml.h:223
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "New Scratchpad"
 msgstr "新增便條紙"
 
-#: ../po/tmp/resources.xml.h:189
+#: ../po/tmp/resources.xml.h:224
 msgctxt "Accel Editor (descriptions)"
 msgid "Load the default scratchpad as a new scratchpad canvas."
 msgstr "載入預設便條紙作為新的便條紙畫布。"
 
-#: ../po/tmp/resources.xml.h:190
+#: ../po/tmp/resources.xml.h:225
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Open Scratchpad…"
 msgstr "開啟便條紙…"
 
-#: ../po/tmp/resources.xml.h:191
+#: ../po/tmp/resources.xml.h:226
 msgctxt "Accel Editor (descriptions)"
 msgid "Load an image file on disk into the scratchpad."
 msgstr "從磁碟中載入圖像檔到便條紙中。"
 
-#: ../po/tmp/resources.xml.h:192
+#: ../po/tmp/resources.xml.h:227
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad"
 msgstr "儲存便條紙"
 
-#: ../po/tmp/resources.xml.h:193
+#: ../po/tmp/resources.xml.h:228
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad to its existing file on disk."
 msgstr "將便條紙儲存至磁碟上的現存檔案。"
 
-#: ../po/tmp/resources.xml.h:194
+#: ../po/tmp/resources.xml.h:229
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Export Scratchpad As…"
 msgstr "匯出便條紙為…"
 
-#: ../po/tmp/resources.xml.h:195
+#: ../po/tmp/resources.xml.h:230
 msgctxt "Accel Editor (descriptions)"
 msgid "Export the scratchpad to disk, under a file name of your choice."
 msgstr "使用由您指定的檔案名稱來匯出便條紙至磁碟。"
 
-#: ../po/tmp/resources.xml.h:196
+#: ../po/tmp/resources.xml.h:231
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Revert Scratchpad"
 msgstr "恢復便條紙"
 
-#: ../po/tmp/resources.xml.h:197
+#: ../po/tmp/resources.xml.h:232
 msgctxt "Accel Editor (descriptions)"
 msgid "Revert the scratchpad to its last saved state."
 msgstr "還原便條紙至上次儲存時的狀態。"
 
-#: ../po/tmp/resources.xml.h:198
+#: ../po/tmp/resources.xml.h:233
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Save Scratchpad as Default"
 msgstr "儲存便條簿作為預設"
 
-#: ../po/tmp/resources.xml.h:199
+#: ../po/tmp/resources.xml.h:234
 msgctxt "Accel Editor (descriptions)"
 msgid "Save the scratchpad as the default for ‘New Scratchpad’."
 msgstr "將便條紙儲存為「新增便條紙」的預設。"
 
-#: ../po/tmp/resources.xml.h:200
+#: ../po/tmp/resources.xml.h:235
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Clear Default Scratchpad"
 msgstr "清除預設便條簿"
 
-#: ../po/tmp/resources.xml.h:201
+#: ../po/tmp/resources.xml.h:236
 msgctxt "Accel Editor (descriptions)"
 msgid "Clear the default scratchpad to a blank canvas."
 msgstr "將預設便條紙清空成空白畫布。"
 
-#: ../po/tmp/resources.xml.h:202
+#: ../po/tmp/resources.xml.h:237
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Copy Main Background to Scratchpad"
 msgstr "複製主背景至便條紙"
 
-#: ../po/tmp/resources.xml.h:203
+#: ../po/tmp/resources.xml.h:238
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Copy the background image from the working document into the Scratchpad."
 msgstr "從工作文件複製背景圖到便條紙。"
 
-#: ../po/tmp/resources.xml.h:204
+#: ../po/tmp/resources.xml.h:239
 msgctxt "Menu (labels)"
 msgid "Window"
 msgstr "視窗"
 
-#: ../po/tmp/resources.xml.h:205
+#: ../po/tmp/resources.xml.h:240
 msgctxt "Menu→Brush (labels)"
 msgid "Brush"
 msgstr "筆刷"
 
-#: ../po/tmp/resources.xml.h:206
+#: ../po/tmp/resources.xml.h:241
 msgctxt "Menu→Brush (labels)"
 msgid "Shortcut Keys"
 msgstr "快捷鍵"
 
-#: ../po/tmp/resources.xml.h:207
+#: ../po/tmp/resources.xml.h:242
 msgctxt "Menu→Brush→Shortcut Keys (labels), Accel Editor (labels)"
 msgid "Brush Shortcut Keys Help"
 msgstr "筆刷快捷鍵幫助"
 
-#: ../po/tmp/resources.xml.h:208
+#: ../po/tmp/resources.xml.h:243
 msgctxt "Accel Editor (descriptions)"
 msgid "Show an explanation of how the shortcut keys work."
 msgstr "顯示快捷鍵如何運作的說明。"
 
-#: ../po/tmp/resources.xml.h:209
+#: ../po/tmp/resources.xml.h:244
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Change Brush…"
 msgstr "切換筆刷…"
 
-#: ../po/tmp/resources.xml.h:210
+#: ../po/tmp/resources.xml.h:245
 msgctxt "Accel Editor (descriptions)"
 msgid "Pop up a brush changer under the cursor."
 msgstr "在游標下顯示筆刷切換彈出式窗。"
 
-#: ../po/tmp/resources.xml.h:211
+#: ../po/tmp/resources.xml.h:246
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color…"
 msgstr "切換色彩…"
 
-#: ../po/tmp/resources.xml.h:212
+#: ../po/tmp/resources.xml.h:247
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with all color selectors listed."
 msgstr "在游標下顯示列出所有色彩選擇器的色彩切換彈出式窗。"
 
-#: ../po/tmp/resources.xml.h:213
+#: ../po/tmp/resources.xml.h:248
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Change Color (fast subset)…"
 msgstr "切換色彩 (快速子集)…"
 
-#: ../po/tmp/resources.xml.h:214
+#: ../po/tmp/resources.xml.h:249
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Pop up a color changer under the cursor, with only single-click selectors "
 "listed."
 msgstr "在游標下顯示只列出單擊選擇器的色彩切換彈出式窗。"
 
-#: ../po/tmp/resources.xml.h:215
+#: ../po/tmp/resources.xml.h:250
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Get More Brushes…"
 msgstr "取得更多筆刷…"
 
-#: ../po/tmp/resources.xml.h:216
+#: ../po/tmp/resources.xml.h:251
 msgctxt "Accel Editor (descriptions)"
 msgid "Download brushpacks from the MyPaint wiki."
 msgstr "從 MyPaint Wiki 下載筆刷包。"
 
-#: ../po/tmp/resources.xml.h:217
+#: ../po/tmp/resources.xml.h:252
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Import Brushes…"
 msgstr "匯入筆刷…"
 
-#: ../po/tmp/resources.xml.h:218
+#: ../po/tmp/resources.xml.h:253
 msgctxt "Accel Editor (descriptions)"
 msgid "Load a brushpack from disk."
 msgstr "從磁碟中載入筆刷包。"
 
-#: ../po/tmp/resources.xml.h:219
+#: ../po/tmp/resources.xml.h:254
 msgctxt "Menu (labels)"
 msgid "Help"
 msgstr "幫助"
 
-#: ../po/tmp/resources.xml.h:220
+#: ../po/tmp/resources.xml.h:255
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "Online Help"
 msgstr "線上幫助"
 
-#: ../po/tmp/resources.xml.h:221
+#: ../po/tmp/resources.xml.h:256
 msgctxt "Accel Editor (descriptions)"
 msgid "Go to MyPaint’s documentation wiki."
 msgstr "前往 MyPaint 的文檔 Wiki。"
 
-#: ../po/tmp/resources.xml.h:222
+#: ../po/tmp/resources.xml.h:257
 msgctxt "Menu→Help (labels), Accel Editor (labels)"
 msgid "About MyPaint"
 msgstr "關於 MyPaint"
 
-#: ../po/tmp/resources.xml.h:223
+#: ../po/tmp/resources.xml.h:258
 msgctxt "Accel Editor (descriptions)"
 msgid "Show MyPaint’s license, version number, and credits."
 msgstr "顯示 MyPaint 的使用條款，版本編號和製作人員名單。"
 
-#: ../po/tmp/resources.xml.h:224
+#: ../po/tmp/resources.xml.h:259
 msgctxt "Menu→Help (labels)"
 msgid "Debug"
 msgstr "除錯"
 
-#: ../po/tmp/resources.xml.h:225
+#: ../po/tmp/resources.xml.h:260
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Print Memory Leak Info to Console (Slow!)"
 msgstr "列印記憶體漏失資訊到主控臺 (慢！)"
 
-#: ../po/tmp/resources.xml.h:226
+#: ../po/tmp/resources.xml.h:261
 msgctxt "Accel Editor (descriptions)"
 msgid "Debug memory leaks."
 msgstr "為記憶體漏失除錯。"
 
-#: ../po/tmp/resources.xml.h:227
+#: ../po/tmp/resources.xml.h:262
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Run Garbage Collector Now"
 msgstr "立刻執行垃圾收集器"
 
-#: ../po/tmp/resources.xml.h:228
+#: ../po/tmp/resources.xml.h:263
 msgctxt "Accel Editor (descriptions)"
 msgid "Free memory used for Python objects which are no longer in use."
 msgstr "釋放已經不在使用中的 Python 物件所佔用的記憶體。"
 
-#: ../po/tmp/resources.xml.h:229
+#: ../po/tmp/resources.xml.h:264
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Start/Stop Profiling…"
 msgstr "開始/停止評測…"
 
-#: ../po/tmp/resources.xml.h:230
+#: ../po/tmp/resources.xml.h:265
 msgctxt "Accel Editor (descriptions)"
 msgid "Start or Stop Python Profiling (cProfile)"
 msgstr "開始/停止 Python 評測 (cProfile)"
 
-#: ../po/tmp/resources.xml.h:231
+#: ../po/tmp/resources.xml.h:266
 msgctxt "Menu→Help→Debug (labels), Accel Editor (labels)"
 msgid "Simulate a Crash…"
 msgstr "模擬當機…"
 
-#: ../po/tmp/resources.xml.h:232
+#: ../po/tmp/resources.xml.h:267
 msgctxt "Accel Editor (descriptions)"
 msgid "Raise a Python exception, to test the crash dialog."
 msgstr "發出 Python 例外來測試當機對話框。"
 
-#: ../po/tmp/resources.xml.h:233
+#: ../po/tmp/resources.xml.h:268
 msgctxt "Menu (labels)"
 msgid "View"
 msgstr "檢視"
 
-#: ../po/tmp/resources.xml.h:234
+#: ../po/tmp/resources.xml.h:269
 msgctxt "Menu→View (labels)"
 msgid "Feedback"
 msgstr "反饋的訊息"
 
-#: ../po/tmp/resources.xml.h:235
+#: ../po/tmp/resources.xml.h:270
 msgctxt "Menu→View (labels)"
 msgid "Adjust View"
 msgstr "調整視圖"
 
-#: ../po/tmp/resources.xml.h:236
+#: ../po/tmp/resources.xml.h:271
+#, fuzzy
 msgctxt "Menu→View (labels), Accel Editor (labels)"
-msgid "Popup Menu"
+msgid "Popup Main Menu"
 msgstr "彈出選單"
 
-#: ../po/tmp/resources.xml.h:237
+#: ../po/tmp/resources.xml.h:272
 msgctxt "Accel Editor (descriptions)"
 msgid "Show the main menu as a popup."
 msgstr "主選單彈出式顯示。"
 
-#: ../po/tmp/resources.xml.h:238
+#: ../po/tmp/resources.xml.h:273
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Fullscreen"
 msgstr "全螢幕"
 
-#: ../po/tmp/resources.xml.h:239
+#: ../po/tmp/resources.xml.h:274
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle between full-screen and windowed mode."
 msgstr "切換全螢幕及視窗模式。"
 
-#: ../po/tmp/resources.xml.h:240
+#: ../po/tmp/resources.xml.h:275
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Edit Preferences"
 msgstr "編輯偏好設定"
 
-#: ../po/tmp/resources.xml.h:241
+#: ../po/tmp/resources.xml.h:276
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit MyPaint’s global settings."
 msgstr "編輯 MyPaint 的整體設定。"
 
-#: ../po/tmp/resources.xml.h:242
+#: ../po/tmp/resources.xml.h:277
 msgctxt "Help→Debug (labels), Accel Editor (labels)"
 msgid "Test Input Devices"
 msgstr "測試輸入裝置"
 
-#: ../po/tmp/resources.xml.h:243
+#: ../po/tmp/resources.xml.h:278
 msgctxt "Accel Editor (descriptions)"
 msgid "Show a dialog which captures all events your input devices send."
 msgstr "顯示擷取您的輸入裝置所傳送的全部事件的對話窗。"
 
-#: ../po/tmp/resources.xml.h:244
+#: ../po/tmp/resources.xml.h:279
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Background Chooser"
 msgstr "背景選擇器"
 
-#: ../po/tmp/resources.xml.h:245
+#: ../po/tmp/resources.xml.h:280
 msgctxt "Accel Editor (descriptions)"
 msgid "Change the background paper texture."
 msgstr "更換背景紙張紋理。"
 
-#: ../po/tmp/resources.xml.h:246
+#: ../po/tmp/resources.xml.h:281
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Settings Editor"
 msgstr "筆刷設定編輯器"
 
-#: ../po/tmp/resources.xml.h:247
+#: ../po/tmp/resources.xml.h:282
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit the active brush’s settings."
 msgstr "編輯使用中筆刷的設定。"
 
-#: ../po/tmp/resources.xml.h:248
+#: ../po/tmp/resources.xml.h:283
 msgctxt "Menu→Brush (labels), Accel Editor (labels)"
 msgid "Brush Icon Editor"
 msgstr "筆刷圖示編輯器"
 
-#: ../po/tmp/resources.xml.h:249
+#: ../po/tmp/resources.xml.h:284
 msgctxt "Accel Editor (descriptions)"
 msgid "Edit brush icons."
 msgstr "編輯筆刷圖示。"
 
-#: ../po/tmp/resources.xml.h:250
-msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
+#: ../po/tmp/resources.xml.h:285
+#, fuzzy
+msgctxt ""
+"Menu→Layer (labels), Menu→Window (labels), Toolbar (labels), Accel Editor "
+"(labels)"
 msgid "Layers Panel"
 msgstr "圖層面板"
 
-#: ../po/tmp/resources.xml.h:251
+#: ../po/tmp/resources.xml.h:286
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
-msgstr "切換圖層停駐面板 (排列圖層，或選定模式) 。"
+msgid "Dockable panel for managing layers."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:252
+#: ../po/tmp/resources.xml.h:287
 msgctxt "Menu→Layers (labels), Accel Editor (labels)"
 msgid "Show Layers Panel"
 msgstr "顯示圖層控制板"
 
-#: ../po/tmp/resources.xml.h:253
+#: ../po/tmp/resources.xml.h:288
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Layers dockpanel (arrange layers, or assign modes)."
 msgstr "展示圖層停駐控制板 (排列圖層，或選定模式) 。"
 
-#: ../po/tmp/resources.xml.h:254
+#: ../po/tmp/resources.xml.h:289
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HCY Wheel"
 msgstr "HCY 色輪"
 
-#: ../po/tmp/resources.xml.h:255
+#: ../po/tmp/resources.xml.h:290
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable cylindrical hue/chroma/luma color selector. The circular slices are "
 "equiluminant."
 msgstr "使用色相/彩度/明度空間圓柱體設定色彩。圓形切片皆相等。"
 
-#: ../po/tmp/resources.xml.h:256
+#: ../po/tmp/resources.xml.h:291
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Color Palette"
 msgstr "色彩調色盤"
 
-#: ../po/tmp/resources.xml.h:257
+#: ../po/tmp/resources.xml.h:292
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable palette color selector."
 msgstr "調色盤顏色選擇器。"
 
-#: ../po/tmp/resources.xml.h:258
+#: ../po/tmp/resources.xml.h:293
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Wheel"
 msgstr "HSV 色輪"
 
-#: ../po/tmp/resources.xml.h:259
+#: ../po/tmp/resources.xml.h:294
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable saturation and Value color changer."
 msgstr "飽和度與明度的換色器。"
 
-#: ../po/tmp/resources.xml.h:260
-msgctxt "Menu→Color (labels), Accel Editor (labels)"
-msgid "HSV Triangle"
-msgstr "HSV 三角"
-
-#: ../po/tmp/resources.xml.h:261
-msgctxt "Accel Editor (descriptions)"
-msgid "Dockable color selector: the old GTK color triangle."
-msgstr "顏色選擇器：舊 GTK 顏色三角。"
-
-#: ../po/tmp/resources.xml.h:262
+#: ../po/tmp/resources.xml.h:295
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Cube"
 msgstr "HSV 方塊"
 
-#: ../po/tmp/resources.xml.h:263
+#: ../po/tmp/resources.xml.h:296
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Dockable color selector: HSV cube which can be rotated to show different "
 "planar slices."
 msgstr "顏色選擇器：HSV 立方體可以旋轉顯示立方體不同的面向。"
 
-#: ../po/tmp/resources.xml.h:264
+#: ../po/tmp/resources.xml.h:297
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "HSV Square"
 msgstr "HSV 正方形"
 
-#: ../po/tmp/resources.xml.h:265
+#: ../po/tmp/resources.xml.h:298
+#, fuzzy
 msgctxt "Accel Editor (descriptions)"
-msgid ""
-"Dockable color selector: HSV square which can be rotated to show different "
-"hues."
-msgstr "顏色選擇器：HSV 正方形可轉動，以顯示不同的色相。"
+msgid "Dockable color selector: HSV square with Hue ring."
+msgstr "顏色選擇器具有同中心的 HSV 色環。"
 
-#: ../po/tmp/resources.xml.h:266
+#: ../po/tmp/resources.xml.h:299
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Component Sliders"
 msgstr "成份滑桿"
 
-#: ../po/tmp/resources.xml.h:267
+#: ../po/tmp/resources.xml.h:300
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing individual components of the color."
 msgstr "顏色選擇器，顯示顏色的各別成份。"
 
-#: ../po/tmp/resources.xml.h:268
+#: ../po/tmp/resources.xml.h:301
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Liquid Wash"
 msgstr "液體洗滌"
 
-#: ../po/tmp/resources.xml.h:269
+#: ../po/tmp/resources.xml.h:302
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector showing a liquid-like wash of nearby colors."
 msgstr "顏色選擇器顯示一液狀洗的相鄰顏色。"
 
-#: ../po/tmp/resources.xml.h:270
+#: ../po/tmp/resources.xml.h:303
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Concentric Rings"
 msgstr "同心色環"
 
-#: ../po/tmp/resources.xml.h:271
+#: ../po/tmp/resources.xml.h:304
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with concentric HSV rings."
 msgstr "顏色選擇器具有同中心的 HSV 色環。"
 
-#: ../po/tmp/resources.xml.h:272
+#: ../po/tmp/resources.xml.h:305
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Crossed Bowl"
 msgstr "跨越碗"
 
-#: ../po/tmp/resources.xml.h:273
+#: ../po/tmp/resources.xml.h:306
 msgctxt "Accel Editor (descriptions)"
 msgid "Dockable color selector with HSV ramps crossing a radial bowl of color."
 msgstr "顏色選擇器用 HSV 斜面跨越一徑向碗的顏色。"
 
-#: ../po/tmp/resources.xml.h:274
+#: ../po/tmp/resources.xml.h:307
 msgctxt "Menu→Window (labels), Accel Editor (labels)"
 msgid "Scratchpad Panel"
 msgstr "便條紙面板"
 
-#: ../po/tmp/resources.xml.h:275
+#: ../po/tmp/resources.xml.h:308
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
-msgstr "切換便條紙停駐面板開關 (調色及畫草圖) 。"
+msgid "Dockable Panel for mixing colors and testing brushes."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:276
+#: ../po/tmp/resources.xml.h:309
 msgctxt "Menu→Scratchpad (labels), Accel Editor (labels)"
 msgid "Show Scratchpad Panel"
 msgstr "顯示圖畫簿控制板"
 
-#: ../po/tmp/resources.xml.h:277
+#: ../po/tmp/resources.xml.h:310
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Scratchpad dockpanel (mix colors and make sketches)."
 msgstr "展現圖畫簿停駐面板 (調色及畫草圖) 。"
 
-#: ../po/tmp/resources.xml.h:278
+#: ../po/tmp/resources.xml.h:311
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Preview Panel"
 msgstr "預覽控制板"
 
-#: ../po/tmp/resources.xml.h:279
+#: ../po/tmp/resources.xml.h:312
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
-msgstr "切換預覽停駐面板 (整個繪圖區域的概覽) 。"
+msgid "Dockable panel for an overview and navigation of the whole canvas."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:280
+#: ../po/tmp/resources.xml.h:313
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Preview"
 msgstr "預覽"
 
-#: ../po/tmp/resources.xml.h:281
+#: ../po/tmp/resources.xml.h:314
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Preview dockpanel (overview of the whole drawing area)."
 msgstr "展示預覽停駐控制板 (整體作畫範圍的概覽) 。"
 
-#: ../po/tmp/resources.xml.h:282
+#: ../po/tmp/resources.xml.h:315
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Tool Options Panel"
 msgstr "工具選項面板"
 
-#: ../po/tmp/resources.xml.h:283
+#: ../po/tmp/resources.xml.h:316
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the Tool Options dockpanel (options for the current tool)."
-msgstr "切換工具選項停駐面板 (目前工具的選項) 。"
+msgid "Dockable panel for adjusting the options with the activated tool."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:284
+#: ../po/tmp/resources.xml.h:317
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Show Tool Options Panel"
 msgstr "顯示工具選項面板"
 
-#: ../po/tmp/resources.xml.h:285
+#: ../po/tmp/resources.xml.h:318
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the Tool Options dockpanel (options for the current tool)."
 msgstr "展示工具選項停駐面板 (目前工具的選項) 。"
 
-#: ../po/tmp/resources.xml.h:286
+#: ../po/tmp/resources.xml.h:319
 msgctxt "Menu→Window (labels), Toolbar (labels), Accel Editor (labels)"
 msgid "Brush & Color History Panel"
 msgstr "筆刷及色彩歷史面板"
 
-#: ../po/tmp/resources.xml.h:287
+#: ../po/tmp/resources.xml.h:320
 msgctxt "Accel Editor (descriptions)"
-msgid "Toggle the History panel (recently used brushes and colors)."
-msgstr "切換歷史面板開關 (最近使用過的筆刷及顏色) 。"
+msgid "Dockable panel for viewing recently changed colors and brushes."
+msgstr ""
 
-#: ../po/tmp/resources.xml.h:288
+#: ../po/tmp/resources.xml.h:321
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Recent Brushes & Colors"
 msgstr "最近使用的筆刷及顏色"
 
-#: ../po/tmp/resources.xml.h:289
+#: ../po/tmp/resources.xml.h:322
 msgctxt "Accel Editor (descriptions)"
 msgid "Reveal the History panel (recently used brushes and colors)."
 msgstr "展示歷史面板 (最近使用過的筆刷及顏色) 。"
 
-#: ../po/tmp/resources.xml.h:290
+#: ../po/tmp/resources.xml.h:323
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Hide Controls in Fullscreen"
 msgstr "全螢幕模式時隱藏控制項"
 
-#: ../po/tmp/resources.xml.h:291
+#: ../po/tmp/resources.xml.h:324
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle automatic hiding of the user interface in fullscreen."
 msgstr "切換至全螢幕模式時自動隱藏使用者界面。"
 
-#: ../po/tmp/resources.xml.h:292
+#: ../po/tmp/resources.xml.h:325
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Zoom Level"
 msgstr "顯示縮放層級"
 
-#: ../po/tmp/resources.xml.h:293
+#: ../po/tmp/resources.xml.h:326
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle zoom level feedback."
 msgstr "切換縮放層級反饋開關。"
 
-#: ../po/tmp/resources.xml.h:294
+#: ../po/tmp/resources.xml.h:327
 msgctxt "Menu→View→Feedback (labels), Accel Editor (labels)"
 msgid "Show Last Painting Position"
 msgstr "顯示最後繪圖位置"
 
-#: ../po/tmp/resources.xml.h:295
+#: ../po/tmp/resources.xml.h:328
 msgctxt "Accel Editor (descriptions)"
 msgid "Toggle feedback showing where the last stroke ended."
 msgstr "切換最後筆畫停止位置的反饋顯示開關。"
 
-#: ../po/tmp/resources.xml.h:296
+#: ../po/tmp/resources.xml.h:329
 msgctxt "Menu→View (labels)"
 msgid "Display Filter"
 msgstr "顯示過濾器"
 
-#: ../po/tmp/resources.xml.h:297
+#: ../po/tmp/resources.xml.h:330
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Normally"
 msgstr "顯示正常色彩"
 
-#: ../po/tmp/resources.xml.h:298
+#: ../po/tmp/resources.xml.h:331
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show colors unchanged."
 msgstr "色彩過濾：顯示原來色彩。"
 
-#: ../po/tmp/resources.xml.h:299
+#: ../po/tmp/resources.xml.h:332
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors as Greyscale"
 msgstr "顯示灰階"
 
-#: ../po/tmp/resources.xml.h:300
+#: ../po/tmp/resources.xml.h:333
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: show brightness only (HCY/YCbCr Luma)"
 msgstr "色彩過濾：只顯示亮度 (HCY/YCbCr 亮度)"
 
-#: ../po/tmp/resources.xml.h:301
+#: ../po/tmp/resources.xml.h:334
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors Inverted"
 msgstr "顯示相反色彩"
 
-#: ../po/tmp/resources.xml.h:302
+#: ../po/tmp/resources.xml.h:335
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors: inverse video. Black is white and red is cyan."
 msgstr "色彩過濾：反白顯示。黑色會變成白色，紅色會變成青綠色。"
 
-#: ../po/tmp/resources.xml.h:303
+#: ../po/tmp/resources.xml.h:336
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Red"
 msgstr "顯示模擬低紅色敏感度的色彩"
 
-#: ../po/tmp/resources.xml.h:304
+#: ../po/tmp/resources.xml.h:337
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Filter colors to simulate deuteranopia, a common form of color blindness."
 msgstr "過濾色彩去模擬綠色盲，一種常見的色盲類形。"
 
-#: ../po/tmp/resources.xml.h:305
+#: ../po/tmp/resources.xml.h:338
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Green"
 msgstr "顯示模擬低綠色敏感度的色彩"
 
-#: ../po/tmp/resources.xml.h:306
+#: ../po/tmp/resources.xml.h:339
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate protanopia, a common form of color blindness."
 msgstr "過濾色彩去模擬紅色盲，一種常見的色盲類形。"
 
-#: ../po/tmp/resources.xml.h:307
+#: ../po/tmp/resources.xml.h:340
 msgctxt "Menu→View→Display Filter (labels), Accel Editor (labels)"
 msgid "Display Colors with Simulated Insensitivity to Blue"
 msgstr "顯示模擬低藍色敏感度的色彩"
 
-#: ../po/tmp/resources.xml.h:308
+#: ../po/tmp/resources.xml.h:341
 msgctxt "Accel Editor (descriptions)"
 msgid "Filter colors to simulate tritanopia, a rare form of color blindness."
 msgstr "過濾色彩去模擬藍色盲，一種罕見的色盲類形。"
 
-#: ../po/tmp/resources.xml.h:309
+#: ../po/tmp/resources.xml.h:342
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Freehand"
 msgstr "徒手繪畫"
 
-#: ../po/tmp/resources.xml.h:310
+#: ../po/tmp/resources.xml.h:343
 msgctxt "Toolbar (short labels)"
 msgid "Freehand"
 msgstr "徒手"
 
-#: ../po/tmp/resources.xml.h:311
+#: ../po/tmp/resources.xml.h:344
 msgctxt "Toolbar (tooltips)"
 msgid "Freehand: draw and paint freely, without geometric constraints."
 msgstr "徒手繪畫：自由描繪，沒有幾何限制。"
 
-#: ../po/tmp/resources.xml.h:312
+#: ../po/tmp/resources.xml.h:345
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Freehand"
 msgstr "徒手繪畫"
 
-#: ../po/tmp/resources.xml.h:313
+#: ../po/tmp/resources.xml.h:346
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw and paint freely, without geometric constraints."
 msgstr "自由描繪，沒有幾何限制。"
 
-#: ../po/tmp/resources.xml.h:314
+#: ../po/tmp/resources.xml.h:347
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pan View"
 msgstr "平移視圖"
 
-#: ../po/tmp/resources.xml.h:315
+#: ../po/tmp/resources.xml.h:348
 msgctxt "Toolbar (short labels)"
 msgid "Pan"
 msgstr "平移"
 
-#: ../po/tmp/resources.xml.h:316
+#: ../po/tmp/resources.xml.h:349
 msgctxt "Toolbar (tooltips)"
 msgid "Pan View: move your view of the canvas horizontally or vertically."
 msgstr "平移視圖：水平或垂直移動您的的畫布視圖。"
 
-#: ../po/tmp/resources.xml.h:317
+#: ../po/tmp/resources.xml.h:350
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Pan View"
 msgstr "移動視圖"
 
-#: ../po/tmp/resources.xml.h:318
+#: ../po/tmp/resources.xml.h:351
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively move your view of the canvas horizontally or vertically."
 msgstr "互動地上下左右移動您的畫布視圖。"
 
-#: ../po/tmp/resources.xml.h:319
+#: ../po/tmp/resources.xml.h:352
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Rotate View"
 msgstr "旋轉視圖"
 
-#: ../po/tmp/resources.xml.h:320
+#: ../po/tmp/resources.xml.h:353
 msgctxt "Toolbar (short labels)"
 msgid "Rotate"
 msgstr "旋轉"
 
-#: ../po/tmp/resources.xml.h:321
+#: ../po/tmp/resources.xml.h:354
 msgctxt "Toolbar (tooltips)"
 msgid "Rotate View: tilt your view of the canvas."
 msgstr "旋轉視圖：傾斜你的畫布視圖。"
 
-#: ../po/tmp/resources.xml.h:322
+#: ../po/tmp/resources.xml.h:355
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Rotate View"
 msgstr "旋轉視圖"
 
-#: ../po/tmp/resources.xml.h:323
+#: ../po/tmp/resources.xml.h:356
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively rotate your view of the canvas."
 msgstr "互動地旋轉您的畫布視圖。"
 
-#: ../po/tmp/resources.xml.h:324
+#: ../po/tmp/resources.xml.h:357
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Zoom View"
 msgstr "縮放視圖"
 
-#: ../po/tmp/resources.xml.h:325
+#: ../po/tmp/resources.xml.h:358
 msgctxt "Toolbar (short labels)"
 msgid "Zoom"
 msgstr "縮放"
 
-#: ../po/tmp/resources.xml.h:326
+#: ../po/tmp/resources.xml.h:359
 msgctxt "Toolbar (tooltips)"
 msgid "Zoom View: zoom into or out of the canvas."
 msgstr "縮放視圖：放大或縮小畫布。"
 
-#: ../po/tmp/resources.xml.h:327
+#: ../po/tmp/resources.xml.h:360
 msgctxt "Menu→View (labels), Accel Editor (labels)"
 msgid "Zoom View"
 msgstr "縮放視圖"
 
-#: ../po/tmp/resources.xml.h:328
+#: ../po/tmp/resources.xml.h:361
 msgctxt "Accel Editor (descriptions)"
 msgid "Interactively zoom into or out of the canvas."
 msgstr "互動地放大縮小畫布視圖。"
 
-#: ../po/tmp/resources.xml.h:329
+#: ../po/tmp/resources.xml.h:362
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Lines and Curves"
 msgstr "線條與曲線"
 
-#: ../po/tmp/resources.xml.h:330
+#: ../po/tmp/resources.xml.h:363
 msgctxt "Toolbar (short labels)"
 msgid "Lines"
 msgstr "線條"
 
-#: ../po/tmp/resources.xml.h:331
+#: ../po/tmp/resources.xml.h:364
 msgctxt "Toolbar (tooltips)"
 msgid "Lines and Curves: draw straight or curved lines."
 msgstr "直線和曲線：畫直線或曲線。"
 
-#: ../po/tmp/resources.xml.h:332
+#: ../po/tmp/resources.xml.h:365
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Lines and Curves"
 msgstr "線條與曲線"
 
-#: ../po/tmp/resources.xml.h:333
+#: ../po/tmp/resources.xml.h:366
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw straight or curved lines."
 msgstr "畫直線或曲線。"
 
-#: ../po/tmp/resources.xml.h:334
+#: ../po/tmp/resources.xml.h:367
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Connected Lines"
 msgstr "連接的線條"
 
-#: ../po/tmp/resources.xml.h:335
+#: ../po/tmp/resources.xml.h:368
 msgctxt "Toolbar (short labels)"
 msgid "Conn. Lines"
 msgstr "連接的線條"
 
-#: ../po/tmp/resources.xml.h:336
+#: ../po/tmp/resources.xml.h:369
 msgctxt "Toolbar (tooltips)"
 msgid "Connected Lines: draw sequences of straight or curved lines."
 msgstr "連接的線條：畫依照順序的直線或曲線。"
 
-#: ../po/tmp/resources.xml.h:337
+#: ../po/tmp/resources.xml.h:370
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Connected Lines"
 msgstr "連接的線條"
 
-#: ../po/tmp/resources.xml.h:338
+#: ../po/tmp/resources.xml.h:371
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw sequences of straight or curved lines."
 msgstr "畫依照順序的直線或曲線。"
 
-#: ../po/tmp/resources.xml.h:339
+#: ../po/tmp/resources.xml.h:372
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Ellipses and Circles"
 msgstr "橢圓與圓形"
 
-#: ../po/tmp/resources.xml.h:340
+#: ../po/tmp/resources.xml.h:373
 msgctxt "Toolbar (short labels)"
 msgid "Ellipse"
 msgstr "橢圓"
 
-#: ../po/tmp/resources.xml.h:341
+#: ../po/tmp/resources.xml.h:374
 msgctxt "Toolbar (tooltips)"
 msgid "Ellipses and Circles: draw rounded shapes."
 msgstr "橢圓與圓形：畫圓的形狀。"
 
-#: ../po/tmp/resources.xml.h:342
+#: ../po/tmp/resources.xml.h:375
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Ellipses and Circles"
 msgstr "橢圓形與圓形"
 
-#: ../po/tmp/resources.xml.h:343
+#: ../po/tmp/resources.xml.h:376
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw circles and ellipses."
 msgstr "畫橢圓形與圓形。"
 
-#: ../po/tmp/resources.xml.h:344
+#: ../po/tmp/resources.xml.h:377
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Inking"
 msgstr "描線"
 
-#: ../po/tmp/resources.xml.h:345
+#: ../po/tmp/resources.xml.h:378
 msgctxt "Toolbar (short labels)"
 msgid "Ink"
 msgstr "墨水"
 
-#: ../po/tmp/resources.xml.h:346
+#: ../po/tmp/resources.xml.h:379
 msgctxt "Toolbar (tooltips)"
 msgid "Inking: draw smooth controlled lines."
 msgstr "描線：畫平滑可控制的線條。"
 
-#: ../po/tmp/resources.xml.h:347
+#: ../po/tmp/resources.xml.h:380
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Inking"
 msgstr "描線"
 
-#: ../po/tmp/resources.xml.h:348
+#: ../po/tmp/resources.xml.h:381
 msgctxt "Accel Editor (descriptions)"
 msgid "Draw smooth controlled lines."
 msgstr "畫平滑可控制的線條。"
 
-#: ../po/tmp/resources.xml.h:349
+#: ../po/tmp/resources.xml.h:382
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Reposition Layer"
 msgstr "移動圖層"
 
-#: ../po/tmp/resources.xml.h:350
+#: ../po/tmp/resources.xml.h:383
 msgctxt "Toolbar (short labels)"
 msgid "Layer Pos."
 msgstr "圖層"
 
-#: ../po/tmp/resources.xml.h:351
+#: ../po/tmp/resources.xml.h:384
 msgctxt "Toolbar (tooltips)"
 msgid "Reposition Layer: move the current layer on the canvas."
 msgstr "移動圖層：在畫布上移動目前的圖層。"
 
-#: ../po/tmp/resources.xml.h:352
+#: ../po/tmp/resources.xml.h:385
 msgctxt "Menu→Layer (labels), Accel Editor (labels)"
 msgid "Reposition Layer"
 msgstr "移動圖層"
 
-#: ../po/tmp/resources.xml.h:353
+#: ../po/tmp/resources.xml.h:386
 msgctxt "Accel Editor (description)"
 msgid "Interactively move the current layer on the canvas."
 msgstr "互動地在畫布上移動目前的圖層。"
 
-#: ../po/tmp/resources.xml.h:354
+#: ../po/tmp/resources.xml.h:387
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Frame"
 msgstr "編輯畫框"
 
-#: ../po/tmp/resources.xml.h:355
+#: ../po/tmp/resources.xml.h:388
 msgctxt "Toolbar (short labels)"
 msgid "Frame"
 msgstr "畫框"
 
-#: ../po/tmp/resources.xml.h:356
+#: ../po/tmp/resources.xml.h:389
 msgctxt "Toolbar (tooltips)"
 msgid ""
 "Edit Frame: define a frame around the document to give it a finite size."
 msgstr "編輯畫框：限定圍繞文件的畫框，給它一個有限的尺寸。"
 
-#: ../po/tmp/resources.xml.h:357
+#: ../po/tmp/resources.xml.h:390
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Frame"
 msgstr "編輯畫框"
 
-#: ../po/tmp/resources.xml.h:358
+#: ../po/tmp/resources.xml.h:391
 msgctxt "Accel Editor (descriptions)"
 msgid ""
 "Interactively define a frame around the document to give it a finite size."
 msgstr "互動地定義畫框為文件設定有限的呎吋。"
 
-#: ../po/tmp/resources.xml.h:359
+#: ../po/tmp/resources.xml.h:392
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "編輯繪畫對稱性"
 
-#: ../po/tmp/resources.xml.h:360
+#: ../po/tmp/resources.xml.h:393
 msgctxt "Toolbar (short labels)"
 msgid "Symmetry"
 msgstr "對稱性"
 
-#: ../po/tmp/resources.xml.h:361
+#: ../po/tmp/resources.xml.h:394
 msgctxt "Toolbar (tooltips)"
 msgid "Edit Painting Symmetry: adjust the axis used for symmetrical painting."
 msgstr "編輯繪畫對稱性：調整用於繪畫對稱的軸線。"
 
-#: ../po/tmp/resources.xml.h:362
+#: ../po/tmp/resources.xml.h:395
 msgctxt "Menu→File (labels), Accel Editor (labels)"
 msgid "Edit Painting Symmetry"
 msgstr "編輯繪畫對稱性"
 
-#: ../po/tmp/resources.xml.h:363
+#: ../po/tmp/resources.xml.h:396
 msgctxt "Accel Editor (description)"
 msgid "Interactively adjust the axis used for symmetrical painting."
 msgstr "互動地調整對稱繪畫用的軸線。"
 
-#: ../po/tmp/resources.xml.h:364
+#: ../po/tmp/resources.xml.h:397
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Pick Color"
 msgstr "挑選顏色"
 
-#: ../po/tmp/resources.xml.h:365
+#: ../po/tmp/resources.xml.h:398
 msgctxt "Toolbar (short labels)"
 msgid "Pick Col."
 msgstr "挑選顏色。"
 
-#: ../po/tmp/resources.xml.h:366
+#: ../po/tmp/resources.xml.h:399
 msgctxt "Toolbar (tooltips)"
 msgid "Pick Color: set the painting color from screen pixels."
 msgstr "挑選顏色：從螢幕像素來設定繪圖的顏色。"
 
-#: ../po/tmp/resources.xml.h:367
+#: ../po/tmp/resources.xml.h:400
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Hue"
+msgstr "挑選顏色"
+
+#: ../po/tmp/resources.xml.h:401
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Hue from screen pixels while preserving the Chroma and Luma."
+msgstr "以螢幕像素設定繪畫色彩。"
+
+#: ../po/tmp/resources.xml.h:402
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Chroma"
+msgstr "挑選顏色"
+
+#: ../po/tmp/resources.xml.h:403
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Chroma from screen pixels while preserving the Hue and Luma."
+msgstr "以螢幕像素設定繪畫色彩。"
+
+#: ../po/tmp/resources.xml.h:404
+#, fuzzy
+msgctxt "Menu→Color (labels), Accel Editor (labels)"
+msgid "Pick Color Luma"
+msgstr "挑選顏色"
+
+#: ../po/tmp/resources.xml.h:405
+#, fuzzy
+msgctxt "Accel Editor (descriptions)"
+msgid ""
+"Set the painting Luma from screen pixels while preserving the Hue and Chroma."
+msgstr "以螢幕像素設定繪畫色彩。"
+
+#: ../po/tmp/resources.xml.h:406
 msgctxt "Menu→Color (labels), Accel Editor (labels)"
 msgid "Pick Color"
 msgstr "挑選顏色"
 
-#: ../po/tmp/resources.xml.h:368
+#: ../po/tmp/resources.xml.h:407
 msgctxt "Accel Editor (descriptions)"
 msgid "Set the painting color from screen pixels."
 msgstr "以螢幕像素設定繪畫色彩。"
 
-#: ../po/tmp/resources.xml.h:369
+#: ../po/tmp/resources.xml.h:408
 msgctxt "Menu→Edit→Current Mode (labels)"
 msgid "Flood Fill"
 msgstr "填充"
 
-#: ../po/tmp/resources.xml.h:370
+#: ../po/tmp/resources.xml.h:409
 msgctxt "Toolbar (short labels)"
 msgid "Fill"
 msgstr "填充"
 
-#: ../po/tmp/resources.xml.h:371
+#: ../po/tmp/resources.xml.h:410
 msgctxt "Toolbar (tooltips)"
 msgid "Flood Fill: fill an area with color."
 msgstr "填充：用顏色填充一區域。"
 
-#: ../po/tmp/resources.xml.h:372
+#: ../po/tmp/resources.xml.h:411
 msgctxt "Menu→Edit (labels), Accel Editor (labels)"
 msgid "Flood Fill"
 msgstr "填充"
 
-#: ../po/tmp/resources.xml.h:373
+#: ../po/tmp/resources.xml.h:412
 msgctxt "Accel Editor (descriptions)"
 msgid "Fill an area with color."
 msgstr "用顏色填充一區域。"
+
+#~ msgctxt "Accelerator map editor: action column markup"
+#~ msgid ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+#~ msgstr ""
+#~ "<b>{action_label}</b><small>\n"
+#~ "{action_desc}</small>"
+
+#~ msgctxt "Accelerator map editor: action column: hidden searchable plaintext"
+#~ msgid "{action_label} {action_desc} {accel_label}"
+#~ msgstr "{action_label} {action_desc} {accel_label}"
+
+#~ msgctxt "brush list context menu"
+#~ msgid "Delete"
+#~ msgstr "刪除"
+
+#~ msgctxt "brush list commands"
+#~ msgid "Really delete brush from disk?"
+#~ msgstr "確定要從磁碟中刪除筆刷？"
+
+#~ msgid "HSV Triangle"
+#~ msgstr "HSV 三角"
+
+#~ msgid "The standard GTK color selector"
+#~ msgstr "標準 GTK 撿色器"
+
+#~ msgid "Pick a color from the screen"
+#~ msgstr "從畫面中挑選顏色"
+
+#~ msgid "Layer Name"
+#~ msgstr "圖層名稱"
+
+#~ msgid ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+#~ msgstr ""
+#~ "<b>{name}</b>\n"
+#~ "{description}"
+
+#~ msgid "Save..."
+#~ msgstr "儲存..."
+
+#~ msgid "Confirm"
+#~ msgstr "確認"
+
+#~ msgid "Open..."
+#~ msgstr "開啟..."
+
+#~ msgid "{default_name} at {path}"
+#~ msgstr "{path}中的{default_name}"
+
+#~ msgid "Type"
+#~ msgstr "種類"
+
+#~ msgid "Mode:"
+#~ msgstr "模式："
+
+#~ msgid ""
+#~ "Blending mode: how the current layer combines with the layers underneath "
+#~ "it."
+#~ msgstr "混合模式：目前的圖層要如何與其下的圖層結合。"
+
+#~ msgid ""
+#~ "Layer opacity: how much of the current layer to use. Smaller values make "
+#~ "it more transparent."
+#~ msgstr "圖層不透明度：目前圖層要顯現的程度有多少。較小的值會變得較透明。"
+
+#~ msgid "%s: edit properties"
+#~ msgstr "%s: 編輯屬性"
+
+#~ msgctxt "layer unique names: match regex (leave untranslated if unsure)"
+#~ msgid "^(.*?)\\s*(\\d+)$"
+#~ msgstr "^(.*?)\\s*(\\d+)$"
+
+#~ msgctxt "layer default names"
+#~ msgid "Unknown Bitmap Layer"
+#~ msgstr "不明點陣圖層"
+
+#~ msgctxt "Autosave Recovery dialog|"
+#~ msgid "_Ignore for Now"
+#~ msgstr "_現在忽略"
+
+#~ msgid "Setting name:"
+#~ msgstr "設定名稱："
+
+#~ msgid "Base value:"
+#~ msgstr "基礎值："
+
+#~ msgid "Reset the base value to its default"
+#~ msgstr "重設基礎值至其預設值"
+
+#~ msgid "<ymin>"
+#~ msgstr "<ymin>"
+
+#~ msgid "<ymax>"
+#~ msgstr "<ymax>"
+
+#~ msgid "<xmin>"
+#~ msgstr "<xmin>"
+
+#~ msgid "<xmax>"
+#~ msgstr "<xmax>"
+
+#~ msgid "Edit Setting"
+#~ msgstr "編輯設定"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Trim Layer to Frame"
+#~ msgstr "裁切圖層至畫框"
+
+#~ msgctxt "Menu→Layer (labels), Accel Editor (labels)"
+#~ msgid "Rename Layer…"
+#~ msgstr "重新命名圖層…"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Enter a new name for the current layer."
+#~ msgstr "為目前圖層輸入新的名稱。"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Turn off mirroring of the view."
+#~ msgstr "關閉視圖的鏡像功能。"
+
+#~ msgctxt "Menu→Edit (labels)"
+#~ msgid "Current Tool"
+#~ msgstr "目前工具"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Layers dockpanel (arrange layers, or assign modes)."
+#~ msgstr "切換圖層停駐面板 (排列圖層，或選定模式) 。"
+
+#~ msgctxt "Menu→Color (labels), Accel Editor (labels)"
+#~ msgid "HSV Triangle"
+#~ msgstr "HSV 三角"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Dockable color selector: the old GTK color triangle."
+#~ msgstr "顏色選擇器：舊 GTK 顏色三角。"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid ""
+#~ "Dockable color selector: HSV square which can be rotated to show "
+#~ "different hues."
+#~ msgstr "顏色選擇器：HSV 正方形可轉動，以顯示不同的色相。"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Scratchpad dockpanel (mix colors and make sketches)."
+#~ msgstr "切換便條紙停駐面板開關 (調色及畫草圖) 。"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Preview dockpanel (overview of the whole drawing area)."
+#~ msgstr "切換預覽停駐面板 (整個繪圖區域的概覽) 。"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the Tool Options dockpanel (options for the current tool)."
+#~ msgstr "切換工具選項停駐面板 (目前工具的選項) 。"
+
+#~ msgctxt "Accel Editor (descriptions)"
+#~ msgid "Toggle the History panel (recently used brushes and colors)."
+#~ msgstr "切換歷史面板開關 (最近使用過的筆刷及顏色) 。"
 
 #~ msgid ""
 #~ "\"%s\" has an alpha channel. Background images with transparency are not "
@@ -5736,18 +7057,12 @@ msgstr "用顏色填充一區域。"
 #~ "關於筆刷設定值 (不透明度、硬度等) 和輸入 (壓力、速度等) 會有工具提示。將您"
 #~ "的滑鼠移到標籤的上方可看見這些提示。\n"
 
-#~ msgid "Open Recent files"
-#~ msgstr "開啟最近的檔案"
-
 #~ msgid "This will discard %d second of unsaved painting."
 #~ msgid_plural "This will discard %d seconds of unsaved painting."
 #~ msgstr[0] "這將會丟棄 %d 秒內尚未儲存的繪畫。"
 
 #~ msgid "Crop to Current Layer"
 #~ msgstr "裁切至目前圖層尺寸"
-
-#~ msgid "Crop frame to the currently active layer"
-#~ msgstr "將畫框裁切至目前使用中的圖層尺寸"
 
 #~ msgid ""
 #~ "While the frame is enabled, it \n"
@@ -5852,9 +7167,6 @@ msgstr "用顏色填充一區域。"
 #~ msgid "Brush Blend Mode"
 #~ msgstr "筆刷混合模式"
 
-#~ msgid "Add Layer"
-#~ msgstr "加入圖層"
-
 #~ msgid "Move Layer on Canvas"
 #~ msgstr "在畫布上移動圖層"
 
@@ -5892,9 +7204,6 @@ msgstr "用顏色填充一區域。"
 #~ msgctxt "Menu|File|"
 #~ msgid "Save"
 #~ msgstr "儲存"
-
-#~ msgid "Export to a file"
-#~ msgstr "匯出至檔案"
 
 #~ msgid ""
 #~ "Saves to a new scrap file. If the drawing is currently saved as a scrap, "
@@ -6286,7 +7595,9 @@ msgstr "用顏色填充一區域。"
 #~ "How fast you currently move. This can change very quickly. Try 'print "
 #~ "input values' from the 'help' menu to get a feeling for the range; "
 #~ "negative values are rare but possible for very low speed."
-#~ msgstr "您目前移動的速度。這個可以變得非常快。用「說明」選單的「列印輸入值」來感受數值範圍的感覺；負值比較罕見，但可用於非常緩慢的速度。"
+#~ msgstr ""
+#~ "您目前移動的速度。這個可以變得非常快。用「說明」選單的「列印輸入值」來感受"
+#~ "數值範圍的感覺；負值比較罕見，但可用於非常緩慢的速度。"
 
 #~ msgid "Gross speed"
 #~ msgstr "粗略速度"
@@ -6308,12 +7619,16 @@ msgstr "用顏色填充一區域。"
 #~ "This input slowly goes from zero to one while you draw a stroke. It can "
 #~ "also be configured to jump back to zero periodically while you move. Look "
 #~ "at the 'stroke duration' and 'stroke hold time' settings."
-#~ msgstr "當您繪製一道筆畫時，這種輸入會緩慢地從零到一。它也可以設定成移動時週期性跳回零。請查看「筆畫持續時間」和「筆畫維持時間」設定值。"
+#~ msgstr ""
+#~ "當您繪製一道筆畫時，這種輸入會緩慢地從零到一。它也可以設定成移動時週期性跳"
+#~ "回零。請查看「筆畫持續時間」和「筆畫維持時間」設定值。"
 
 #~ msgid ""
 #~ "The angle of the stroke, in degrees. The value will stay between 0.0 and "
 #~ "180.0, effectively ignoring turns of 180 degrees."
-#~ msgstr "筆畫的角度，單位為度。此數值會在 0.0 到 180.0 之間，有效地忽略 180 度轉彎。"
+#~ msgstr ""
+#~ "筆畫的角度，單位為度。此數值會在 0.0 到 180.0 之間，有效地忽略 180 度轉"
+#~ "彎。"
 
 #~ msgid ""
 #~ "Declination of stylus tilt. 0 when stylus is parallel to tablet and 90.0 "
@@ -6327,7 +7642,9 @@ msgstr "用顏色填充一區域。"
 #~ "Right ascension of stylus tilt. 0 when stylus working end points to you, "
 #~ "+90 when rotated 90 degrees clockwise, -90 when rotated 90 degrees "
 #~ "counterclockwise."
-#~ msgstr "筆尖傾斜的右增。0 當筆尖的工作端指向您；+90 當筆尖順時鐘旋轉 90 度；-90 當筆尖逆時鐘旋轉 90 度。"
+#~ msgstr ""
+#~ "筆尖傾斜的右增。0 當筆尖的工作端指向您；+90 當筆尖順時鐘旋轉 90 度；-90 當"
+#~ "筆尖逆時鐘旋轉 90 度。"
 
 #~ msgid ""
 #~ "This is a user defined input. Look at the 'custom input' setting for "
@@ -6341,9 +7658,6 @@ msgstr "用顏色填充一區域。"
 #~ "0 表示筆刷為透明，1 則完全可看見\n"
 #~ "(亦稱為 alpha 或不透明度)"
 
-#~ msgid "Opacity multiply"
-#~ msgstr "不透明度相乘"
-
 #~ msgid ""
 #~ "This gets multiplied with opaque. You should only change the pressure "
 #~ "input of this setting. Use 'opaque' instead to make opacity depend on "
@@ -6351,7 +7665,8 @@ msgstr "用顏色填充一區域。"
 #~ "This setting is responsible to stop painting when there is zero pressure. "
 #~ "This is just a convention, the behaviour is identical to 'opaque'."
 #~ msgstr ""
-#~ "這會與不透明度相乘。您應該只需改變此設定值的壓力輸入。改用「不透明」以根據速度決定不透明度。\n"
+#~ "這會與不透明度相乘。您應該只需改變此設定值的壓力輸入。改用「不透明」以根據"
+#~ "速度決定不透明度。\n"
 #~ "當壓力為零時，此設定值負責停止繪畫。這只是個慣例，行為與「不透明」相同。"
 
 #~ msgid "Opacity linearize"
@@ -6367,10 +7682,13 @@ msgstr "用顏色填充一區域。"
 #~ "1.0 the opaque value above is for the final brush stroke, assuming each "
 #~ "pixel gets (dabs_per_radius*2) brushdabs on average during a stroke"
 #~ msgstr ""
-#~ "修正在混合重疊筆觸時的非線性表現。當壓力控制套用到「不透明度相乘」時，這項修正會讓您得到如平常表現一樣的線性（亦即是「自然」）壓力反應。0.9適用於一般筆"
-#~ "觸，如果筆刷表現分散的話請將設定值調低，使用「每秒筆觸數量」的話則將設定值調高。\n"
+#~ "修正在混合重疊筆觸時的非線性表現。當壓力控制套用到「不透明度相乘」時，這項"
+#~ "修正會讓您得到如平常表現一樣的線性（亦即是「自然」）壓力反應。0.9適用於一"
+#~ "般筆觸，如果筆刷表現分散的話請將設定值調低，使用「每秒筆觸數量」的話則將設"
+#~ "定值調高。\n"
 #~ "0.0 以上的不透明值是針對個別筆觸\n"
-#~ "1.0 以上的不透明值是針對最終筆畫，假設一道筆畫中每個像素平均會有 (每半徑筆觸數量*2) 個筆刷筆觸"
+#~ "1.0 以上的不透明值是針對最終筆畫，假設一道筆畫中每個像素平均會有 (每半徑筆"
+#~ "觸數量*2) 個筆刷筆觸"
 
 #~ msgid "Radius"
 #~ msgstr "半徑"
@@ -6412,7 +7730,8 @@ msgstr "用顏色填充一區域。"
 #~ msgid ""
 #~ "How many dabs to draw while the pointer moves a distance of one brush "
 #~ "radius (more precise: the base value of the radius)"
-#~ msgstr "當指標移動一個筆刷半徑距離時要描繪多少個筆觸 (更精確的說法：半徑的基礎值)"
+#~ msgstr ""
+#~ "當指標移動一個筆刷半徑距離時要描繪多少個筆觸 (更精確的說法：半徑的基礎值)"
 
 #~ msgid "Dabs per actual radius"
 #~ msgstr "每實際半徑筆觸數"
@@ -6439,7 +7758,8 @@ msgstr "用顏色填充一區域。"
 #~ "transparent\n"
 #~ "2) it will not change the actual radius seen by dabs_per_actual_radius"
 #~ msgstr ""
-#~ "隨機改變每個筆觸的半徑。您也可以使用半徑設定值上的「隨機」 輸入來做出相同效果。如果您在這裡進行設定的話會有兩個不同的地方：\n"
+#~ "隨機改變每個筆觸的半徑。您也可以使用半徑設定值上的「隨機」 輸入來做出相同"
+#~ "效果。如果您在這裡進行設定的話會有兩個不同的地方：\n"
 #~ "1) 不透明度會被修正使大半徑的筆觸變得更透明。\n"
 #~ "2) 「每實際半徑的筆觸數量」所見的實際半徑將不會被改變"
 
@@ -6470,7 +7790,8 @@ msgstr "用顏色填充一區域。"
 #~ "+8.0 very fast speed increases 'fine speed' a lot\n"
 #~ "For very slow speed the opposite happens."
 #~ msgstr ""
-#~ "這會將「精細速度」的反應改變為極端的物理速度。如果將「精細速度」套用到半徑上，您會看到明顯的差別。\n"
+#~ "這會將「精細速度」的反應改變為極端的物理速度。如果將「精細速度」套用到半徑"
+#~ "上，您會看到明顯的差別。\n"
 #~ "-8.0 非常快的速度但不會再增加「精細速度」\n"
 #~ "+8.0 非常快的速度並會大幅增加「精細速度」\n"
 #~ "若速度非常慢則會有相反表現。"
@@ -6522,7 +7843,9 @@ msgstr "用顏色填充一區域。"
 #~ "Slowdown pointer tracking speed. 0 disables it, higher values remove more "
 #~ "jitter in cursor movements. Useful for drawing smooth, comic-like "
 #~ "outlines."
-#~ msgstr "減慢指標曳跡速度。0 為停用，較高的數值會移除游標移動中較多的抖動。對於繪製平滑、類似漫畫輪廓時很有用。"
+#~ msgstr ""
+#~ "減慢指標曳跡速度。0 為停用，較高的數值會移除游標移動中較多的抖動。對於繪製"
+#~ "平滑、類似漫畫輪廓時很有用。"
 
 #~ msgid "Slow tracking per dab"
 #~ msgstr "每個筆觸緩慢曳跡"
@@ -6540,7 +7863,9 @@ msgstr "用顏色填充一區域。"
 #~ msgid ""
 #~ "Add randomness to the mouse pointer; this usually generates many small "
 #~ "lines in random directions; maybe try this together with 'slow tracking'"
-#~ msgstr "加入隨機性雜點到滑鼠游標；這通常會產生許多隨機方向的小線條；也許試試和「緩慢曳跡」一起使用"
+#~ msgstr ""
+#~ "加入隨機性雜點到滑鼠游標；這通常會產生許多隨機方向的小線條；也許試試和「緩"
+#~ "慢曳跡」一起使用"
 
 #~ msgid "Color value (brightness, intensity)"
 #~ msgstr "色彩明度 (亮度，光強度)"
@@ -6609,7 +7934,8 @@ msgstr "用顏色填充一區域。"
 #~ " 0.0 disable\n"
 #~ " 1.0 brigher"
 #~ msgstr ""
-#~ "使用 HSV 色彩模型來改變色彩的明度 (亮度，強度)。HSV 的改變會在 HSL 之前套用。\n"
+#~ "使用 HSV 色彩模型來改變色彩的明度 (亮度，強度)。HSV 的改變會在 HSL 之前套"
+#~ "用。\n"
 #~ "-1.0 更暗\n"
 #~ "0.0 停用\n"
 #~ "1.0 更亮"
@@ -6726,8 +8052,9 @@ msgstr "用顏色填充一區域。"
 #~ "If you make it change 'by random' you can generate a slow (smooth) random "
 #~ "input."
 #~ msgstr ""
-#~ "將自訂輸入設定為這數值。如果速度減慢的話，就將它調至這個數值 "
-#~ "(如下面所示)。這是讓您將壓力/速度/其他控制組合設定成這個輸入，然後只要於需要時在其他設定上參照這個「自訂輸入」就無須重覆進行相同的設定。\n"
+#~ "將自訂輸入設定為這數值。如果速度減慢的話，就將它調至這個數值 (如下面所"
+#~ "示)。這是讓您將壓力/速度/其他控制組合設定成這個輸入，然後只要於需要時在其"
+#~ "他設定上參照這個「自訂輸入」就無須重覆進行相同的設定。\n"
 #~ "如果您設定成「隨機」改變，就可以產生出緩慢 (順滑) 的隨機輸入。"
 
 #~ msgid "Custom input filter"
@@ -6749,7 +8076,9 @@ msgstr "用顏色填充一區域。"
 #~ msgid ""
 #~ "Aspect ratio of the dabs; must be >= 1.0, where 1.0 means a perfectly "
 #~ "round dab. TODO: linearize? start at 0.0 maybe, or log?"
-#~ msgstr "筆觸外觀的比例；必須是 >= 1.0，這裡的 1.0 代表一個完美圓形筆觸。待完成：線性化？可能從 0.0 開始，或者對數？"
+#~ msgstr ""
+#~ "筆觸外觀的比例；必須是 >= 1.0，這裡的 1.0 代表一個完美圓形筆觸。待完成：線"
+#~ "性化？可能從 0.0 開始，或者對數？"
 
 #~ msgid "Elliptical dab: angle"
 #~ msgstr "橢圓筆觸：角度"
@@ -6764,9 +8093,6 @@ msgstr "用顏色填充一區域。"
 #~ "0.0 水平筆觸\n"
 #~ "45.0 順時針轉 45 度\n"
 #~ "180.0 再次水平"
-
-#~ msgid "Direction filter"
-#~ msgstr "方向過濾"
 
 #~ msgid ""
 #~ "A low value will make the direction input adapt more quickly, a high "


### PR DESCRIPTION
Merges all of the previously unmerged strings - with a few fixes before being merged - into the translation files.

Also incorporates the patch from @leela52452 (modified slightly by me) to replace the occurrences of triple dots in the code strings (non-xml) with ellipsis glyphs. In order to avoid unnecessary work I have updated the msgid and (most) msgstr entries accordingly - just merging as usual would have marked all those strings as fuzzy, requiring manual intervention to be used by gettext,